### PR TITLE
fix(viewer): drop the giant bottom padding that creates a fake gap under footnotes

### DIFF
--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -116,8 +116,16 @@ export function MarkdownViewer({
           onClose={handleSearchClose}
         />
       )}
-      <div ref={scrollRef} className="h-full overflow-y-auto">
-        <div ref={contentRef} className="markdown-body px-8 py-6 pb-[60vh]">
+      <div
+        ref={scrollRef}
+        className="h-full overflow-y-auto"
+        // Reserve room at the top so anchor scrolls land below the floating
+        // header area. With this, navigating to a heading or footnote near
+        // the end of the document doesn't leave a giant blank gap above the
+        // status bar — natural scroll positioning takes over.
+        style={{ scrollPaddingTop: "16px" }}
+      >
+        <div ref={contentRef} className="markdown-body px-8 py-6 pb-12">
           <ReactMarkdown
             remarkPlugins={remarkPlugins}
             rehypePlugins={rehypePlugins}


### PR DESCRIPTION
## Summary

Clicking a footnote ref scrolled to the footnote at the top of the viewport — but with ~60vh of empty space below it before the status bar. The status bar appeared to have grown a huge padding. It hadn't; the markdown body was carrying \`pb-[60vh]\` so any heading anywhere in the doc could be aligned to the top.

## Fix

Replace \`pb-[60vh]\` on the markdown body with \`pb-12\` (~48px), and add \`scroll-padding-top: 16px\` to the scroll container so anchor targets still land slightly below the top edge for breathing room. Headings at the very end of a document may not pin to the absolute top anymore, but they remain in view and the visible gap above the status bar is gone.

## Testing

- 254 vitest tests pass; \`pnpm typecheck\` and \`pnpm check\` clean.
- [x] Manually verified: clicking footnote refs no longer leaves a visible gap above the status bar; in-document anchor links and outline-click navigation still scroll to a sensible position.