### PR TITLE
feat(markdown): render allowlisted raw HTML (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Built with [Tauri v2](https://v2.tauri.app), React 19, and TypeScript.
 - Copy button on code blocks
 - Math/LaTeX rendering — inline (`$...$`) and block (`$$...$$`) equations via KaTeX
 - Mermaid diagrams — flowcharts, sequence diagrams, Gantt charts, and more (theme-aware)
+- Inline HTML — `<kbd>`, `<sub>`, `<sup>`, `<details>`, alignment attributes (sanitised allowlist)
 - YAML frontmatter stripping — frontmatter is parsed and hidden from rendered output
 - Emoji shortcodes — `:smile:` → 😊, `:+1:` → 👍
 - Local and remote image display

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "react-markdown": "^10",
     "rehype-highlight": "^7",
     "rehype-katex": "^7.0.1",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gemoji": "^8.0.0",
     "remark-gfm": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,12 @@ importers:
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-frontmatter:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1710,8 +1716,17 @@ packages:
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
 
   hast-util-to-text@4.0.2:
     resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
@@ -1735,6 +1750,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2192,6 +2210,12 @@ packages:
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
@@ -4248,6 +4272,28 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -4267,6 +4313,16 @@ snapshots:
       vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
 
   hast-util-to-text@4.0.2:
     dependencies:
@@ -4299,6 +4355,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -5020,6 +5078,17 @@ snapshots:
       katex: 0.16.45
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   remark-frontmatter@5.0.0:
     dependencies:

--- a/sample.md
+++ b/sample.md
@@ -130,6 +130,23 @@ Glyph converts GitHub-style emoji shortcodes to Unicode:
 > "The best way to predict the future is to invent it."
 > — Alan Kay
 
+## Raw HTML
+
+Glyph allows a curated subset of inline HTML — the elements GitHub renders inside READMEs.
+
+Subscript: H<sub>2</sub>O. Superscript: E = mc<sup>2</sup>.
+
+Press <kbd>Cmd</kbd>+<kbd>K</kbd> to open the command palette.
+
+<details>
+<summary>Click to expand</summary>
+
+Hidden content lives inside `<details>` blocks. Useful for FAQs, troubleshooting steps, and changelog entries.
+
+</details>
+
+<p align="center">Centered paragraphs work too.</p>
+
 ## Images
 
 ### Remote Images

--- a/src/components/markdown/MarkdownViewer.test.tsx
+++ b/src/components/markdown/MarkdownViewer.test.tsx
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MarkdownViewer } from "./MarkdownViewer";
+
+vi.mock("./MermaidDiagram", () => ({
+  MermaidDiagram: ({ code }: { code: string }) => <div data-testid="mermaid-diagram">{code}</div>,
+}));
+
+function renderMd(content: string) {
+  return render(<MarkdownViewer content={content} searchOpen={false} onSearchClose={() => {}} />);
+}
+
+describe("MarkdownViewer raw HTML", () => {
+  it("renders allowed inline HTML elements", () => {
+    const { container } = renderMd("Press <kbd>Cmd</kbd>+<kbd>K</kbd> for H<sub>2</sub>O.");
+    expect(container.querySelectorAll("kbd")).toHaveLength(2);
+    expect(container.querySelector("sub")?.textContent).toBe("2");
+  });
+
+  it("renders <details>/<summary> blocks", () => {
+    const { container } = renderMd("<details>\n<summary>More</summary>\n\nhidden\n\n</details>");
+    expect(container.querySelector("details")).not.toBeNull();
+    expect(container.querySelector("summary")?.textContent).toBe("More");
+  });
+
+  it("strips <script> tags from raw HTML", () => {
+    const { container } = renderMd("ok <script>alert('xss')</script> done");
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.textContent).not.toContain("alert(");
+  });
+
+  it("strips on* event handlers", () => {
+    const { container } = renderMd('<p onclick="alert(1)">click</p>');
+    const p = container.querySelector("p");
+    expect(p).not.toBeNull();
+    expect(p?.getAttribute("onclick")).toBeNull();
+  });
+
+  it("strips javascript: URLs", () => {
+    const { container } = renderMd("[bad](javascript:alert(1))");
+    const a = container.querySelector("a");
+    const href = a?.getAttribute("href") ?? "";
+    expect(href.toLowerCase()).not.toMatch(/^javascript:/);
+  });
+});

--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef } from "react";
 import ReactMarkdown, { type Options } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGemoji from "remark-gemoji";
 import remarkGfm from "remark-gfm";
@@ -12,6 +14,7 @@ import { CodeBlockComponent } from "./CodeBlockComponent";
 import { headingComponents } from "./HeadingComponent";
 import { useImageComponent } from "./ImageComponent";
 import { LinkComponent } from "./LinkComponent";
