### PR TITLE
feat: add copy button on code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@tauri-apps/cli": "^2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -882,6 +885,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2917,6 +2926,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@types/aria-query@5.0.4': {}
 

--- a/src/components/markdown/CodeBlockComponent.test.tsx
+++ b/src/components/markdown/CodeBlockComponent.test.tsx
@@ -1,10 +1,16 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CodeBlockComponent } from "./CodeBlockComponent";
 
 vi.mock("./MermaidDiagram", () => ({
   MermaidDiagram: ({ code }: { code: string }) => <div data-testid="mermaid-diagram">{code}</div>,
 }));
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined);
+Object.defineProperty(navigator, "clipboard", {
+  value: { writeText: writeTextMock },
+  configurable: true,
+});
 
 describe("CodeBlockComponent", () => {
   it("renders a normal pre element for non-mermaid code", () => {
@@ -60,5 +66,97 @@ describe("CodeBlockComponent", () => {
     );
     const pre = container.querySelector("pre");
     expect(pre?.className).toBe("custom-pre");
+  });
+
+  describe("copy button", () => {
+    it("renders a copy button for code blocks", () => {
+      render(
+        <CodeBlockComponent>
+          <code className="language-javascript">const x = 1;</code>
+        </CodeBlockComponent>,
+      );
+      expect(screen.getByRole("button", { name: "Copy code" })).toBeInTheDocument();
+    });
+
+    it("does not render a copy button for mermaid blocks", () => {
+      render(
+        <CodeBlockComponent>
+          <code className="language-mermaid">graph TD; A--&gt;B;</code>
+        </CodeBlockComponent>,
+      );
+      expect(screen.queryByRole("button", { name: "Copy code" })).not.toBeInTheDocument();
+    });
+
+    it("does not render a copy button when code is empty", () => {
+      render(
+        <CodeBlockComponent>
+          <code className="language-javascript">{""}</code>
+        </CodeBlockComponent>,
+      );
+      expect(screen.queryByRole("button", { name: "Copy code" })).not.toBeInTheDocument();
+    });
+
+    afterEach(() => {
+      writeTextMock.mockClear();
+    });
+
+    it("copies code text to clipboard on click", async () => {
+      render(
+        <CodeBlockComponent>
+          <code className="language-javascript">const x = 1;</code>
+        </CodeBlockComponent>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+      await vi.waitFor(() => {
+        expect(writeTextMock).toHaveBeenCalledWith("const x = 1;");
+      });
+    });
+
+    it("shows copied feedback after clicking", async () => {
+      render(
+        <CodeBlockComponent>
+          <code className="language-javascript">const x = 1;</code>
+        </CodeBlockComponent>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+      await vi.waitFor(() => {
+        expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+      });
+    });
+
+    it("reverts to copy icon after timeout", async () => {
+      vi.useFakeTimers();
+
+      render(
+        <CodeBlockComponent>
+          <code className="language-javascript">const x = 1;</code>
+        </CodeBlockComponent>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+      await vi.waitFor(() => {
+        expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(screen.getByRole("button", { name: "Copy code" })).toBeInTheDocument();
+      vi.useRealTimers();
+    });
+
+    it("wraps pre in a code-block-wrapper div", () => {
+      const { container } = render(
+        <CodeBlockComponent>
+          <code className="language-javascript">const x = 1;</code>
+        </CodeBlockComponent>,
+      );
+      const wrapper = container.querySelector(".code-block-wrapper");
+      expect(wrapper).toBeTruthy();
+      expect(wrapper?.querySelector("pre")).toBeTruthy();
+    });
   });
 });

--- a/src/components/markdown/CodeBlockComponent.tsx
+++ b/src/components/markdown/CodeBlockComponent.tsx
@@ -1,4 +1,12 @@
-import { type ComponentPropsWithoutRef, isValidElement, type ReactNode } from "react";
+import {
+  type ComponentPropsWithoutRef,
+  isValidElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { MermaidDiagram } from "./MermaidDiagram";
 
 interface CodeProps {
@@ -15,6 +23,64 @@ function extractText(node: ReactNode): string {
   return "";
 }
 
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    });
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      className={`code-copy-button${copied ? " copied" : ""}`}
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy code"}
+    >
+      {copied ? (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path
+            d="M13.5 4.5L6 12L2.5 8.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <rect
+            x="5.5"
+            y="5.5"
+            width="8"
+            height="8"
+            rx="1.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          />
+          <path
+            d="M10.5 5.5V3.5C10.5 2.67 9.83 2 9 2H3.5C2.67 2 2 2.67 2 3.5V9C2 9.83 2.67 10.5 3.5 10.5H5.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}
+
 export function CodeBlockComponent(props: ComponentPropsWithoutRef<"pre">) {
   const { children, ...rest } = props;
 
@@ -26,5 +92,14 @@ export function CodeBlockComponent(props: ComponentPropsWithoutRef<"pre">) {
     }
   }
 
-  return <pre {...rest}>{children}</pre>;
+  const codeText = isValidElement<CodeProps>(children)
+    ? extractText(children.props.children).trim()
+    : "";
+
+  return (
+    <div className="code-block-wrapper">
+      {codeText && <CopyButton text={codeText} />}
+      <pre {...rest}>{children}</pre>
+    </div>
+  );
 }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -89,6 +89,50 @@
   border-radius: var(--glyph-radius-sm);
 }
 
+.markdown-body .code-block-wrapper {
+  position: relative;
+  margin: 0 0 1em;
+}
+
+.markdown-body .code-block-wrapper pre {
+  margin: 0;
+}
+
+.markdown-body .code-copy-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--glyph-radius-sm);
+  background: var(--color-surface-secondary);
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease;
+  z-index: 1;
+}
+
+.markdown-body .code-block-wrapper:hover .code-copy-button,
+.markdown-body .code-copy-button:focus-visible {
+  opacity: 1;
+}
+
+.markdown-body .code-copy-button:hover {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.markdown-body .code-copy-button.copied {
+  opacity: 1;
+  color: var(--color-accent);
+}
+
 .markdown-body pre {
   margin: 0 0 1em;
   padding: 1em;


### PR DESCRIPTION
## Summary
- Adds a copy-to-clipboard button on code blocks that appears on hover in the top-right corner
- Shows clipboard icon by default, switches to checkmark for 2s after copying
- Accessible with `aria-label` ("Copy code" / "Copied"), keyboard focusable
- Theme-aware styling using existing CSS custom properties
- 7 new tests covering rendering, clipboard interaction, feedback state, and edge cases

Closes #7

## Test plan
- [x] Verify copy button appears on hover over code blocks
- [x] Verify clicking copies code text to clipboard
- [x] Verify checkmark feedback appears for ~2 seconds then reverts
- [x] Verify button does NOT appear on Mermaid diagram blocks
- [x] Verify dark mode styling
- [x] Verify all 143 tests pass (`pnpm test`)
- [x] Verify typecheck passes (`pnpm typecheck`)
- [x] Verify lint passes (`pnpm check`)