### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -66,15 +66,24 @@ function setNestedValue(
 
   const result = { ...obj };
   let current: Record<string, unknown> = result;
+  let schemaCurrent: Record<string, unknown> = DEFAULT_SETTINGS as unknown as Record<string, unknown>;
 
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
     if (FORBIDDEN_OBJECT_KEYS.has(key)) {
       return obj;
     }
-    if (!isSafePlainObject(current)) {
+    if (!isSafePlainObject(current) || !isSafePlainObject(schemaCurrent)) {
       return obj;
     }
+    if (!Object.hasOwn(schemaCurrent, key)) {
+      return obj;
+    }
+    const schemaNext = schemaCurrent[key];
+    if (!isSafePlainObject(schemaNext)) {
+      return obj;
+    }
+
     const existing = Object.hasOwn(current, key) ? current[key] : undefined;
     if (isSafePlainObject(existing)) {
       current[key] = { ...existing };
@@ -86,13 +95,17 @@ function setNestedValue(
       return obj;
     }
     current = next;
+    schemaCurrent = schemaNext;
   }
 
   const lastKey = keys[keys.length - 1];
   if (FORBIDDEN_OBJECT_KEYS.has(lastKey)) {
     return obj;
   }
-  if (!isSafePlainObject(current)) {
+  if (!isSafePlainObject(current) || !isSafePlainObject(schemaCurrent)) {
+    return obj;
+  }
+  if (!Object.hasOwn(schemaCurrent, lastKey)) {
     return obj;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/hamidfzm/glyph/security/code-scanning/2](https://github.com/hamidfzm/glyph/security/code-scanning/2)

General fix: constrain deep assignment so recursive traversal and final write are only allowed through known-safe, own-property paths on the destination schema, rather than accepting arbitrary path segments.

Best concrete fix in `src/contexts/SettingsContext.tsx`: in `setNestedValue`, before creating/interacting with nested objects, verify each segment is an own property of the corresponding node in `DEFAULT_SETTINGS` (schema object). Keep existing forbidden-key checks, but add schema-walk validation for both intermediate keys and final key. If any segment is invalid, return original `obj`. This preserves behavior for legitimate settings paths while blocking any unexpected or attacker-crafted chains.

Changes needed:
- In `setNestedValue`, introduce a `schemaCurrent` pointer initialized from `DEFAULT_SETTINGS`.
- During loop (`keys.length - 1`), require `Object.hasOwn(schemaCurrent, key)` and advance `schemaCurrent`.
- Before final assignment, require `Object.hasOwn(schemaCurrent, lastKey)`.
- No new imports/dependencies needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
