### PR TITLE
fix(ci): install xdg-utils for Tauri Linux bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         if: startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri


### PR DESCRIPTION
Adds `xdg-utils` to the Linux build job so `/usr/bin/xdg-open` exists when Tauri bundles the Linux app.

Fixes CI failure on `ubuntu-22.04-arm`: `failed to bundle project xdg-open binary not found`.