### PR TITLE
feat: add multiple files in tabs

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ pub fn run() {
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
-        .manage(FileWatcherState(Arc::new(Mutex::new(None))))
+        .manage(FileWatcherState(Arc::new(Mutex::new(std::collections::HashMap::new()))))
         .manage(commands::InitialFile(Mutex::new(None)))
         .setup(|app| {
             let menu = menu::build_menu(app)?;

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -1,24 +1,28 @@
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Manager};
 
-pub struct FileWatcherState(pub Arc<Mutex<Option<RecommendedWatcher>>>);
+pub struct FileWatcherState(pub Arc<Mutex<HashMap<String, RecommendedWatcher>>>);
 
 #[tauri::command]
 pub fn watch_file(path: String, app: AppHandle) -> Result<(), String> {
     let state = app.state::<FileWatcherState>();
-    let mut watcher_lock = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
+    let mut watchers = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
 
-    // Drop the previous watcher to stop watching the old file
-    *watcher_lock = None;
+    // Already watching this path
+    if watchers.contains_key(&path) {
+        return Ok(());
+    }
 
     let app_handle = app.clone();
+    let watched_path = path.clone();
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
         if let Ok(event) = res {
             match event.kind {
                 EventKind::Modify(_) | EventKind::Create(_) => {
-                    let _ = app_handle.emit("file-changed", ());
+                    let _ = app_handle.emit("file-changed", &watched_path);
                 }
                 _ => {}
             }
@@ -30,14 +34,14 @@ pub fn watch_file(path: String, app: AppHandle) -> Result<(), String> {
         .watch(Path::new(&path), RecursiveMode::NonRecursive)
         .map_err(|e| format!("Failed to watch file: {e}"))?;
 
-    *watcher_lock = Some(watcher);
+    watchers.insert(path, watcher);
     Ok(())
 }
 
 #[tauri::command]
-pub fn unwatch_file(app: AppHandle) -> Result<(), String> {
+pub fn unwatch_file(path: String, app: AppHandle) -> Result<(), String> {
     let state = app.state::<FileWatcherState>();
-    let mut watcher_lock = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
-    *watcher_lock = None;
+    let mut watchers = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
+    watchers.remove(&path);
     Ok(())
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,11 +2,10 @@ import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { type AIAction, useAI } from "../hooks/useAI";
 import { useContextMenu } from "../hooks/useContextMenu";
-import { useFileLoader } from "../hooks/useFileLoader";
-import { useFileWatcher } from "../hooks/useFileWatcher";
 import { usePlatform } from "../hooks/usePlatform";
 import { useSettings } from "../hooks/useSettings";
 import { useTableOfContents } from "../hooks/useTableOfContents";
+import { useTabs } from "../hooks/useTabs";
 import { useTheme } from "../hooks/useTheme";
 import { useTTS } from "../hooks/useTTS";
 import { ZOOM_DEFAULT, ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from "../lib/settings";
@@ -20,6 +19,7 @@ import solarizedLightThemeCSS from "../styles/highlight-solarized-light.css?inli
 import { EmptyState } from "./layout/EmptyState";
 import { Sidebar } from "./layout/Sidebar";
 import { StatusBar } from "./layout/StatusBar";
+import { TabBar } from "./layout/TabBar";
 import { MarkdownViewer } from "./markdown/MarkdownViewer";
 import { AIPanel } from "./modals/AIPanel";
 import { SettingsModal } from "./modals/SettingsModal";
@@ -40,15 +40,26 @@ export function App() {
   // Pass settings theme override to useTheme
   useTheme(settings.appearance.theme);
 
-  const { content, metadata, initializing, loadFile, openFileDialog } = useFileLoader({
+  const {
+    tabs,
+    activeTab,
+    activeTabId,
+    initializing,
+    closeTab,
+    setActiveTab,
+    saveScrollPosition,
+    openFileDialog,
+  } = useTabs({
     reopenLastFile: settings.behavior.reopenLastFile,
+    openTabs: settings.behavior.openTabs,
+    activeTabPath: settings.behavior.activeTabPath,
     recentFiles: settings.behavior.recentFiles,
-    onRecentFilesChange: useCallback(
-      (files: string[]) => updateSettings("behavior.recentFiles", files),
-      [updateSettings],
-    ),
     autoReload: settings.behavior.autoReload,
+    onSettingsChange: updateSettings,
   });
+
+  const content = activeTab?.content ?? null;
+  const filePath = activeTab?.path;
 
   const tocEntries = useTableOfContents(content);
   const [sidebarVisible, setSidebarVisible] = useState(settings.layout.sidebarVisible);
@@ -61,15 +72,6 @@ export function App() {
   // AI
   const ai = useAI(settings.ai);
   const aiConfigured = settings.ai.provider !== "none";
-
-  // Reload file on external change (respecting autoReload setting)
-  useFileWatcher(
-    useCallback(() => {
-      if (metadata?.path && settings.behavior.autoReload) {
-        loadFile(metadata.path);
-      }
-    }, [metadata?.path, loadFile, settings.behavior.autoReload]),
-  );
 
   // Sync sidebar visibility with settings
   useEffect(() => {
@@ -187,10 +189,17 @@ export function App() {
 
   return (
     <div className="flex flex-col h-full bg-[var(--color-surface)]">
+      <TabBar tabs={tabs} activeTabId={activeTabId} onActivate={setActiveTab} onClose={closeTab} />
       <div className="flex flex-1 min-h-0">
         {sidebarPosition === "left" && sidebarElement}
-        {content ? (
-          <MarkdownViewer content={content} filePath={metadata?.path} />
+        {content && activeTabId ? (
+          <MarkdownViewer
+            key={activeTabId}
+            content={content}
+            filePath={filePath}
+            initialScrollTop={activeTab?.scrollTop ?? 0}
+            onScrollChange={saveScrollPosition}
+          />
         ) : !initializing ? (
           <div className="flex-1">
             <EmptyState platform={platform} onOpenFile={openFileDialog} />
@@ -200,7 +209,7 @@ export function App() {
         )}
         {sidebarPosition === "right" && sidebarElement}
       </div>
-      <StatusBar filePath={metadata?.path} content={content} />
+      <StatusBar filePath={filePath} content={content} />
 
       <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
       <AIPanel

--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Tab } from "../../hooks/useTabs";
+import { TabBar } from "./TabBar";
+
+const makeTabs = (count: number): Tab[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `tab-${i}`,
+    path: `/path/to/file${i}.md`,
+    content: `# File ${i}`,
+    metadata: { name: `file${i}.md`, path: `/path/to/file${i}.md`, size: 100, modified: 0 },
+    scrollTop: 0,
+  }));
+
+describe("TabBar", () => {
+  it("renders nothing when no tabs", () => {
+    const { container } = render(
+      <TabBar tabs={[]} activeTabId={null} onActivate={vi.fn()} onClose={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders tab items with file names", () => {
+    const tabs = makeTabs(3);
+    render(<TabBar tabs={tabs} activeTabId="tab-0" onActivate={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByText("file0.md")).toBeInTheDocument();
+    expect(screen.getByText("file1.md")).toBeInTheDocument();
+    expect(screen.getByText("file2.md")).toBeInTheDocument();
+  });
+
+  it("highlights the active tab", () => {
+    const tabs = makeTabs(2);
+    render(<TabBar tabs={tabs} activeTabId="tab-1" onActivate={vi.fn()} onClose={vi.fn()} />);
+    const activeTab = screen.getByText("file1.md").closest(".tab-item");
+    expect(activeTab?.getAttribute("data-active")).toBe("true");
+  });
+
+  it("calls onActivate when clicking a tab", () => {
+    const onActivate = vi.fn();
+    const tabs = makeTabs(2);
+    render(<TabBar tabs={tabs} activeTabId="tab-0" onActivate={onActivate} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText("file1.md"));
+    expect(onActivate).toHaveBeenCalledWith("tab-1");
+  });
+
+  it("calls onClose when clicking close button", () => {
+    const onClose = vi.fn();
+    const tabs = makeTabs(1);
+    render(<TabBar tabs={tabs} activeTabId="tab-0" onActivate={vi.fn()} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "Close file0.md" }));
+    expect(onClose).toHaveBeenCalledWith("tab-0");
+  });
+
+  it("calls onClose on middle-click", () => {
+    const onClose = vi.fn();
+    const tabs = makeTabs(1);
+    render(<TabBar tabs={tabs} activeTabId="tab-0" onActivate={vi.fn()} onClose={onClose} />);
+    const tabEl = screen.getByText("file0.md").closest(".tab-item")!;
+    fireEvent(tabEl, new MouseEvent("auxclick", { bubbles: true, button: 1 }));
+    expect(onClose).toHaveBeenCalledWith("tab-0");
+  });
+});

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -1,0 +1,54 @@
+import type { Tab } from "../../hooks/useTabs";
+
+interface TabBarProps {
+  tabs: Tab[];
+  activeTabId: string | null;
+  onActivate: (id: string) => void;
+  onClose: (id: string) => void;
+}
+
+export function TabBar({ tabs, activeTabId, onActivate, onClose }: TabBarProps) {
+  if (tabs.length === 0) return null;
+
+  return (
+    <div className="tab-bar">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          className="tab-item"
+          data-active={tab.id === activeTabId || undefined}
+          onClick={() => onActivate(tab.id)}
+          onAuxClick={(e) => {
+            if (e.button === 1) {
+              e.preventDefault();
+              onClose(tab.id);
+            }
+          }}
+          title={tab.path}
+        >
+          <span className="tab-label">{tab.metadata?.name ?? "Untitled"}</span>
+          <button
+            type="button"
+            className="tab-close"
+            tabIndex={-1}
+            aria-label={`Close ${tab.metadata?.name ?? "tab"}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose(tab.id);
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path
+                d="M3 3L9 9M9 3L3 9"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -12,31 +12,40 @@ import { LinkComponent } from "./LinkComponent";
 interface MarkdownViewerProps {
   content: string;
   filePath?: string;
+  initialScrollTop?: number;
+  onScrollChange?: (scrollTop: number) => void;
 }
 
-export function MarkdownViewer({ content, filePath }: MarkdownViewerProps) {
+export function MarkdownViewer({
+  content,
+  filePath,
+  initialScrollTop = 0,
+  onScrollChange,
+}: MarkdownViewerProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const scrollPosRef = useRef(0);
 
+  // Restore scroll position on mount
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only — restore once when tab activates
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el) return;
+    if (el && initialScrollTop > 0) {
+      requestAnimationFrame(() => {
+        el.scrollTop = initialScrollTop;
+      });
+    }
+  }, []);
+
+  // Report scroll position changes to parent
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !onScrollChange) return;
 
     const handler = () => {
-      scrollPosRef.current = el.scrollTop;
+      onScrollChange(el.scrollTop);
     };
     el.addEventListener("scroll", handler, { passive: true });
     return () => el.removeEventListener("scroll", handler);
-  }, []);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el && scrollPosRef.current > 0) {
-      requestAnimationFrame(() => {
-        el.scrollTop = scrollPosRef.current;
-      });
-    }
-  });
+  }, [onScrollChange]);
 
   const ImageComponent = useImageComponent(filePath);
 

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,0 +1,247 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface FileMetadata {
+  name: string;
+  path: string;
+  size: number;
+  modified: number;
+}
+
+export interface Tab {
+  id: string;
+  path: string;
+  content: string | null;
+  metadata: FileMetadata | null;
+  scrollTop: number;
+}
+
+interface TabsState {
+  tabs: Tab[];
+  activeTabId: string | null;
+}
+
+const MAX_RECENT_FILES = 10;
+
+let nextId = 0;
+function generateId() {
+  nextId++;
+  return `tab-${nextId}`;
+}
+
+interface UseTabsOptions {
+  reopenLastFile: boolean;
+  openTabs: string[];
+  activeTabPath: string;
+  recentFiles: string[];
+  autoReload: boolean;
+  onSettingsChange: (key: string, value: unknown) => void;
+}
+
+async function loadFileContent(path: string) {
+  const [content, metadata] = await Promise.all([
+    invoke<string>("read_file", { path }),
+    invoke<FileMetadata>("get_file_metadata", { path }),
+  ]);
+  return { content, metadata };
+}
+
+export function useTabs(options: UseTabsOptions) {
+  const [state, setState] = useState<TabsState>({ tabs: [], activeTabId: null });
+  const [initializing, setInitializing] = useState(true);
+  const scrollRefsMap = useRef<Map<string, number>>(new Map());
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const { tabs, activeTabId } = state;
+  const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
+
+  // Persist tabs to settings whenever state changes
+  useEffect(() => {
+    if (initializing) return;
+    const paths = tabs.map((t) => t.path);
+    const activePath = tabs.find((t) => t.id === activeTabId)?.path ?? "";
+    optionsRef.current.onSettingsChange("behavior.openTabs", paths);
+    optionsRef.current.onSettingsChange("behavior.activeTabPath", activePath);
+  }, [tabs, activeTabId, initializing]);
+
+  const addToRecent = useCallback((path: string) => {
+    const current = optionsRef.current.recentFiles ?? [];
+    const updated = [path, ...current.filter((f) => f !== path)].slice(0, MAX_RECENT_FILES);
+    optionsRef.current.onSettingsChange("behavior.recentFiles", updated);
+  }, []);
+
+  const openFile = useCallback(
+    async (path: string) => {
+      // Check for duplicate via ref (avoids stale closure)
+      const existing = stateRef.current.tabs.find((t) => t.path === path);
+      if (existing) {
+        setState((prev) => ({ ...prev, activeTabId: existing.id }));
+        return;
+      }
+
+      const id = generateId();
+      try {
+        const { content, metadata } = await loadFileContent(path);
+        await invoke("watch_file", { path });
+        const newTab: Tab = { id, path, content, metadata, scrollTop: 0 };
+        setState((prev) => {
+          // Double-check inside updater
+          if (prev.tabs.some((t) => t.path === path)) {
+            const match = prev.tabs.find((t) => t.path === path)!;
+            return { ...prev, activeTabId: match.id };
+          }
+          return { tabs: [...prev.tabs, newTab], activeTabId: id };
+        });
+        addToRecent(path);
+      } catch (err) {
+        console.error("Failed to open file:", err);
+      }
+    },
+    [addToRecent],
+  );
+
+  const closeTab = useCallback((id: string) => {
+    setState((prev) => {
+      const idx = prev.tabs.findIndex((t) => t.id === id);
+      if (idx === -1) return prev;
+
+      const tab = prev.tabs[idx];
+      invoke("unwatch_file", { path: tab.path }).catch(() => {});
+      scrollRefsMap.current.delete(id);
+
+      const updated = prev.tabs.filter((t) => t.id !== id);
+      let newActiveId = prev.activeTabId;
+      if (prev.activeTabId === id) {
+        const newActive = updated[Math.min(idx, updated.length - 1)] ?? null;
+        newActiveId = newActive?.id ?? null;
+      }
+      return { tabs: updated, activeTabId: newActiveId };
+    });
+  }, []);
+
+  const setActiveTab = useCallback((id: string) => {
+    setState((prev) => {
+      // Save scroll position of current tab
+      if (prev.activeTabId) {
+        const savedScroll = scrollRefsMap.current.get(prev.activeTabId) ?? 0;
+        return {
+          tabs: prev.tabs.map((t) =>
+            t.id === prev.activeTabId ? { ...t, scrollTop: savedScroll } : t,
+          ),
+          activeTabId: id,
+        };
+      }
+      return { ...prev, activeTabId: id };
+    });
+  }, []);
+
+  const saveScrollPosition = useCallback(
+    (scrollTop: number) => {
+      if (activeTabId) {
+        scrollRefsMap.current.set(activeTabId, scrollTop);
+      }
+    },
+    [activeTabId],
+  );
+
+  const openFileDialog = useCallback(async () => {
+    const selected = await open({
+      multiple: true,
+      filters: [
+        {
+          name: "Markdown",
+          extensions: ["md", "markdown", "mdown", "mkd", "mkdn"],
+        },
+      ],
+    });
+    if (selected) {
+      const paths = Array.isArray(selected) ? selected : [selected];
+      for (const path of paths) {
+        await openFile(path);
+      }
+    }
+  }, [openFile]);
+
+  // Initialize: load CLI arg, restore tabs, or reopen last file
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only effect
+  useEffect(() => {
+    (async () => {
+      try {
+        const initialPath = await invoke<string | null>("get_initial_file");
+        if (initialPath) {
+          await openFile(initialPath);
+        } else if (options.openTabs.length > 0) {
+          for (const path of options.openTabs) {
+            await openFile(path);
+          }
+          // Activate the previously active tab
+          if (options.activeTabPath) {
+            setState((prev) => {
+              const match = prev.tabs.find((t) => t.path === options.activeTabPath);
+              return match ? { ...prev, activeTabId: match.id } : prev;
+            });
+          }
+        } else if (options.reopenLastFile && options.recentFiles[0]) {
+          await openFile(options.recentFiles[0]);
+        }
+      } catch {
+        // ignore
+      }
+      setInitializing(false);
+    })();
+  }, []);
+
+  // Listen for open-file events (drag-drop, file associations)
+  useEffect(() => {
+    const unlisten = listen<string>("open-file", (event) => {
+      openFile(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [openFile]);
+
+  // Listen for file-changed events (auto-reload)
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+
+    const unlisten = listen<string>("file-changed", (event) => {
+      if (!optionsRef.current.autoReload) return;
+      clearTimeout(timeout);
+      timeout = setTimeout(async () => {
+        const changedPath = event.payload;
+        try {
+          const { content, metadata } = await loadFileContent(changedPath);
+          setState((prev) => ({
+            ...prev,
+            tabs: prev.tabs.map((t) => (t.path === changedPath ? { ...t, content, metadata } : t)),
+          }));
+        } catch {
+          // ignore reload errors
+        }
+      }, 300);
+    });
+
+    return () => {
+      clearTimeout(timeout);
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  return {
+    tabs,
+    activeTab,
+    activeTabId,
+    initializing,
+    openFile,
+    closeTab,
+    setActiveTab,
+    saveScrollPosition,
+    openFileDialog,
+  };
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -20,6 +20,8 @@ export interface BehaviorSettings {
   reopenLastFile: boolean;
   confirmExternalLinks: boolean;
   recentFiles: string[];
+  openTabs: string[];
+  activeTabPath: string;
 }
 
 export interface AISettings {
@@ -59,6 +61,8 @@ export const DEFAULT_SETTINGS: Settings = {
     reopenLastFile: false,
     confirmExternalLinks: true,
     recentFiles: [],
+    openTabs: [],
+    activeTabPath: "",
   },
   ai: {
     provider: "none",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3,6 +3,7 @@
 @import "./platform.css";
 @import "./markdown.css";
 @import "./settings.css";
+@import "./tabs.css";
 
 :root {
   --color-surface: #ffffff;

--- a/src/styles/tabs.css
+++ b/src/styles/tabs.css
@@ -1,0 +1,74 @@
+.tab-bar {
+  display: flex;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-secondary);
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  shrink: 0;
+}
+
+.tab-bar::-webkit-scrollbar {
+  display: none;
+}
+
+.tab-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  border-right: 1px solid var(--color-border);
+  cursor: pointer;
+  white-space: nowrap;
+  min-width: 0;
+  max-width: 200px;
+  transition: background 0.1s ease, color 0.1s ease;
+  font-family: inherit;
+}
+
+.tab-item:hover {
+  background: var(--color-surface-tertiary);
+}
+
+.tab-item[data-active] {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.tab-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tab-close {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: none;
+  border-radius: var(--glyph-radius-sm);
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s ease, background 0.1s ease, color 0.1s ease;
+  flex-shrink: 0;
+}
+
+.tab-item:hover .tab-close,
+.tab-item[data-active] .tab-close {
+  opacity: 1;
+}
+
+.tab-close:hover {
+  background: var(--color-surface-tertiary);
+  color: var(--color-text-primary);
+}


### PR DESCRIPTION
## Summary

- Adds tab bar for managing multiple open markdown files
- Multi-file watcher: each tab's file is watched independently for live reload
- Session restore: all open tabs and active tab persist across app restarts
- Multi-select file dialog: open several files at once via Cmd/Ctrl+O
- Scroll position preserved per tab when switching
- Middle-click or close button to close tabs
- Duplicate detection: opening an already-open file activates its tab

## Changes

- `src-tauri/src/watcher.rs` — Refactored from single `Option<Watcher>` to `HashMap<String, Watcher>` for multi-file watching; event payload now includes file path
- `src-tauri/src/lib.rs` — Updated `FileWatcherState` initialization
- `src/hooks/useTabs.ts` — New hook managing tab state (open/close/switch/persist/restore)
- `src/components/layout/TabBar.tsx` — New tab bar component with active state, close buttons
- `src/styles/tabs.css` — Tab bar styling with theme-aware colors
- `src/components/App.tsx` — Replaced `useFileLoader` with `useTabs`, added TabBar to layout
- `src/components/markdown/MarkdownViewer.tsx` — Accepts scroll position props, keyed by tab ID
- `src/lib/settings.ts` — Added `openTabs` and `activeTabPath` to BehaviorSettings

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Closes #6