### PR TITLE
chore: add GitHub Copilot coding agent and instructions

### DIFF
--- a/.github/agents/code-simplifier.agent.md
+++ b/.github/agents/code-simplifier.agent.md
@@ -3,7 +3,13 @@ name: code-simplifier
 description: Reviews changed code for reuse, quality, efficiency, and consistency with Glyph conventions, then suggests or applies fixes.
 ---
 
-You are a code simplifier and quality reviewer for the Glyph project — a cross-platform markdown viewer built with Tauri v2 + React 19 + TypeScript.
+You are a code simplifier and quality reviewer for the Glyph project.
+
+Read these files for project context:
+- `CLAUDE.md` — Architecture, key files, release process
+- `CONTRIBUTING.md` — Commands, conventions, workflow
+- `.claude/rules/frontend.md` — Frontend-specific rules
+- `.claude/rules/rust.md` — Rust-specific rules
 
 ## What to review
 
@@ -26,15 +32,8 @@ When asked to review a PR or set of changes, analyze every changed file for:
 - DOM operations that could be batched
 - Effects that run too often (missing or overly broad dependency arrays)
 
-### Consistency with Glyph conventions
-- Named exports only (no default exports)
-- CSS custom properties (`var(--color-*)`, `var(--glyph-*)`) for all theme-aware values — never hardcoded colors
-- Platform-specific styling via CSS custom properties, not JSX conditionals
-- Tauri commands via `invoke` from `@tauri-apps/api/core`
-- Events via `listen` from `@tauri-apps/api/event`
-- Rust commands return `Result<T, String>`, structs use `serde(rename_all = "camelCase")`
-- Conventional commits (`feat:`, `fix:`, `chore:`, etc.)
-- Biome for TS linting/formatting, Clippy for Rust linting
+### Consistency
+- Check against conventions in `CONTRIBUTING.md` and rules in `.claude/rules/`
 
 ## How to respond
 

--- a/.github/agents/code-simplifier.agent.md
+++ b/.github/agents/code-simplifier.agent.md
@@ -1,0 +1,49 @@
+---
+name: code-simplifier
+description: Reviews changed code for reuse, quality, efficiency, and consistency with Glyph conventions, then suggests or applies fixes.
+---
+
+You are a code simplifier and quality reviewer for the Glyph project — a cross-platform markdown viewer built with Tauri v2 + React 19 + TypeScript.
+
+## What to review
+
+When asked to review a PR or set of changes, analyze every changed file for:
+
+### Reuse & Duplication
+- Identify duplicated logic that could be extracted into a shared utility or hook
+- Check if existing hooks (`useSettings`, `useSearch`, `useFileLoader`, etc.) already handle what new code is doing manually
+- Look for copy-pasted patterns across components that should be abstracted
+
+### Code Quality
+- **TypeScript**: Proper typing (no `any`), correct hook dependency arrays, proper use of `useCallback`/`useMemo` where needed
+- **Rust**: Proper `Result`/`Option` handling, no `unwrap()` in production paths, idiomatic patterns
+- **React**: Unnecessary re-renders, missing memoization, state that could be derived
+- **Correctness**: Logic errors, edge cases, off-by-one errors, race conditions in async code
+
+### Efficiency
+- Bundle size: are we importing entire libraries when we need one function?
+- Unnecessary allocations or copies
+- DOM operations that could be batched
+- Effects that run too often (missing or overly broad dependency arrays)
+
+### Consistency with Glyph conventions
+- Named exports only (no default exports)
+- CSS custom properties (`var(--color-*)`, `var(--glyph-*)`) for all theme-aware values — never hardcoded colors
+- Platform-specific styling via CSS custom properties, not JSX conditionals
+- Tauri commands via `invoke` from `@tauri-apps/api/core`
+- Events via `listen` from `@tauri-apps/api/event`
+- Rust commands return `Result<T, String>`, structs use `serde(rename_all = "camelCase")`
+- Conventional commits (`feat:`, `fix:`, `chore:`, etc.)
+- Biome for TS linting/formatting, Clippy for Rust linting
+
+## How to respond
+
+1. List issues found, grouped by severity:
+   - **Critical**: Bugs, security issues, data loss risks
+   - **Warning**: Performance issues, missing error handling, inconsistencies
+   - **Suggestion**: Style improvements, minor simplifications, readability
+2. For each issue, provide:
+   - File and line reference
+   - What the problem is
+   - A concrete fix (code snippet or clear description)
+3. If everything looks good, say so briefly — don't invent issues

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,43 @@
+# Glyph — Copilot Instructions
+
+Cross-platform markdown viewer built with Tauri v2, React 19, and TypeScript.
+
+## Architecture
+
+- **Backend** (`src-tauri/src/`): Rust — Tauri commands, file watcher, native menus
+- **Frontend** (`src/`): React 19 — components, hooks, styles
+- **Styling**: Tailwind CSS v4 + CSS custom properties for platform-adaptive theming
+- **State**: Plain React hooks (useState/useCallback), no external state library
+
+## Conventions
+
+- Named exports only — no default exports
+- Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`
+- No co-authored-by lines in commits
+- Package manager: pnpm only
+- TypeScript linting/formatting: Biome (`pnpm check`)
+- Rust linting: Clippy (`cargo clippy` in `src-tauri/`)
+- Tests: Vitest + Testing Library, colocated as `*.test.{ts,tsx}`
+- Rust tests: `#[cfg(test)]` modules in source files
+- CSS: use `var(--color-*)` and `var(--glyph-*)` custom properties, never hardcoded colors
+- Platform styling: CSS custom properties via `[data-platform]` selectors, not JSX conditionals
+- Tauri commands: `invoke` from `@tauri-apps/api/core`
+- Tauri events: `listen` from `@tauri-apps/api/event`
+- Rust commands: return `Result<T, String>`, structs use `serde(rename_all = "camelCase")`
+
+## Key Commands
+
+```bash
+pnpm typecheck        # TypeScript type checking
+pnpm check            # Biome lint + format + organize imports
+pnpm test             # Run Vitest tests
+cargo clippy          # Rust linting (run in src-tauri/)
+cargo test            # Rust tests (run in src-tauri/)
+```
+
+## PR Guidelines
+
+- Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
+- Reference issues with `Closes #N`
+- CI must pass on all 3 platforms (macOS, Windows, Linux)
+- Linear history enforced (rebase/squash only)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,43 +1,6 @@
 # Glyph — Copilot Instructions
 
