### PR TITLE
fix(deps): override postcss to >=8.5.10 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
       "picomatch": "4.0.4",
       "lodash-es": "4.18.0",
       "dompurify": ">=3.4.0",
-      "uuid": ">=14.0.0"
+      "uuid": ">=14.0.0",
+      "postcss": ">=8.5.10"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   lodash-es: 4.18.0
   dompurify: '>=3.4.0'
   uuid: '>=14.0.0'
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -2164,8 +2165,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -5010,7 +5011,7 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.5.8:
+  postcss@8.5.13:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5368,7 +5369,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.13
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary

Resolves the open Dependabot security alert for postcss (GHSA-qx2v-qp2m-jg93, CVSS 6.1 — XSS via unescaped \`</style>\` in CSS stringify output).

postcss is a transitive dev-dependency through vite (and tailwindcss/vitest). We can't bump vite past it, so the cleanest fix is a pnpm override pinning postcss to a patched version.

## Changes

- `package.json` — add \`"postcss": ">=8.5.10"\` to \`pnpm.overrides\`
- `pnpm-lock.yaml` — regenerated; postcss now resolves to 8.5.13 (was 8.5.8)

## Vulnerability

| Field | Value |
|---|---|
| Advisory | [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) |
| Severity | Moderate (CVSS 6.1) |
| Vulnerable | postcss < 8.5.10 |
| Patched | postcss >= 8.5.10 |
| Path | dev → vite → postcss |

## Testing

- [x] \`pnpm install\` succeeds
- [x] \`pnpm why postcss\` shows 8.5.13
- [x] \`pnpm typecheck\` passes
- [ ] Tested on macOS — n/a (dev tooling only)
- [ ] Tested on Windows — n/a
- [ ] Tested on Linux — n/a

## Screenshots

n/a — config + lockfile.