### PR TITLE
docs: promote local conventions into repo

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -12,3 +12,8 @@ When shipping a user-facing feature, update in the same commit:
 - **`sample.md`** — showcase the feature where applicable (new markdown syntax gets a demo section; new shortcuts go in sample.md's shortcuts table)
 
 Treat these as part of the feature's definition of done, not a follow-up.
+
+## Style
+
+- **Don't name implementation libraries in user-facing copy.** Feature bullets describe what the user gets — "Markdown editor mode — syntax highlighting, line numbers", not "Editor mode with CodeMirror 6". Implementation details belong in `CONTRIBUTING.md`'s architecture section or PR descriptions.
+- Exceptions: KaTeX and Mermaid stay named because the library identity *is* the feature contract — users recognize the syntax (`$...$`, ` ```mermaid `) by the library name. If the library is just an internal choice, leave it out.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ cd src-tauri && cargo test      # Rust tests
 - **Testing (TS)**: Vitest + Testing Library — test files colocated as `*.test.{ts,tsx}`
 - **Testing (Rust)**: `#[cfg(test)]` modules in source files
 - **Imports**: Named exports, no default exports
+- **Issue titles**: imperative mood (e.g. "Add search within document", not "Search feature" or "feat: search"). Always tag with `enhancement`/`bug` + a `priority: *` label + a category label (`markdown`/`ui`/`navigation`) where it fits. Add new issues to the **Glyph Roadmap** project board with status **Todo**.
 
 ## Workflow
 
@@ -93,6 +94,8 @@ Run the **Create Release** workflow from GitHub Actions (`create-release.yml`) w
 The release workflow builds all platforms and publishes to Homebrew, Chocolatey, Scoop, AUR, PPA, and the Debian apt repo.
 
 Do **not** create releases manually with `gh release create` or push tags by hand — use the workflow.
+
+**Wait for CI to pass on `main` before triggering Create Release.** The release workflow assumes the latest commit is green; running it on a red `main` produces broken artifacts that get published to every package manager simultaneously. Check the CI badge or `gh run list --branch main --limit 1` first.
 
 ## Reporting Issues
 


### PR DESCRIPTION
## Summary

Promotes three conventions that lived only in local Claude memory into the repo, so they apply consistently when developing from another machine (or by other contributors).

## Changes

- **`CONTRIBUTING.md` — Conventions**: add issue-title rule (imperative mood, label set, project board status). Was implicit before; now explicit.
- **`CONTRIBUTING.md` — Releases**: add explicit "wait for CI to pass on `main`" guard before triggering the Create Release workflow. Avoids publishing broken artifacts to Homebrew/Chocolatey/Scoop/AUR/PPA simultaneously.
- **`.claude/rules/docs.md`**: add a "Style" subsection saying not to name implementation libraries in user-facing feature copy (KaTeX/Mermaid stay because the library identity is the feature contract).

## Testing

- [x] Reads cleanly on GitHub
- [ ] Tested on macOS — n/a
- [ ] Tested on Windows — n/a
- [ ] Tested on Linux — n/a

Docs only.

## Screenshots

n/a