### PR TITLE
docs: consolidate CLAUDE.md and add CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,20 @@ When creating PRs, always follow the PR template. When creating issues, use the 
 - `src/components/icons/` — SVG icon components
 - `src/components/modals/` — Overlay UI (SettingsModal, AIPanel)
 
+## Releases
+
+To create a new release:
+
+1. Bump version in `package.json` and `src-tauri/Cargo.toml` (keep in sync)
+2. Run `cargo check` in `src-tauri/` to update `Cargo.lock`
+3. Commit: `chore: bump version to X.Y.Z`
+4. Push to `main`
+5. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`
+
+The tag push triggers `.github/workflows/release.yml` which builds, creates the GitHub release, and publishes to Homebrew, Chocolatey, AUR, and PPA.
+
+Do **not** create releases manually with `gh release create` — let the CI workflow handle it.
+
 ## Key Files
 
 - `src-tauri/tauri.conf.json` — App window config, CLI plugin config, bundle settings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,55 +2,25 @@
 
 Cross-platform markdown viewer built with Tauri v2 + React 19 + TypeScript.
 
-## Commands
+## Community & Project Files
 
-```bash
-pnpm install                    # Install frontend dependencies
-pnpm tauri dev                  # Run in development (starts Vite + Cargo)
-pnpm tauri dev -- -- /path.md   # Dev mode with a file argument
-pnpm tauri build                # Production build
-pnpm typecheck                  # TypeScript type checking
-pnpm lint                       # Lint TypeScript with Biome
-pnpm format:check               # Check formatting with Biome
-pnpm format                     # Auto-format with Biome
-pnpm check                      # Biome lint + format + organize imports
-pnpm check:fix                  # Auto-fix all Biome issues
-pnpm test                       # Run frontend tests (Vitest)
-pnpm test:watch                 # Run frontend tests in watch mode
-pnpm test:coverage              # Run frontend tests with coverage
-cd src-tauri && cargo check     # Rust type checking
-cd src-tauri && cargo clippy    # Rust linting
-cd src-tauri && cargo test      # Rust tests
-```
+- [README.md](README.md) — Project overview, installation, and usage
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Development setup, commands, conventions, workflow, and release process
+- [SECURITY.md](SECURITY.md) — Security vulnerability reporting policy
+- [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) — PR template (always use when creating PRs)
+- [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) — Bug report and feature request templates
+
+When creating PRs, always follow the PR template. When creating issues, use the appropriate issue template.
 
 ## Architecture
 
-- **Backend** (`src-tauri/src/`): Rust — Tauri commands, file watcher via `notify` crate, plugin setup
+- **Backend** (`src-tauri/src/`): Rust — Tauri commands, file watcher via `notify` crate, plugin setup, native menus
 - **Frontend** (`src/`): React 19 — components, hooks, styles
 - **Styling**: Tailwind CSS v4 + CSS custom properties for platform-adaptive theming
 - **State**: Plain React hooks (useState/useCallback), no external state library
 - File I/O goes through Rust commands, not the Tauri FS plugin directly
 - File watching uses `notify` crate with events pushed via Tauri event system
 - CLI args stored in Rust managed state, queried by frontend on mount
-
-## Branch Protection
-
-- `main` requires CI to pass on all 3 platforms before merge
-- Strict status checks — branch must be up to date with `main`
-- Linear history enforced (rebase/squash only, no merge commits)
-- No force pushes or branch deletion on `main`
-
-## Conventions
-
-- **Commits**: Use conventional commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`)
-- **No co-authored-by** lines in commits
-- **Package manager**: pnpm only (not npm/yarn)
-- **Linting (TS)**: Biome (configured in `biome.json`) — run `pnpm lint`
-- **Linting (Rust)**: Clippy — run `cargo clippy` in `src-tauri/`
-- **Formatting**: Biome for TypeScript, rustfmt for Rust
-- **Testing (TS)**: Vitest + Testing Library — test files colocated as `*.test.{ts,tsx}`
-- **Testing (Rust)**: `#[cfg(test)]` modules in source files
-- **Imports**: Named exports, no default exports
 
 ## Component Structure
 
