### PR TITLE
fix(ui): ensure last TOC items activate on click

### DIFF
--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -40,7 +40,7 @@ export function MarkdownViewer({ content, filePath }: MarkdownViewerProps) {
 
   return (
     <div ref={scrollRef} className="flex-1 overflow-y-auto">
-      <div className="markdown-body px-8 py-6 pb-24">
+      <div className="markdown-body px-8 py-6 pb-[60vh]">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[[rehypeHighlight, { plainText: ["mermaid"] }]]}


### PR DESCRIPTION
## Summary
- Increase bottom padding from `pb-24` (96px) to `pb-[60vh]` so the last headings in short documents can scroll high enough to enter the IntersectionObserver detection zone
- The sidebar's observer uses `rootMargin: -20px 0px -60% 0px` — without enough bottom space, the last headings never reach the active zone when clicked

## Test plan
- [ ] Open a short markdown file with multiple headings
- [ ] Click the last TOC item in the sidebar — it should highlight as active
- [ ] Verify scrolling still works normally for longer documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)