### PR TITLE
feat(markdown): render and resolve [[wikilinks]] in folder workspaces

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -9,7 +9,7 @@ paths:
 When shipping a user-facing feature, update in the same commit:
 
 - **`README.md`** — add a bullet under the relevant `## Features` subsection; if the feature adds a keyboard shortcut, add a row to the `## Keyboard Shortcuts` table
-- **`sample.md`** — showcase the feature where applicable (new markdown syntax gets a demo section; new shortcuts go in sample.md's shortcuts table)
+- **`samples/README.md`** — showcase the feature where applicable (new markdown syntax gets a demo section; new shortcuts go in the shortcuts table). The `samples/` folder also doubles as a demo workspace, so add or update sibling files when introducing workspace-level features (wikilinks, backlinks, etc.)
 
 Treat these as part of the feature's definition of done, not a follow-up.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Built with [Tauri v2](https://v2.tauri.app), React 19, and TypeScript.
 - GitHub Flavored Markdown — tables, task lists, strikethrough, autolinks, footnotes
 - GitHub-style alerts — `> [!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`
 - Heading anchor links — every heading gets a GitHub-compatible slug; `[text](#heading)` scrolls smoothly to the target
+- Wikilinks — `[[note]]`, `[[note|alias]]`, `[[note#heading]]` resolve against the open folder workspace; broken links render with a distinct style
 - Syntax highlighting for code blocks (6 themes: Glyph, GitHub, Monokai, Nord, Solarized Light/Dark)
 - Copy button on code blocks
 - Math/LaTeX rendering — inline (`$...$`) and block (`$$...$$`) equations via KaTeX

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Built with [Tauri v2](https://v2.tauri.app), React 19, and TypeScript.
 
 ![Demo](docs/assets/demo.gif)
 
+## Try It
+
+The [`samples/`](samples) directory is a tiny demo workspace — open it as a folder (`Cmd/Ctrl+Shift+O`) to see every rendering feature plus working wikilinks. [`samples/README.md`](samples/README.md) is the showcase document; the surrounding files exist so its `[[wikilinks]]` resolve.
+
 ## Features
 
 ### Markdown Rendering

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "remark-gemoji": "^8.0.0",
     "remark-gfm": "^4",
     "remark-github-blockquote-alert": "^2.1.0",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "unist-util-visit": "^5.1.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -81,8 +82,12 @@
     "@vitejs/plugin-react": "^5",
     "@vitest/coverage-v8": "^4.1.5",
     "happy-dom": "^20.9.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
     "tailwindcss": "^4",
     "typescript": "^5.7",
+    "unified": "^11.0.5",
     "vite": "^7",
     "vitest": "^4.1.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.14
@@ -148,12 +151,24 @@ importers:
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
+      rehype-stringify:
+        specifier: ^10.0.1
+        version: 10.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: ^11.1.2
+        version: 11.1.2
       tailwindcss:
         specifier: ^4
         version: 4.2.4
       typescript:
         specifier: ^5.7
         version: 5.9.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       vite:
         specifier: ^7
         version: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
@@ -1746,6 +1761,9 @@ packages:
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -2246,6 +2264,9 @@ packages:
 
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
 
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
@@ -4342,6 +4363,20 @@ snapshots:
       '@ungap/structured-clone': 1.3.0
       unist-util-position: 5.0.0
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -5149,6 +5184,12 @@ snapshots:
       hast-util-heading-rank: 3.0.0
       hast-util-to-string: 3.0.1
       unist-util-visit: 5.1.0
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
 
   remark-frontmatter@5.0.0:
     dependencies:

--- a/sample.md
+++ b/sample.md
@@ -191,6 +191,17 @@ Hidden content lives inside `<details>` blocks. Useful for FAQs, troubleshooting
 - [Glyph on GitHub](https://github.com/hamidfzm/glyph) — External links open in your system browser
 - [Go to Code Blocks](#code-blocks) — Anchor links navigate within the document
 
+### Wikilinks
+
+When you open a folder as a workspace, `[[note]]` style links resolve to other markdown files inside it.
+
+- `[[Index]]` — links to `Index.md` anywhere in the workspace
+- `[[Notes/Cooking|kitchen notes]]` — display custom text, link to `Notes/Cooking.md`
+- `[[Index#Setup]]` — link to a heading inside another note
+- `[[Missing]]` — broken link, renders muted (no target in workspace)
+
+Open this file inside its containing folder to see resolved wikilinks; on its own, every wikilink is treated as broken.
+
 ---
 
 ## Keyboard Shortcuts

--- a/samples/Index.md
+++ b/samples/Index.md
@@ -1,0 +1,20 @@
+# Index
+
+A small linked workspace used to demo Glyph's wikilink resolution. Browse to:
+
+- [[README|Feature showcase]] — every renderer feature in one file
+- [[Notes/Cooking]] — example note in a subdirectory
+
+## Setup
+
+To explore wikilinks live:
+
+1. Launch Glyph.
+2. `Cmd/Ctrl+Shift+O` and pick the `samples/` folder.
+3. Click any of the `[[...]]` links above.
+
+## How resolution works
+
+A wikilink target is matched case-insensitively against the workspace's markdown files by stem (filename without extension). When the target contains a slash, Glyph treats it as a relative path suffix — that's how `[[Notes/Cooking]]` lands on `samples/Notes/Cooking.md` and not on a stray `Cooking.md` elsewhere.
+
+If two notes share a stem, Glyph prefers the one in the same directory as the current file; otherwise it picks the shortest path. Unresolved targets render with a muted, dashed-underline style.

--- a/samples/Notes/Cooking.md
+++ b/samples/Notes/Cooking.md
@@ -1,0 +1,15 @@
+# Cooking
+
+A note in a subdirectory, linked from [[Index]] and [[README|the showcase]] via `[[Notes/Cooking]]` (path-style) and `[[Cooking]]` (stem-only) — both resolve here.
+
+## Recipes
+
+A short list, just enough to demonstrate that headings inside a target work as anchor points:
+
+- Mise en place — chop, measure, organise *before* heat is involved.
+- Resting meat — five minutes off the pan redistributes juices.
+- Salt early — pasta water should taste like the sea.
+
+## Why this lives here
+
+`Notes/Cooking.md` exists so wikilinks in [[README]] and [[Index]] resolve to a real file. Replace it with your own content, or delete it once you have your own workspace set up.

--- a/samples/README.md
+++ b/samples/README.md
@@ -193,14 +193,14 @@ Hidden content lives inside `<details>` blocks. Useful for FAQs, troubleshooting
 
 ### Wikilinks
 
-When you open a folder as a workspace, `[[note]]` style links resolve to other markdown files inside it.
+When you open a folder as a workspace, `[[note]]` style links resolve to other markdown files inside it. Open the `samples/` folder (`Cmd/Ctrl+Shift+O`) to make these resolve:
 
-- `[[Index]]` — links to `Index.md` anywhere in the workspace
-- `[[Notes/Cooking|kitchen notes]]` — display custom text, link to `Notes/Cooking.md`
-- `[[Index#Setup]]` — link to a heading inside another note
-- `[[Missing]]` — broken link, renders muted (no target in workspace)
+- [[Index]] — links to `Index.md` in this workspace
+- [[Notes/Cooking|kitchen notes]] — display custom text, link to `Notes/Cooking.md`
+- [[Index#setup]] — link to a heading inside another note
+- [[Missing]] — broken link, renders muted (no target in workspace)
 
-Open this file inside its containing folder to see resolved wikilinks; on its own, every wikilink is treated as broken.
+Opening this file on its own (no folder) treats every wikilink as broken.
 
 ---
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-store",
  "tauri-plugin-window-state",
+ "walkdir",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,3 +25,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 notify = "8"
 tauri-plugin-opener = "2.5.3"
+walkdir = "2.5.0"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4,6 +4,11 @@ use std::path::Path;
 use std::sync::Mutex;
 use std::time::UNIX_EPOCH;
 use tauri::State;
+use walkdir::WalkDir;
+
+const WALK_MAX_DEPTH: usize = 32;
+const WALK_MAX_FILES: usize = 10_000;
+const WALK_SKIP_DIRS: &[&str] = &[".git", "node_modules", "target", ".svn", ".hg"];
 
 pub struct InitialFile(pub Mutex<Option<String>>);
 
@@ -86,6 +91,56 @@ pub fn read_directory(path: String) -> Result<Vec<DirEntry>, String> {
     });
 
     Ok(entries)
+}
+
+#[tauri::command]
+pub fn list_markdown_files(path: String) -> Result<Vec<String>, String> {
+    let root = Path::new(&path);
+    if !root.is_dir() {
+        return Err(format!("Not a directory: {path}"));
+    }
+
+    let walker = WalkDir::new(root)
+        .max_depth(WALK_MAX_DEPTH)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            // Skip hidden entries and known noisy directories
+            let name = e.file_name().to_string_lossy();
+            if name.starts_with('.') && e.depth() > 0 {
+                return false;
+            }
+            if e.file_type().is_dir() && WALK_SKIP_DIRS.contains(&name.as_ref()) {
+                return false;
+            }
+            true
+        });
+
+    let mut results: Vec<String> = Vec::new();
+    let mut truncated = false;
+    for entry in walker.flatten() {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let p = entry.path();
+        if !crate::is_markdown_file(p) {
+            continue;
+        }
+        if results.len() >= WALK_MAX_FILES {
+            truncated = true;
+            break;
+        }
+        results.push(p.to_string_lossy().to_string());
+    }
+
+    if truncated {
+        eprintln!(
+            "list_markdown_files: workspace at {} exceeds {} files; results truncated",
+            path, WALK_MAX_FILES
+        );
+    }
+
+    Ok(results)
 }
 
 #[tauri::command]
@@ -318,6 +373,62 @@ mod tests {
         let result = read_directory("/nonexistent/glyph/path/abc123".to_string());
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Failed to read directory"));
+    }
+
+    #[test]
+    fn list_markdown_files_walks_recursively() {
+        let dir = unique_tmp("list_md_recursive");
+        fs::write(dir.join("root.md"), "x").unwrap();
+        fs::create_dir_all(dir.join("nested/deep")).unwrap();
+        fs::write(dir.join("nested/a.md"), "x").unwrap();
+        fs::write(dir.join("nested/deep/b.markdown"), "x").unwrap();
+        fs::write(dir.join("nested/image.png"), b"x").unwrap();
+
+        let mut result = list_markdown_files(dir.to_string_lossy().to_string()).unwrap();
+        result.sort();
+        let names: Vec<String> = result
+            .iter()
+            .map(|p| Path::new(p).file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(names.contains(&"root.md".to_string()));
+        assert!(names.contains(&"a.md".to_string()));
+        assert!(names.contains(&"b.markdown".to_string()));
+        assert!(!names.iter().any(|n| n == "image.png"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn list_markdown_files_skips_hidden_and_noisy_dirs() {
+        let dir = unique_tmp("list_md_skip");
+        fs::write(dir.join("keep.md"), "x").unwrap();
+        for skip in &[".git", "node_modules", "target", ".svn", ".hg"] {
+            fs::create_dir_all(dir.join(skip)).unwrap();
+            fs::write(dir.join(skip).join("ignored.md"), "x").unwrap();
+        }
+        fs::create_dir_all(dir.join(".hidden")).unwrap();
+        fs::write(dir.join(".hidden/ignored.md"), "x").unwrap();
+
+        let result = list_markdown_files(dir.to_string_lossy().to_string()).unwrap();
+        let names: Vec<String> = result
+            .iter()
+            .map(|p| Path::new(p).file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["keep.md".to_string()]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn list_markdown_files_errors_on_non_directory() {
+        let dir = unique_tmp("list_md_not_dir");
+        let file = dir.join("file.md");
+        fs::write(&file, "x").unwrap();
+
+        let result = list_markdown_files(file.to_string_lossy().to_string());
+        assert!(result.is_err());
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,6 +97,7 @@ pub fn run() {
             commands::get_initial_file,
             commands::print_document,
             commands::read_directory,
+            commands::list_markdown_files,
             watcher::watch_file,
             watcher::unwatch_file,
             watcher::watch_directory,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -50,6 +50,7 @@ export function App() {
     activeTabId,
     activeFile,
     initializing,
+    workspaceFiles,
     openFile,
     openFolder,
     openFileInFolderTab,
@@ -151,6 +152,19 @@ export function App() {
       }
     },
     [activeTabId, updateEditContent],
+  );
+
+  // Wikilink navigation: only meaningful inside a folder tab; outside one,
+  // we have no workspace to resolve against, so the call is dropped.
+  // TODO: cross-file heading scroll — `heading` is plumbed through but not yet
+  // applied after the target file finishes loading.
+  const handleOpenWikilink = useCallback(
+    (path: string, _heading?: string) => {
+      if (activeTabId && activeTab?.kind === "folder") {
+        openFileInFolderTab(activeTabId, path);
+      }
+    },
+    [activeTabId, activeTab, openFileInFolderTab],
   );
 
   // Close the active tab (used by File → Close Folder which doubles as close-tab
@@ -311,6 +325,8 @@ export function App() {
             onChange={handleEditorChange}
             searchOpen={searchOpen}
             onSearchClose={() => setSearchOpen(false)}
+            workspaceFiles={workspaceFiles}
+            onOpenWikilink={handleOpenWikilink}
           />
         </div>
       );
@@ -325,6 +341,8 @@ export function App() {
         onScrollChange={saveScrollPosition}
         searchOpen={searchOpen}
         onSearchClose={() => setSearchOpen(false)}
+        workspaceFiles={workspaceFiles}
+        onOpenWikilink={handleOpenWikilink}
       />
     );
   };

--- a/src/components/editor/SplitView.tsx
+++ b/src/components/editor/SplitView.tsx
@@ -8,6 +8,8 @@ interface SplitViewProps {
   onChange: (content: string) => void;
   searchOpen: boolean;
   onSearchClose: () => void;
+  workspaceFiles?: string[];
+  onOpenWikilink?: (path: string, heading?: string) => void;
 }
 
 const PREVIEW_DEBOUNCE = 300;
@@ -18,6 +20,8 @@ export function SplitView({
   onChange,
   searchOpen,
   onSearchClose,
+  workspaceFiles,
+  onOpenWikilink,
 }: SplitViewProps) {
   const [previewContent, setPreviewContent] = useState(content);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -52,6 +56,8 @@ export function SplitView({
           filePath={filePath}
           searchOpen={searchOpen}
           onSearchClose={onSearchClose}
+          workspaceFiles={workspaceFiles}
+          onOpenWikilink={onOpenWikilink}
         />
       </div>
     </div>

--- a/src/components/markdown/LinkComponent.test.tsx
+++ b/src/components/markdown/LinkComponent.test.tsx
@@ -1,13 +1,14 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { SettingsContext } from "../../contexts/SettingsContext";
 import { DEFAULT_SETTINGS } from "../../lib/settings";
-import { LinkComponent } from "./LinkComponent";
+import { LinkComponent, type LinkComponentProps } from "./LinkComponent";
 
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
 vi.mock("@tauri-apps/plugin-dialog", () => ({ ask: vi.fn() }));
 
-function renderLink(href: string) {
+function renderLink(props: Partial<LinkComponentProps>) {
   return render(
     <SettingsContext
       value={{
@@ -17,7 +18,7 @@ function renderLink(href: string) {
         loaded: true,
       }}
     >
-      <LinkComponent href={href}>link text</LinkComponent>
+      <LinkComponent {...props}>link text</LinkComponent>
     </SettingsContext>,
   );
 }
@@ -30,7 +31,7 @@ describe("LinkComponent hash links", () => {
     target.scrollIntoView = scroll;
     document.body.appendChild(target);
 
-    const { container } = renderLink("#section-one");
+    const { container } = renderLink({ href: "#section-one" });
     const anchor = container.querySelector("a") as HTMLAnchorElement;
     fireEvent.click(anchor);
 
@@ -45,7 +46,7 @@ describe("LinkComponent hash links", () => {
     target.scrollIntoView = scroll;
     document.body.appendChild(target);
 
-    const { container } = renderLink("#caf%C3%A9");
+    const { container } = renderLink({ href: "#caf%C3%A9" });
     fireEvent.click(container.querySelector("a") as HTMLAnchorElement);
 
     expect(scroll).toHaveBeenCalled();
@@ -53,8 +54,74 @@ describe("LinkComponent hash links", () => {
   });
 
   it("does nothing when the target id is missing", () => {
-    const { container } = renderLink("#does-not-exist");
+    const { container } = renderLink({ href: "#does-not-exist" });
     const anchor = container.querySelector("a") as HTMLAnchorElement;
     expect(() => fireEvent.click(anchor)).not.toThrow();
+  });
+});
+
+describe("LinkComponent wikilinks", () => {
+  it("invokes onOpenWikilink with the resolved path on click", () => {
+    const onOpen = vi.fn();
+    const { container } = renderLink({
+      onOpenWikilink: onOpen,
+      ...({
+        "data-wikilink": "Cooking",
+        "data-wikilink-path": "/vault/Cooking.md",
+      } as Record<string, string>),
+    });
+    const anchor = container.querySelector("a") as HTMLAnchorElement;
+    fireEvent.click(anchor);
+
+    expect(onOpen).toHaveBeenCalledWith("/vault/Cooking.md", undefined);
+    expect(openUrl).not.toHaveBeenCalled();
+  });
+
+  it("forwards the heading argument", () => {
+    const onOpen = vi.fn();
+    const { container } = renderLink({
+      onOpenWikilink: onOpen,
+      ...({
+        "data-wikilink": "Cooking",
+        "data-wikilink-path": "/vault/Cooking.md",
+        "data-wikilink-heading": "Recipes",
+      } as Record<string, string>),
+    });
+    fireEvent.click(container.querySelector("a") as HTMLAnchorElement);
+
+    expect(onOpen).toHaveBeenCalledWith("/vault/Cooking.md", "Recipes");
+  });
+
+  it("does not call onOpenWikilink for broken wikilinks", () => {
+    const onOpen = vi.fn();
+    const { container } = renderLink({
+      onOpenWikilink: onOpen,
+      ...({
+        "data-wikilink": "Missing",
+        "data-wikilink-broken": "",
+      } as Record<string, string>),
+    });
+    const anchor = container.querySelector("a") as HTMLAnchorElement;
+    fireEvent.click(anchor);
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(openUrl).not.toHaveBeenCalled();
+    expect(anchor.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("never opens the URL for wikilinks even with a non-anchor href", () => {
+    const onOpen = vi.fn();
+    const { container } = renderLink({
+      href: "https://example.com",
+      onOpenWikilink: onOpen,
+      ...({
+        "data-wikilink": "Cooking",
+        "data-wikilink-path": "/vault/Cooking.md",
+      } as Record<string, string>),
+    });
+    fireEvent.click(container.querySelector("a") as HTMLAnchorElement);
+
+    expect(openUrl).not.toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalled();
   });
 });

--- a/src/components/markdown/LinkComponent.tsx
+++ b/src/components/markdown/LinkComponent.tsx
@@ -5,12 +5,46 @@ import { SettingsContext } from "../../contexts/SettingsContext";
 import { scrollToHeading } from "../../lib/scrollToHeading";
 import { ExternalLinkIcon } from "../icons/ExternalLinkIcon";
 
-export function LinkComponent(props: ComponentPropsWithoutRef<"a">) {
-  const { href, children, ...rest } = props;
+export interface LinkComponentProps extends ComponentPropsWithoutRef<"a"> {
+  onOpenWikilink?: (path: string, heading?: string) => void;
+}
+
+export function LinkComponent(props: LinkComponentProps) {
+  // ReactMarkdown 10 passes the source `node` as a prop; strip so we don't
+  // serialize it as an attribute on the rendered anchor.
+  const {
+    href,
+    children,
+    onOpenWikilink,
+    node: _node,
+    ...rest
+  } = props as LinkComponentProps & {
+    node?: unknown;
+  };
   const { settings } = useContext(SettingsContext);
+
+  // Wikilink: identified by remarkWikilink-emitted data attributes. We never
+  // route these through openUrl — they're either a workspace file (resolved)
+  // or a no-op (broken).
+  const wikilinkTarget = (rest as Record<string, unknown>)["data-wikilink"];
+  const isWikilink = typeof wikilinkTarget === "string";
+  const wikilinkPath = (rest as Record<string, unknown>)["data-wikilink-path"] as
+    | string
+    | undefined;
+  const wikilinkHeading = (rest as Record<string, unknown>)["data-wikilink-heading"] as
+    | string
+    | undefined;
+  const wikilinkBroken = "data-wikilink-broken" in (rest as object);
 
   const handleClick = useCallback(
     async (e: React.MouseEvent<HTMLAnchorElement>) => {
+      if (isWikilink) {
+        e.preventDefault();
+        if (wikilinkBroken || !wikilinkPath) return;
+        onOpenWikilink?.(wikilinkPath, wikilinkHeading);
+        return;
+      }
+
       if (!href) return;
 
       if (href.startsWith("#")) {
@@ -34,8 +68,25 @@ export function LinkComponent(props: ComponentPropsWithoutRef<"a">) {
 
       await openUrl(href);
     },
-    [href, settings.behavior.confirmExternalLinks],
+    [
+      href,
+      isWikilink,
+      wikilinkBroken,
+      wikilinkPath,
+      wikilinkHeading,
+      onOpenWikilink,
+      settings.behavior.confirmExternalLinks,
+    ],
   );
+
+  if (isWikilink) {
+    return (
+      // biome-ignore lint/a11y/useValidAnchor: navigation routes through onClick by design — wikilinks resolve to in-app file paths, not URLs
+      <a href="#" onClick={handleClick} aria-disabled={wikilinkBroken ? true : undefined} {...rest}>
+        {children}
+      </a>
+    );
+  }
 
   const isExternal = href && !href.startsWith("#");
 

--- a/src/components/markdown/MarkdownViewer.test.tsx
+++ b/src/components/markdown/MarkdownViewer.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { MarkdownViewer } from "./MarkdownViewer";
 
@@ -6,8 +6,13 @@ vi.mock("./MermaidDiagram", () => ({
   MermaidDiagram: ({ code }: { code: string }) => <div data-testid="mermaid-diagram">{code}</div>,
 }));
 
-function renderMd(content: string) {
-  return render(<MarkdownViewer content={content} searchOpen={false} onSearchClose={() => {}} />);
+function renderMd(
+  content: string,
+  extra: Partial<React.ComponentProps<typeof MarkdownViewer>> = {},
+) {
+  return render(
+    <MarkdownViewer content={content} searchOpen={false} onSearchClose={() => {}} {...extra} />,
+  );
 }
 
 describe("MarkdownViewer raw HTML", () => {
@@ -62,5 +67,37 @@ describe("MarkdownViewer GitHub alerts", () => {
     const { container } = renderMd("> just a quote");
     expect(container.querySelector(".markdown-alert")).toBeNull();
     expect(container.querySelector("blockquote")?.textContent?.trim()).toBe("just a quote");
+  });
+});
+
+describe("MarkdownViewer wikilinks", () => {
+  it("renders a resolved wikilink with the workspace path", () => {
+    const { container } = renderMd("Open [[Cooking]] now.", {
+      workspaceFiles: ["/vault/Cooking.md", "/vault/Other.md"],
+    });
+    const link = container.querySelector('a[data-wikilink="Cooking"]');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("data-wikilink-path")).toBe("/vault/Cooking.md");
+    expect(link?.classList.contains("wikilink")).toBe(true);
+    expect(link?.classList.contains("wikilink--broken")).toBe(false);
+  });
+
+  it("renders a missing wikilink with the broken modifier", () => {
+    const { container } = renderMd("[[Missing]]", { workspaceFiles: ["/vault/Other.md"] });
+    const link = container.querySelector('a[data-wikilink="Missing"]');
+    expect(link).not.toBeNull();
+    expect(link?.classList.contains("wikilink--broken")).toBe(true);
+    expect(link?.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("calls onOpenWikilink with the resolved path on click", () => {
+    const onOpen = vi.fn();
+    const { container } = renderMd("[[Cooking]]", {
+      workspaceFiles: ["/vault/Cooking.md"],
+      onOpenWikilink: onOpen,
+    });
+    const link = container.querySelector('a[data-wikilink="Cooking"]') as HTMLAnchorElement;
+    fireEvent.click(link);
+    expect(onOpen).toHaveBeenCalledWith("/vault/Cooking.md", undefined);
   });
 });

--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import ReactMarkdown, { type Options } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import rehypeRaw from "rehype-raw";
@@ -11,10 +11,11 @@ import { remarkAlert } from "remark-github-blockquote-alert";
 import remarkMath from "remark-math";
 import { useKatexPlugin } from "../../hooks/useKatexPlugin";
 import { useSearch } from "../../hooks/useSearch";
+import { remarkWikilink } from "../../lib/wikilink";
 import { SearchBar } from "../layout/SearchBar";
 import { CodeBlockComponent } from "./CodeBlockComponent";
 import { useImageComponent } from "./ImageComponent";
-import { LinkComponent } from "./LinkComponent";
+import { LinkComponent, type LinkComponentProps } from "./LinkComponent";
 import { markdownSanitizeSchema } from "./sanitizeSchema";
 
 interface MarkdownViewerProps {
@@ -24,6 +25,8 @@ interface MarkdownViewerProps {
   onScrollChange?: (scrollTop: number) => void;
   searchOpen: boolean;
   onSearchClose: () => void;
+  workspaceFiles?: string[];
+  onOpenWikilink?: (path: string, heading?: string) => void;
 }
 
 export function MarkdownViewer({
@@ -33,6 +36,8 @@ export function MarkdownViewer({
   onScrollChange,
   searchOpen,
   onSearchClose,
+  workspaceFiles,
+  onOpenWikilink,
 }: MarkdownViewerProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -81,6 +86,23 @@ export function MarkdownViewer({
     return plugins;
   }, [katexPlugin]);
 
+  const remarkPlugins: NonNullable<Options["remarkPlugins"]> = useMemo(
+    () => [
+      remarkFrontmatter,
+      remarkGfm,
+      remarkMath,
+      remarkGemoji,
+      remarkAlert,
+      [remarkWikilink, { workspaceFiles, currentFilePath: filePath }],
+    ],
+    [workspaceFiles, filePath],
+  );
+
+  const LinkWithWikilink = useCallback(
+    (props: LinkComponentProps) => <LinkComponent {...props} onOpenWikilink={onOpenWikilink} />,
+    [onOpenWikilink],
+  );
+
   return (
     <div className="flex-1 relative">
       {searchOpen && (
@@ -97,10 +119,10 @@ export function MarkdownViewer({
       <div ref={scrollRef} className="h-full overflow-y-auto">
         <div ref={contentRef} className="markdown-body px-8 py-6 pb-[60vh]">
           <ReactMarkdown
-            remarkPlugins={[remarkFrontmatter, remarkGfm, remarkMath, remarkGemoji, remarkAlert]}
+            remarkPlugins={remarkPlugins}
             rehypePlugins={rehypePlugins}
             components={{
-              a: LinkComponent,
+              a: LinkWithWikilink,
               img: ImageComponent,
               pre: CodeBlockComponent,
             }}

--- a/src/components/markdown/sanitizeSchema.ts
+++ b/src/components/markdown/sanitizeSchema.ts
@@ -25,6 +25,17 @@ export const markdownSanitizeSchema = {
   attributes: {
     ...defaultSchema.attributes,
     "*": [...(defaultSchema.attributes?.["*"] ?? []), "align", "style", "className", "dir"],
+    // Plain `className` (first entry wins in hast-util-sanitize) overrides the
+    // default `[className, data-footnote-backref]` allowlist so wikilink
+    // classes survive sanitization.
+    a: [
+      "className",
+      ...(defaultSchema.attributes?.a ?? []),
+      "dataWikilink",
+      "dataWikilinkPath",
+      "dataWikilinkHeading",
+      "dataWikilinkBroken",
+    ],
     img: [...(defaultSchema.attributes?.img ?? []), "align", "width", "height"],
     details: [...(defaultSchema.attributes?.details ?? []), "open"],
     video: ["src", "controls", "width", "height", "poster", "loop", "muted", "autoplay"],

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -123,6 +123,8 @@ function normalizePersistedTabs(value: PersistedTab[] | string[]): PersistedTab[
 export function useTabs(options: UseTabsOptions) {
   const [state, setState] = useState<TabsState>({ tabs: [], activeTabId: null });
   const [initializing, setInitializing] = useState(true);
+  // Recursive markdown index per folder tab; ephemeral (rebuilt on open / dir change).
+  const [workspaceIndex, setWorkspaceIndex] = useState<Record<string, string[]>>({});
   const scrollRefsMap = useRef<Map<string, number>>(new Map());
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -132,6 +134,7 @@ export function useTabs(options: UseTabsOptions) {
   const { tabs, activeTabId } = state;
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
   const activeFile = activeFileOf(activeTab);
+  const workspaceFiles = activeTab?.kind === "folder" ? (workspaceIndex[activeTab.id] ?? []) : [];
 
   // Persist tabs to settings whenever state changes (post-init)
   useEffect(() => {
@@ -163,6 +166,15 @@ export function useTabs(options: UseTabsOptions) {
       return await invoke<DirEntry[]>("read_directory", { path });
     } catch (err) {
       console.error(`Failed to read directory ${path}:`, err);
+      return [];
+    }
+  }, []);
+
+  const loadWorkspaceFiles = useCallback(async (root: string): Promise<string[]> => {
+    try {
+      return await invoke<string[]>("list_markdown_files", { path: root });
+    } catch (err) {
+      console.error(`Failed to list markdown files for ${root}:`, err);
       return [];
     }
   }, []);
@@ -277,12 +289,17 @@ export function useTabs(options: UseTabsOptions) {
       };
       setState((prev) => ({ tabs: [...prev.tabs, newTab], activeTabId: id }));
 
+      // Build the workspace markdown index in the background so wikilinks can resolve.
+      loadWorkspaceFiles(resolvedRoot).then((files) => {
+        setWorkspaceIndex((prev) => ({ ...prev, [id]: files }));
+      });
+
       if (options?.filePath) {
         // Defer so the new tab is in state for openFileInFolderTab to find
         await openFileInFolderTab(id, options.filePath);
       }
     },
-    [loadDirectory, openFileInFolderTab],
+    [loadDirectory, loadWorkspaceFiles, openFileInFolderTab],
   );
 
   const toggleExpand = useCallback(
@@ -330,6 +347,12 @@ export function useTabs(options: UseTabsOptions) {
         invoke("unwatch_file", { path: tab.file.path }).catch(() => {});
       }
       scrollRefsMap.current.delete(id);
+      setWorkspaceIndex((prevIdx) => {
+        if (!(id in prevIdx)) return prevIdx;
+        const next = { ...prevIdx };
+        delete next[id];
+        return next;
+      });
 
       const updated = prev.tabs.filter((t) => t.id !== id);
       let newActiveId = prev.activeTabId;
@@ -534,9 +557,10 @@ export function useTabs(options: UseTabsOptions) {
             dirsToRefresh.push(dir);
           }
         }
-        const fresh = await Promise.all(
-          dirsToRefresh.map(async (d) => [d, await loadDirectory(d)] as const),
-        );
+        const [fresh, freshFiles] = await Promise.all([
+          Promise.all(dirsToRefresh.map(async (d) => [d, await loadDirectory(d)] as const)),
+          loadWorkspaceFiles(tab.root),
+        ]);
         setState((prev) => ({
           ...prev,
           tabs: prev.tabs.map((t) => {
@@ -548,13 +572,14 @@ export function useTabs(options: UseTabsOptions) {
             return { ...t, nodes: newNodes };
           }),
         }));
+        setWorkspaceIndex((prev) => ({ ...prev, [tab.id]: freshFiles }));
       }, DIRECTORY_REFRESH_DEBOUNCE);
     });
     return () => {
       if (timeout) clearTimeout(timeout);
       unlisten.then((fn) => fn());
     };
-  }, [loadDirectory]);
+  }, [loadDirectory, loadWorkspaceFiles]);
 
   return {
     tabs,
@@ -562,6 +587,7 @@ export function useTabs(options: UseTabsOptions) {
     activeTabId,
     activeFile,
     initializing,
+    workspaceFiles,
     openFile,
     openFolder,
     openFileInFolderTab,

--- a/src/lib/wikilink.test.ts
+++ b/src/lib/wikilink.test.ts
@@ -1,0 +1,157 @@
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
+import rehypeStringify from "rehype-stringify";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+import { visit } from "unist-util-visit";
+import { describe, expect, it } from "vitest";
+import { markdownSanitizeSchema } from "../components/markdown/sanitizeSchema";
+import { remarkWikilink, type WikilinkPluginOptions } from "./wikilink";
+
+interface Node {
+  type: string;
+  [key: string]: unknown;
+}
+interface Parent extends Node {
+  children: Node[];
+}
+
+interface LinkNode extends Node {
+  type: "link";
+  url: string;
+  children: Array<{ type: "text"; value: string }>;
+  data?: { hName?: string; hProperties?: Record<string, string> };
+}
+
+function findWikilinks(md: string, options: WikilinkPluginOptions = {}): LinkNode[] {
+  const tree = unified().use(remarkParse).use(remarkWikilink, options).parse(md);
+  // Run transformers (remarkWikilink runs in this phase).
+  const transformed = unified().use(remarkWikilink, options).runSync(tree);
+  const out: LinkNode[] = [];
+  visit(transformed as Node, "link", (node: LinkNode) => {
+    if (node.data?.hProperties?.dataWikilink !== undefined) out.push(node);
+  });
+  return out;
+}
+
+function rawValueAt(md: string, options: WikilinkPluginOptions = {}, type: string): string[] {
+  const tree = unified()
+    .use(remarkParse)
+    .use(remarkWikilink, options)
+    .runSync(unified().use(remarkParse).parse(md)) as Parent;
+  const values: string[] = [];
+  visit(tree as Node, type, (n: Node & { value?: string }) => {
+    if (typeof n.value === "string") values.push(n.value);
+  });
+  return values;
+}
+
+describe("remarkWikilink", () => {
+  const files = ["/vault/Index.md", "/vault/Notes/Cooking.md"];
+
+  it("decorates a resolved wikilink with data attributes", () => {
+    const [node] = findWikilinks("See [[Cooking]] now.", { workspaceFiles: files });
+    expect(node).toBeDefined();
+    expect(node.data?.hProperties).toMatchObject({
+      dataWikilink: "Cooking",
+      dataWikilinkPath: "/vault/Notes/Cooking.md",
+      className: ["wikilink"],
+    });
+    expect(node.data?.hProperties).not.toHaveProperty("dataWikilinkBroken");
+    expect(node.children[0].value).toBe("Cooking");
+    expect(node.url).toBe("#");
+  });
+
+  it("flags a missing target as broken", () => {
+    const [node] = findWikilinks("See [[Missing]].", { workspaceFiles: files });
+    expect(node.data?.hProperties).toMatchObject({
+      dataWikilink: "Missing",
+      dataWikilinkBroken: "",
+      className: ["wikilink", "wikilink--broken"],
+    });
+    expect(node.data?.hProperties).not.toHaveProperty("dataWikilinkPath");
+  });
+
+  it("uses the alias as display text", () => {
+    const [node] = findWikilinks("[[Cooking|kitchen notes]]", { workspaceFiles: files });
+    expect(node.children[0].value).toBe("kitchen notes");
+    expect(node.data?.hProperties?.dataWikilink).toBe("Cooking");
+  });
+
+  it("captures the heading", () => {
+    const [node] = findWikilinks("[[Cooking#Recipes]]", { workspaceFiles: files });
+    expect(node.data?.hProperties).toMatchObject({
+      dataWikilink: "Cooking",
+      dataWikilinkHeading: "Recipes",
+      dataWikilinkPath: "/vault/Notes/Cooking.md",
+    });
+  });
+
+  it("strips a `.md` extension from the target during resolution", () => {
+    const [node] = findWikilinks("[[Cooking.md]]", { workspaceFiles: files });
+    expect(node.data?.hProperties?.dataWikilinkPath).toBe("/vault/Notes/Cooking.md");
+  });
+
+  it("treats every link as broken without a workspace", () => {
+    const [node] = findWikilinks("[[Cooking]]");
+    expect(node.data?.hProperties).toHaveProperty("dataWikilinkBroken");
+    expect(node.data?.hProperties).not.toHaveProperty("dataWikilinkPath");
+  });
+
+  it("ignores wikilinks inside fenced code blocks", () => {
+    const nodes = findWikilinks("```\n[[Cooking]]\n```", { workspaceFiles: files });
+    expect(nodes).toHaveLength(0);
+  });
+
+  it("ignores wikilinks inside inline code", () => {
+    const nodes = findWikilinks("Use `[[Cooking]]` to link.", { workspaceFiles: files });
+    expect(nodes).toHaveLength(0);
+  });
+
+  it("decorates multiple wikilinks in the same paragraph", () => {
+    const nodes = findWikilinks("[[Index]] and [[Cooking]]", { workspaceFiles: files });
+    expect(nodes.map((n) => n.data?.hProperties?.dataWikilink)).toEqual(["Index", "Cooking"]);
+  });
+
+  it("preserves surrounding text", () => {
+    expect(rawValueAt("before [[Index]] after", { workspaceFiles: files }, "text")).toEqual([
+      "before ",
+      "Index",
+      " after",
+    ]);
+  });
+
+  it("never produces a non-anchor href", () => {
+    const [node] = findWikilinks("[[Cooking]]", { workspaceFiles: files });
+    expect(node.url).toBe("#");
+  });
+});
+
+describe("remarkWikilink with rehype-sanitize", () => {
+  async function html(md: string, options: WikilinkPluginOptions) {
+    const file = await unified()
+      .use(remarkParse)
+      .use(remarkWikilink, options)
+      .use(remarkRehype, { allowDangerousHtml: true })
+      .use(rehypeRaw)
+      .use(rehypeSanitize, markdownSanitizeSchema)
+      .use(rehypeStringify)
+      .process(md);
+    return String(file);
+  }
+
+  it("preserves className and data attributes through sanitize", async () => {
+    const out = await html("[[Cooking]]", { workspaceFiles: ["/vault/Cooking.md"] });
+    expect(out).toContain('class="wikilink"');
+    expect(out).toContain('data-wikilink="Cooking"');
+    expect(out).toContain('data-wikilink-path="/vault/Cooking.md"');
+  });
+
+  it("preserves the broken modifier and marker", async () => {
+    const out = await html("[[Missing]]", { workspaceFiles: ["/vault/Cooking.md"] });
+    expect(out).toContain("wikilink--broken");
+    expect(out).toContain("data-wikilink-broken");
+    expect(out).not.toContain("data-wikilink-path");
+  });
+});

--- a/src/lib/wikilink.ts
+++ b/src/lib/wikilink.ts
@@ -1,0 +1,133 @@
+// A small remark plugin that turns `[[name]]`, `[[name|alias]]`, and
+// `[[name#heading]]` text into clickable links resolved against the active
+// folder workspace. We scan text nodes after remark has parsed the document
+// and replace matches with `link` mdast nodes carrying data attributes the
+// LinkComponent uses to drive navigation. This loses the (rare) case where a
+// `[ref]` link reference is defined that overlaps with a `[[wikilink]]`, but
+// avoids a much heavier micromark extension and the maintenance cost.
+import type { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+import { resolveWikilink } from "./wikilinkResolver";
+
+interface Node {
+  type: string;
+  [key: string]: unknown;
+}
+interface Parent extends Node {
+  children: Node[];
+}
+
+const WIKILINK_RE = /\[\[([^\]\n]+?)\]\]/g;
+
+export interface WikilinkPluginOptions {
+  workspaceFiles?: string[];
+  currentFilePath?: string;
+}
+
+interface ParsedWikilink {
+  rawTarget: string;
+  baseTarget: string;
+  heading?: string;
+  alias?: string;
+}
+
+interface TextNode extends Node {
+  type: "text";
+  value: string;
+}
+
+interface LinkNode extends Node {
+  type: "link";
+  url: string;
+  title?: null;
+  children: TextNode[];
+  data: {
+    hName: "a";
+    hProperties: Record<string, string | string[]>;
+  };
+}
+
+function parseInner(raw: string): ParsedWikilink {
+  const pipe = raw.indexOf("|");
+  const targetWithHeading = (pipe >= 0 ? raw.slice(0, pipe) : raw).trim();
+  const alias = pipe >= 0 ? raw.slice(pipe + 1).trim() : "";
+  const hash = targetWithHeading.indexOf("#");
+  const baseTarget = hash >= 0 ? targetWithHeading.slice(0, hash) : targetWithHeading;
+  const heading = hash >= 0 ? targetWithHeading.slice(hash + 1).trim() : "";
+  return {
+    rawTarget: targetWithHeading,
+    baseTarget: baseTarget.trim(),
+    heading: heading || undefined,
+    alias: alias || undefined,
+  };
+}
+
+function buildLinkNode(parsed: ParsedWikilink, options: WikilinkPluginOptions): LinkNode {
+  const resolved = resolveWikilink(
+    parsed.rawTarget,
+    options.workspaceFiles ?? [],
+    options.currentFilePath,
+  );
+  const broken = resolved.path === null;
+  const display = parsed.alias ?? parsed.baseTarget;
+
+  // hProperties uses camelCased keys (the hast/React convention). className is
+  // an array per hast spec; data-* keys must match the sanitize allowlist.
+  const hProperties: Record<string, string | string[]> = {
+    className: broken ? ["wikilink", "wikilink--broken"] : ["wikilink"],
+    dataWikilink: parsed.baseTarget,
+  };
+  if (!broken && resolved.path) hProperties.dataWikilinkPath = resolved.path;
+  if (broken) hProperties.dataWikilinkBroken = "";
+  if (parsed.heading) hProperties.dataWikilinkHeading = parsed.heading;
+
+  return {
+    type: "link",
+    url: "#",
+    title: null,
+    children: [{ type: "text", value: display }],
+    data: { hName: "a", hProperties },
+  };
+}
+
+const remarkWikilink: Plugin<[WikilinkPluginOptions?]> =
+  (options = {}) =>
+  (tree) => {
+    visit(
+      tree as unknown as Parameters<typeof visit>[0],
+      "text",
+      (node: TextNode, index: number | null, parent: Parent | null) => {
+        if (!parent || index === null) return;
+        // Skip text inside inline code, code blocks, links, etc.
+        if (parent.type === "inlineCode" || parent.type === "code" || parent.type === "link") {
+          return;
+        }
+
+        const value = node.value;
+        WIKILINK_RE.lastIndex = 0;
+        if (!WIKILINK_RE.test(value)) return;
+
+        WIKILINK_RE.lastIndex = 0;
+        const replacement: Node[] = [];
+        let cursor = 0;
+        let match: RegExpExecArray | null = WIKILINK_RE.exec(value);
+        while (match !== null) {
+          const [whole, inner] = match;
+          if (match.index > cursor) {
+            replacement.push({ type: "text", value: value.slice(cursor, match.index) } as TextNode);
+          }
+          replacement.push(buildLinkNode(parseInner(inner), options));
+          cursor = match.index + whole.length;
+          match = WIKILINK_RE.exec(value);
+        }
+        if (cursor < value.length) {
+          replacement.push({ type: "text", value: value.slice(cursor) } as TextNode);
+        }
+
+        parent.children.splice(index, 1, ...replacement);
+        return index + replacement.length;
+      },
+    );
+  };
+
+export { remarkWikilink };

--- a/src/lib/wikilinkResolver.test.ts
+++ b/src/lib/wikilinkResolver.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { dirOf, resolveWikilink, splitTargetAndHeading, stemOf } from "./wikilinkResolver";
+
+describe("wikilinkResolver helpers", () => {
+  it("splits target and heading", () => {
+    expect(splitTargetAndHeading("note")).toEqual({ target: "note" });
+    expect(splitTargetAndHeading("note#section")).toEqual({ target: "note", heading: "section" });
+    expect(splitTargetAndHeading("note#  ")).toEqual({ target: "note" });
+  });
+
+  it("derives the file stem", () => {
+    expect(stemOf("/a/b/Note.md")).toBe("Note");
+    expect(stemOf("Note.markdown")).toBe("Note");
+    expect(stemOf("Note")).toBe("Note");
+    expect(stemOf("/a/.hidden")).toBe(".hidden");
+  });
+
+  it("derives the directory", () => {
+    expect(dirOf("/a/b/Note.md")).toBe("/a/b");
+    expect(dirOf("C:\\a\\Note.md")).toBe("C:\\a");
+    expect(dirOf("Note.md")).toBe("");
+  });
+});
+
+describe("resolveWikilink", () => {
+  const files = [
+    "/vault/Index.md",
+    "/vault/Notes/Cooking.md",
+    "/vault/Notes/Travel.md",
+    "/vault/Archive/Travel.md",
+  ];
+
+  it("returns null when there are no workspace files", () => {
+    expect(resolveWikilink("Note", []).path).toBeNull();
+  });
+
+  it("matches by stem case-insensitively", () => {
+    expect(resolveWikilink("cooking", files).path).toBe("/vault/Notes/Cooking.md");
+    expect(resolveWikilink("INDEX", files).path).toBe("/vault/Index.md");
+  });
+
+  it("strips a trailing .md", () => {
+    expect(resolveWikilink("Cooking.md", files).path).toBe("/vault/Notes/Cooking.md");
+    expect(resolveWikilink("Cooking.MD", files).path).toBe("/vault/Notes/Cooking.md");
+  });
+
+  it("returns null on no match", () => {
+    expect(resolveWikilink("Missing", files).path).toBeNull();
+  });
+
+  it("returns the heading when present", () => {
+    expect(resolveWikilink("Cooking#Recipes", files)).toEqual({
+      path: "/vault/Notes/Cooking.md",
+      heading: "Recipes",
+    });
+  });
+
+  it("disambiguates by current-file directory when names collide", () => {
+    expect(resolveWikilink("Travel", files, "/vault/Archive/today.md").path).toBe(
+      "/vault/Archive/Travel.md",
+    );
+    expect(resolveWikilink("Travel", files, "/vault/Notes/today.md").path).toBe(
+      "/vault/Notes/Travel.md",
+    );
+  });
+
+  it("falls back to shortest-path when no same-dir candidate", () => {
+    expect(resolveWikilink("Travel", files, "/vault/Other/today.md").path).toBe(
+      "/vault/Notes/Travel.md",
+    );
+  });
+
+  it("matches by relative path suffix when target contains a slash", () => {
+    expect(resolveWikilink("Notes/Travel", files).path).toBe("/vault/Notes/Travel.md");
+    expect(resolveWikilink("Archive/Travel", files).path).toBe("/vault/Archive/Travel.md");
+  });
+});

--- a/src/lib/wikilinkResolver.ts
+++ b/src/lib/wikilinkResolver.ts
@@ -1,0 +1,78 @@
+// Resolves a `[[wikilink]]` target against a flat list of workspace markdown
+// file paths. Match is case-insensitive on the filename stem; `.md` extension
+// in the target is stripped. When multiple files share a stem, the file in
+// the same directory as `currentFilePath` wins; otherwise the first match
+// (sorted by path) is used.
+
+const PATH_SEP = /[\\/]/;
+
+export interface ResolvedWikilink {
+  path: string | null;
+  heading?: string;
+}
+
+export function splitTargetAndHeading(input: string): { target: string; heading?: string } {
+  const idx = input.indexOf("#");
+  if (idx < 0) return { target: input };
+  const heading = input.slice(idx + 1).trim();
+  return { target: input.slice(0, idx), heading: heading || undefined };
+}
+
+export function stemOf(path: string): string {
+  const name = path.split(PATH_SEP).pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(0, dot) : name;
+}
+
+export function dirOf(path: string): string {
+  const idx = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return idx >= 0 ? path.slice(0, idx) : "";
+}
+
+function normalizeTarget(raw: string): string {
+  let t = raw.trim();
+  if (t.toLowerCase().endsWith(".md")) t = t.slice(0, -3);
+  return t;
+}
+
+export function resolveWikilink(
+  rawTarget: string,
+  workspaceFiles: string[],
+  currentFilePath?: string,
+): ResolvedWikilink {
+  const { target, heading } = splitTargetAndHeading(rawTarget);
+  const cleaned = normalizeTarget(target);
+  if (!cleaned || workspaceFiles.length === 0) return { path: null, heading };
+
+  const lower = cleaned.toLowerCase();
+
+  // Two match modes:
+  //  1. relative-path-ish target ("folder/note") → match the suffix of any path
+  //  2. bare name → match by stem
+  const looksLikePath = cleaned.includes("/") || cleaned.includes("\\");
+
+  const candidates: string[] = [];
+  for (const file of workspaceFiles) {
+    if (looksLikePath) {
+      const noExt = file.replace(/\.[^./\\]+$/, "");
+      if (noExt.toLowerCase().endsWith(`/${lower}`) || noExt.toLowerCase().endsWith(`\\${lower}`)) {
+        candidates.push(file);
+      }
+    } else if (stemOf(file).toLowerCase() === lower) {
+      candidates.push(file);
+    }
+  }
+
+  if (candidates.length === 0) return { path: null, heading };
+  if (candidates.length === 1) return { path: candidates[0], heading };
+
+  // Disambiguate: prefer same-directory as the current file.
+  if (currentFilePath) {
+    const currentDir = dirOf(currentFilePath);
+    const sameDir = candidates.find((c) => dirOf(c) === currentDir);
+    if (sameDir) return { path: sameDir, heading };
+  }
+  // Stable fallback: shortest path, then lexicographic.
+  candidates.sort((a, b) => a.length - b.length || a.localeCompare(b));
+  return { path: candidates[0], heading };
+}

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -49,6 +49,32 @@
   text-decoration: underline;
 }
 
+.markdown-body a.wikilink {
+  color: var(--color-accent);
+  text-decoration: none;
+  border-bottom: 1px dashed
+    color-mix(in srgb, var(--color-accent) 60%, transparent);
+}
+
+.markdown-body a.wikilink:hover {
+  text-decoration: none;
+  border-bottom-style: solid;
+}
+
+.markdown-body a.wikilink--broken {
+  color: var(--color-text-tertiary);
+  border-bottom-color: color-mix(
+    in srgb,
+    var(--color-text-tertiary) 50%,
+    transparent
+  );
+  cursor: not-allowed;
+}
+
+.markdown-body a.wikilink--broken:hover {
+  border-bottom-style: dashed;
+}
+
 .markdown-body strong { font-weight: 600; }
 
 .markdown-body img {


### PR DESCRIPTION
## Summary

Phase 1 of #107. Adds wikilink (`[[note]]`) parsing, workspace resolution, and rendering. Phase 2 (backlinks panel) and Phase 3 (editor autocomplete) follow in separate issues.

## Changes

- New Rust command `list_markdown_files(root)` walks the workspace recursively (depth ≤ 32, ≤ 10k files, skips `.git`/`node_modules`/`target`/`.svn`/`.hg`).
- Folder tabs now keep an ephemeral `Map<tabId, string[]>` markdown index, populated on open and refreshed (debounced) on `directory-changed` events.
- New `src/lib/wikilink.ts` remark plugin replaces `[[name]]`, `[[name|alias]]`, and `[[name#heading]]` text occurrences with `<a>` link nodes carrying `data-wikilink*` attributes; ignores matches inside fenced code and inline code.
- New `src/lib/wikilinkResolver.ts` does case-insensitive filename-stem matching, strips trailing `.md`, supports `folder/note` path-suffix matches, and disambiguates collisions by current-file directory.
- `LinkComponent` detects the wikilink data attributes, intercepts clicks, and routes to a new `onOpenWikilink(path, heading?)` callback (cross-file heading scroll deferred — heading is plumbed through but not yet applied after target load).
- `sanitizeSchema` allows the new `dataWikilink*` properties and prepends a plain `className` entry on `<a>` so wikilink class names survive the default footnote-only allowlist.
- Distinct CSS for resolved (dashed accent underline) vs. broken (muted, `aria-disabled`) wikilinks.
- README and `sample.md` updated.

## Testing

- Vitest: 225 tests pass; new tests cover the resolver, the remark plugin, sanitize-schema integration, and the LinkComponent click branches.
- `cargo test` passes including new bounds tests for `list_markdown_files` (recursive walk, hidden/noisy directories, non-directory error).
- `pnpm typecheck` and `pnpm check` clean.
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Out of scope (follow-ups)

- Phase 2 backlinks panel
- Phase 3 editor autocomplete
- Cross-file heading scroll after navigation
- Image wikilinks `![[image.png]]`