@@ -59,36 +29,12 @@ cd src-tauri && cargo test      # Rust tests
 - `src/components/icons/` — SVG icon components
 - `src/components/modals/` — Overlay UI (SettingsModal, AIPanel)
 
-## Workflow: Issues, PRs, and Project Board
-
-- **GitHub Project**: "Glyph Roadmap" (kanban board linked to this repo)
-- When starting work on a feature/fix, move the corresponding issue to **In Progress** on the project board
-- Create a branch from `main` for the work (e.g. `feat/search`, `fix/link-opening`)
-- When done, create a PR referencing the issue (e.g. `Closes #7`)
-- After merge, the issue moves to **Done** automatically via GitHub's linked issue resolution
-- When creating new feature ideas, create a GitHub issue and add it to the project board as **Todo**
-
-## Releases
-
-To create a new release:
-
-1. Bump version in `package.json` and `src-tauri/Cargo.toml` (keep in sync)
-2. Run `cargo check` in `src-tauri/` to update `Cargo.lock`
-3. Commit: `chore: bump version to X.Y.Z`
-4. Push to `main`
-5. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`
-
-The tag push triggers `.github/workflows/release.yml` which:
-- Builds binaries for all platforms via `tauri-action`
-- Creates the GitHub release with install instructions
-- Appends an auto-generated changelog (categorized by PR labels via `.github/release.yml`)
-- Publishes to Homebrew, Chocolatey, AUR, and PPA
-
-Do **not** create releases manually with `gh release create` — let the CI workflow handle it.
-
 ## Key Files
 
 - `src-tauri/tauri.conf.json` — App window config, CLI plugin config, bundle settings
 - `src-tauri/capabilities/default.json` — Tauri permission grants
+- `src-tauri/src/menu.rs` — Native menu items and keyboard shortcut accelerators
 - `src/hooks/useFileLoader.ts` — Core file loading logic (CLI args + dialog)
-- `src/components/App.tsx` — Root layout and keyboard shortcuts
+- `src/components/App.tsx` — Root layout, menu event listeners, and theme injection
+- `src/lib/settings.ts` — Settings types, defaults, and constants
+- `src/contexts/SettingsContext.tsx` — Settings persistence via Tauri store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,37 +13,93 @@ pnpm install
 pnpm tauri dev
 ```
 
