### PR TITLE
feat(markdown): add backlinks panel for folder workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - GitHub-style alerts — `> [!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`
 - Heading anchor links — every heading gets a GitHub-compatible slug; `[text](#heading)` scrolls smoothly to the target
 - Wikilinks — `[[note]]`, `[[note|alias]]`, `[[note#heading]]` resolve against the open folder workspace; broken links render with a distinct style
+- Backlinks panel — sidebar list of every workspace note that links to the current file, with surrounding-line snippets
 - Syntax highlighting for code blocks (6 themes: Glyph, GitHub, Monokai, Nord, Solarized Light/Dark)
 - Copy button on code blocks
 - Math/LaTeX rendering — inline (`$...$`) and block (`$$...$$`) equations via KaTeX

--- a/samples/README.md
+++ b/samples/README.md
@@ -202,6 +202,10 @@ When you open a folder as a workspace, `[[note]]` style links resolve to other m
 
 Opening this file on its own (no folder) treats every wikilink as broken.
 
+### Backlinks
+
+When you have the `samples/` folder open, the **Backlinks** section under the file tree lists every other note that links to the current document. This file is referenced from [[Index]] and [[Notes/Cooking]], so opening either of them will show *this* file in their backlinks panel.
+
 ---
 
 ## Keyboard Shortcuts

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,6 +9,8 @@ use walkdir::WalkDir;
 const WALK_MAX_DEPTH: usize = 32;
 const WALK_MAX_FILES: usize = 10_000;
 const WALK_SKIP_DIRS: &[&str] = &[".git", "node_modules", "target", ".svn", ".hg"];
+const SCAN_MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
+const SCAN_MAX_SNIPPET: usize = 200;
 
 pub struct InitialFile(pub Mutex<Option<String>>);
 
@@ -19,6 +21,19 @@ pub struct FileMetadata {
     pub path: String,
     pub size: u64,
     pub modified: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikilinkRef {
+    /// Absolute path of the file containing the wikilink.
+    pub source: String,
+    /// Raw target as written, including any `name|alias` and `#heading`.
+    pub target: String,
+    /// 1-based line number of the match.
+    pub line: u32,
+    /// Trimmed snippet of surrounding text (line, capped to ~200 chars).
+    pub snippet: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -141,6 +156,117 @@ pub fn list_markdown_files(path: String) -> Result<Vec<String>, String> {
     }
 
     Ok(results)
+}
+
+#[tauri::command]
+pub fn scan_wikilinks(path: String) -> Result<Vec<WikilinkRef>, String> {
+    let root = Path::new(&path);
+    if !root.is_dir() {
+        return Err(format!("Not a directory: {path}"));
+    }
+
+    let walker = WalkDir::new(root)
+        .max_depth(WALK_MAX_DEPTH)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            let name = e.file_name().to_string_lossy();
+            if name.starts_with('.') && e.depth() > 0 {
+                return false;
+            }
+            if e.file_type().is_dir() && WALK_SKIP_DIRS.contains(&name.as_ref()) {
+                return false;
+            }
+            true
+        });
+
+    let mut refs: Vec<WikilinkRef> = Vec::new();
+    let mut files_scanned = 0usize;
+    for entry in walker.flatten() {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let p = entry.path();
+        if !crate::is_markdown_file(p) {
+            continue;
+        }
+        if files_scanned >= WALK_MAX_FILES {
+            break;
+        }
+        files_scanned += 1;
+
+        if let Ok(meta) = entry.metadata() {
+            if meta.len() > SCAN_MAX_FILE_BYTES {
+                continue;
+            }
+        }
+
+        let Ok(content) = fs::read_to_string(p) else {
+            continue;
+        };
+        let source = p.to_string_lossy().to_string();
+        scan_wikilinks_in_file(&content, &source, &mut refs);
+    }
+
+    Ok(refs)
+}
+
+fn scan_wikilinks_in_file(content: &str, source: &str, out: &mut Vec<WikilinkRef>) {
+    let mut in_fence = false;
+    for (idx, line) in content.lines().enumerate() {
+        let trimmed_start = line.trim_start();
+        if trimmed_start.starts_with("```") || trimmed_start.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+
+        let bytes = line.as_bytes();
+        let mut i = 0;
+        while i + 1 < bytes.len() {
+            if bytes[i] != b'[' || bytes[i + 1] != b'[' {
+                i += 1;
+                continue;
+            }
+            let inner_start = i + 2;
+            let mut j = inner_start;
+            let mut found = false;
+            while j + 1 < bytes.len() {
+                if bytes[j] == b']' && bytes[j + 1] == b']' {
+                    found = true;
+                    break;
+                }
+                j += 1;
+            }
+            if !found {
+                break;
+            }
+            if let Ok(target_str) = std::str::from_utf8(&bytes[inner_start..j]) {
+                let target = target_str.trim();
+                if !target.is_empty() && !target.contains('\n') {
+                    out.push(WikilinkRef {
+                        source: source.to_string(),
+                        target: target.to_string(),
+                        line: (idx + 1) as u32,
+                        snippet: snippet_for(line),
+                    });
+                }
+            }
+            i = j + 2;
+        }
+    }
+}
+
+fn snippet_for(line: &str) -> String {
+    let trimmed = line.trim();
+    if trimmed.chars().count() <= SCAN_MAX_SNIPPET {
+        return trimmed.to_string();
+    }
+    let mut out: String = trimmed.chars().take(SCAN_MAX_SNIPPET).collect();
+    out.push('…');
+    out
 }
 
 #[tauri::command]
