### PR TITLE
fix(markdown): restore footnote navigation broken by id namespacing

### DIFF
--- a/src/components/markdown/MarkdownViewer.test.tsx
+++ b/src/components/markdown/MarkdownViewer.test.tsx
@@ -102,6 +102,24 @@ describe("MarkdownViewer task lists", () => {
   });
 });
 
+describe("MarkdownViewer footnotes", () => {
+  // Regression: rehype-sanitize's default `clobber` option used to prepend
+  // `user-content-` to every id, which doubled remark-gfm v4's already
+  // prefixed footnote ids and broke `[^1]` click navigation.
+  it("keeps footnote ref hrefs aligned with their target ids", () => {
+    const { container } = renderMd("Text[^1].\n\n[^1]: The note.");
+    const ref = container.querySelector("a[data-footnote-ref]") as HTMLAnchorElement | null;
+    expect(ref).not.toBeNull();
+    const targetId = ref!.getAttribute("href")!.slice(1);
+    expect(container.querySelector(`#${CSS.escape(targetId)}`)).not.toBeNull();
+
+    const back = container.querySelector("a[data-footnote-backref]") as HTMLAnchorElement | null;
+    expect(back).not.toBeNull();
+    const backTargetId = back!.getAttribute("href")!.slice(1);
+    expect(container.querySelector(`#${CSS.escape(backTargetId)}`)).not.toBeNull();
+  });
+});
+
 describe("MarkdownViewer wikilinks", () => {
   it("renders a resolved wikilink with the workspace path", () => {
     const { container } = renderMd("Open [[Cooking]] now.", {

--- a/src/components/markdown/sanitizeSchema.ts
+++ b/src/components/markdown/sanitizeSchema.ts
@@ -10,6 +10,14 @@ import { defaultSchema } from "rehype-sanitize";
 // content this needs to be revisited.
 export const markdownSanitizeSchema = {
   ...defaultSchema,
+  // Disable id/name namespacing. The default schema rewrites these by
+  // prepending `user-content-`, but remark-gfm v4 already emits footnote
+  // ids with that prefix (`user-content-fn-1`). The double-prefix breaks
+  // footnote `[^1]` navigation because the href stays `#user-content-fn-1`
+  // while the target id becomes `#user-content-user-content-fn-1`.
+  // Glyph is a local viewer with no host-page collisions to worry about.
+  clobberPrefix: "",
+  clobber: [],
   tagNames: [
     ...(defaultSchema.tagNames ?? []),
     "kbd",


### PR DESCRIPTION
Closes #150 (the navigation half of the footnote regression on #14).

## Summary

Clicking a footnote ref like `[^1]` did not scroll to the footnote body. The href and target id were out of sync because rehype-sanitize was double-prefixing ids that remark-gfm v4 already prefixed.

## Root cause

`rehype-sanitize`'s default schema enables `clobber: ['id', 'name', 'ariaDescribedBy', 'ariaLabelledBy']` with `clobberPrefix: 'user-content-'`. The intent is to namespace user-rendered ids so they can't collide with the host page's own ids.

`remark-gfm` v4 already emits footnote ids with that prefix (`user-content-fn-1`, `user-content-fnref-1`). Sanitisation then turned them into `user-content-user-content-fn-1`, but the matching `<a href="#user-content-fn-1">` was untouched. Click → `document.getElementById` → null → no scroll.

## Fix

Set `clobberPrefix: ''` and `clobber: []` in `markdownSanitizeSchema`. Glyph is a local file viewer; there is no external host page whose ids could collide.

## Testing

- New regression test in `MarkdownViewer.test.tsx` asserts that every footnote ref and back-ref has a matching target id in the rendered DOM.
- 255 vitest tests pass; `pnpm typecheck` and `pnpm check` clean.
- [x] Manually verified.