### PR TITLE
docs(claude): add code organization rule

### DIFF
--- a/.claude/rules/code-organization.md
+++ b/.claude/rules/code-organization.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "src/**/*.{ts,tsx}"
+  - "src-tauri/src/**/*.rs"
+---
+
+# Code Organization Rules
+
+Keep files focused and readable. When a file starts to do more than one thing, split it before adding more.
+
+- One concern per file. A component file renders the component; pull schemas, regexes, lazy-loaders, sanitizers, and pure helpers into siblings.
+- Soft cap of ~200 lines per file. Hitting the cap is a signal to split, not a hard error.
+- Hooks live in `src/hooks/`. UI in `src/components/`. Pure logic next to its consumer or in `src/lib/`.
+- Module-level singletons (cached promises, counters) belong in their own module so the cache is shared and easy to find.
+- Tests sit beside the file under test (`Foo.tsx` ↔ `Foo.test.tsx`).
+- Don't pre-split for hypothetical reuse — split when the current file actually has two responsibilities.


### PR DESCRIPTION
## Summary

Adds `.claude/rules/code-organization.md` so the soft 200-line cap and one-concern-per-file split are persisted as a project rule for Claude Code sessions, alongside the existing `frontend.md`, `docs.md`, and `rust.md` rules.

Came up while landing #99 — pulling `lazyKatex` and `useKatexPlugin` out of `MarkdownViewer.tsx` instead of inlining was an explicit user direction; this commits the rule so future sessions follow it without re-prompting.

## Changes

- `.claude/rules/code-organization.md` (new)

## Testing

N/A — docs-only.