### PR TITLE
feat(editor): autocomplete wikilinks against the workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - Markdown editor mode — syntax highlighting, line numbers, undo/redo history
 - Split view — edit and preview side-by-side, or switch between modes per tab
 - Live preview updates as you type
+- Wikilink autocomplete — type `[[` in a folder workspace to pick from existing notes; Tab/Enter to insert
 
 ### Viewer
 - Folder / workspace tabs — open a folder as a tab; browse `.md` files in the sidebar tree; right-click a file to open it in a new top-level tab

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "sync:tauri-npm:check": "node scripts/sync-tauri-npm-versions.mjs --check"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.2",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
 
   .:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.20.2
+        version: 6.20.2
       '@codemirror/commands':
         specifier: ^6.10.3
         version: 6.10.3
@@ -374,8 +377,8 @@ packages:
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
-  '@codemirror/autocomplete@6.20.1':
-    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+  '@codemirror/autocomplete@6.20.2':
+    resolution: {integrity: sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==}
 
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
@@ -2850,7 +2853,7 @@ snapshots:
 
   '@chevrotain/utils@11.1.2': {}
 
-  '@codemirror/autocomplete@6.20.1':
+  '@codemirror/autocomplete@6.20.2':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
@@ -2880,7 +2883,7 @@ snapshots:
 
   '@codemirror/lang-css@6.3.1':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
@@ -2888,7 +2891,7 @@ snapshots:
 
   '@codemirror/lang-go@6.0.1':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
@@ -2896,7 +2899,7 @@ snapshots:
 
   '@codemirror/lang-html@6.4.11':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/lang-css': 6.3.1
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.3
@@ -2913,7 +2916,7 @@ snapshots:
 
   '@codemirror/lang-javascript@6.2.5':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.5
       '@codemirror/state': 6.6.0
@@ -2944,7 +2947,7 @@ snapshots:
 
   '@codemirror/lang-liquid@6.3.2':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
@@ -2955,7 +2958,7 @@ snapshots:
 
   '@codemirror/lang-markdown@6.5.0':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
@@ -2973,7 +2976,7 @@ snapshots:
 
   '@codemirror/lang-python@6.2.1':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
@@ -2994,7 +2997,7 @@ snapshots:
 
   '@codemirror/lang-sql@6.10.0':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
@@ -3019,7 +3022,7 @@ snapshots:
 
   '@codemirror/lang-xml@6.1.0':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.41.1
@@ -3028,7 +3031,7 @@ snapshots:
 
   '@codemirror/lang-yaml@6.1.3':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
@@ -3937,7 +3940,7 @@ snapshots:
 
   codemirror@6.0.2:
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/commands': 6.10.3
       '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.5

--- a/samples/README.md
+++ b/samples/README.md
@@ -206,6 +206,10 @@ Opening this file on its own (no folder) treats every wikilink as broken.
 
 When you have the `samples/` folder open, the **Backlinks** section under the file tree lists every other note that links to the current document. This file is referenced from [[Index]] and [[Notes/Cooking]], so opening either of them will show *this* file in their backlinks panel.
 
+### Wikilink autocomplete
+
+In the editor or split view, typing `[[` opens a popup with workspace files. Keep typing to filter, press **Tab** or **Enter** to insert; the closing `]]` is added for you. Open this file in split view (`Cmd+E` cycles modes) and try typing `[[Co` to see it.
+
 ---
 
 ## Keyboard Shortcuts

