### PR TITLE
feat: add Debian apt repository publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,11 @@ jobs:
             sudo add-apt-repository ppa:hamidfzm/glyph
             sudo apt update
             sudo apt install glyph
+
+            # Debian (apt repo)
+            curl -fsSL https://hamidfzm.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+            echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://hamidfzm.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+            sudo apt update && sudo apt install glyph
             ```
             Or download the `.deb` / `.AppImage` below.
           releaseDraft: false
@@ -119,6 +124,11 @@ jobs:
           sudo add-apt-repository ppa:hamidfzm/glyph
           sudo apt update
           sudo apt install glyph
+
+          # Debian (apt repo)
+          curl -fsSL https://hamidfzm.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://hamidfzm.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+          sudo apt update && sudo apt install glyph
           ```
           Or download the `.deb` / `.AppImage` below.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,7 +410,7 @@ jobs:
             --pattern "Glyph_${VERSION}_arm64.deb"
       - name: Clone apt-repo and update
         env:
-          GH_TOKEN: ${{ secrets.APT_REPO_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,3 +378,91 @@ jobs:
           SERIES="${{ matrix.series }}"
           cd /tmp
           dput ppa:hamidfzm/glyph glyph_${VERSION}-1~${SERIES}1_source.changes
+
+  publish-debian:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install packaging tools
+        run: sudo apt-get update && sudo apt-get install -y dpkg-dev gpg
+      - name: Get version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Download deb packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release download "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "Glyph_${VERSION}_amd64.deb" \
+            --pattern "Glyph_${VERSION}_arm64.deb"
+      - name: Clone apt-repo and update
+        env:
+          GH_TOKEN: ${{ secrets.APT_REPO_GITHUB_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Import GPG key
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format long 2>/dev/null | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
+
+          # Clone the apt repo
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/hamidfzm/apt-repo.git" /tmp/apt-repo
+          cd /tmp/apt-repo
+
+          # Set up pool directory
+          mkdir -p pool/main
+
+          # Copy new debs
+          cp "$GITHUB_WORKSPACE/Glyph_${VERSION}_amd64.deb" pool/main/
+          cp "$GITHUB_WORKSPACE/Glyph_${VERSION}_arm64.deb" pool/main/
+
+          # Generate Packages files
+          mkdir -p dists/stable/main/binary-amd64
+          mkdir -p dists/stable/main/binary-arm64
+
+          dpkg-scanpackages --arch amd64 pool/ > dists/stable/main/binary-amd64/Packages
+          gzip -k -f dists/stable/main/binary-amd64/Packages
+
+          dpkg-scanpackages --arch arm64 pool/ > dists/stable/main/binary-arm64/Packages
+          gzip -k -f dists/stable/main/binary-arm64/Packages
+
+          # Generate Release file
+          {
+            echo "Origin: Glyph"
+            echo "Label: Glyph"
+            echo "Suite: stable"
+            echo "Codename: stable"
+            echo "Architectures: amd64 arm64"
+            echo "Components: main"
+            echo "Description: Glyph apt repository"
+            echo "Date: $(date -Ru)"
+            echo "MD5Sum:"
+            for f in dists/stable/main/binary-*/Packages*; do
+              echo " $(md5sum "$f" | awk '{print $1}') $(wc -c < "$f") ${f#dists/stable/}"
+            done
+            echo "SHA256:"
+            for f in dists/stable/main/binary-*/Packages*; do
+              echo " $(sha256sum "$f" | awk '{print $1}') $(wc -c < "$f") ${f#dists/stable/}"
+            done
+          } > dists/stable/Release
+
+          # Sign the Release file
+          gpg --batch --yes --default-key "$GPG_KEY_ID" -abs -o dists/stable/Release.gpg dists/stable/Release
+          gpg --batch --yes --default-key "$GPG_KEY_ID" --clearsign -o dists/stable/InRelease dists/stable/Release
+
+          # Export public key
+          gpg --armor --export "$GPG_KEY_ID" > gpg.key
+
+          # Commit and push
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || {
+            git commit -m "chore: update packages to $VERSION"
+            git push
+          }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ sudo apt update
 sudo apt install glyph
 ```
 
+### Debian
+
+```bash
+curl -fsSL https://hamidfzm.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://hamidfzm.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+sudo apt update
+sudo apt install glyph
+```
+
 ### Linux (manual)
 
 Download the `.deb` or `.AppImage` from [Releases](https://github.com/hamidfzm/glyph/releases).


### PR DESCRIPTION
## Summary

- Add `publish-debian` job to release workflow that publishes `.deb` packages to a GitHub Pages-based apt repository (`hamidfzm/apt-repo`)
- Generates signed `Packages`, `Release`, and `InRelease` files
- Supports both `amd64` and `arm64` architectures

Closes #60

## Prerequisites

- [x] Create the `hamidfzm/apt-repo` repository with GitHub Pages enabled (deploy from main branch)
- [x] ~~Add `APT_REPO_GITHUB_TOKEN` secret~~ — reuses existing `TAP_GITHUB_TOKEN`
- [x] Ensure `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` secrets are set (already used by PPA job)

## Install instructions (for users)

```bash
curl -fsSL https://hamidfzm.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://hamidfzm.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
sudo apt update
sudo apt install glyph
```

## Test plan

- [ ] Verify workflow YAML syntax is valid
- [ ] Set up apt-repo, trigger a release, and verify the repo is populated
- [ ] Test installing on a Debian system using the install instructions above