### PR TITLE
feat: add emoji shortcode support

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-markdown": "^10",
     "rehype-highlight": "^7",
     "rehype-katex": "^7.0.1",
+    "remark-gemoji": "^8.0.0",
     "remark-gfm": "^4",
     "remark-math": "^6.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
+      remark-gemoji:
+        specifier: ^8.0.0
+        version: 8.0.0
       remark-gfm:
         specifier: ^4
         version: 4.0.1
@@ -1471,6 +1474,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  gemoji@8.1.0:
+    resolution: {integrity: sha512-HA4Gx59dw2+tn+UAa7XEV4ufUKI4fH1KgcbenVA9YKSj1QJTT0xh5Mwv5HMFNN3l2OtUe3ZIfuRwSyZS5pLIWw==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -1983,6 +1989,9 @@ packages:
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
+  remark-gemoji@8.0.0:
+    resolution: {integrity: sha512-/fL9rc72FYwFGtOKcT+QeQdx9Q9t5v4N6KLXSDOTEgaedzK85I9judBqB2eqz+g4b0ERMejlwSOuPK+wket6aA==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -3582,6 +3591,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  gemoji@8.1.0: {}
+
   gensync@1.0.0-beta.2: {}
 
   graceful-fs@4.2.11: {}
@@ -4397,6 +4408,12 @@ snapshots:
       katex: 0.16.45
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
+
+  remark-gemoji@8.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      gemoji: 8.1.0
+      mdast-util-find-and-replace: 3.0.2
 
   remark-gfm@4.0.1:
     dependencies:

--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
+import remarkGemoji from "remark-gemoji";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { CodeBlockComponent } from "./CodeBlockComponent";
@@ -44,7 +45,7 @@ export function MarkdownViewer({ content, filePath }: MarkdownViewerProps) {
     <div ref={scrollRef} className="flex-1 overflow-y-auto">
       <div className="markdown-body px-8 py-6 pb-[60vh]">
         <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkMath]}
+          remarkPlugins={[remarkGfm, remarkMath, remarkGemoji]}
           rehypePlugins={[[rehypeHighlight, { plainText: ["mermaid"] }], rehypeKatex]}
           components={{
             ...headingComponents,


### PR DESCRIPTION
## Summary

- Adds `remark-gemoji` plugin to convert GitHub-style emoji shortcodes to Unicode emoji
- Shortcodes like `:smile:`, `:+1:`, `:tada:` now render as their emoji equivalents

## Changes

- `package.json` — Added `remark-gemoji` dependency
- `src/components/markdown/MarkdownViewer.tsx` — Added `remarkGemoji` to remarkPlugins array

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Closes #15