### PR TITLE
ci: switch PPA upload to SFTP via ssh-ppa

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -484,12 +484,51 @@ jobs:
           # Build source package
           cd /tmp/glyph-${VERSION}
           DEBUILD_LINTIAN=no debuild -S -sa -d -k"$GPG_KEY_ID"
+      - name: Set up SSH for Launchpad
+        env:
+          LAUNCHPAD_SSH_PRIVATE_KEY: ${{ secrets.LAUNCHPAD_SSH_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$LAUNCHPAD_SSH_PRIVATE_KEY" > ~/.ssh/id_launchpad
+          chmod 600 ~/.ssh/id_launchpad
+          ssh-keyscan -t rsa,ecdsa,ed25519 ppa.launchpad.net >> ~/.ssh/known_hosts 2>/dev/null
+          cat >> ~/.ssh/config <<'EOF'
+          Host ppa.launchpad.net
+            IdentityFile ~/.ssh/id_launchpad
+            IdentitiesOnly yes
+          EOF
+          chmod 600 ~/.ssh/config
+      - name: Configure dput for SFTP upload
+        run: |
+          cat > ~/.dput.cf <<'EOF'
+          [ssh-ppa]
+          fqdn = ppa.launchpad.net
+          method = sftp
+          incoming = ~%(ssh-ppa)s
+          login = hamidfzm
+          allow_unsigned_uploads = 0
+          EOF
       - name: Upload to PPA
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           SERIES="${{ matrix.series }}"
+          CHANGES="glyph_${VERSION}-1~${SERIES}1_source.changes"
           cd /tmp
-          dput ppa:hamidfzm/glyph glyph_${VERSION}-1~${SERIES}1_source.changes
+          # SFTP via ssh-ppa: avoids Launchpad's FTP endpoint, which
+          # intermittently returns 550 mid-upload or rejects connections
+          # entirely from GitHub Actions runners.
+          for attempt in 1 2 3; do
+            if dput "ssh-ppa:hamidfzm/glyph" "$CHANGES"; then
+              echo "Upload succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Upload attempt $attempt failed; retrying in 30s..."
+            rm -f "/tmp/${CHANGES%.changes}.upload"
+            sleep 30
+          done
+          echo "All upload attempts failed"
+          exit 1
 
   publish-debian:
     needs: build


### PR DESCRIPTION
## Summary

Switch the `publish-ppa` job to upload via SFTP (`ssh-ppa:`) instead of Launchpad's anonymous FTP endpoint, which has been unreliable from GitHub-hosted runners.

The v0.5.0 release saw both PPA matrix jobs fail:
- `jammy`: `[Errno 101] Network is unreachable` — couldn't connect to ppa.launchpad.net at all (likely IPv6 routing on the Azure runner).
- `noble`: `550 Requested action not taken: internal server error` — server-side failure mid-upload after `.dsc` and `.orig.tar.gz` had already uploaded fine.

Launchpad's docs now recommend SFTP over FTP for exactly these reasons.

> ⚠️ **Draft / blocked on setup** — see "Required setup" below. The job will fail until both items are done.

## Changes

- Add **Set up SSH for Launchpad** step: writes `LAUNCHPAD_SSH_PRIVATE_KEY` to `~/.ssh/id_launchpad`, seeds `known_hosts` via `ssh-keyscan`, and pins the identity in `~/.ssh/config`.
- Add **Configure dput for SFTP upload** step: writes `~/.dput.cf` with an `[ssh-ppa]` stanza (`method = sftp`, `incoming = ~%(ssh-ppa)s`, `login = hamidfzm`).
- Replace `dput ppa:hamidfzm/glyph …` with `dput ssh-ppa:hamidfzm/glyph …` inside a 3-attempt retry loop with 30s backoff.

## Required setup (before merging)

This PR cannot be merged until both of these are in place, otherwise the next release will fail.

1. **Generate a CI-only SSH keypair**:
   \`\`\`
   ssh-keygen -t ed25519 -f launchpad_ci -C "glyph CI → Launchpad" -N ""
   \`\`\`
2. **Register the public key** on Launchpad: https://launchpad.net/~hamidfzm/+editsshkeys → paste contents of `launchpad_ci.pub`.
3. **Add the private key** as a repo secret named `LAUNCHPAD_SSH_PRIVATE_KEY` (paste the entire contents of `launchpad_ci`, including the `-----BEGIN/END-----` lines).

## Testing

- [ ] Cannot be tested locally — exercised on the next release tag (`vX.Y.Z`) once the secret is in place.
- [ ] Confirm both `publish-ppa (jammy)` and `publish-ppa (noble)` succeed on the next release run.

Refs: #95 unrelated — this fixes the publish-ppa job specifically.