### PR TITLE
feat: add print and PDF export

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "src/**/*.{ts,tsx}"
+  - "src-tauri/**/*.rs"
+---
+
+# Documentation Rules
+
+When shipping a user-facing feature, update in the same commit:
+
+- **`README.md`** — add a bullet under the relevant `## Features` subsection; if the feature adds a keyboard shortcut, add a row to the `## Keyboard Shortcuts` table
+- **`sample.md`** — showcase the feature where applicable (new markdown syntax gets a demo section; new shortcuts go in sample.md's shortcuts table)
+
+Treat these as part of the feature's definition of done, not a follow-up.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Built with [Tauri v2](https://v2.tauri.app), React 19, and TypeScript.
 - In-document search — `Cmd/Ctrl+F` with match highlighting and navigation
 - Zoom in/out — `Cmd/Ctrl+=/-/0` with zoom level in status bar
 - Table of Contents sidebar with active heading tracking
+- Print & PDF export — `Cmd/Ctrl+P` with configurable page breaks, optional TOC, and theme-color control
 - Live reload — file watcher auto-updates on external changes
 - Drag and drop markdown files to open
 - File associations — double-click `.md` files to open in Glyph
@@ -160,6 +161,7 @@ cd src-tauri && cargo clippy    # Lint Rust
 | Shortcut | Action |
 |----------|--------|
 | `Cmd+O` / `Ctrl+O` | Open file(s) |
+| `Cmd+P` / `Ctrl+P` | Print / Export to PDF |
 | `Cmd+F` / `Ctrl+F` | Find in document |
 | `Cmd+=` / `Ctrl+=` | Zoom in |
 | `Cmd+-` / `Ctrl+-` | Zoom out |

--- a/sample.md
+++ b/sample.md
@@ -150,10 +150,11 @@ Glyph converts GitHub-style emoji shortcodes to Unicode:
 | Shortcut | Action |
 |----------|--------|
 | `Cmd+O` | Open file(s) |
+| `Cmd+P` | Print / Export to PDF |
 | `Cmd+F` | Find in document |
 | `Cmd+=` / `Cmd+-` | Zoom in / out |
 | `Cmd+0` | Reset zoom |
 | `Cmd+B` | Toggle sidebar |
 | `Cmd+,` | Settings |
 
-*Try pressing `Cmd+F` to search this document, or `Cmd+=` to zoom in!*
+*Try pressing `Cmd+F` to search this document, or `Cmd+P` to print / save as PDF.*

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -27,6 +27,11 @@ pub fn read_file(path: String) -> Result<String, String> {
 }
 
 #[tauri::command]
+pub fn print_document(window: tauri::WebviewWindow) -> Result<(), String> {
+    window.print().map_err(|e| format!("Failed to print: {e}"))
+}
+
+#[tauri::command]
 pub fn write_file(path: String, content: String) -> Result<(), String> {
     fs::write(&path, &content).map_err(|e| format!("Failed to write file: {e}"))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,6 +92,7 @@ pub fn run() {
             commands::write_file,
             commands::get_file_metadata,
             commands::get_initial_file,
+            commands::print_document,
             watcher::watch_file,
             watcher::unwatch_file,
         ])

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -10,6 +10,9 @@ pub fn build_menu(app: &App) -> tauri::Result<tauri::menu::Menu<Wry>> {
     let open = MenuItemBuilder::with_id("open", "Open\u{2026}")
         .accelerator("CmdOrCtrl+O")
         .build(handle)?;
+    let print = MenuItemBuilder::with_id("print", "Print\u{2026}")
+        .accelerator("CmdOrCtrl+P")
+        .build(handle)?;
     let close = MenuItemBuilder::with_id("close", "Close Window")
         .accelerator("CmdOrCtrl+W")
         .build(handle)?;
@@ -97,6 +100,8 @@ pub fn build_menu(app: &App) -> tauri::Result<tauri::menu::Menu<Wry>> {
         let file_menu = SubmenuBuilder::new(handle, "File")
             .item(&open)
             .separator()
+            .item(&print)
+            .separator()
             .item(&close)
             .build()?;
 
@@ -130,6 +135,8 @@ pub fn build_menu(app: &App) -> tauri::Result<tauri::menu::Menu<Wry>> {
         let file_menu = SubmenuBuilder::new(handle, "File")
             .item(&open)
             .separator()
+            .item(&print)
+            .separator()
             .item(&settings)
             .separator()
             .item(&close)
@@ -151,6 +158,9 @@ pub fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) 
     match event.id().as_ref() {
         "open" => {
             let _ = app.emit("menu-open-file", ());
+        }
+        "print" => {
+            let _ = app.emit("menu-print", ());
         }
         "close" => {
             if let Some(window) = app.get_webview_window("main") {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,6 +4,7 @@ import { type AIAction, useAI } from "../hooks/useAI";
 import { useAutoSave } from "../hooks/useAutoSave";
 import { useContextMenu } from "../hooks/useContextMenu";
 import { usePlatform } from "../hooks/usePlatform";
+import { usePrint } from "../hooks/usePrint";
 import { useSettings } from "../hooks/useSettings";
 import { useTableOfContents } from "../hooks/useTableOfContents";
 import { useTabs } from "../hooks/useTabs";
@@ -98,6 +99,9 @@ export function App() {
   const ai = useAI(settings.ai);
   const aiConfigured = settings.ai.provider !== "none";
 
+  // Print
+  const printDoc = usePrint({ entries: tocEntries, settings: settings.print });
+
   // Sync sidebar visibility with settings
   useEffect(() => {
     setSidebarVisible(settings.layout.sidebarVisible);
@@ -152,6 +156,9 @@ export function App() {
       const nextMode = activeMode === "view" ? "edit" : activeMode === "edit" ? "split" : "view";
       setTabMode(activeTabId, nextMode);
     });
+    const unlistenPrint = listen("menu-print", () => {
+      printDoc();
+    });
     const unlistenReadAloud = listen("menu-ai-read-aloud", () => {
       if (tts.speaking) {
         tts.stop();
@@ -185,6 +192,7 @@ export function App() {
       unlistenZoomReset.then((fn) => fn());
       unlistenFind.then((fn) => fn());
       unlistenToggleEdit.then((fn) => fn());
+      unlistenPrint.then((fn) => fn());
     };
   }, [
     openFileDialog,
@@ -197,6 +205,7 @@ export function App() {
     activeTabId,
     activeMode,
     setTabMode,
+    printDoc,
   ]);
 
   // Apply code theme via injected <style> element

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -45,6 +45,7 @@ export function Sidebar({ entries, visible, width }: SidebarProps) {
 
   return (
     <nav
+      data-print-hide="true"
       className="shrink-0 overflow-y-auto border-r border-[var(--color-border)] select-none pt-3"
       style={{
         width: width ?? 224,

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -16,7 +16,10 @@ export function StatusBar({ filePath, content }: StatusBarProps) {
   const words = countWords(content);
 
   return (
-    <div className="flex items-center gap-4 px-4 h-7 border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-xs text-[var(--color-text-secondary)] select-none shrink-0">
+    <div
+      data-print-hide="true"
+      className="flex items-center gap-4 px-4 h-7 border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-xs text-[var(--color-text-secondary)] select-none shrink-0"
+    >
       {filePath && (
         <span className="truncate max-w-[50%]" title={filePath}>
           {filePath}

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -15,7 +15,7 @@ export function TabBar({ tabs, activeTabId, onActivate, onClose, onModeChange }:
   const activeTab = tabs.find((t) => t.id === activeTabId);
 
   return (
-    <div className="tab-bar-container">
+    <div className="tab-bar-container" data-print-hide="true">
       <div className="tab-bar-scroll">
         {tabs.map((tab) => (
           <button

--- a/src/components/layout/Titlebar.tsx
+++ b/src/components/layout/Titlebar.tsx
@@ -6,6 +6,7 @@ export function Titlebar({ fileName }: TitlebarProps) {
   return (
     <div
       data-tauri-drag-region
+      data-print-hide="true"
       className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center border-b border-[var(--color-border)]"
       style={{
         height: "var(--glyph-titlebar-height)",

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useSettings } from "../../hooks/useSettings";
 import { MODEL_SUGGESTIONS } from "../../lib/settings";
 
-type Tab = "appearance" | "layout" | "behavior" | "ai";
+type Tab = "appearance" | "layout" | "behavior" | "ai" | "print";
 
 interface SettingsModalProps {
   open: boolean;
@@ -72,6 +72,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
     { id: "layout", label: "Layout" },
     { id: "behavior", label: "Behavior" },
     { id: "ai", label: "AI" },
+    { id: "print", label: "Print" },
   ];
 
   return (
@@ -117,6 +118,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           {tab === "layout" && <LayoutTab />}
           {tab === "behavior" && <BehaviorTab />}
           {tab === "ai" && <AITab />}
+          {tab === "print" && <PrintTab />}
         </div>
 
         <div className="settings-footer">
@@ -372,6 +374,54 @@ function BehaviorTab() {
         </div>
       )}
     </>
+  );
+}
+
+function PrintTab() {
+  const { settings, updateSettings } = useSettings();
+  const { print } = settings;
+
+  return (
+    <div className="settings-section">
+      <div className="settings-section-title">Print & PDF Export</div>
+      <div className="settings-row">
+        <div>
+          <span className="settings-label">Page Breaks</span>
+          <div className="settings-description">Start a new page at heading level</div>
+        </div>
+        <Segmented
+          value={print.pageBreakLevel}
+          options={[
+            { value: "none", label: "None" },
+            { value: "h1", label: "At H1" },
+            { value: "h2", label: "At H2" },
+          ]}
+          onChange={(v) => updateSettings("print.pageBreakLevel", v)}
+        />
+      </div>
+
+      <div className="settings-row">
+        <div>
+          <span className="settings-label">Include Table of Contents</span>
+          <div className="settings-description">Insert a contents page at the start</div>
+        </div>
+        <Toggle
+          checked={print.includeToc}
+          onChange={(v) => updateSettings("print.includeToc", v)}
+        />
+      </div>
+
+      <div className="settings-row">
+        <div>
+          <span className="settings-label">Print Backgrounds & Colors</span>
+          <div className="settings-description">Preserve theme colors in output</div>
+        </div>
+        <Toggle
+          checked={print.includeBackground}
+          onChange={(v) => updateSettings("print.includeBackground", v)}
+        />
+      </div>
+    </div>
   );
 }
 

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,11 +1,11 @@
-import { createContext, useState, useEffect, useCallback, useRef, type ReactNode } from "react";
 import { load, type Store } from "@tauri-apps/plugin-store";
+import { createContext, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import {
-  type Settings,
+  CONTENT_WIDTH_MAP,
   DEFAULT_SETTINGS,
   FONT_FAMILY_MAP,
   LINE_HEIGHT_MAP,
-  CONTENT_WIDTH_MAP,
+  type Settings,
 } from "../lib/settings";
 
 export interface SettingsContextValue {

--- a/src/hooks/usePrint.test.ts
+++ b/src/hooks/usePrint.test.ts
@@ -4,6 +4,11 @@ import type { PrintSettings } from "../lib/settings";
 import { usePrint } from "./usePrint";
 import type { TocEntry } from "./useTableOfContents";
 
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
 const DEFAULT_PRINT: PrintSettings = {
   pageBreakLevel: "none",
   includeToc: false,
@@ -16,38 +21,25 @@ const ENTRIES: TocEntry[] = [
 ];
 
 describe("usePrint", () => {
-  let printMock: ReturnType<typeof vi.fn>;
-  let originalPrint: typeof window.print | undefined;
-
   beforeEach(() => {
     const body = document.createElement("div");
     body.className = "markdown-body";
     document.body.appendChild(body);
-    originalPrint = window.print;
-    printMock = vi.fn();
-    Object.defineProperty(window, "print", {
-      configurable: true,
-      writable: true,
-      value: printMock,
-    });
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     document.documentElement.removeAttribute("data-print-breaks");
     document.documentElement.removeAttribute("data-print-bg");
     document.body.innerHTML = "";
-    Object.defineProperty(window, "print", {
-      configurable: true,
-      writable: true,
-      value: originalPrint,
-    });
   });
 
   it("no-ops when no .markdown-body is present", () => {
     document.body.innerHTML = "";
     const { result } = renderHook(() => usePrint({ entries: ENTRIES, settings: DEFAULT_PRINT }));
     result.current();
-    expect(printMock).not.toHaveBeenCalled();
+    expect(invokeMock).not.toHaveBeenCalled();
   });
 
   it("sets html data attributes from settings before printing", () => {
@@ -60,7 +52,7 @@ describe("usePrint", () => {
     result.current();
     expect(document.documentElement.getAttribute("data-print-breaks")).toBe("h2");
     expect(document.documentElement.getAttribute("data-print-bg")).toBe("true");
-    expect(printMock).toHaveBeenCalledOnce();
+    expect(invokeMock).toHaveBeenCalledWith("print_document");
   });
 
   it("injects a print-toc when includeToc is true and entries exist", () => {

--- a/src/hooks/usePrint.test.ts
+++ b/src/hooks/usePrint.test.ts
@@ -1,0 +1,109 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrintSettings } from "../lib/settings";
+import { usePrint } from "./usePrint";
+import type { TocEntry } from "./useTableOfContents";
+
+const DEFAULT_PRINT: PrintSettings = {
+  pageBreakLevel: "none",
+  includeToc: false,
+  includeBackground: false,
+};
+
+const ENTRIES: TocEntry[] = [
+  { id: "intro", text: "Intro", level: 1 },
+  { id: "details", text: "Details", level: 2 },
+];
+
+describe("usePrint", () => {
+  let printMock: ReturnType<typeof vi.fn>;
+  let originalPrint: typeof window.print | undefined;
+
+  beforeEach(() => {
+    const body = document.createElement("div");
+    body.className = "markdown-body";
+    document.body.appendChild(body);
+    originalPrint = window.print;
+    printMock = vi.fn();
+    Object.defineProperty(window, "print", {
+      configurable: true,
+      writable: true,
+      value: printMock,
+    });
+  });
+
+  afterEach(() => {
+    document.documentElement.removeAttribute("data-print-breaks");
+    document.documentElement.removeAttribute("data-print-bg");
+    document.body.innerHTML = "";
+    Object.defineProperty(window, "print", {
+      configurable: true,
+      writable: true,
+      value: originalPrint,
+    });
+  });
+
+  it("no-ops when no .markdown-body is present", () => {
+    document.body.innerHTML = "";
+    const { result } = renderHook(() => usePrint({ entries: ENTRIES, settings: DEFAULT_PRINT }));
+    result.current();
+    expect(printMock).not.toHaveBeenCalled();
+  });
+
+  it("sets html data attributes from settings before printing", () => {
+    const { result } = renderHook(() =>
+      usePrint({
+        entries: ENTRIES,
+        settings: { pageBreakLevel: "h2", includeToc: false, includeBackground: true },
+      }),
+    );
+    result.current();
+    expect(document.documentElement.getAttribute("data-print-breaks")).toBe("h2");
+    expect(document.documentElement.getAttribute("data-print-bg")).toBe("true");
+    expect(printMock).toHaveBeenCalledOnce();
+  });
+
+  it("injects a print-toc when includeToc is true and entries exist", () => {
+    const { result } = renderHook(() =>
+      usePrint({
+        entries: ENTRIES,
+        settings: { ...DEFAULT_PRINT, includeToc: true },
+      }),
+    );
+    result.current();
+    const toc = document.querySelector(".print-toc");
+    expect(toc).toBeTruthy();
+    const links = toc?.querySelectorAll("a") ?? [];
+    expect(links.length).toBe(2);
+    expect(links[0].getAttribute("href")).toBe("#intro");
+    expect(links[1].textContent).toBe("Details");
+  });
+
+  it("does not inject a print-toc when includeToc is true but entries are empty", () => {
+    const { result } = renderHook(() =>
+      usePrint({
+        entries: [],
+        settings: { ...DEFAULT_PRINT, includeToc: true },
+      }),
+    );
+    result.current();
+    expect(document.querySelector(".print-toc")).toBeNull();
+  });
+
+  it("cleans up attributes and toc on afterprint", () => {
+    const { result } = renderHook(() =>
+      usePrint({
+        entries: ENTRIES,
+        settings: { pageBreakLevel: "h1", includeToc: true, includeBackground: false },
+      }),
+    );
+    result.current();
+    expect(document.querySelector(".print-toc")).toBeTruthy();
+
+    window.dispatchEvent(new Event("afterprint"));
+
+    expect(document.documentElement.hasAttribute("data-print-breaks")).toBe(false);
+    expect(document.documentElement.hasAttribute("data-print-bg")).toBe(false);
+    expect(document.querySelector(".print-toc")).toBeNull();
+  });
+});

--- a/src/hooks/usePrint.ts
+++ b/src/hooks/usePrint.ts
@@ -1,0 +1,62 @@
+import { useCallback } from "react";
+import type { PrintSettings } from "../lib/settings";
+import type { TocEntry } from "./useTableOfContents";
+
+interface UsePrintOptions {
+  entries: TocEntry[];
+  settings: PrintSettings;
+}
+
+const TOC_CLASS = "print-toc";
+
+function buildTocElement(entries: TocEntry[]): HTMLElement {
+  const nav = document.createElement("nav");
+  nav.className = TOC_CLASS;
+  nav.setAttribute("aria-label", "Table of contents");
+
+  const heading = document.createElement("h2");
+  heading.textContent = "Contents";
+  nav.appendChild(heading);
+
+  const list = document.createElement("ul");
+  for (const entry of entries) {
+    const li = document.createElement("li");
+    li.style.paddingLeft = `${(entry.level - 1) * 16}px`;
+    const a = document.createElement("a");
+    a.href = `#${entry.id}`;
+    a.textContent = entry.text;
+    li.appendChild(a);
+    list.appendChild(li);
+  }
+  nav.appendChild(list);
+  return nav;
+}
+
+export function usePrint({ entries, settings }: UsePrintOptions) {
+  return useCallback(() => {
+    const body = document.querySelector<HTMLElement>(".markdown-body");
+    if (!body) return;
+
+    const root = document.documentElement;
+    root.setAttribute("data-print-breaks", settings.pageBreakLevel);
+    root.setAttribute("data-print-bg", String(settings.includeBackground));
+
+    let injected: HTMLElement | null = null;
+    if (settings.includeToc && entries.length > 0) {
+      injected = buildTocElement(entries);
+      body.insertBefore(injected, body.firstChild);
+    }
+
+    const cleanup = () => {
+      root.removeAttribute("data-print-breaks");
+      root.removeAttribute("data-print-bg");
+      if (injected?.parentNode) {
+        injected.parentNode.removeChild(injected);
+      }
+      window.removeEventListener("afterprint", cleanup);
+    };
+
+    window.addEventListener("afterprint", cleanup);
+    window.print();
+  }, [entries, settings.pageBreakLevel, settings.includeBackground, settings.includeToc]);
+}

--- a/src/hooks/usePrint.ts
+++ b/src/hooks/usePrint.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { useCallback } from "react";
 import type { PrintSettings } from "../lib/settings";
 import type { TocEntry } from "./useTableOfContents";
@@ -57,6 +58,12 @@ export function usePrint({ entries, settings }: UsePrintOptions) {
     };
 
     window.addEventListener("afterprint", cleanup);
-    window.print();
+
+    // Use the native Tauri webview print() — window.print() is unreliable
+    // on macOS WKWebView. Fall back to window.print() if the command fails
+    // (e.g. running in a plain browser for tests).
+    invoke("print_document").catch(() => {
+      window.print();
+    });
   }, [entries, settings.pageBreakLevel, settings.includeBackground, settings.includeToc]);
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -36,11 +36,18 @@ export interface AISettings {
   ttsSpeed: number;
 }
 
+export interface PrintSettings {
+  pageBreakLevel: "none" | "h1" | "h2";
+  includeToc: boolean;
+  includeBackground: boolean;
+}
+
 export interface Settings {
   appearance: AppearanceSettings;
   layout: LayoutSettings;
   behavior: BehaviorSettings;
   ai: AISettings;
+  print: PrintSettings;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -75,6 +82,11 @@ export const DEFAULT_SETTINGS: Settings = {
     model: "",
     ttsVoice: "",
     ttsSpeed: 1.0,
+  },
+  print: {
+    pageBreakLevel: "none",
+    includeToc: false,
+    includeBackground: false,
   },
 };
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6,6 +6,7 @@
 @import "./tabs.css";
 @import "./search.css";
 @import "./editor.css";
+@import "./print.css";
 
 :root {
   --color-surface: #ffffff;

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -1,0 +1,152 @@
+@media print {
+  @page {
+    margin: 2cm;
+  }
+
+  html,
+  body,
+  #root {
+    height: auto !important;
+    overflow: visible !important;
+    background: #ffffff !important;
+  }
+
+  [data-print-hide="true"],
+  .settings-overlay,
+  .search-bar,
+  .ai-panel {
+    display: none !important;
+  }
+
+  .markdown-body {
+    max-width: none !important;
+    width: 100% !important;
+    padding: 0 !important;
+    padding-bottom: 0 !important;
+    overflow: visible !important;
+    height: auto !important;
+  }
+
+  .markdown-body > *:last-child {
+    margin-bottom: 0 !important;
+  }
+
+  [class*="overflow-y-auto"],
+  [class*="overflow-hidden"] {
+    overflow: visible !important;
+    height: auto !important;
+    max-height: none !important;
+  }
+
+  .markdown-body h1,
+  .markdown-body h2,
+  .markdown-body h3,
+  .markdown-body h4,
+  .markdown-body h5,
+  .markdown-body h6 {
+    break-after: avoid;
+    page-break-after: avoid;
+  }
+
+  .markdown-body pre,
+  .markdown-body table,
+  .markdown-body figure,
+  .markdown-body img,
+  .markdown-body blockquote {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  [data-print-breaks="h1"] .markdown-body h1 {
+    break-before: page;
+    page-break-before: always;
+  }
+
+  [data-print-breaks="h2"] .markdown-body h1,
+  [data-print-breaks="h2"] .markdown-body h2 {
+    break-before: page;
+    page-break-before: always;
+  }
+
+  [data-print-breaks] .markdown-body > :first-child,
+  [data-print-breaks] .print-toc + * {
+    break-before: auto !important;
+    page-break-before: auto !important;
+  }
+
+  [data-print-bg="true"] .markdown-body,
+  [data-print-bg="true"] .markdown-body * {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  [data-print-bg="false"] .markdown-body,
+  [data-print-bg="false"] .markdown-body * {
+    background: transparent !important;
+    color: #000000 !important;
+  }
+
+  [data-print-bg="false"] .markdown-body a {
+    color: #000000 !important;
+    text-decoration: underline;
+  }
+
+  [data-print-bg="false"] .markdown-body pre,
+  [data-print-bg="false"] .markdown-body code {
+    background: #f5f5f5 !important;
+    color: #000000 !important;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .markdown-body a[href^="http"]::after,
+  .markdown-body a[href^="https"]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.85em;
+    word-break: break-all;
+    color: inherit;
+  }
+
+  .markdown-body a[href^="#"]::after {
+    content: none;
+  }
+
+  .print-toc {
+    break-after: page;
+    page-break-after: always;
+    margin-bottom: 1.5rem;
+  }
+
+  .print-toc h2 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    font-size: 1.4rem;
+  }
+
+  .print-toc ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+  }
+
+  .print-toc li {
+    padding: 0.15rem 0;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .print-toc a {
+    text-decoration: none;
+    color: inherit;
+  }
+}
+
+.print-toc {
+  display: none;
+}
+
+@media print {
+  .print-toc {
+    display: block;
+  }
+}


### PR DESCRIPTION
## Summary

Adds print and PDF export (issue #9). `Cmd/Ctrl+P` triggers the native print dialog, which offers "Save as PDF" on macOS / Windows / Linux — no new dependencies, no extra tooling, native paper-size and margin UI.

Closes #9.

## Changes

- **Menu + shortcut**: `Print…` item in the File menu with `CmdOrCtrl+P` accelerator (`src-tauri/src/menu.rs`), emits `menu-print` to the frontend.
- **`usePrint` hook** (`src/hooks/usePrint.ts`): sets `data-print-breaks` / `data-print-bg` attributes on `<html>`, optionally injects a `<nav class="print-toc">` at the top of `.markdown-body`, calls `window.print()`, and cleans up on `afterprint`.
- **Print stylesheet** (`src/styles/print.css`): hides chrome via `data-print-hide="true"`, unwraps scroll containers, applies configurable page breaks at H1/H2, appends external link URLs, and honors the "Print backgrounds & colors" toggle (falls back to black on white when off).
- **Chrome markers**: `data-print-hide="true"` on Titlebar, TabBar, StatusBar, Sidebar.
- **Settings**: new `PrintSettings` (`pageBreakLevel`, `includeToc`, `includeBackground`) + new "Print" tab in the Settings modal.
- **Docs**: README gets a Viewer bullet and a `Cmd/Ctrl+P` row; `sample.md` mentions the new shortcut; a new `.claude/rules/docs.md` codifies README + sample.md as part of every feature's definition of done.
- **Tests**: `src/hooks/usePrint.test.ts` (5 cases) — no-op without `.markdown-body`, attribute setting, TOC injection, empty-entries guard, cleanup on `afterprint`.

## Testing

- `pnpm test` — 165 tests pass (19 files)
- `pnpm typecheck`, `pnpm check` — clean
- `cd src-tauri && cargo check` — clean
- `pnpm build` — production build succeeds

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

_Add before/after of the Print settings tab and a PDF output sample when verifying on each platform._