### PR TITLE
feat: add zoom in/out controls

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -28,8 +28,22 @@ pub fn build_menu(app: &App) -> tauri::Result<tauri::menu::Menu<Wry>> {
         .accelerator("CmdOrCtrl+B")
         .build(handle)?;
 
+    let zoom_in = MenuItemBuilder::with_id("zoom-in", "Zoom In")
+        .accelerator("CmdOrCtrl+=")
+        .build(handle)?;
+    let zoom_out = MenuItemBuilder::with_id("zoom-out", "Zoom Out")
+        .accelerator("CmdOrCtrl+-")
+        .build(handle)?;
+    let actual_size = MenuItemBuilder::with_id("actual-size", "Actual Size")
+        .accelerator("CmdOrCtrl+0")
+        .build(handle)?;
+
     let view_menu = SubmenuBuilder::new(handle, "View")
         .item(&toggle_sidebar)
+        .separator()
+        .item(&zoom_in)
+        .item(&zoom_out)
+        .item(&actual_size)
         .separator()
         .fullscreen()
         .build()?;
@@ -149,6 +163,15 @@ pub fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) 
         }
         "ai-read-aloud" => {
             let _ = app.emit("menu-ai-read-aloud", ());
+        }
+        "zoom-in" => {
+            let _ = app.emit("menu-zoom-in", ());
+        }
+        "zoom-out" => {
+            let _ = app.emit("menu-zoom-out", ());
+        }
+        "actual-size" => {
+            let _ = app.emit("menu-zoom-reset", ());
         }
         _ => {}
     }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,6 +9,7 @@ import { useSettings } from "../hooks/useSettings";
 import { useTableOfContents } from "../hooks/useTableOfContents";
 import { useTheme } from "../hooks/useTheme";
 import { useTTS } from "../hooks/useTTS";
+import { ZOOM_DEFAULT, ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from "../lib/settings";
 // Code theme CSS (inline imports for production compatibility)
 import glyphThemeCSS from "../styles/highlight.css?inline";
 import githubThemeCSS from "../styles/highlight-github.css?inline";
@@ -113,14 +114,40 @@ export function App() {
         tts.speak(content);
       }
     });
+    const unlistenZoomIn = listen("menu-zoom-in", () => {
+      updateSettings(
+        "appearance.fontSize",
+        Math.min(settings.appearance.fontSize + ZOOM_STEP, ZOOM_MAX),
+      );
+    });
+    const unlistenZoomOut = listen("menu-zoom-out", () => {
+      updateSettings(
+        "appearance.fontSize",
+        Math.max(settings.appearance.fontSize - ZOOM_STEP, ZOOM_MIN),
+      );
+    });
+    const unlistenZoomReset = listen("menu-zoom-reset", () => {
+      updateSettings("appearance.fontSize", ZOOM_DEFAULT);
+    });
     return () => {
       unlistenOpen.then((fn) => fn());
       unlistenSidebar.then((fn) => fn());
       unlistenSettings.then((fn) => fn());
       unlistenAI.then((fn) => fn());
       unlistenReadAloud.then((fn) => fn());
+      unlistenZoomIn.then((fn) => fn());
+      unlistenZoomOut.then((fn) => fn());
+      unlistenZoomReset.then((fn) => fn());
     };
-  }, [openFileDialog, toggleSidebar, content, handleAIAction, tts]);
+  }, [
+    openFileDialog,
+    toggleSidebar,
+    content,
+    handleAIAction,
+    tts,
+    settings.appearance.fontSize,
+    updateSettings,
+  ]);
 
   // Apply code theme via injected <style> element
   useEffect(() => {

--- a/src/components/layout/StatusBar.test.tsx
+++ b/src/components/layout/StatusBar.test.tsx
@@ -1,6 +1,24 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "../../lib/settings";
 import { StatusBar } from "./StatusBar";
+
+function mockSettings(fontSize: number) {
+  vi.doMock("../../hooks/useSettings", () => ({
+    useSettings: () => ({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        appearance: { ...DEFAULT_SETTINGS.appearance, fontSize },
+      },
+      updateSettings: vi.fn(),
+      resetSettings: vi.fn(),
+      loaded: true,
+    }),
+  }));
+}
+
+// Default mock at 100% zoom
+mockSettings(16);
 
 describe("StatusBar", () => {
   it("renders nothing when content is null", () => {
@@ -27,5 +45,10 @@ describe("StatusBar", () => {
   it("does not display file path when not provided", () => {
     render(<StatusBar content="some content" />);
     expect(screen.queryByText(/\//)).toBeNull();
+  });
+
+  it("does not show zoom percentage at default zoom (100%)", () => {
+    render(<StatusBar content="some content" />);
+    expect(screen.queryByText("100%")).toBeNull();
   });
 });

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,4 +1,6 @@
+import { useSettings } from "../../hooks/useSettings";
 import { countWords, readingTime } from "../../lib/markdown";
+import { ZOOM_DEFAULT } from "../../lib/settings";
 
 interface StatusBarProps {
   filePath?: string;
@@ -6,6 +8,9 @@ interface StatusBarProps {
 }
 
 export function StatusBar({ filePath, content }: StatusBarProps) {
+  const { settings } = useSettings();
+  const zoomPercent = Math.round((settings.appearance.fontSize / ZOOM_DEFAULT) * 100);
+
   if (!content) return null;
 
   const words = countWords(content);
@@ -19,6 +24,7 @@ export function StatusBar({ filePath, content }: StatusBarProps) {
       )}
       <span className="ml-auto">{words.toLocaleString()} words</span>
       <span>{readingTime(words)}</span>
+      {zoomPercent !== 100 && <span>{zoomPercent}%</span>}
     </div>
   );
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -70,6 +70,11 @@ export const DEFAULT_SETTINGS: Settings = {
   },
 };
 
+export const ZOOM_DEFAULT = 16;
+export const ZOOM_MIN = 8;
+export const ZOOM_MAX = 32;
+export const ZOOM_STEP = 1;
+
 export const FONT_FAMILY_MAP: Record<string, string> = {
   system: "",
   serif: "Georgia, 'Times New Roman', serif",


### PR DESCRIPTION
## Summary
- Adds View menu items: Zoom In (Cmd/Ctrl+=), Zoom Out (Cmd/Ctrl+-), Actual Size (Cmd/Ctrl+0)
- Zoom adjusts text font size from 50% to 200% (8px–32px), persisted across sessions
- Shows current zoom percentage in the status bar when not at 100%
- Text-only zoom — images remain at original size

Closes #8

## Test plan
- [x] Verify Cmd+=/-/0 shortcuts work from View menu
- [x] Verify zoom level persists across app restart
- [x] Verify status bar shows zoom % when zoomed, hidden at 100%
- [x] Verify images don't scale with zoom
- [x] All tests pass (`pnpm test`)
- [x] TypeScript (`pnpm typecheck`) and Biome (`pnpm check`) clean
- [x] Rust compiles and passes clippy