+## Development Commands
+
+```bash
+pnpm install                    # Install frontend dependencies
+pnpm tauri dev                  # Run in development (starts Vite + Cargo)
+pnpm tauri dev -- -- /path.md   # Dev mode with a file argument
+pnpm tauri build                # Production build
+pnpm typecheck                  # TypeScript type checking
+pnpm lint                       # Lint TypeScript with Biome
+pnpm format:check               # Check formatting with Biome
+pnpm format                     # Auto-format with Biome
+pnpm check                      # Biome lint + format + organize imports
+pnpm check:fix                  # Auto-fix all Biome issues
+pnpm test                       # Run frontend tests (Vitest)
+pnpm test:watch                 # Run frontend tests in watch mode
+pnpm test:coverage              # Run frontend tests with coverage
+cd src-tauri && cargo check     # Rust type checking
+cd src-tauri && cargo clippy    # Rust linting
+cd src-tauri && cargo test      # Rust tests
+```
+
+## Conventions
+
+- **Commits**: [Conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`)
+- **No co-authored-by** lines in commits
+- **Package manager**: pnpm only (not npm/yarn)
+- **Linting (TS)**: Biome (configured in `biome.json`) — run `pnpm lint`
+- **Linting (Rust)**: Clippy — run `cargo clippy` in `src-tauri/`
+- **Formatting**: Biome for TypeScript, rustfmt for Rust
+- **Testing (TS)**: Vitest + Testing Library — test files colocated as `*.test.{ts,tsx}`
+- **Testing (Rust)**: `#[cfg(test)]` modules in source files
+- **Imports**: Named exports, no default exports
+
 ## Workflow
 
-1. Fork and clone the repository
-2. Create a feature branch: `git checkout -b feat/my-feature`
-3. Make your changes
-4. Run checks:
+1. Check the [GitHub Issues](https://github.com/hamidfzm/glyph/issues) for open tasks
+2. Create a branch from `main` (e.g. `feat/search`, `fix/link-opening`)
+3. Make your changes following the conventions above
+4. Run all checks before submitting:
    ```bash
-   pnpm typecheck
+   pnpm typecheck && pnpm check && pnpm test
    cd src-tauri && cargo clippy
    ```
-5. Commit using [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:`, etc.
-6. Open a pull request against `main`
+5. Open a pull request referencing the issue (e.g. `Closes #7`)
 
-## Architecture
+### Pull Requests
 
-- **Backend** (`src-tauri/`): Rust with Tauri v2 — commands, file watcher, menus
-- **Frontend** (`src/`): React 19 + TypeScript — components and hooks
-- **Styling**: Tailwind CSS v4 with CSS custom properties for platform-adaptive theming
-
-## Branch Protection
-
-The `main` branch has the following protections:
-
-- **Required CI checks**: All three platform builds (macOS, Ubuntu, Windows) must pass
-- **Strict status checks**: Branch must be up to date with `main` before merging
-- **Linear history**: No merge commits — use rebase or squash
-- **No force pushes** or branch deletion
-
-## Guidelines
-
+- Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — fill in all sections
 - Keep PRs focused — one feature or fix per PR
-- Add yourself to the contributors list if this is your first PR
-- Test on your platform before submitting
-- No default exports — use named exports only
+- Include tests for new functionality
+- Ensure CI passes on all 3 platforms (macOS, Windows, Linux)
+- Use conventional commit style for the PR title (e.g. `feat: add search`)
+
+### Branch Protection
+
+- `main` requires CI to pass on all 3 platforms before merge
+- Strict status checks — branch must be up to date with `main`
+- Linear history enforced (rebase/squash only, no merge commits)
+- No force pushes or branch deletion on `main`
+
+### Project Board
+
+- **GitHub Project**: "Glyph Roadmap" (kanban board linked to this repo)
+- Move issues to **In Progress** when starting work
+- After merge, issues move to **Done** automatically via linked issue resolution
+- New feature ideas: create a GitHub issue and add to the board as **Todo**
+
+## Releases
+
+To create a new release:
+
+1. Bump version in `package.json` and `src-tauri/Cargo.toml` (keep in sync)
+2. Run `cargo check` in `src-tauri/` to update `Cargo.lock`
+3. Commit: `chore: bump version to X.Y.Z`
+4. Push to `main`
+5. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`
+
+The tag push triggers `.github/workflows/release.yml` which builds, creates the GitHub release, and publishes to Homebrew, Chocolatey, AUR, and PPA.
+
+Do **not** create releases manually with `gh release create` — let the CI workflow handle it.
+
+## Reporting Issues
+
+- **Bugs**: Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml)
+- **Features**: Use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml)
+- **Security**: See [SECURITY.md](SECURITY.md) — do **not** open public issues for vulnerabilities
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- Rewrites CONTRIBUTING.md with full development setup, commands, conventions, workflow, PR guidelines, and release process
- Slims down CLAUDE.md to focus on architecture, key files, releases, and references to community files
- Adds references to README.md, SECURITY.md, PR template, and issue templates in CLAUDE.md

## Changes

- CLAUDE.md: removed duplicated commands/conventions (now in CONTRIBUTING.md), added community files section, kept architecture/key files/releases
- CONTRIBUTING.md: comprehensive contributor guide with all commands, conventions, workflow, branch protection, project board, release process, and reporting guidelines

## Testing

- [x] No code changes — documentation only