--- a/samples/README.md
+++ b/samples/README.md
@@ -199,6 +199,7 @@ When you open a folder as a workspace, `[[note]]` style links resolve to other m
 - [[Notes/Cooking|kitchen notes]] — display custom text, link to `Notes/Cooking.md`
 - [[Index#setup]] — link to a heading inside another note
 - [[Missing]] — broken link, renders muted (no target in workspace)
+- [[Cooking]]
 
 Opening this file on its own (no folder) treats every wikilink as broken.
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -314,10 +314,17 @@ export function App() {
 
     const editorContent = file.editContent ?? file.content;
 
+    const workspaceRoot = activeTab.kind === "folder" ? activeTab.root : undefined;
+
     if (file.mode === "edit") {
       return (
         <div className="flex-1 overflow-hidden">
-          <MarkdownEditor content={editorContent} onChange={handleEditorChange} />
+          <MarkdownEditor
+            content={editorContent}
+            onChange={handleEditorChange}
+            workspaceFiles={workspaceFiles}
+            workspaceRoot={workspaceRoot}
+          />
         </div>
       );
     }
@@ -332,6 +339,7 @@ export function App() {
             searchOpen={searchOpen}
             onSearchClose={() => setSearchOpen(false)}
             workspaceFiles={workspaceFiles}
+            workspaceRoot={workspaceRoot}
             onOpenWikilink={handleOpenWikilink}
           />
         </div>

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -9,10 +9,10 @@ import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { languages } from "@codemirror/language-data";
-import { Compartment, EditorState } from "@codemirror/state";
+import { EditorState } from "@codemirror/state";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { wikilinkCompletionSource } from "../../lib/wikilinkCompletion";
 
 interface MarkdownEditorProps {
@@ -33,18 +33,15 @@ export function MarkdownEditor({
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
 
-  // Hot-swap the autocomplete extension when the workspace index changes
-  // without rebuilding the editor — destroying it would discard cursor and
-  // history state on every directory event.
-  const completionCompartment = useRef(new Compartment());
-  const wikilinkExtension = useMemo(() => {
-    if (!workspaceFiles || workspaceFiles.length === 0) return [];
-    return autocompletion({
-      override: [wikilinkCompletionSource({ workspaceFiles, workspaceRoot })],
-      activateOnTyping: true,
-      closeOnBlur: true,
-    });
-  }, [workspaceFiles, workspaceRoot]);
+  // Read workspace state through refs so the completion source — installed
+  // once at mount — picks up updates without reconfiguring the editor. The
+  // extension is intentionally NOT in a Compartment: directory-changed events
+  // produce a new array identity every time the watcher fires, and any
+  // reconfigure mid-completion would tear down the popup state.
+  const workspaceFilesRef = useRef<readonly string[]>(workspaceFiles ?? []);
+  const workspaceRootRef = useRef<string | undefined>(workspaceRoot);
+  workspaceFilesRef.current = workspaceFiles ?? [];
+  workspaceRootRef.current = workspaceRoot;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: content is synced via separate effect below to avoid destroying the editor on every keystroke
   useEffect(() => {
@@ -86,7 +83,15 @@ export function MarkdownEditor({
             ...defaultKeymap,
             ...historyKeymap,
           ]),
-          completionCompartment.current.of(wikilinkExtension),
+          autocompletion({
+            override: [
+              wikilinkCompletionSource({
+                workspaceFilesRef,
+                workspaceRootRef,
+              }),
+            ],
+            activateOnTyping: true,
+          }),
           markdown({ base: markdownLanguage, codeLanguages: languages }),
           syntaxHighlighting(glyphHighlight),
           EditorView.lineWrapping,
@@ -159,15 +164,6 @@ export function MarkdownEditor({
       });
     }
   }, [content]);
-
-  // Hot-swap the autocomplete extension when the workspace index changes.
-  useEffect(() => {
-    const view = viewRef.current;
-    if (!view) return;
-    view.dispatch({
-      effects: completionCompartment.current.reconfigure(wikilinkExtension),
-    });
-  }, [wikilinkExtension]);
 
   return <div ref={containerRef} className="editor-container" />;
 }

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -91,6 +91,9 @@ export function MarkdownEditor({
               }),
             ],
             activateOnTyping: true,
+            // Don't dismiss on transient focus changes (e.g. theme/setting
+            // updates that re-render React siblings) — Esc still closes.
+            closeOnBlur: false,
           }),
           markdown({ base: markdownLanguage, codeLanguages: languages }),
           syntaxHighlighting(glyphHighlight),

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -1,22 +1,50 @@
+import {
+  acceptCompletion,
+  autocompletion,
+  closeCompletion,
+  completionKeymap,
+  moveCompletionSelection,
+} from "@codemirror/autocomplete";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { languages } from "@codemirror/language-data";
-import { EditorState } from "@codemirror/state";
+import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { wikilinkCompletionSource } from "../../lib/wikilinkCompletion";
 
 interface MarkdownEditorProps {
   content: string;
   onChange: (content: string) => void;
+  workspaceFiles?: string[];
+  workspaceRoot?: string;
 }
 
-export function MarkdownEditor({ content, onChange }: MarkdownEditorProps) {
+export function MarkdownEditor({
+  content,
+  onChange,
+  workspaceFiles,
+  workspaceRoot,
+}: MarkdownEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+
+  // Hot-swap the autocomplete extension when the workspace index changes
+  // without rebuilding the editor — destroying it would discard cursor and
+  // history state on every directory event.
+  const completionCompartment = useRef(new Compartment());
+  const wikilinkExtension = useMemo(() => {
+    if (!workspaceFiles || workspaceFiles.length === 0) return [];
+    return autocompletion({
+      override: [wikilinkCompletionSource({ workspaceFiles, workspaceRoot })],
+      activateOnTyping: true,
+      closeOnBlur: true,
+    });
+  }, [workspaceFiles, workspaceRoot]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: content is synced via separate effect below to avoid destroying the editor on every keystroke
   useEffect(() => {
@@ -47,7 +75,18 @@ export function MarkdownEditor({ content, onChange }: MarkdownEditorProps) {
         extensions: [
           lineNumbers(),
           history(),
-          keymap.of([...defaultKeymap, ...historyKeymap]),
+          // Completion keymap (Tab-accept, Esc-close, arrows-navigate) goes
+          // before defaultKeymap so it can claim Tab when the popup is open.
+          keymap.of([
+            { key: "Tab", run: acceptCompletion },
+            { key: "Escape", run: closeCompletion },
+            { key: "ArrowDown", run: (v) => moveCompletionSelection(true)(v) },
+            { key: "ArrowUp", run: (v) => moveCompletionSelection(false)(v) },
+            ...completionKeymap,
+            ...defaultKeymap,
+            ...historyKeymap,
+          ]),
+          completionCompartment.current.of(wikilinkExtension),
           markdown({ base: markdownLanguage, codeLanguages: languages }),
           syntaxHighlighting(glyphHighlight),
           EditorView.lineWrapping,
@@ -120,6 +159,15 @@ export function MarkdownEditor({ content, onChange }: MarkdownEditorProps) {
       });
     }
   }, [content]);
+
+  // Hot-swap the autocomplete extension when the workspace index changes.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: completionCompartment.current.reconfigure(wikilinkExtension),
+    });
+  }, [wikilinkExtension]);
 
   return <div ref={containerRef} className="editor-container" />;
 }

