### PR TITLE
ci(deps): auto-sync Tauri npm + regenerate ACL schemas on dependabot Cargo PRs

### DIFF
--- a/.github/workflows/dependabot-tauri-npm-sync.yml
+++ b/.github/workflows/dependabot-tauri-npm-sync.yml
@@ -1,0 +1,82 @@
+# Run from Actions → this workflow after a Dependabot Cargo PR bumps `tauri*` crates.
+# Two things happen on the Dependabot branch:
+#   1. `pnpm sync:tauri-npm` — re-aligns @tauri-apps/plugin-* npm packages with
+#      their matching Rust tauri-plugin-* crate versions.
+#   2. `cargo check` — invokes `tauri-build`, which regenerates the schemas under
+#      `src-tauri/gen/schemas/` (acl-manifests, capabilities, desktop-schema,
+#      macOS-schema). These are tracked for IDE autocomplete on capability files
+#      and drift whenever any tauri/tauri-plugin-* version changes.
+#
+# Any changes from either step are committed and pushed back to the branch in a
+# single commit so the PR ends up green and self-contained.
+#
+# Uses the default `GITHUB_TOKEN` (workflow_dispatch runs in your repo context,
+# unlike Dependabot-triggered workflows, which cannot access custom secrets or
+# push reliably to Dependabot branches).
+#
+# Input: branch name (e.g. `dependabot/cargo/src-tauri/tauri-plugins-…` or
+# `dependabot/cargo/src-tauri/all-dependencies-…`).
+
+name: Sync Tauri artifacts on Dependabot branches
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to update (e.g. dependabot/cargo/…)"
+        required: true
+        type: string
+
+concurrency:
+  group: tauri-sync-${{ inputs.branch }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - name: Install Linux Tauri build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Align @tauri-apps plugins with Cargo
+        run: pnpm sync:tauri-npm
+
+      - name: Regenerate Tauri ACL / capabilities schemas
+        working-directory: src-tauri
+        run: cargo check
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json pnpm-lock.yaml src-tauri/gen/schemas/
+          if git diff --cached --quiet; then
+            echo "No changes from sync (already aligned)"
+            exit 0
+          fi
+          git commit -m "chore(deps): align @tauri-apps plugins and regenerate schemas"
+          git push

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "sync:tauri-npm": "node scripts/sync-tauri-npm-versions.mjs",
+    "sync:tauri-npm:check": "node scripts/sync-tauri-npm-versions.mjs --check"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",

--- a/scripts/sync-tauri-npm-versions.mjs
+++ b/scripts/sync-tauri-npm-versions.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Keeps @tauri-apps/plugin-* versions in package.json aligned with resolved
+ * tauri-plugin-* versions from Cargo (Tauri requires matching major.minor for `tauri build`).
+ *
+ * Usage:
+ *   node scripts/sync-tauri-npm-versions.mjs           # pin package.json to Cargo + refresh lockfile
+ *   node scripts/sync-tauri-npm-versions.mjs --check   # exit 1 if major.minor diverges
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+const manifestPath = join(root, "src-tauri", "Cargo.toml");
+const packagePath = join(root, "package.json");
+const lockPath = join(root, "pnpm-lock.yaml");
+
+const checkOnly = process.argv.includes("--check");
+
+function rustPluginToNpmName(rustName) {
+	if (!rustName.startsWith("tauri-plugin-")) {
+		return null;
+	}
+	const rest = rustName.slice("tauri-plugin-".length);
+	return `@tauri-apps/plugin-${rest}`;
+}
+
+/** @param {string} v */
+function majorMinor(v) {
+	const m = /^(\d+)\.(\d+)/.exec(v);
+	if (!m) {
+		throw new Error(`Invalid semver: ${v}`);
+	}
+	return `${m[1]}.${m[2]}`;
+}
+
+/**
+ * Resolved versions from importers..dependencies in pnpm-lock.yaml
+ * @returns {Record<string, string>}
+ */
+function getPnpmResolvedPluginVersions() {
+	const text = readFileSync(lockPath, "utf8");
+	const start = text.indexOf("\n  .:");
+	if (start === -1) {
+		throw new Error("pnpm-lock.yaml: missing importers '.'");
+	}
+	const sub = text.slice(start);
+	const depStart = sub.indexOf("dependencies:");
+	if (depStart === -1) {
+		throw new Error("pnpm-lock.yaml: missing dependencies under importer");
+	}
+	const afterDeps = sub.slice(depStart);
+	const devStart = afterDeps.search(/\n {4}devDependencies:/);
+	const depBlock = devStart === -1 ? afterDeps : afterDeps.slice(0, devStart);
+	const map = {};
+	const re = / {6}['"](@tauri-apps\/plugin-[^'"]+)['"]:\s*\n {8}specifier:[^\n]+\n {8}version:\s+([0-9]+(?:\.[0-9]+)*)/g;
+	let m;
+	while ((m = re.exec(depBlock))) {
+		map[m[1]] = m[2];
+	}
+	return map;
+}
+
+function getResolvedRustPluginVersions() {
+	const json = execFileSync(
+		"cargo",
+		["metadata", "--format-version", "1", "--locked", "--manifest-path", manifestPath],
+		{ encoding: "utf8", maxBuffer: 32 * 1024 * 1024 },
+	);
+	const meta = JSON.parse(json);
+	const rootId = meta.resolve?.root;
+	if (!rootId) {
+		throw new Error("cargo metadata: missing resolve.root (need full metadata, not --no-deps)");
+	}
+	const rootNode = meta.resolve.nodes.find((n) => n.id === rootId);
+	if (!rootNode) {
+		throw new Error(`cargo metadata: could not find resolve node for ${rootId}`);
+	}
+	const byId = new Map(meta.packages.map((p) => [p.id, p]));
+	const out = new Map();
+	for (const dep of rootNode.deps) {
+		const pkg = byId.get(dep.pkg);
+		if (!pkg?.name?.startsWith("tauri-plugin-")) {
+			continue;
+		}
+		out.set(pkg.name, pkg.version);
+	}
+	return out;
+}
+
+function main() {
+	const rustVersions = getResolvedRustPluginVersions();
+	const pnpmResolved = getPnpmResolvedPluginVersions();
+
+	if (checkOnly) {
+		const mismatches = [];
+		for (const [rustName, rustVer] of rustVersions) {
+			const npmName = rustPluginToNpmName(rustName);
+			if (!npmName) {
+				continue;
+			}
+			const npmResolved = pnpmResolved[npmName];
+			if (!npmResolved) {
+				mismatches.push(`${npmName}: missing from pnpm-lock.yaml (add to package.json dependencies)`);
+				continue;
+			}
+			if (majorMinor(rustVer) !== majorMinor(npmResolved)) {
+				mismatches.push(
+					`${npmName}: Cargo resolves tauri ${rustVer} (major.minor ${majorMinor(rustVer)}), pnpm has ${npmResolved} (${majorMinor(npmResolved)})`,
+				);
+			}
+		}
+		if (mismatches.length > 0) {
+			console.error(
+				["Tauri plugin major.minor mismatch (breaks `tauri build`):", ...mismatches.map((l) => `  ${l}`), "", "Fix: pnpm sync:tauri-npm"].join("\n"),
+			);
+			process.exit(1);
+		}
+		console.log("Tauri Rust/npm plugin major.minor alignment OK.");
+		return;
+	}
+
+	const pkgRaw = readFileSync(packagePath, "utf8");
+	const pkg = JSON.parse(pkgRaw);
+	const deps = pkg.dependencies;
+	if (!deps || typeof deps !== "object") {
+		throw new Error("package.json: missing dependencies");
+	}
+
+	let changed = false;
+	for (const [rustName, version] of rustVersions) {
+		const npmName = rustPluginToNpmName(rustName);
+		if (!npmName || !(npmName in deps)) {
+			continue;
+		}
+		const current = String(deps[npmName]);
+		const normalized = current.replace(/^[\^~]/, "");
+		if (normalized !== version) {
+			deps[npmName] = version;
+			changed = true;
+		}
+	}
+
+	if (changed) {
+		writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+		execFileSync("pnpm", ["install"], { cwd: root, stdio: "inherit" });
+		console.log("Updated package.json and lockfile from Cargo resolved versions.");
+	} else {
+		console.log("Already aligned; no changes.");
+	}
+}
+
+main();


### PR DESCRIPTION
## Summary

Whenever Dependabot bumps a Tauri-ecosystem Cargo crate, two repo artifacts drift out of sync with the new versions and have to be regenerated by hand:

1. **`@tauri-apps/plugin-*` npm packages** must match the Rust `tauri-plugin-*` crates at major.minor — otherwise `tauri build` refuses with a version-mismatch error.
2. **`src-tauri/gen/schemas/*.json`** are emitted by `tauri-build` and must be re-emitted whenever any tauri version changes (otherwise IDEs lose autocomplete on capability files and PRs ship stale schemas).

Up to now neither was automated. PR #124 surfaced this — the schemas needed manual regeneration on the dependabot branch.

## Changes

- **`.github/workflows/dependabot-tauri-npm-sync.yml`** (new) — workflow_dispatch workflow that:
  - Checks out the named branch (typically a `dependabot/cargo/...` branch)
  - Installs Rust + Linux Tauri build deps + pnpm
  - Runs `pnpm sync:tauri-npm` to align the npm plugins
  - Runs `cargo check` so `tauri-build` regenerates `src-tauri/gen/schemas/`
  - Commits any changes to `package.json`, `pnpm-lock.yaml`, and `src-tauri/gen/schemas/` and pushes back to the branch
- **`scripts/sync-tauri-npm-versions.mjs`** (new) — node script that reads resolved versions from `cargo metadata`, rewrites matching `@tauri-apps/plugin-*` entries in `package.json`, and re-runs `pnpm install`. Supports a `--check` flag for CI assertions.
- **`package.json`** — adds two scripts:
  - `sync:tauri-npm` — pin and refresh
  - `sync:tauri-npm:check` — exit 1 if drift detected

## How to use

After Dependabot opens a Cargo PR that touches anything Tauri-related:

1. Go to **Actions → Sync Tauri artifacts on Dependabot branches → Run workflow**
2. Enter the branch name (e.g. `dependabot/cargo/src-tauri/tauri-plugins-…` or `dependabot/cargo/src-tauri/all-dependencies-…`)
3. The workflow pushes the alignment commit; CI re-runs and the PR can merge clean

Token: uses default `GITHUB_TOKEN` (no PAT needed) — `workflow_dispatch` runs in the repo context, unlike Dependabot-triggered workflows.

## Why workflow_dispatch and not pull_request

Dependabot-triggered `pull_request` runs use a restricted token that can't push to the dependabot branch reliably and can't access secrets. `workflow_dispatch` sidesteps both limits at the cost of one manual click per Cargo PR.

## Testing

- [x] `pnpm sync:tauri-npm:check` passes locally on main (no drift)
- [x] Workflow YAML validates
- [ ] Tested on macOS — n/a (CI workflow only)
- [ ] Tested on Windows — n/a
- [ ] Tested on Linux — exercised once the next dependabot Cargo PR lands

## Screenshots

n/a — CI + tooling.