### PR TITLE
fix(deps): override uuid to >=14.0.0 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "overrides": {
       "picomatch": "4.0.4",
       "lodash-es": "4.18.0",
-      "dompurify": ">=3.4.0"
+      "dompurify": ">=3.4.0",
+      "uuid": ">=14.0.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   picomatch: 4.0.4
   lodash-es: 4.18.0
   dompurify: '>=3.4.0'
+  uuid: '>=14.0.0'
 
 importers:
 
@@ -2388,8 +2389,8 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vfile-location@5.0.3:
@@ -4682,7 +4683,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 11.1.0
+      uuid: 14.0.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -5276,7 +5277,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  uuid@11.1.0: {}
+  uuid@14.0.0: {}
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

Pins `uuid` to `>=14.0.0` via pnpm overrides to address [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) — missing buffer bounds check in `v3`/`v5`/`v6` when a `buf` is provided. We pull in `uuid@11.1.0` transitively from `mermaid`; the override forces it to a patched release until upstream bumps.

## Changes

- Add `"uuid": ">=14.0.0"` to `pnpm.overrides` in `package.json`
- Refresh `pnpm-lock.yaml` (uuid 11.1.0 → 14.0.0)

## Testing

- `pnpm typecheck` passes
- `pnpm test` — 173 passed
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A — dependency-only change.