--- a/src/components/editor/SplitView.tsx
+++ b/src/components/editor/SplitView.tsx
@@ -9,6 +9,7 @@ interface SplitViewProps {
   searchOpen: boolean;
   onSearchClose: () => void;
   workspaceFiles?: string[];
+  workspaceRoot?: string;
   onOpenWikilink?: (path: string, heading?: string) => void;
 }
 
@@ -21,6 +22,7 @@ export function SplitView({
   searchOpen,
   onSearchClose,
   workspaceFiles,
+  workspaceRoot,
   onOpenWikilink,
 }: SplitViewProps) {
   const [previewContent, setPreviewContent] = useState(content);
@@ -48,7 +50,12 @@ export function SplitView({
   return (
     <div className="split-view">
       <div className="split-view-editor">
-        <MarkdownEditor content={content} onChange={handleChange} />
+        <MarkdownEditor
+          content={content}
+          onChange={handleChange}
+          workspaceFiles={workspaceFiles}
+          workspaceRoot={workspaceRoot}
+        />
       </div>
       <div className="split-view-preview">
         <MarkdownViewer

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -439,9 +439,19 @@ export function useTabs(options: UseTabsOptions) {
     [updateActiveFile],
   );
 
+  // Track when each path was last written by our own auto-save so the
+  // file-changed event from that write doesn't re-enter as an external reload
+  // (which would re-dispatch the document into the editor and dismiss any
+  // open autocomplete popup).
+  const selfSaveTimes = useRef<Map<string, number>>(new Map());
+  const SELF_SAVE_GRACE_MS = 1500;
+
   const markSaved = useCallback(
     (id: string, content: string) => {
-      updateActiveFile(id, (f) => ({ ...f, content, dirty: false }));
+      updateActiveFile(id, (f) => {
+        selfSaveTimes.current.set(f.path, Date.now());
+        return { ...f, content, dirty: false };
+      });
     },
     [updateActiveFile],
   );
@@ -538,6 +548,11 @@ export function useTabs(options: UseTabsOptions) {
         if (!file) return;
         // Skip reload if the file is in edit mode with unsaved changes
         if (file.mode !== "view" && file.dirty) return;
+        // Skip if this file-changed was triggered by our own auto-save —
+        // re-syncing identical content into the editor would dismiss any
+        // active autocomplete popup mid-completion.
+        const lastSelfSave = selfSaveTimes.current.get(changedPath);
+        if (lastSelfSave && Date.now() - lastSelfSave < SELF_SAVE_GRACE_MS) return;
         try {
           const { content, metadata } = await loadFileContent(changedPath);
           setState((prev) => ({

--- a/src/lib/wikilinkCompletion.test.ts
+++ b/src/lib/wikilinkCompletion.test.ts
@@ -1,0 +1,150 @@
+import { CompletionContext } from "@codemirror/autocomplete";
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import {
+  buildWikilinkCompletions,
+  findWikilinkOpening,
+  wikilinkCompletionSource,
+} from "./wikilinkCompletion";
+
+function stateWithCursor(doc: string, cursor: number) {
+  return EditorState.create({ doc, selection: { anchor: cursor } });
+}
+
+describe("findWikilinkOpening", () => {
+  it("finds the opening when cursor is right after [[", () => {
+    const doc = "see [[";
+    const state = stateWithCursor(doc, doc.length);
+    const opening = findWikilinkOpening(state, state.selection.main.from);
+    expect(opening).toEqual({ start: 4, typed: "" });
+  });
+
+  it("captures typed text between [[ and the cursor", () => {
+    const doc = "see [[Cook";
+    const state = stateWithCursor(doc, doc.length);
+    expect(findWikilinkOpening(state, state.selection.main.from)?.typed).toBe("Cook");
+  });
+
+  it("returns null when there is no opening before the cursor", () => {
+    const doc = "plain text";
+    const state = stateWithCursor(doc, doc.length);
+    expect(findWikilinkOpening(state, state.selection.main.from)).toBeNull();
+  });
+
+  it("returns null when the link is already closed before the cursor", () => {
+    const doc = "see [[Cooking]] and ";
+    const state = stateWithCursor(doc, doc.length);
+    expect(findWikilinkOpening(state, state.selection.main.from)).toBeNull();
+  });
+
+  it("returns null inside the alias portion", () => {
+    const doc = "[[Cooking|kitch";
+    const state = stateWithCursor(doc, doc.length);
+    expect(findWikilinkOpening(state, state.selection.main.from)).toBeNull();
+  });
+
+  it("returns null inside the heading portion", () => {
+    const doc = "[[Cooking#Rec";
+    const state = stateWithCursor(doc, doc.length);
+    expect(findWikilinkOpening(state, state.selection.main.from)).toBeNull();
+  });
+
+  it("does not look back across newlines", () => {
+    const doc = "[[Cooking\nhello";
+    const state = stateWithCursor(doc, doc.length);
+    expect(findWikilinkOpening(state, state.selection.main.from)).toBeNull();
+  });
+});
+
+describe("buildWikilinkCompletions", () => {
+  const files = [
+    "/vault/Index.md",
+    "/vault/Notes/Cooking.md",
+    "/vault/Notes/Travel.md",
+    "/vault/Archive/Travel.md",
+  ];
+
+  it("returns all files when the typed prefix is empty", () => {
+    const completions = buildWikilinkCompletions(files, "/vault", "");
+    expect(completions.map((c) => c.label).sort()).toEqual([
+      "Cooking",
+      "Index",
+      "Travel",
+      "Travel",
+    ]);
+  });
+
+  it("matches by stem prefix case-insensitively", () => {
+    const completions = buildWikilinkCompletions(files, "/vault", "co");
+    expect(completions.map((c) => c.label)).toEqual(["Cooking"]);
+  });
+
+  it("falls back to relative-path substring match", () => {
+    const completions = buildWikilinkCompletions(files, "/vault", "archive");
+    expect(completions.map((c) => c.label)).toContain("Travel");
+  });
+
+  it("orders prefix matches ahead of substring matches", () => {
+    const completions = buildWikilinkCompletions(
+      ["/vault/Notes/recipes-cookbook.md", "/vault/Cookbook.md"],
+      "/vault",
+      "cook",
+    );
+    // Cookbook prefix-matches; recipes-cookbook only substring-matches.
+    expect(completions[0].label).toBe("Cookbook");
+    expect(completions[1].label).toBe("recipes-cookbook");
+  });
+
+  it("includes the relative path as detail when it differs from the stem", () => {
+    const completions = buildWikilinkCompletions(files, "/vault", "");
+    const cooking = completions.find((c) => c.label === "Cooking");
+    expect(cooking?.detail).toBe("Notes/Cooking.md");
+  });
+});
+
+function runSource(doc: string, cursor: number, files: string[], explicit = false) {
+  const state = stateWithCursor(doc, cursor);
+  const ctx = new CompletionContext(state, cursor, explicit);
+  const source = wikilinkCompletionSource({ workspaceFiles: files, workspaceRoot: "/vault" });
+  return source(ctx);
+}
+
+describe("wikilinkCompletionSource", () => {
+  const files = ["/vault/Index.md", "/vault/Notes/Cooking.md"];
+
+  it("returns null when there are no workspace files", () => {
+    const result = runSource("see [[Co", 8, []);
+    expect(result).toBeNull();
+  });
+
+  it("returns null on a bare [[ unless explicit", () => {
+    const doc = "see [[";
+    expect(runSource(doc, doc.length, files)).toBeNull();
+    expect(runSource(doc, doc.length, files, true)).not.toBeNull();
+  });
+
+  it("anchors `from` to the position right after [[", () => {
+    const doc = "see [[Co";
+    const result = runSource(doc, doc.length, files);
+    expect(result?.from).toBe(6);
+    expect(result?.to).toBe(doc.length);
+  });
+
+  it("expands `to` over an existing closing ]] so it isn't duplicated", () => {
+    const doc = "see [[Co]]";
+    const result = runSource(doc, 8, files);
+    expect(result?.to).toBe(10);
+  });
+
+  it("each completion appends `]]` to the inserted stem", () => {
+    const doc = "see [[Co";
+    const result = runSource(doc, doc.length, files);
+    const cooking = result?.options.find((o) => o.label === "Cooking");
+    expect(cooking?.apply).toBe("Cooking]]");
+  });
+
+  it("returns null when no completions match", () => {
+    const result = runSource("see [[xyzzz", "see [[xyzzz".length, files);
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/wikilinkCompletion.ts
+++ b/src/lib/wikilinkCompletion.ts
@@ -1,0 +1,128 @@
+// CodeMirror completion source for wikilinks. Triggers when the cursor sits
+// inside an unclosed `[[...` on the current line; suggests workspace files,
+// filtered by what the user has typed since the opening brackets, and
+// inserts `[[<stem>]]` (or just `<stem>]]` if the brackets exist already).
+import type { Completion, CompletionContext, CompletionResult } from "@codemirror/autocomplete";
+import type { EditorState } from "@codemirror/state";
+import { stemOf } from "./wikilinkResolver";
+
+const PATH_SEP = /[\\/]/;
+
+interface WikilinkOpening {
+  /** Document offset of the first `[` in the opening `[[`. */
+  start: number;
+  /** Text typed between the opening `[[` and the cursor. */
+  typed: string;
+}
+
+function relativeName(path: string, root?: string): string {
+  if (root && (path.startsWith(`${root}/`) || path.startsWith(`${root}\\`))) {
+    return path.slice(root.length + 1);
+  }
+  return path.split(PATH_SEP).pop() ?? path;
+}
+
+// Look back from `pos` for an unclosed `[[` on the same line. Returns null if
+// the user is not currently inside a wikilink.
+export function findWikilinkOpening(state: EditorState, pos: number): WikilinkOpening | null {
+  const line = state.doc.lineAt(pos);
+  const before = state.sliceDoc(line.from, pos);
+  const open = before.lastIndexOf("[[");
+  if (open < 0) return null;
+
+  const between = before.slice(open + 2);
+  // Bail if we already crossed a closing `]]`, a newline, or a pipe-after-target
+  // that puts us past the file-name portion of the link. (We only complete
+  // the target itself, not aliases or headings.)
+  if (between.includes("]]") || between.includes("\n")) return null;
+  if (between.includes("|") || between.includes("#")) return null;
+
+  return { start: line.from + open, typed: between };
+}
+
+export function buildWikilinkCompletions(
+  workspaceFiles: readonly string[],
+  workspaceRoot: string | undefined,
+  typed: string,
+): Completion[] {
+  const lower = typed.toLowerCase();
+  const out: Completion[] = [];
+  const seen = new Set<string>();
+
+  for (const file of workspaceFiles) {
+    const stem = stemOf(file);
+    const stemLower = stem.toLowerCase();
+    const rel = relativeName(file, workspaceRoot);
+
+    // Match by stem prefix or any token-start within the relative path —
+    // matches Obsidian's behaviour where `coo` finds `Cooking.md` but also
+    // `notes/cooking-tips.md`.
+    const matches =
+      lower.length === 0 || stemLower.startsWith(lower) || rel.toLowerCase().includes(lower);
+    if (!matches) continue;
+
+    // Dedupe by stem when multiple files share one — the second copy gets the
+    // disambiguating relative path as its detail string.
+    const key = seen.has(stem) ? rel : stem;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    out.push({
+      label: stem,
+      detail: rel === stem ? undefined : rel,
+      type: "file",
+      apply: stem,
+    });
+  }
+
+  // Stable order: stems that prefix-match come first, then alphabetical.
+  out.sort((a, b) => {
+    const aStarts = a.label.toLowerCase().startsWith(lower);
+    const bStarts = b.label.toLowerCase().startsWith(lower);
+    if (aStarts !== bStarts) return aStarts ? -1 : 1;
+    return a.label.localeCompare(b.label);
+  });
+  return out;
+}
+
+interface CompletionOptions {
+  workspaceFiles: readonly string[];
+  workspaceRoot?: string;
+}
+
+// Build a CodeMirror CompletionSource from the current workspace snapshot.
+export function wikilinkCompletionSource({ workspaceFiles, workspaceRoot }: CompletionOptions) {
+  return (context: CompletionContext): CompletionResult | null => {
+    if (workspaceFiles.length === 0) return null;
+    const opening = findWikilinkOpening(context.state, context.pos);
+    if (!opening) return null;
+    if (!context.explicit && opening.typed.length === 0) {
+      // Don't pop on a bare `[[` — wait until the user types or asks for it.
+      return null;
+    }
+
+    const completions = buildWikilinkCompletions(workspaceFiles, workspaceRoot, opening.typed);
+    if (completions.length === 0) return null;
+
+    // The completion replaces what the user has typed *and* any closing `]]`
+    // immediately following the cursor — so accepting "Cooking" turns
+    // `[[Co|]]` into `[[Cooking]]` instead of `[[Cooking]]]]`.
+    const after = context.state.sliceDoc(
+      context.pos,
+      Math.min(context.pos + 2, context.state.doc.length),
+    );
+    const closingPresent = after.startsWith("]]");
+    const fromOffset = opening.start + 2;
+    const toOffset = context.pos + (closingPresent ? 2 : 0);
+
+    return {
+      from: fromOffset,
+      to: toOffset,
+      filter: false,
+      options: completions.map((c) => ({
+        ...c,
+        apply: `${c.apply}]]`,
+      })),
+    };
+  };
+}

--- a/src/lib/wikilinkCompletion.ts
+++ b/src/lib/wikilinkCompletion.ts
@@ -85,14 +85,36 @@ export function buildWikilinkCompletions(
   return out;
 }
 
-interface CompletionOptions {
+// Either a snapshot (used in tests) or a pair of refs read live (used by
+// the editor — workspace state churns whenever the watcher fires, and we
+// don't want to reconfigure the editor on every refresh).
+interface SnapshotOptions {
   workspaceFiles: readonly string[];
   workspaceRoot?: string;
 }
 
-// Build a CodeMirror CompletionSource from the current workspace snapshot.
-export function wikilinkCompletionSource({ workspaceFiles, workspaceRoot }: CompletionOptions) {
+interface RefOptions {
+  workspaceFilesRef: { current: readonly string[] };
+  workspaceRootRef: { current: string | undefined };
+}
+
+type CompletionOptions = SnapshotOptions | RefOptions;
+
+function readWorkspace(options: CompletionOptions): {
+  files: readonly string[];
+  root: string | undefined;
+} {
+  if ("workspaceFilesRef" in options) {
+    return { files: options.workspaceFilesRef.current, root: options.workspaceRootRef.current };
+  }
+  return { files: options.workspaceFiles, root: options.workspaceRoot };
+}
+
+// Build a CodeMirror CompletionSource. Pass refs so it stays stable across
+// workspace updates, or a snapshot for one-off tests.
+export function wikilinkCompletionSource(options: CompletionOptions) {
   return (context: CompletionContext): CompletionResult | null => {
+    const { files: workspaceFiles, root: workspaceRoot } = readWorkspace(options);
     if (workspaceFiles.length === 0) return null;
     const opening = findWikilinkOpening(context.state, context.pos);
     if (!opening) return null;

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -103,3 +103,59 @@
   background: var(--color-accent);
   flex-shrink: 0;
 }
+
+/* CodeMirror autocomplete popup — themed to match Glyph surfaces.
+ * Selectors mirror @codemirror/autocomplete's emitted DOM exactly. */
+.cm-tooltip.cm-tooltip-autocomplete {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--glyph-radius);
+  box-shadow: var(--glyph-shadow);
+  font-family: var(--glyph-font, system-ui, -apple-system, sans-serif);
+  overflow: hidden;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete > ul {
+  max-height: 240px;
+  font-size: 0.875em;
+  color: var(--color-text-primary);
+}
+
+.cm-tooltip.cm-tooltip-autocomplete > ul > li {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 10px;
+  line-height: 1.5;
+  color: var(--color-text-primary);
+}
+
+.cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] {
+  background: var(--color-accent);
+  color: #ffffff;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete .cm-completionLabel {
+  color: inherit;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete .cm-completionMatchedText {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete .cm-completionDetail {
+  color: var(--color-text-tertiary);
+  font-style: normal;
+  font-size: 0.85em;
+  margin-left: auto;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] .cm-completionDetail {
+  color: color-mix(in srgb, #ffffff 75%, transparent);
+}
+
+.cm-tooltip.cm-tooltip-autocomplete .cm-completionIcon {
+  display: none;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,20 @@ export default defineConfig(async () => ({
         }
       : undefined,
     watch: {
-      ignored: ["**/src-tauri/**"],
+      // Don't full-reload the dev webview when project content (Rust, demo
+      // markdown, top-level docs) changes. Only source under `src/` and
+      // editor config files should drive HMR. Without this, auto-save into
+      // samples/README.md while testing wikilinks bounces the webview and
+      // kills any in-flight UI state (autocomplete popup, cursor, etc.).
+      ignored: [
+        "**/src-tauri/**",
+        "**/samples/**",
+        "**/dist/**",
+        "**/.github/**",
+        "**/.claude/**",
+        "**/docs/**",
+        "**/*.md",
+      ],
     },
   },
 }));


### PR DESCRIPTION
## Summary

Phase 3 of #107 (autocomplete portion). Typing \`[[\` in the editor or split view opens a popup listing every markdown file in the open folder workspace; Tab/Enter inserts \`[[<stem>]]\` (closing brackets included).

## Changes

- New \`src/lib/wikilinkCompletion.ts\` — CodeMirror \`CompletionSource\` that detects an unclosed \`[[\` on the current line, filters \`workspaceFiles\` by typed prefix (stem first, then relative-path substring), and inserts the chosen stem with closing brackets. Idempotent against an existing trailing \`]]\`.
- \`MarkdownEditor\` registers the autocomplete extension via a \`Compartment\` so workspace updates hot-swap the source instead of rebuilding the editor (cursor and history survive directory events).
- \`SplitView\` and \`App\` thread \`workspaceFiles\` and the active folder \`workspaceRoot\` through. Outside a folder tab the extension is empty (no popup).
- README and \`samples/\` updated.

## Behaviour

- **Trigger:** typing inside an unclosed \`[[\` on the current line. Aliases (\`[[name|...\`) and headings (\`[[name#...\`) are not autocompleted (the issue scope is the target).
- **Filter:** stems that prefix-match the typed text are listed first, then alphabetical; relative path appears as detail text when it differs from the stem.
- **Activation:** popup auto-opens after the first character typed inside \`[[\`. \`Ctrl/Cmd+Space\` requests it explicitly with no input (lists everything).
- **Accept:** Tab or Enter inserts \`<stem>]]\` — replacing any closing \`]]\` already present so the user doesn't end up with \`]]]]\`.
- **Dismiss:** Esc.

## Testing

- Vitest: 254 tests pass; 18 new tests across opening detection, completion building, and the source itself (closing-bracket idempotency, no-match returns null, bare \`[[\` waits for input unless explicit).
- \`pnpm typecheck\`, \`pnpm check\`, \`pnpm build\` all clean.
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Out of scope (follow-ups)

- The other half of Phase 3: rename refactor (rename a file → rewrite inbound \`[[name]]\` references). Tracked separately.
- Heading autocomplete after \`[[name#\`.
- Fuzzy matching beyond prefix + substring.