### PR TITLE
chore: ignore RUSTSEC-2026-0097 (rand unsoundness, not exploitable)

### DIFF
--- a/src-tauri/audit.toml
+++ b/src-tauri/audit.toml
@@ -1,0 +1,21 @@
+# cargo-audit configuration
+# https://docs.rs/cargo-audit/latest/cargo_audit/
+
+[advisories]
+ignore = [
+    # RUSTSEC-2026-0097 / GHSA-cq8v-f236-94qc — low-severity unsoundness in `rand`
+    # (ThreadRng reseeding under a custom logger that calls `rand::rng()` at
+    # trace level).
+    #
+    # Not exploitable in Glyph: `rand` 0.7.3 and 0.8.5 are transitive, build-time
+    # only, pulled in by `phf_generator` (via `cssparser`/`selectors`/`kuchikiki`
+    # in `tauri-utils`) to seed perfect-hash-function tables during proc-macro
+    # expansion. No custom logger is installed in that path and none of the
+    # conditions for the unsoundness are met.
+    #
+    # Upstream fix is rand >= 0.9.3, but the 0.7/0.8 chain is pinned by the
+    # `phf_generator` versions that `cssparser`/`selectors` depend on — not
+    # something we can force via Cargo.toml. Revisit when Tauri's HTML/CSS
+    # pipeline upgrades to newer `cssparser`/`selectors`.
+    "RUSTSEC-2026-0097",
+]


### PR DESCRIPTION
## Summary

Adds a `cargo audit` ignore for [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097) / [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (low-severity unsoundness in `rand`), silencing [Dependabot alert #7](https://github.com/hamidfzm/glyph/security/dependabot/7).

## Why ignore rather than fix

The advisory requires **all** of the following to trigger UB:
- A custom logger that calls `rand::rng()` is installed
- That logger calls `TryRng` methods on `ThreadRng`
- The `ThreadRng` attempts to reseed (every 64 kB generated)
- `trace`-level logging is enabled (or `warn` with seed failure)

In Glyph's dependency graph, `rand` 0.7.3 and 0.8.5 are pulled in **transitively at build-time only**, via `phf_generator` → `cssparser`/`selectors`/`kuchikiki` → `tauri-utils`. They're used to seed perfect-hash tables during proc-macro expansion. No custom logger is installed in that path, none of the preconditions are met, and nothing from `rand` ships into the runtime binary.

The advisory is first fixed in `rand >= 0.9.3`, but the 0.7/0.8 chain is **pinned by `phf_generator`**, which is in turn pinned by the `cssparser`/`selectors` versions that Tauri's HTML pipeline uses. We can't force a newer `rand` via `Cargo.toml` — the transitive contract is API-incompatible. This will naturally resolve when Tauri upgrades its CSS stack.

## Changes

- **`src-tauri/audit.toml`** — new file. Single ignore entry with a documented rationale so the review trail is explicit. `cargo audit` already reads `audit.toml` from its working directory; our `Security / Cargo Audit` CI job runs from `src-tauri/` (see `.github/workflows/security.yml:41`), so no workflow changes are needed.

## Follow-up

I'll also dismiss Dependabot alert #7 with reason "Risk tolerable" pointing at this PR, so GitHub stops re-surfacing it on every scan.

## Testing

- [ ] Wait for CI — `Cargo Audit` should remain green
- [x] Tested on macOS (no local `cargo audit` install required — the ignore format matches the [cargo-audit config](https://docs.rs/cargo-audit/latest/cargo_audit/) spec)
- [ ] Tested on Windows
- [ ] Tested on Linux