### PR TITLE
fix(theme): apply OS dark preference before first paint

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Glyph</title>
+    <script>
+      // Set the theme class before any stylesheet evaluates so the first paint
+      // already has the right --color-surface, --color-text-primary, etc.
+      // SettingsContext will reapply this once the persisted theme loads;
+      // until then, we mirror the OS preference (matches the default "system" theme).
+      (function () {
+        try {
+          if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+            document.documentElement.classList.add("dark");
+          }
+        } catch (_) {}
+      })();
+    </script>
     <style>
       html, body, #root { height: 100%; margin: 0; padding: 0; }
       body {


### PR DESCRIPTION
## Summary

Fix a brief white flash visible when launching the app on a dark-mode OS.

## Root cause

`body { background: var(--color-surface) }`. On `:root` that token is `#ffffff`. The `.dark` class lives on `<html>` and is only added after `SettingsContext` finishes its async `Store.load()` — so the gap between first paint and that callback showed the light-theme surface.

## Change

Inline a tiny synchronous script in `<head>` that mirrors `prefers-color-scheme` onto `<html class="dark">` before any stylesheet evaluates. `SettingsContext` still reapplies the persisted theme on load; this just gets the first paint right for the default `system` theme.

Caveat: users who picked an explicit `light`/`dark` theme that contradicts their OS preference will still flash for one frame. That'd need persisting the resolved theme to localStorage on every change — a follow-up if anyone reports it.

## Testing

- [x] `pnpm typecheck`, `pnpm build` green
- [x] Confirmed locally: dark-OS launch no longer shows the white flash
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux