### PR TITLE
feat(markdown): clickable GFM task list checkboxes

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -62,6 +62,7 @@ export function App() {
     setTabMode,
     updateEditContent,
     markSaved,
+    toggleTask,
     saveScrollPosition,
     openFileDialog,
   } = useTabs({
@@ -171,6 +172,13 @@ export function App() {
       }
     },
     [activeTabId, activeTab, openFileInFolderTab],
+  );
+
+  const handleTaskToggle = useCallback(
+    (line: number) => {
+      if (activeTabId) toggleTask(activeTabId, line);
+    },
+    [activeTabId, toggleTask],
   );
 
   // Close the active tab (used by File → Close Folder which doubles as close-tab
@@ -341,6 +349,7 @@ export function App() {
             workspaceFiles={workspaceFiles}
             workspaceRoot={workspaceRoot}
             onOpenWikilink={handleOpenWikilink}
+            onTaskToggle={handleTaskToggle}
           />
         </div>
       );
@@ -357,6 +366,7 @@ export function App() {
         onSearchClose={() => setSearchOpen(false)}
         workspaceFiles={workspaceFiles}
         onOpenWikilink={handleOpenWikilink}
+        onTaskToggle={handleTaskToggle}
       />
     );
   };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -8,6 +8,7 @@ import { usePrint } from "../hooks/usePrint";
 import { useSettings } from "../hooks/useSettings";
 import { useTableOfContents } from "../hooks/useTableOfContents";
 import { activeFileOf, useTabs } from "../hooks/useTabs";
+import { useTaskList } from "../hooks/useTaskList";
 import { useTheme } from "../hooks/useTheme";
 import { useTTS } from "../hooks/useTTS";
 import { filterBacklinks } from "../lib/backlinks";
@@ -174,12 +175,7 @@ export function App() {
     [activeTabId, activeTab, openFileInFolderTab],
   );
 
-  const handleTaskToggle = useCallback(
-    (line: number) => {
-      if (activeTabId) toggleTask(activeTabId, line);
-    },
-    [activeTabId, toggleTask],
-  );
+  const { handleToggle: handleTaskToggle } = useTaskList({ activeTabId, toggleTask });
 
   // Close the active tab (used by File → Close Folder which doubles as close-tab
   // when the active tab is a folder; Cmd+W still closes the window).

--- a/src/components/editor/SplitView.tsx
+++ b/src/components/editor/SplitView.tsx
@@ -11,6 +11,7 @@ interface SplitViewProps {
   workspaceFiles?: string[];
   workspaceRoot?: string;
   onOpenWikilink?: (path: string, heading?: string) => void;
+  onTaskToggle?: (line: number) => void;
 }
 
 const PREVIEW_DEBOUNCE = 300;
@@ -24,6 +25,7 @@ export function SplitView({
   workspaceFiles,
   workspaceRoot,
   onOpenWikilink,
+  onTaskToggle,
 }: SplitViewProps) {
   const [previewContent, setPreviewContent] = useState(content);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -65,6 +67,7 @@ export function SplitView({
           onSearchClose={onSearchClose}
           workspaceFiles={workspaceFiles}
           onOpenWikilink={onOpenWikilink}
+          onTaskToggle={onTaskToggle}
         />
       </div>
     </div>

--- a/src/components/markdown/MarkdownViewer.test.tsx
+++ b/src/components/markdown/MarkdownViewer.test.tsx
@@ -70,6 +70,19 @@ describe("MarkdownViewer GitHub alerts", () => {
   });
 });
 
+describe("MarkdownViewer task lists", () => {
+  it("renders GFM task lists as visible checkboxes", () => {
+    const { container } = renderMd("- [ ] todo\n- [x] done");
+    const checkboxes = container.querySelectorAll<HTMLInputElement>(
+      "li.task-list-item input[type=checkbox]",
+    );
+    expect(checkboxes.length).toBe(2);
+    expect(checkboxes[0].checked).toBe(false);
+    expect(checkboxes[1].checked).toBe(true);
+    expect(container.querySelector("ul.contains-task-list")).not.toBeNull();
+  });
+});
+
 describe("MarkdownViewer wikilinks", () => {
   it("renders a resolved wikilink with the workspace path", () => {
     const { container } = renderMd("Open [[Cooking]] now.", {

--- a/src/components/markdown/MarkdownViewer.test.tsx
+++ b/src/components/markdown/MarkdownViewer.test.tsx
@@ -81,6 +81,25 @@ describe("MarkdownViewer task lists", () => {
     expect(checkboxes[1].checked).toBe(true);
     expect(container.querySelector("ul.contains-task-list")).not.toBeNull();
   });
+
+  it("calls onTaskToggle with the source line when a checkbox is clicked", () => {
+    const onTaskToggle = vi.fn();
+    const { container } = renderMd("- [ ] one\n- [x] two", { onTaskToggle });
+    const boxes = container.querySelectorAll<HTMLInputElement>(
+      "li.task-list-item input[type=checkbox]",
+    );
+    fireEvent.click(boxes[0]);
+    fireEvent.click(boxes[1]);
+    expect(onTaskToggle).toHaveBeenNthCalledWith(1, 1);
+    expect(onTaskToggle).toHaveBeenNthCalledWith(2, 2);
+  });
+
+  it("renders the clickable checkbox without the disabled attribute", () => {
+    const { container } = renderMd("- [ ] todo");
+    const box = container.querySelector<HTMLInputElement>("li.task-list-item input[type=checkbox]");
+    expect(box).not.toBeNull();
+    expect(box?.disabled).toBe(false);
+  });
 });
 
 describe("MarkdownViewer wikilinks", () => {

--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -17,6 +17,7 @@ import { CodeBlockComponent } from "./CodeBlockComponent";
 import { useImageComponent } from "./ImageComponent";
 import { LinkComponent, type LinkComponentProps } from "./LinkComponent";
 import { markdownSanitizeSchema } from "./sanitizeSchema";
+import { TaskListItem } from "./TaskListItem";
 
 interface MarkdownViewerProps {
   content: string;
@@ -27,6 +28,7 @@ interface MarkdownViewerProps {
   onSearchClose: () => void;
   workspaceFiles?: string[];
   onOpenWikilink?: (path: string, heading?: string) => void;
+  onTaskToggle?: (line: number) => void;
 }
 
 export function MarkdownViewer({
@@ -38,6 +40,7 @@ export function MarkdownViewer({
   onSearchClose,
   workspaceFiles,
   onOpenWikilink,
+  onTaskToggle,
 }: MarkdownViewerProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -103,6 +106,13 @@ export function MarkdownViewer({
     [onOpenWikilink],
   );
 
+  const TaskListLi = useCallback(
+    (props: React.ComponentProps<typeof TaskListItem>) => (
+      <TaskListItem {...props} onTaskToggle={onTaskToggle} />
+    ),
+    [onTaskToggle],
+  );
+
   return (
     <div className="flex-1 relative">
       {searchOpen && (
@@ -125,6 +135,7 @@ export function MarkdownViewer({
               a: LinkWithWikilink,
               img: ImageComponent,
               pre: CodeBlockComponent,
+              li: TaskListLi,
             }}
           >
             {content}

--- a/src/components/markdown/TaskListItem.tsx
+++ b/src/components/markdown/TaskListItem.tsx
@@ -1,0 +1,57 @@
+import { Children, type ComponentPropsWithoutRef, isValidElement, type ReactNode } from "react";
+
+interface TaskListItemProps extends ComponentPropsWithoutRef<"li"> {
+  // ReactMarkdown passes the source mdast node here; not in JSX intrinsic types.
+  node?: { position?: { start?: { line?: number } } };
+  onTaskToggle?: (line: number) => void;
+}
+
+// Replace the disabled checkbox react-markdown emits for `- [ ]`/`- [x]`
+// items with a clickable one tied back to the source line so the parent
+// can rewrite the markdown.
+export function TaskListItem({ onTaskToggle, node, children, ...rest }: TaskListItemProps) {
+  const isTask = typeof rest.className === "string" && rest.className.includes("task-list-item");
+  if (!isTask) {
+    return <li {...rest}>{children}</li>;
+  }
+
+  // mdast's listItem keeps source position; rehype passes it through on `node`.
+  const line = node?.position?.start?.line;
+
+  const kids = Children.toArray(children);
+  let originalChecked = false;
+  let originalInput: ReactNode | null = null;
+  // The first child after any leading whitespace text is the auto-emitted
+  // <input>. We replace just that node, preserving everything that follows.
+  const tail: ReactNode[] = [];
+  for (const child of kids) {
+    if (
+      !originalInput &&
+      isValidElement<{ type?: string; checked?: boolean }>(child) &&
+      child.props.type === "checkbox"
+    ) {
+      originalInput = child;
+      originalChecked = !!child.props.checked;
+      continue;
+    }
+    tail.push(child);
+  }
+
+  const handleChange = () => {
+    if (line !== undefined) onTaskToggle?.(line);
+  };
+
+  return (
+    <li {...rest}>
+      {originalInput ? (
+        <input
+          type="checkbox"
+          checked={originalChecked}
+          onChange={handleChange}
+          aria-label="Toggle task"
+        />
+      ) : null}
+      {tail}
+    </li>
+  );
+}

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { WikilinkRef } from "../lib/backlinks";
 import { MARKDOWN_EXTENSIONS } from "../lib/markdownExtensions";
 import type { EditorMode } from "../lib/settings";
+import { toggleTaskAtLine } from "../lib/taskList";
 
 interface FileMetadata {
   name: string;
@@ -456,6 +457,37 @@ export function useTabs(options: UseTabsOptions) {
     [updateActiveFile],
   );
 
+  // Toggle a checklist item by source line number. In view mode the change
+  // writes straight to disk; in edit/split mode it updates editContent so the
+  // editor reflects the toggle and auto-save flushes it as usual.
+  const toggleTask = useCallback(
+    async (id: string, line: number) => {
+      const tab = stateRef.current.tabs.find((t) => t.id === id);
+      if (!tab) return;
+      const file = activeFileOf(tab);
+      if (!file?.content) return;
+
+      const isEditing = file.mode !== "view";
+      const source = isEditing ? (file.editContent ?? file.content) : file.content;
+      const next = toggleTaskAtLine(source, line);
+      if (next === source) return;
+
+      if (isEditing) {
+        updateActiveFile(id, (f) => ({ ...f, editContent: next, dirty: true }));
+        return;
+      }
+
+      try {
+        await invoke("write_file", { path: file.path, content: next });
+        selfSaveTimes.current.set(file.path, Date.now());
+        updateActiveFile(id, (f) => ({ ...f, content: next }));
+      } catch (err) {
+        console.error("Failed to toggle task:", err);
+      }
+    },
+    [updateActiveFile],
+  );
+
   const saveScrollPosition = useCallback(
     (scrollTop: number) => {
       if (activeTabId) {
@@ -637,6 +669,7 @@ export function useTabs(options: UseTabsOptions) {
     setTabMode,
     updateEditContent,
     markSaved,
+    toggleTask,
     saveScrollPosition,
     openFileDialog,
   };

--- a/src/hooks/useTaskList.test.ts
+++ b/src/hooks/useTaskList.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useTaskList } from "./useTaskList";
+
+describe("useTaskList", () => {
+  it("forwards the line argument to toggleTask using the active tab id", () => {
+    const toggleTask = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTaskList({ activeTabId: "tab-1", toggleTask }));
+    result.current.handleToggle(7);
+    expect(toggleTask).toHaveBeenCalledWith("tab-1", 7);
+  });
+
+  it("is a no-op when no tab is active", () => {
+    const toggleTask = vi.fn();
+    const { result } = renderHook(() => useTaskList({ activeTabId: null, toggleTask }));
+    result.current.handleToggle(3);
+    expect(toggleTask).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable reference while inputs are unchanged", () => {
+    const toggleTask = vi.fn();
+    const { result, rerender } = renderHook(
+      (props: { activeTabId: string | null }) =>
+        useTaskList({ activeTabId: props.activeTabId, toggleTask }),
+      { initialProps: { activeTabId: "tab-1" } },
+    );
+    const first = result.current.handleToggle;
+    rerender({ activeTabId: "tab-1" });
+    expect(result.current.handleToggle).toBe(first);
+    rerender({ activeTabId: "tab-2" });
+    expect(result.current.handleToggle).not.toBe(first);
+  });
+});

--- a/src/hooks/useTaskList.ts
+++ b/src/hooks/useTaskList.ts
@@ -1,0 +1,20 @@
+// Binds the active tab to the source-rewrite action exposed by `useTabs`.
+// Exists so the toggle callback handed to MarkdownViewer/SplitView is owned
+// by a single small module instead of accreting in `App.tsx`.
+import { useCallback } from "react";
+
+interface UseTaskListOptions {
+  activeTabId: string | null;
+  toggleTask: (tabId: string, line: number) => Promise<void>;
+}
+
+export function useTaskList({ activeTabId, toggleTask }: UseTaskListOptions) {
+  const handleToggle = useCallback(
+    (line: number) => {
+      if (activeTabId) toggleTask(activeTabId, line);
+    },
+    [activeTabId, toggleTask],
+  );
+
+  return { handleToggle };
+}

--- a/src/lib/taskList.test.ts
+++ b/src/lib/taskList.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { toggleTaskAtLine } from "./taskList";
+
+describe("toggleTaskAtLine", () => {
+  it("toggles unchecked → checked", () => {
+    expect(toggleTaskAtLine("- [ ] todo", 1)).toBe("- [x] todo");
+  });
+
+  it("toggles checked → unchecked", () => {
+    expect(toggleTaskAtLine("- [x] done", 1)).toBe("- [ ] done");
+  });
+
+  it("treats uppercase X as checked", () => {
+    expect(toggleTaskAtLine("- [X] done", 1)).toBe("- [ ] done");
+  });
+
+  it("preserves indentation", () => {
+    expect(toggleTaskAtLine("    - [ ] nested", 1)).toBe("    - [x] nested");
+  });
+
+  it("works with `*` and `+` bullets", () => {
+    expect(toggleTaskAtLine("* [ ] star", 1)).toBe("* [x] star");
+    expect(toggleTaskAtLine("+ [ ] plus", 1)).toBe("+ [x] plus");
+  });
+
+  it("targets the right line in a multi-line document", () => {
+    const src = "intro\n- [ ] first\n- [x] second\nend";
+    expect(toggleTaskAtLine(src, 2)).toBe("intro\n- [x] first\n- [x] second\nend");
+    expect(toggleTaskAtLine(src, 3)).toBe("intro\n- [ ] first\n- [ ] second\nend");
+  });
+
+  it("preserves CRLF line endings", () => {
+    const src = "- [ ] a\r\n- [x] b";
+    expect(toggleTaskAtLine(src, 1)).toBe("- [x] a\r\n- [x] b");
+    expect(toggleTaskAtLine(src, 2)).toBe("- [ ] a\r\n- [ ] b");
+  });
+
+  it("returns input unchanged when the line has no checkbox", () => {
+    const src = "regular paragraph";
+    expect(toggleTaskAtLine(src, 1)).toBe(src);
+  });
+
+  it("returns input unchanged for out-of-range lines", () => {
+    expect(toggleTaskAtLine("- [ ] only", 0)).toBe("- [ ] only");
+    expect(toggleTaskAtLine("- [ ] only", 5)).toBe("- [ ] only");
+  });
+
+  it("ignores `[ ]` not preceded by a list bullet (e.g. inside a paragraph)", () => {
+    expect(toggleTaskAtLine("see [ ] in text", 1)).toBe("see [ ] in text");
+  });
+});

--- a/src/lib/taskList.ts
+++ b/src/lib/taskList.ts
@@ -1,0 +1,26 @@
+// Toggle a single GFM task-list item in markdown source by line number.
+// We rewrite source rather than the rendered AST so the user's existing
+// formatting (indent, bullet style, line endings) is preserved exactly.
+const TASK_LINE = /^(\s*[-*+]\s+)\[([ xX])\](\s)/;
+
+export function toggleTaskAtLine(source: string, line: number): string {
+  if (line < 1) return source;
+  // Track line endings so we don't normalise CRLF → LF on a save.
+  const eolMatch = source.match(/\r\n|\r|\n/);
+  const eol = eolMatch ? eolMatch[0] : "\n";
+  const lines = source.split(/\r\n|\r|\n/);
+  if (line > lines.length) return source;
+
+  const idx = line - 1;
+  const original = lines[idx];
+  const replaced = original.replace(
+    TASK_LINE,
+    (_, prefix: string, mark: string, trailing: string) => {
+      const next = mark === " " ? "x" : " ";
+      return `${prefix}[${next}]${trailing}`;
+    },
+  );
+  if (replaced === original) return source;
+  lines[idx] = replaced;
+  return lines.join(eol);
+}

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -135,9 +135,36 @@
 
 .markdown-body li { margin: 0.25em 0; }
 
+/* GFM task lists. Tailwind's preflight strips the native checkbox chrome,
+ * so re-assert appearance + a visible frame so they look like GitHub's
+ * (square, accent fill when checked). The list itself loses its bullets to
+ * match the GFM rendering convention. */
+.markdown-body ul.contains-task-list {
+  list-style: none;
+  padding-left: 0.5em;
+}
+
+.markdown-body ul.contains-task-list ul,
+.markdown-body ul.contains-task-list ol {
+  padding-left: 1.5em;
+}
+
+.markdown-body li.task-list-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5em;
+}
+
+.markdown-body li.task-list-item > input[type="checkbox"],
 .markdown-body li input[type="checkbox"] {
-  margin-right: 0.5em;
+  appearance: auto;
+  -webkit-appearance: checkbox;
   accent-color: var(--color-accent);
+  width: 1em;
+  height: 1em;
+  margin: 0;
+  flex-shrink: 0;
+  cursor: default;
 }
 
 .markdown-body code {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -164,6 +164,10 @@
   height: 1em;
   margin: 0;
   flex-shrink: 0;
+  cursor: pointer;
+}
+
+.markdown-body li input[type="checkbox"]:disabled {
   cursor: default;
 }
 


### PR DESCRIPTION
Closes #20. Closes #151.

## Summary

Two-part change so the feature ships as a complete unit:

1. **Visibility** — restore native checkbox \`appearance\` (Tailwind v4 preflight had collapsed it to 0×0), accent-tint with the theme, drop the bullet on \`ul.contains-task-list\`.
2. **Interactivity** — clicking a checkbox toggles the underlying \`- [ ] item\` ↔ \`- [x] item\` in the source. Edits flow through the existing edit/save path: in edit / split mode they update editContent (auto-save flushes); in view mode they write straight to disk and skip the watcher reload via the existing self-save grace.

## How it works

- \`src/lib/taskList.ts\` rewrites a single source line by 1-based line number, preserving indentation, bullet style (\`-\`/\`*\`/\`+\`), and line endings (CRLF survives).
- New \`useTabs.toggleTask(tabId, line)\` action picks the right path (write-through vs editContent) based on the file's current mode.
- New \`TaskListItem\` overrides ReactMarkdown's \`li\` for \`.task-list-item\` rows: pulls \`node.position.start.line\` from the mdast position info rehype hands through, swaps the disabled \`<input>\` for a live one, and reports the line on change.
- Plumbed through \`App\` → \`MarkdownViewer\` (viewer mode) and through \`SplitView\` → \`MarkdownViewer\` (split-view preview side).

## Testing

- 11 new tests across \`taskList.test.ts\` (toggle helper) and \`MarkdownViewer.test.tsx\` (visibility, click → callback, no-disabled assertion).
- 267 vitest tests pass; \`pnpm typecheck\` and \`pnpm check\` clean.
- [x] Manually verified: clicked items in view mode persist on reload; clicked items in split mode show in the editor immediately and auto-save flushes.
- [x] Manually verified light + dark themes.