### PR TITLE
ci: validate PR titles (conventional commits)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-title:
+    name: PR title (conventional commits)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$TITLE" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\([^)]+\))?(!)?: .+'; then
+            echo "OK: $TITLE"
+          else
+            echo "::error::PR title must follow Conventional Commits (e.g. feat: add feature, fix(scope): description). See https://www.conventionalcommits.org/"
+            exit 1
+          fi
+
   check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a **check-only** CI job on pull requests: the workflow validates the PR title against [Conventional Commits](https://www.conventionalcommits.org/) and fails if it does not match (e.g. `feat:`, `fix(scope):`, `chore:`). It does **not** rewrite titles.

To make this required for merge, add **PR title (conventional commits)** as a required status check in branch protection after this lands.