### PR TITLE
feat: add in-document search

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -18,9 +18,15 @@ pub fn build_menu(app: &App) -> tauri::Result<tauri::menu::Menu<Wry>> {
         .build(handle)?;
 
     // Edit menu
+    let find = MenuItemBuilder::with_id("find", "Find\u{2026}")
+        .accelerator("CmdOrCtrl+F")
+        .build(handle)?;
+
     let edit_menu = SubmenuBuilder::new(handle, "Edit")
         .copy()
         .select_all()
+        .separator()
+        .item(&find)
         .build()?;
 
     // View menu
@@ -172,6 +178,9 @@ pub fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) 
         }
         "actual-size" => {
             let _ = app.emit("menu-zoom-reset", ());
+        }
+        "find" => {
+            let _ = app.emit("menu-find", ());
         }
         _ => {}
     }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -65,6 +65,7 @@ export function App() {
   const [sidebarVisible, setSidebarVisible] = useState(settings.layout.sidebarVisible);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [aiPanelOpen, setAIPanelOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
 
   // TTS
   const tts = useTTS({ voice: settings.ai.ttsVoice, speed: settings.ai.ttsSpeed });
@@ -109,6 +110,9 @@ export function App() {
       const text = content ?? "";
       if (text) handleAIAction(event.payload, text);
     });
+    const unlistenFind = listen("menu-find", () => {
+      setSearchOpen(true);
+    });
     const unlistenReadAloud = listen("menu-ai-read-aloud", () => {
       if (tts.speaking) {
         tts.stop();
@@ -140,6 +144,7 @@ export function App() {
       unlistenZoomIn.then((fn) => fn());
       unlistenZoomOut.then((fn) => fn());
       unlistenZoomReset.then((fn) => fn());
+      unlistenFind.then((fn) => fn());
     };
   }, [
     openFileDialog,
@@ -199,6 +204,8 @@ export function App() {
             filePath={filePath}
             initialScrollTop={activeTab?.scrollTop ?? 0}
             onScrollChange={saveScrollPosition}
+            searchOpen={searchOpen}
+            onSearchClose={() => setSearchOpen(false)}
           />
         ) : !initializing ? (
           <div className="flex-1">

--- a/src/components/layout/SearchBar.test.tsx
+++ b/src/components/layout/SearchBar.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SearchBar } from "./SearchBar";
+
+const defaultProps = {
+  query: "",
+  onQueryChange: vi.fn(),
+  matchCount: 0,
+  currentMatch: 0,
+  onNext: vi.fn(),
+  onPrev: vi.fn(),
+  onClose: vi.fn(),
+};
+
+describe("SearchBar", () => {
+  it("renders input and navigation buttons", () => {
+    render(<SearchBar {...defaultProps} />);
+    expect(screen.getByRole("textbox", { name: "Search" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous match" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next match" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close search" })).toBeInTheDocument();
+  });
+
+  it("auto-focuses input on mount", () => {
+    render(<SearchBar {...defaultProps} />);
+    expect(screen.getByRole("textbox", { name: "Search" })).toHaveFocus();
+  });
+
+  it("shows match count when query is non-empty", () => {
+    render(<SearchBar {...defaultProps} query="test" matchCount={5} currentMatch={2} />);
+    expect(screen.getByText("2 of 5")).toBeInTheDocument();
+  });
+
+  it("shows no results when query has no matches", () => {
+    render(<SearchBar {...defaultProps} query="test" matchCount={0} currentMatch={0} />);
+    expect(screen.getByText("No results")).toBeInTheDocument();
+  });
+
+  it("hides match count when query is empty", () => {
+    render(<SearchBar {...defaultProps} />);
+    expect(screen.queryByText("No results")).not.toBeInTheDocument();
+    expect(screen.queryByText(/of/)).not.toBeInTheDocument();
+  });
+
+  it("calls onNext on Enter", () => {
+    const onNext = vi.fn();
+    render(<SearchBar {...defaultProps} onNext={onNext} />);
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it("calls onPrev on Shift+Enter", () => {
+    const onPrev = vi.fn();
+    render(<SearchBar {...defaultProps} onPrev={onPrev} />);
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", shiftKey: true });
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose on Escape", () => {
+    const onClose = vi.fn();
+    render(<SearchBar {...defaultProps} onClose={onClose} />);
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("disables navigation buttons when no matches", () => {
+    render(<SearchBar {...defaultProps} query="test" matchCount={0} />);
+    expect(screen.getByRole("button", { name: "Previous match" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next match" })).toBeDisabled();
+  });
+
+  it("calls onQueryChange when typing", () => {
+    const onQueryChange = vi.fn();
+    render(<SearchBar {...defaultProps} onQueryChange={onQueryChange} />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "hello" } });
+    expect(onQueryChange).toHaveBeenCalledWith("hello");
+  });
+});

--- a/src/components/layout/SearchBar.tsx
+++ b/src/components/layout/SearchBar.tsx
@@ -1,0 +1,106 @@
+import { type KeyboardEvent, useEffect, useRef } from "react";
+
+interface SearchBarProps {
+  query: string;
+  onQueryChange: (q: string) => void;
+  matchCount: number;
+  currentMatch: number;
+  onNext: () => void;
+  onPrev: () => void;
+  onClose: () => void;
+}
+
+export function SearchBar({
+  query,
+  onQueryChange,
+  matchCount,
+  currentMatch,
+  onNext,
+  onPrev,
+  onClose,
+}: SearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) {
+        onPrev();
+      } else {
+        onNext();
+      }
+    }
+  };
+
+  const noResults = query.length > 0 && matchCount === 0;
+
+  return (
+    <search className="search-bar">
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Find in document..."
+        aria-label="Search"
+      />
+      {query.length > 0 && (
+        <span className="search-match-count" data-no-results={noResults}>
+          {noResults ? "No results" : `${currentMatch} of ${matchCount}`}
+        </span>
+      )}
+      <button
+        type="button"
+        className="search-nav-btn"
+        onClick={onPrev}
+        disabled={matchCount === 0}
+        aria-label="Previous match"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+          <path
+            d="M3.5 8.75L7 5.25L10.5 8.75"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      <button
+        type="button"
+        className="search-nav-btn"
+        onClick={onNext}
+        disabled={matchCount === 0}
+        aria-label="Next match"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+          <path
+            d="M3.5 5.25L7 8.75L10.5 5.25"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      <button type="button" className="search-nav-btn" onClick={onClose} aria-label="Close search">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+          <path
+            d="M3.5 3.5L10.5 10.5M10.5 3.5L3.5 10.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+    </search>
+  );
+}

--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -6,6 +6,8 @@ import remarkFrontmatter from "remark-frontmatter";
 import remarkGemoji from "remark-gemoji";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
+import { useSearch } from "../../hooks/useSearch";
+import { SearchBar } from "../layout/SearchBar";
 import { CodeBlockComponent } from "./CodeBlockComponent";
 import { headingComponents } from "./HeadingComponent";
 import { useImageComponent } from "./ImageComponent";
@@ -16,6 +18,8 @@ interface MarkdownViewerProps {
   filePath?: string;
   initialScrollTop?: number;
   onScrollChange?: (scrollTop: number) => void;
+  searchOpen: boolean;
+  onSearchClose: () => void;
 }
 
 export function MarkdownViewer({
@@ -23,8 +27,13 @@ export function MarkdownViewer({
   filePath,
   initialScrollTop = 0,
   onScrollChange,
+  searchOpen,
+  onSearchClose,
 }: MarkdownViewerProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const search = useSearch({ containerRef: contentRef });
 
   // Restore scroll position on mount
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only — restore once when tab activates
@@ -51,21 +60,39 @@ export function MarkdownViewer({
 
   const ImageComponent = useImageComponent(filePath);
 
+  const handleSearchClose = () => {
+    search.clear();
+    onSearchClose();
+  };
+
   return (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto">
-      <div className="markdown-body px-8 py-6 pb-[60vh]">
-        <ReactMarkdown
-          remarkPlugins={[remarkFrontmatter, remarkGfm, remarkMath, remarkGemoji]}
-          rehypePlugins={[[rehypeHighlight, { plainText: ["mermaid"] }], rehypeKatex]}
-          components={{
-            ...headingComponents,
-            a: LinkComponent,
-            img: ImageComponent,
-            pre: CodeBlockComponent,
-          }}
-        >
-          {content}
-        </ReactMarkdown>
+    <div className="flex-1 relative">
+      {searchOpen && (
+        <SearchBar
+          query={search.query}
+          onQueryChange={search.setQuery}
+          matchCount={search.matchCount}
+          currentMatch={search.currentMatch}
+          onNext={search.nextMatch}
+          onPrev={search.prevMatch}
+          onClose={handleSearchClose}
+        />
+      )}
+      <div ref={scrollRef} className="h-full overflow-y-auto">
+        <div ref={contentRef} className="markdown-body px-8 py-6 pb-[60vh]">
+          <ReactMarkdown
+            remarkPlugins={[remarkFrontmatter, remarkGfm, remarkMath, remarkGemoji]}
+            rehypePlugins={[[rehypeHighlight, { plainText: ["mermaid"] }], rehypeKatex]}
+            components={{
+              ...headingComponents,
+              a: LinkComponent,
+              img: ImageComponent,
+              pre: CodeBlockComponent,
+            }}
+          >
+            {content}
+          </ReactMarkdown>
+        </div>
       </div>
     </div>
   );

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,172 @@
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+interface UseSearchOptions {
+  containerRef: RefObject<HTMLDivElement | null>;
+}
+
+interface UseSearchReturn {
+  query: string;
+  setQuery: (q: string) => void;
+  matchCount: number;
+  currentMatch: number;
+  nextMatch: () => void;
+  prevMatch: () => void;
+  clear: () => void;
+}
+
+function clearHighlights(container: HTMLElement) {
+  const marks = container.querySelectorAll("mark.search-highlight");
+  for (const mark of marks) {
+    const parent = mark.parentNode;
+    if (parent) {
+      parent.replaceChild(document.createTextNode(mark.textContent ?? ""), mark);
+      parent.normalize();
+    }
+  }
+}
+
+function highlightMatches(container: HTMLElement, query: string): number {
+  clearHighlights(container);
+  if (!query) return 0;
+
+  const lowerQuery = query.toLowerCase();
+  let count = 0;
+
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = node.parentElement;
+      if (parent?.closest("mark.search-highlight, script, style, .mermaid-diagram")) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  const textNodes: Text[] = [];
+  let node = walker.nextNode();
+  while (node) {
+    textNodes.push(node as Text);
+    node = walker.nextNode();
+  }
+
+  for (const textNode of textNodes) {
+    const text = textNode.textContent ?? "";
+    const lowerText = text.toLowerCase();
+    let idx = lowerText.indexOf(lowerQuery);
+    if (idx === -1) continue;
+
+    const fragment = document.createDocumentFragment();
+    let lastIdx = 0;
+
+    while (idx !== -1) {
+      if (idx > lastIdx) {
+        fragment.appendChild(document.createTextNode(text.slice(lastIdx, idx)));
+      }
+      const mark = document.createElement("mark");
+      mark.className = "search-highlight";
+      mark.textContent = text.slice(idx, idx + query.length);
+      fragment.appendChild(mark);
+      count++;
+      lastIdx = idx + query.length;
+      idx = lowerText.indexOf(lowerQuery, lastIdx);
+    }
+
+    if (lastIdx < text.length) {
+      fragment.appendChild(document.createTextNode(text.slice(lastIdx)));
+    }
+
+    textNode.parentNode?.replaceChild(fragment, textNode);
+  }
+
+  return count;
+}
+
+function setActiveMatch(container: HTMLElement, index: number) {
+  const marks = container.querySelectorAll("mark.search-highlight");
+  for (const mark of marks) {
+    mark.classList.remove("search-highlight-active");
+  }
+  const active = marks[index];
+  if (active) {
+    active.classList.add("search-highlight-active");
+    active.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+}
+
+export function useSearch({ containerRef }: UseSearchOptions): UseSearchReturn {
+  const [query, setQueryState] = useState("");
+  const [matchCount, setMatchCount] = useState(0);
+  const [currentMatch, setCurrentMatch] = useState(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const activeQuery = useRef("");
+
+  const runHighlight = useCallback(
+    (q: string) => {
+      const container = containerRef.current;
+      if (!container) return;
+      activeQuery.current = q;
+      const count = highlightMatches(container, q);
+      setMatchCount(count);
+      if (count > 0) {
+        setCurrentMatch(1);
+        setActiveMatch(container, 0);
+      } else {
+        setCurrentMatch(0);
+      }
+    },
+    [containerRef],
+  );
+
+  const setQuery = useCallback(
+    (q: string) => {
+      setQueryState(q);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => runHighlight(q), 150);
+    },
+    [runHighlight],
+  );
+
+  const nextMatch = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || matchCount === 0) return;
+    const next = currentMatch >= matchCount ? 1 : currentMatch + 1;
+    setCurrentMatch(next);
+    setActiveMatch(container, next - 1);
+  }, [containerRef, matchCount, currentMatch]);
+
+  const prevMatch = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || matchCount === 0) return;
+    const prev = currentMatch <= 1 ? matchCount : currentMatch - 1;
+    setCurrentMatch(prev);
+    setActiveMatch(container, prev - 1);
+  }, [containerRef, matchCount, currentMatch]);
+
+  const clear = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    const container = containerRef.current;
+    if (container) clearHighlights(container);
+    activeQuery.current = "";
+    setQueryState("");
+    setMatchCount(0);
+    setCurrentMatch(0);
+  }, [containerRef]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  // Re-highlight when content changes (React re-renders the DOM)
+  useEffect(() => {
+    if (!activeQuery.current) return;
+    const q = activeQuery.current;
+    requestAnimationFrame(() => {
+      runHighlight(q);
+    });
+  });
+
+  return { query, setQuery, matchCount, currentMatch, nextMatch, prevMatch, clear };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4,6 +4,7 @@
 @import "./markdown.css";
 @import "./settings.css";
 @import "./tabs.css";
+@import "./search.css";
 
 :root {
   --color-surface: #ffffff;

--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -1,0 +1,89 @@
+.search-bar {
+  position: absolute;
+  top: 8px;
+  right: 24px;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--glyph-radius);
+  box-shadow: var(--glyph-shadow), 0 4px 12px rgba(0, 0, 0, 0.08);
+  font-size: 13px;
+  animation: search-slide-in 0.15s ease-out;
+}
+
+@keyframes search-slide-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.search-bar input {
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--glyph-radius-sm);
+  padding: 4px 8px;
+  font-size: 13px;
+  color: var(--color-text-primary);
+  width: 200px;
+  font-family: inherit;
+  outline: none;
+}
+
+.search-bar input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 25%, transparent);
+}
+
+.search-match-count {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  min-width: 60px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.search-match-count[data-no-results="true"] {
+  color: #e53e3e;
+}
+
+.search-nav-btn {
+  appearance: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: var(--color-text-secondary);
+  border-radius: var(--glyph-radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.search-nav-btn:hover {
+  background: var(--color-surface-tertiary);
+  color: var(--color-text-primary);
+}
+
+.search-nav-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+  pointer-events: none;
+}
+
+mark.search-highlight {
+  background: color-mix(in srgb, var(--color-accent) 25%, transparent);
+  color: inherit;
+  padding: 1px 0;
+  border-radius: 2px;
+}
+
+mark.search-highlight.search-highlight-active {
+  background: var(--color-accent);
+  color: white;
+  outline: 2px solid color-mix(in srgb, var(--color-accent) 40%, transparent);
+  outline-offset: 1px;
+}


### PR DESCRIPTION
## Summary

- Adds Cmd/Ctrl+F in-document search with real-time text highlighting
- Search bar appears at top-right of content area with match count and navigation
- DOM-based highlighting using TreeWalker — works with all rendered content (code blocks, headings, etc.)
- Supports next/prev navigation (Enter/Shift+Enter or arrow buttons), scrolls to active match
- Case-insensitive search, debounced input (150ms)

Closes #10

## Changes

- `src-tauri/src/menu.rs` — Added "Find..." menu item with CmdOrCtrl+F accelerator
- `src/hooks/useSearch.ts` — Core search hook: TreeWalker highlighting, match navigation, cleanup
- `src/components/layout/SearchBar.tsx` — Floating search bar UI component
- `src/styles/search.css` — Search bar and highlight mark styles (themed)
- `src/components/markdown/MarkdownViewer.tsx` — Integrated search bar and content ref
- `src/components/App.tsx` — Wired menu event to toggle search state

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux