### PR TITLE
perf: lazy-load Mermaid and KaTeX (#99)

### DIFF
--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -67,7 +67,9 @@ export function MarkdownViewer({
   };
 
   const rehypePlugins: NonNullable<Options["rehypePlugins"]> = useMemo(() => {
-    const plugins: NonNullable<Options["rehypePlugins"]> = [[rehypeHighlight, { plainText: ["mermaid"] }]];
+    const plugins: NonNullable<Options["rehypePlugins"]> = [
+      [rehypeHighlight, { plainText: ["mermaid"] }],
+    ];
     if (katexPlugin) plugins.push(katexPlugin);
     return plugins;
   }, [katexPlugin]);

--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef } from "react";
-import ReactMarkdown from "react-markdown";
+import { useEffect, useMemo, useRef } from "react";
+import ReactMarkdown, { type Options } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
-import rehypeKatex from "rehype-katex";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGemoji from "remark-gemoji";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
+import { useKatexPlugin } from "../../hooks/useKatexPlugin";
 import { useSearch } from "../../hooks/useSearch";
 import { SearchBar } from "../layout/SearchBar";
 import { CodeBlockComponent } from "./CodeBlockComponent";
@@ -34,6 +34,7 @@ export function MarkdownViewer({
   const contentRef = useRef<HTMLDivElement>(null);
 
   const search = useSearch({ containerRef: contentRef });
+  const katexPlugin = useKatexPlugin(content);
 
   // Restore scroll position on mount
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only — restore once when tab activates
@@ -65,6 +66,12 @@ export function MarkdownViewer({
     onSearchClose();
   };
 
+  const rehypePlugins: NonNullable<Options["rehypePlugins"]> = useMemo(() => {
+    const plugins: NonNullable<Options["rehypePlugins"]> = [[rehypeHighlight, { plainText: ["mermaid"] }]];
+    if (katexPlugin) plugins.push(katexPlugin);
+    return plugins;
+  }, [katexPlugin]);
+
   return (
     <div className="flex-1 relative">
       {searchOpen && (
@@ -82,7 +89,7 @@ export function MarkdownViewer({
         <div ref={contentRef} className="markdown-body px-8 py-6 pb-[60vh]">
           <ReactMarkdown
             remarkPlugins={[remarkFrontmatter, remarkGfm, remarkMath, remarkGemoji]}
-            rehypePlugins={[[rehypeHighlight, { plainText: ["mermaid"] }], rehypeKatex]}
+            rehypePlugins={rehypePlugins}
             components={{
               ...headingComponents,
               a: LinkComponent,

--- a/src/components/markdown/MermaidDiagram.tsx
+++ b/src/components/markdown/MermaidDiagram.tsx
@@ -1,7 +1,14 @@
-import mermaid from "mermaid";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 let idCounter = 0;
+let mermaidPromise: Promise<typeof import("mermaid").default> | null = null;
+
+function loadMermaid() {
+  if (!mermaidPromise) {
+    mermaidPromise = import("mermaid").then((m) => m.default);
+  }
+  return mermaidPromise;
+}
 
 interface MermaidDiagramProps {
   code: string;
@@ -16,6 +23,7 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
 
   const renderDiagram = useCallback(async () => {
     try {
+      const mermaid = await loadMermaid();
       mermaid.initialize({
         startOnLoad: false,
         theme: isDark() ? "dark" : "default",

--- a/src/components/markdown/lazyKatex.ts
+++ b/src/components/markdown/lazyKatex.ts
@@ -14,10 +14,9 @@ export function hasMath(content: string): boolean {
 
 export function loadKatex(): Promise<RehypePlugin> {
   if (!katexPromise) {
-    katexPromise = Promise.all([
-      import("rehype-katex"),
-      import("katex/dist/katex.min.css"),
-    ]).then(([mod]) => mod.default as RehypePlugin);
+    katexPromise = Promise.all([import("rehype-katex"), import("katex/dist/katex.min.css")]).then(
+      ([mod]) => mod.default as RehypePlugin,
+    );
   }
   return katexPromise;
 }

--- a/src/components/markdown/lazyKatex.ts
+++ b/src/components/markdown/lazyKatex.ts
@@ -1,0 +1,23 @@
+import type { Options } from "react-markdown";
+
+type RehypePlugin = NonNullable<Options["rehypePlugins"]>[number];
+
+// Cheap detector — false positives just mean KaTeX loads when it didn't have to,
+// not a correctness problem. Matches $...$, $$...$$, \(...\), \[...\].
+const MATH_PATTERN = /\$\$[\s\S]+?\$\$|(?<!\\)\$[^\n$]+?\$|\\\(|\\\[/;
+
+let katexPromise: Promise<RehypePlugin> | null = null;
+
+export function hasMath(content: string): boolean {
+  return MATH_PATTERN.test(content);
+}
+
+export function loadKatex(): Promise<RehypePlugin> {
+  if (!katexPromise) {
+    katexPromise = Promise.all([
+      import("rehype-katex"),
+      import("katex/dist/katex.min.css"),
+    ]).then(([mod]) => mod.default as RehypePlugin);
+  }
+  return katexPromise;
+}

--- a/src/hooks/useKatexPlugin.ts
+++ b/src/hooks/useKatexPlugin.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import type { Options } from "react-markdown";
+import { hasMath, loadKatex } from "../components/markdown/lazyKatex";
+
+type RehypePlugin = NonNullable<Options["rehypePlugins"]>[number];
+
+/**
+ * Lazily loads `rehype-katex` (and its CSS) the first time `content` contains
+ * math. Returns `null` until the plugin is ready or if no math is present.
+ */
+export function useKatexPlugin(content: string): RehypePlugin | null {
+  const contentHasMath = hasMath(content);
+  const [plugin, setPlugin] = useState<RehypePlugin | null>(null);
+
+  useEffect(() => {
+    if (!contentHasMath) return;
+    let cancelled = false;
+    loadKatex().then((p) => {
+      if (!cancelled) setPlugin(() => p);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [contentHasMath]);
+
+  return contentHasMath ? plugin : null;
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "katex/dist/katex.min.css";
 @import "./platform.css";
 @import "./markdown.css";
 @import "./settings.css";


### PR DESCRIPTION
## Summary

Closes #99. Removes Mermaid core and KaTeX (JS + CSS + fonts) from the initial main chunk. Mermaid is fetched the first time a `mermaid` code block is rendered; KaTeX is fetched the first time a document contains math syntax. Both are cached at module scope, so they load once per webview and that single instance is shared across every tab.

## Changes

- `MermaidDiagram.tsx` — replace static `import mermaid` with a cached `import("mermaid")` inside the render effect.
- `lazyKatex.ts` (new) — `hasMath()` content scan and `loadKatex()` that dynamically imports `rehype-katex` + `katex/dist/katex.min.css` once.
- `useKatexPlugin.ts` (new) — small hook returning the rehype plugin once it's loaded for documents that need it.
- `MarkdownViewer.tsx` — consume the hook; conditionally include the KaTeX plugin in `rehypePlugins`.
- `app.css` — drop the global `katex/dist/katex.min.css` import (now lazy).

## Bundle impact

Measured with `pnpm build`:

| chunk                     | before     | after      | delta       |
|---------------------------|-----------:|-----------:|------------:|
| main JS chunk             | 2,047 KB   | 1,177 KB   | **-870 KB** (-42%) |
| KaTeX (own chunk)         | inlined    | 259 KB     | lazy        |
| Mermaid core (own chunk)  | inlined    | 600 KB     | lazy        |
| main CSS                  | 60 KB      | 31 KB      | -29 KB      |
| KaTeX CSS (own chunk)     | inlined    | 29 KB      | lazy        |
| total JS across all chunks| 5,412 KB   | 5,416 KB   | ~same       |

Result on a markdown doc with no math and no mermaid: ~900 KB fewer bytes downloaded and parsed at startup (main JS + KaTeX CSS that previously shipped in the global stylesheet).

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — 173/173 passing
- `pnpm build` — chunks verified (see table above)
- [x] Tested on macOS — diagram rendering still works; math still renders; documents with neither don't fetch the chunks
- [ ] Tested on Windows
- [ ] Tested on Linux

## Notes

The math detector is intentionally cheap (regex). False positives only mean KaTeX loads when it didn't strictly have to, which is harmless. False negatives are avoided by matching all four delimiters react-markdown's `remark-math` accepts.