+import { markdownSanitizeSchema } from "./sanitizeSchema";
 
 interface MarkdownViewerProps {
   content: string;
@@ -68,6 +71,8 @@ export function MarkdownViewer({
 
   const rehypePlugins: NonNullable<Options["rehypePlugins"]> = useMemo(() => {
     const plugins: NonNullable<Options["rehypePlugins"]> = [
+      rehypeRaw,
+      [rehypeSanitize, markdownSanitizeSchema],
       [rehypeHighlight, { plainText: ["mermaid"] }],
     ];
     if (katexPlugin) plugins.push(katexPlugin);

--- a/src/components/markdown/sanitizeSchema.ts
+++ b/src/components/markdown/sanitizeSchema.ts
@@ -1,0 +1,31 @@
+import { defaultSchema } from "rehype-sanitize";
+
+// Allowlist for raw HTML in markdown. Glyph is a local-file viewer so the
+// XSS surface is small, but we still strip <script>, on* handlers, and
+// javascript: URLs (defaultSchema's behaviour) and only widen the allowlist
+// to the GitHub-style elements/attributes README authors actually use.
+//
+// `style` is intentionally allowed: badges and centered headers in GitHub
+// READMEs frequently rely on inline style. If Glyph ever loads remote
+// content this needs to be revisited.
+export const markdownSanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames ?? []),
+    "kbd",
+    "sub",
+    "sup",
+    "details",
+    "summary",
+    "video",
+    "source",
+  ],
+  attributes: {
+    ...defaultSchema.attributes,
+    "*": [...(defaultSchema.attributes?.["*"] ?? []), "align", "style"],
+    img: [...(defaultSchema.attributes?.img ?? []), "align", "width", "height"],
+    details: [...(defaultSchema.attributes?.details ?? []), "open"],
+    video: ["src", "controls", "width", "height", "poster", "loop", "muted", "autoplay"],
+    source: ["src", "type"],
+  },
+};

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -254,3 +254,45 @@
   white-space: nowrap;
   border-width: 0;
 }
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 0.15em 0.4em;
+  font-family: var(--glyph-code-font, ui-monospace, monospace);
+  font-size: 0.85em;
+  line-height: 1;
+  color: var(--color-text-primary);
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  box-shadow: inset 0 -1px 0 var(--color-border);
+  vertical-align: middle;
+}
+
+.markdown-body details {
+  margin: 0 0 1em;
+  padding: 0.5em 0.75em;
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+}
+
+.markdown-body details > summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: revert;
+}
+
+.markdown-body details[open] > summary {
+  margin-bottom: 0.5em;
+}
+
+.markdown-body details > summary::marker {
+  color: var(--color-text-secondary);
+}
+
+.markdown-body sub,
+.markdown-body sup {
+  font-size: 0.75em;
+  line-height: 0;
+}


### PR DESCRIPTION
## Summary

Closes #96. Adds `rehype-raw` + `rehype-sanitize` to the rehype pipeline so the inline HTML elements GitHub renders inside READMEs survive: `<kbd>`, `<sub>`, `<sup>`, `<details>`/`<summary>`, `<video>`/`<source>`, plus `align`/`width`/`height` attributes and inline `style`.

The sanitiser starts from `rehype-sanitize`'s default schema (the one GitHub publishes) and only widens the allowlist for the elements/attributes README authors actually use. `<script>`, `on*` event handlers, `javascript:` URLs, and any non-allowlisted attribute are still stripped.

## Changes

- `package.json` — add `rehype-raw`, `rehype-sanitize`
- `MarkdownViewer.tsx` — wire `rehypeRaw` then `rehypeSanitize` ahead of highlight/katex (order matters)
- `sanitizeSchema.ts` (new) — extracted allowlist with the rationale for `style` documented inline
- `markdown.css` — styles for `kbd`, `details`/`summary`, `sub`/`sup`
- `MarkdownViewer.test.tsx` (new) — covers `<kbd>`/`<sub>` rendering, `<details>` rendering, `<script>` strip, `on*` strip, `javascript:` URL strip
- `sample.md` — new "Raw HTML" section demoing kbd / sup / details / centered alignment
- `README.md` — bullet under Markdown Rendering

## Bundle impact

Main chunk grows ~176 KB (rehype-raw + rehype-sanitize + parse5). With the lazy-loading from #99 in place this is dwarfed by the main-chunk savings there.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — 178/178 passing (5 new)
- `pnpm build` — succeeds
- [x] Tested on macOS — sample.md's new section renders correctly; injecting `<script>` in a doc renders nothing
- [ ] Tested on Windows
- [ ] Tested on Linux

## Security note

`style` is allowed globally (badges + centered headers in GitHub READMEs need it). `hast-util-sanitize` does not parse CSS values, so if Glyph ever loads remote markdown the `style` allowance should be revisited (documented in `sanitizeSchema.ts`).