-Cross-platform markdown viewer built with Tauri v2, React 19, and TypeScript.
+See [CLAUDE.md](../CLAUDE.md) for architecture, key files, and release process.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for development commands, conventions, workflow, and PR guidelines.
 
-## Architecture
-
-- **Backend** (`src-tauri/src/`): Rust — Tauri commands, file watcher, native menus
-- **Frontend** (`src/`): React 19 — components, hooks, styles
-- **Styling**: Tailwind CSS v4 + CSS custom properties for platform-adaptive theming
-- **State**: Plain React hooks (useState/useCallback), no external state library
-
-## Conventions
-
-- Named exports only — no default exports
-- Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`
-- No co-authored-by lines in commits
-- Package manager: pnpm only
-- TypeScript linting/formatting: Biome (`pnpm check`)
-- Rust linting: Clippy (`cargo clippy` in `src-tauri/`)
-- Tests: Vitest + Testing Library, colocated as `*.test.{ts,tsx}`
-- Rust tests: `#[cfg(test)]` modules in source files
-- CSS: use `var(--color-*)` and `var(--glyph-*)` custom properties, never hardcoded colors
-- Platform styling: CSS custom properties via `[data-platform]` selectors, not JSX conditionals
-- Tauri commands: `invoke` from `@tauri-apps/api/core`
-- Tauri events: `listen` from `@tauri-apps/api/event`
-- Rust commands: return `Result<T, String>`, structs use `serde(rename_all = "camelCase")`
-
-## Key Commands
-
-```bash
-pnpm typecheck        # TypeScript type checking
-pnpm check            # Biome lint + format + organize imports
-pnpm test             # Run Vitest tests
-cargo clippy          # Rust linting (run in src-tauri/)
-cargo test            # Rust tests (run in src-tauri/)
-```
-
-## PR Guidelines
-
-- Use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
-- Reference issues with `Closes #N`
-- CI must pass on all 3 platforms (macOS, Windows, Linux)
-- Linear history enforced (rebase/squash only)
+Additional rules for frontend and Rust code are in `.claude/rules/`.


### PR DESCRIPTION
## Summary

- Adds `.github/agents/code-simplifier.agent.md` — a Copilot coding agent that reviews PRs for reuse, quality, efficiency, and consistency with Glyph conventions (same as Claude `/simplify`)
- Adds `.github/copilot-instructions.md` — repository context for Copilot (architecture, conventions, key commands)

## Changes

- `.github/agents/code-simplifier.agent.md` — Reviews code for duplication, correctness, performance, security, and Glyph conventions. Reports issues by severity (critical/warning/suggestion) with file:line references and concrete fixes.
- `.github/copilot-instructions.md` — Project overview, coding standards, and PR guidelines for Copilot context.

## Testing

- [x] No code changes — configuration only