@@ -429,6 +555,110 @@ mod tests {
         assert!(result.is_err());
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_finds_basic_targets() {
+        let dir = unique_tmp("scan_basic");
+        fs::write(dir.join("a.md"), "Read [[B]] today.\nAlso [[B|the second]].\n").unwrap();
+        fs::write(dir.join("b.md"), "no links here").unwrap();
+
+        let mut refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
+        refs.sort_by_key(|r| (r.source.clone(), r.line));
+        let from_a: Vec<_> = refs.iter().filter(|r| r.source.ends_with("a.md")).collect();
+        assert_eq!(from_a.len(), 2);
+        assert_eq!(from_a[0].target, "B");
+        assert_eq!(from_a[0].line, 1);
+        assert_eq!(from_a[1].target, "B|the second");
+        assert_eq!(from_a[1].line, 2);
+        assert!(from_a[0].snippet.contains("[[B]]"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_skips_fenced_code() {
+        let dir = unique_tmp("scan_fenced");
+        fs::write(
+            dir.join("a.md"),
+            "before [[Real]]\n```\n[[InsideFence]]\n```\nafter [[AlsoReal]]\n",
+        )
+        .unwrap();
+
+        let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
+        let targets: Vec<&str> = refs.iter().map(|r| r.target.as_str()).collect();
+        assert!(targets.contains(&"Real"));
+        assert!(targets.contains(&"AlsoReal"));
+        assert!(!targets.contains(&"InsideFence"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_handles_multiple_per_line() {
+        let dir = unique_tmp("scan_multi");
+        fs::write(dir.join("a.md"), "[[One]] then [[Two]] then [[Three]]\n").unwrap();
+
+        let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
+        let targets: Vec<&str> = refs.iter().map(|r| r.target.as_str()).collect();
+        assert_eq!(targets, vec!["One", "Two", "Three"]);
+        for r in &refs {
+            assert_eq!(r.line, 1);
+        }
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_records_line_and_snippet() {
+        let dir = unique_tmp("scan_meta");
+        fs::write(dir.join("a.md"), "line one\nline two has [[Target#section|alias]] here\n").unwrap();
+
+        let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].line, 2);
+        assert_eq!(refs[0].target, "Target#section|alias");
+        assert!(refs[0].snippet.starts_with("line two has"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_truncates_long_snippets() {
+        let dir = unique_tmp("scan_long");
+        let long_line = format!("{}[[Target]]{}", "x".repeat(150), "y".repeat(150));
+        fs::write(dir.join("a.md"), &long_line).unwrap();
+
+        let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
+        assert_eq!(refs.len(), 1);
+        assert!(refs[0].snippet.ends_with('…'));
+        assert!(refs[0].snippet.chars().count() <= SCAN_MAX_SNIPPET + 1);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_errors_on_non_directory() {
+        let dir = unique_tmp("scan_not_dir");
+        let file = dir.join("a.md");
+        fs::write(&file, "x").unwrap();
+        let result = scan_wikilinks(file.to_string_lossy().to_string());
+        assert!(result.is_err());
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn wikilink_ref_camel_case_keys() {
+        let r = WikilinkRef {
+            source: "/x/a.md".to_string(),
+            target: "B".to_string(),
+            line: 3,
+            snippet: "see [[B]]".to_string(),
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"source\":"));
+        assert!(json.contains("\"line\":3"));
+        assert!(!json.contains("source_path"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -98,6 +98,7 @@ pub fn run() {
             commands::print_document,
             commands::read_directory,
             commands::list_markdown_files,
+            commands::scan_wikilinks,
             watcher::watch_file,
             watcher::unwatch_file,
             watcher::watch_directory,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,6 +10,7 @@ import { useTableOfContents } from "../hooks/useTableOfContents";
 import { activeFileOf, useTabs } from "../hooks/useTabs";
 import { useTheme } from "../hooks/useTheme";
 import { useTTS } from "../hooks/useTTS";
+import { filterBacklinks } from "../lib/backlinks";
 import { ZOOM_DEFAULT, ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from "../lib/settings";
 // Code theme CSS (inline imports for production compatibility)
 import glyphThemeCSS from "../styles/highlight.css?inline";
@@ -51,6 +52,7 @@ export function App() {
     activeFile,
     initializing,
     workspaceFiles,
+    wikilinkRefs,
     openFile,
     openFolder,
     openFileInFolderTab,
@@ -80,6 +82,10 @@ export function App() {
   const displayContent = activeMode !== "view" ? (activeFile?.editContent ?? content) : content;
 
   const tocEntries = useTableOfContents(displayContent);
+  const backlinks = useMemo(
+    () => (filePath ? filterBacklinks(wikilinkRefs, workspaceFiles, filePath) : []),
+    [wikilinkRefs, workspaceFiles, filePath],
+  );
   const [filesSidebarVisible, setFilesSidebarVisible] = useState(
     settings.layout.filesSidebarVisible,
   );
@@ -367,6 +373,7 @@ export function App() {
           side="left"
           activeTab={activeTab}
           tocEntries={tocEntries}
+          backlinks={backlinks}
           filesVisible={filesSidebarVisible}
           outlineVisible={outlineSidebarVisible}
           sidebarLayout={settings.layout.sidebarLayout}
@@ -396,6 +403,7 @@ export function App() {
           side="right"
           activeTab={activeTab}
           tocEntries={tocEntries}
+          backlinks={backlinks}
           filesVisible={filesSidebarVisible}
           outlineVisible={outlineSidebarVisible}
           sidebarLayout={settings.layout.sidebarLayout}

--- a/src/components/layout/BacklinksSection.test.tsx
+++ b/src/components/layout/BacklinksSection.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Backlink } from "../../lib/backlinks";
+import { BacklinksSection } from "./BacklinksSection";
+
+const root = "/vault";
+const backlinks: Backlink[] = [
+  { source: "/vault/Index.md", line: 4, snippet: "see [[Cooking]]" },
+  { source: "/vault/Notes/Travel.md", line: 12, snippet: "ref to [[Cooking]] here" },
+];
+
+describe("BacklinksSection", () => {
+  it("renders nothing when there are no backlinks", () => {
+    const { container } = render(
+      <BacklinksSection backlinks={[]} workspaceRoot={root} onOpen={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows the count and one row per backlink", () => {
+    render(<BacklinksSection backlinks={backlinks} workspaceRoot={root} onOpen={vi.fn()} />);
+    expect(screen.getByText("Backlinks")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("Index.md")).toBeTruthy();
+    expect(screen.getByText("Notes/Travel.md")).toBeTruthy();
+  });
+
+  it("renders snippets for each entry", () => {
+    render(<BacklinksSection backlinks={backlinks} workspaceRoot={root} onOpen={vi.fn()} />);
+    expect(screen.getByText("see [[Cooking]]")).toBeTruthy();
+    expect(screen.getByText("ref to [[Cooking]] here")).toBeTruthy();
+  });
+
+  it("invokes onOpen with source and line on click", () => {
+    const onOpen = vi.fn();
+    render(<BacklinksSection backlinks={backlinks} workspaceRoot={root} onOpen={onOpen} />);
+    fireEvent.click(screen.getByText("Index.md"));
+    expect(onOpen).toHaveBeenCalledWith("/vault/Index.md", 4);
+  });
+
+  it("collapses on header click", () => {
+    render(<BacklinksSection backlinks={backlinks} workspaceRoot={root} onOpen={vi.fn()} />);
+    const header = screen.getByRole("button", { name: /backlinks/i });
+    fireEvent.click(header);
+    expect(screen.queryByText("Index.md")).toBeNull();
+  });
+});

--- a/src/components/layout/BacklinksSection.tsx
+++ b/src/components/layout/BacklinksSection.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import type { Backlink } from "../../lib/backlinks";
+
+interface BacklinksSectionProps {
+  backlinks: Backlink[];
+  workspaceRoot: string;
+  onOpen: (path: string, line?: number) => void;
+}
+
+function relativeName(path: string, root: string): string {
+  if (path.startsWith(`${root}/`) || path.startsWith(`${root}\\`)) {
+    return path.slice(root.length + 1);
+  }
+  return path.split(/[\\/]/).pop() ?? path;
+}
+
+export function BacklinksSection({ backlinks, workspaceRoot, onOpen }: BacklinksSectionProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  if (backlinks.length === 0) return null;
+
+  return (
+    <section className="backlinks-section">
+      <button
+        type="button"
+        onClick={() => setCollapsed((c) => !c)}
+        className="flex items-center gap-1 w-full text-left text-xs font-semibold text-[var(--color-text-tertiary)] uppercase tracking-wider mb-2 hover:text-[var(--color-text-secondary)] transition-colors"
+        aria-expanded={!collapsed}
+      >
+        <span aria-hidden="true" className="inline-block w-3">
+          {collapsed ? "▸" : "▾"}
+        </span>
+        <span>Backlinks</span>
+        <span className="text-[var(--color-text-tertiary)] font-normal normal-case tracking-normal">
+          {backlinks.length}
+        </span>
+      </button>
+      {!collapsed && (
+        <ul className="space-y-1">
+          {backlinks.map((b) => (
+            <li key={`${b.source}:${b.line}`}>
+              <button
+                type="button"
+                onClick={() => onOpen(b.source, b.line)}
+                className="block w-full text-left text-sm px-2 py-1 rounded-[var(--glyph-radius-sm)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] hover:text-[var(--color-text-primary)] transition-colors"
+                title={`${b.source}:${b.line}`}
+              >
+                <div className="truncate font-medium">{relativeName(b.source, workspaceRoot)}</div>
+                <div className="truncate text-xs text-[var(--color-text-tertiary)]">
+                  {b.snippet}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,17 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { TocEntry } from "../../hooks/useTableOfContents";
 import type { Tab } from "../../hooks/useTabs";
+import type { Backlink } from "../../lib/backlinks";
 import { onActiveHeadingChange, scrollToHeading } from "../../lib/scrollToHeading";
 import type { SidebarLayout } from "../../lib/settings";
 import { FolderIcon } from "../icons/FolderIcon";
 import { OutlineIcon } from "../icons/OutlineIcon";
 import { PanelCollapseIcon } from "../icons/PanelCollapseIcon";
+import { BacklinksSection } from "./BacklinksSection";
 import { FileTree } from "./FileTree";
 
 interface SidebarProps {
   side: "left" | "right";
   activeTab: Tab | null;
   tocEntries: TocEntry[];
+  backlinks?: Backlink[];
   filesVisible: boolean;
   outlineVisible: boolean;
   sidebarLayout: SidebarLayout;
@@ -196,6 +199,7 @@ export function Sidebar({
   side,
   activeTab,
   tocEntries,
+  backlinks = [],
   filesVisible,
   outlineVisible,
   sidebarLayout,
@@ -244,6 +248,15 @@ export function Sidebar({
         onOpenFile={(path) => onOpenFileInTab(folder.id, path)}
         onOpenFileInNewTab={onOpenFileInNewTab}
       />
+      {backlinks.length > 0 && (
+        <div className="mt-4 pt-3 border-t border-[var(--color-border)]">
+          <BacklinksSection
+            backlinks={backlinks}
+            workspaceRoot={folder.root}
+            onOpen={(path) => onOpenFileInTab(folder.id, path)}
+          />
+        </div>
+      )}
     </div>
   );
 

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { WikilinkRef } from "../lib/backlinks";
 import { MARKDOWN_EXTENSIONS } from "../lib/markdownExtensions";
 import type { EditorMode } from "../lib/settings";
 
@@ -125,6 +126,8 @@ export function useTabs(options: UseTabsOptions) {
   const [initializing, setInitializing] = useState(true);
   // Recursive markdown index per folder tab; ephemeral (rebuilt on open / dir change).
   const [workspaceIndex, setWorkspaceIndex] = useState<Record<string, string[]>>({});
+  // Outbound wikilink references per folder tab; used to compute backlinks.
+  const [wikilinkIndex, setWikilinkIndex] = useState<Record<string, WikilinkRef[]>>({});
   const scrollRefsMap = useRef<Map<string, number>>(new Map());
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -135,6 +138,7 @@ export function useTabs(options: UseTabsOptions) {
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
   const activeFile = activeFileOf(activeTab);
   const workspaceFiles = activeTab?.kind === "folder" ? (workspaceIndex[activeTab.id] ?? []) : [];
+  const wikilinkRefs = activeTab?.kind === "folder" ? (wikilinkIndex[activeTab.id] ?? []) : [];
 
   // Persist tabs to settings whenever state changes (post-init)
   useEffect(() => {
@@ -175,6 +179,15 @@ export function useTabs(options: UseTabsOptions) {
       return await invoke<string[]>("list_markdown_files", { path: root });
     } catch (err) {
       console.error(`Failed to list markdown files for ${root}:`, err);
+      return [];
+    }
+  }, []);
+
+  const loadWikilinkRefs = useCallback(async (root: string): Promise<WikilinkRef[]> => {
+    try {
+      return await invoke<WikilinkRef[]>("scan_wikilinks", { path: root });
+    } catch (err) {
+      console.error(`Failed to scan wikilinks for ${root}:`, err);
       return [];
     }
   }, []);
@@ -293,13 +306,16 @@ export function useTabs(options: UseTabsOptions) {
       loadWorkspaceFiles(resolvedRoot).then((files) => {
         setWorkspaceIndex((prev) => ({ ...prev, [id]: files }));
       });
+      loadWikilinkRefs(resolvedRoot).then((refs) => {
+        setWikilinkIndex((prev) => ({ ...prev, [id]: refs }));
+      });
 
       if (options?.filePath) {
         // Defer so the new tab is in state for openFileInFolderTab to find
         await openFileInFolderTab(id, options.filePath);
       }
     },
-    [loadDirectory, loadWorkspaceFiles, openFileInFolderTab],
+    [loadDirectory, loadWikilinkRefs, loadWorkspaceFiles, openFileInFolderTab],
   );
 
   const toggleExpand = useCallback(
@@ -348,6 +364,12 @@ export function useTabs(options: UseTabsOptions) {
       }
       scrollRefsMap.current.delete(id);
       setWorkspaceIndex((prevIdx) => {
+        if (!(id in prevIdx)) return prevIdx;
+        const next = { ...prevIdx };
+        delete next[id];
+        return next;
+      });
+      setWikilinkIndex((prevIdx) => {
         if (!(id in prevIdx)) return prevIdx;
         const next = { ...prevIdx };
         delete next[id];
@@ -557,9 +579,10 @@ export function useTabs(options: UseTabsOptions) {
             dirsToRefresh.push(dir);
           }
         }
-        const [fresh, freshFiles] = await Promise.all([
+        const [fresh, freshFiles, freshRefs] = await Promise.all([
           Promise.all(dirsToRefresh.map(async (d) => [d, await loadDirectory(d)] as const)),
           loadWorkspaceFiles(tab.root),
+          loadWikilinkRefs(tab.root),
         ]);
         setState((prev) => ({
           ...prev,
@@ -573,13 +596,14 @@ export function useTabs(options: UseTabsOptions) {
           }),
         }));
         setWorkspaceIndex((prev) => ({ ...prev, [tab.id]: freshFiles }));
+        setWikilinkIndex((prev) => ({ ...prev, [tab.id]: freshRefs }));
       }, DIRECTORY_REFRESH_DEBOUNCE);
     });
     return () => {
       if (timeout) clearTimeout(timeout);
       unlisten.then((fn) => fn());
     };
-  }, [loadDirectory, loadWorkspaceFiles]);
+  }, [loadDirectory, loadWikilinkRefs, loadWorkspaceFiles]);
 
   return {
     tabs,
@@ -588,6 +612,7 @@ export function useTabs(options: UseTabsOptions) {
     activeFile,
     initializing,
     workspaceFiles,
+    wikilinkRefs,
     openFile,
     openFolder,
     openFileInFolderTab,

--- a/src/lib/backlinks.test.ts
+++ b/src/lib/backlinks.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { filterBacklinks, type WikilinkRef } from "./backlinks";
+
+const workspaceFiles = ["/vault/Index.md", "/vault/Notes/Cooking.md", "/vault/Notes/Travel.md"];
+
+function ref(source: string, target: string, line = 1, snippet = `see [[${target}]]`): WikilinkRef {
+  return { source, target, line, snippet };
+}
+
+describe("filterBacklinks", () => {
+  it("returns refs that resolve to the current file", () => {
+    const refs = [
+      ref("/vault/Index.md", "Cooking"),
+      ref("/vault/Notes/Travel.md", "Cooking"),
+      ref("/vault/Index.md", "Travel"),
+    ];
+    const result = filterBacklinks(refs, workspaceFiles, "/vault/Notes/Cooking.md");
+    expect(result.map((b) => b.source)).toEqual(["/vault/Index.md", "/vault/Notes/Travel.md"]);
+  });
+
+  it("drops self-links", () => {
+    const refs = [ref("/vault/Notes/Cooking.md", "Cooking")];
+    const result = filterBacklinks(refs, workspaceFiles, "/vault/Notes/Cooking.md");
+    expect(result).toEqual([]);
+  });
+
+  it("respects target syntax variants", () => {
+    const refs = [
+      ref("/vault/Index.md", "Cooking|kitchen"),
+      ref("/vault/Index.md", "Cooking#Recipes"),
+      ref("/vault/Index.md", "Cooking.md"),
+    ];
+    const result = filterBacklinks(refs, workspaceFiles, "/vault/Notes/Cooking.md");
+    expect(result).toHaveLength(3);
+  });
+
+  it("ignores refs whose target resolves elsewhere", () => {
+    const refs = [ref("/vault/Index.md", "Travel"), ref("/vault/Notes/Cooking.md", "Travel")];
+    const result = filterBacklinks(refs, workspaceFiles, "/vault/Notes/Cooking.md");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when there is no current file or workspace", () => {
+    const refs = [ref("/vault/Index.md", "Cooking")];
+    expect(filterBacklinks(refs, workspaceFiles, "")).toEqual([]);
+    expect(filterBacklinks(refs, [], "/vault/Notes/Cooking.md")).toEqual([]);
+  });
+
+  it("sorts by source filename then line", () => {
+    const refs = [
+      ref("/vault/Notes/Travel.md", "Cooking", 7),
+      ref("/vault/Index.md", "Cooking", 12),
+      ref("/vault/Index.md", "Cooking", 4),
+    ];
+    const result = filterBacklinks(refs, workspaceFiles, "/vault/Notes/Cooking.md");
+    expect(result.map((b) => [b.source, b.line])).toEqual([
+      ["/vault/Index.md", 4],
+      ["/vault/Index.md", 12],
+      ["/vault/Notes/Travel.md", 7],
+    ]);
+  });
+});

--- a/src/lib/backlinks.ts
+++ b/src/lib/backlinks.ts
@@ -1,0 +1,45 @@
+// Filters a flat list of wikilink references (produced by the Rust
+// `scan_wikilinks` command) down to those that resolve to the currently-open
+// file, using the same resolver that powers Phase 1 rendering. Self-links —
+// where the source file is the current file — are dropped so the panel only
+// surfaces *inbound* links from elsewhere in the workspace.
+import { resolveWikilink } from "./wikilinkResolver";
+
+export interface WikilinkRef {
+  source: string;
+  target: string;
+  line: number;
+  snippet: string;
+}
+
+export interface Backlink {
+  source: string;
+  line: number;
+  snippet: string;
+}
+
+export function filterBacklinks(
+  refs: readonly WikilinkRef[],
+  workspaceFiles: readonly string[],
+  currentFilePath: string,
+): Backlink[] {
+  if (!currentFilePath || workspaceFiles.length === 0) return [];
+
+  const out: Backlink[] = [];
+  const files = workspaceFiles as string[];
+  for (const ref of refs) {
+    if (ref.source === currentFilePath) continue;
+    // Strip the optional `|alias` — the resolver only cares about the target
+    // and heading (matches what remarkWikilink does at parse time).
+    const pipe = ref.target.indexOf("|");
+    const target = pipe >= 0 ? ref.target.slice(0, pipe) : ref.target;
+    const resolved = resolveWikilink(target, files, ref.source);
+    if (resolved.path === currentFilePath) {
+      out.push({ source: ref.source, line: ref.line, snippet: ref.snippet });
+    }
+  }
+
+  // Stable order: by source filename, then line.
+  out.sort((a, b) => a.source.localeCompare(b.source) || a.line - b.line);
+  return out;
+}


### PR DESCRIPTION
## Summary

Phase 2 of #107. Adds a Backlinks panel under the file tree that lists every other note in the workspace linking to the currently-open file. Reuses the wikilink resolver shipped in Phase 1; no rendering changes to the document body.

## Changes

- New Rust command \`scan_wikilinks(root) -> Vec<WikilinkRef>\` walks the workspace, extracts \`[[...]]\` occurrences (skipping fenced code), and returns \`{ source, target, line, snippet }\` records. Same depth/file-count bounds as \`list_markdown_files\`, plus a 5 MB per-file size cap and 200-char snippet trim.
- \`useTabs\` keeps an ephemeral \`Map<tabId, WikilinkRef[]>\` next to the markdown index; both populate on folder open and refresh in the existing debounced \`directory-changed\` handler.
- New \`src/lib/backlinks.ts\` filters the flat refs to the current file via the Phase 1 \`resolveWikilink\`, drops self-links, and sorts by source filename + line.
- \`BacklinksSection\` component renders a collapsible list under the file tree (count badge, source filename, snippet); hidden when zero. Click opens the source file in the active folder tab.
- \`samples/\` already cross-links to itself, so opening any of the sample files now shows non-empty backlinks.

## Testing

- Vitest: 236 tests pass; new tests cover the resolver filter (target syntax variants, self-links, sort order) and the section UI (count, snippet, click, collapse).
- \`cargo test\` passes including new bounds tests for \`scan_wikilinks\` (basic, fenced-code skip, multiple-per-line, line/snippet capture, snippet truncation, non-directory error).
- \`pnpm typecheck\` and \`pnpm check\` clean.
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Notes

- Closes the panel with the toggle in the header; the section auto-hides when there are no backlinks.
- Backlinks click drops the user at the source file; jumping to the specific line is not yet wired (the line is captured for a follow-up — opening into the editor at a precise line will need an editor API).
- Inline-code wikilinks (\`\\\`[[X]]\\\`\`) are *not* skipped by the Rust scanner. Fenced code blocks are. This matches Obsidian's behavior and keeps the scanner simple; if it becomes a problem we can add a single-line inline-code tracker.

## Out of scope (follow-ups)

- Phase 3 editor autocomplete (separate issue/PR)
- Cross-file heading scroll after navigation (#107 follow-up)
- Jump to line on backlink click