### PR TITLE
fix(markdown): render footnote refs as [1] like GitHub

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -293,6 +293,15 @@
   font-weight: 600;
 }
 
+/* Match GitHub: footnote refs render as `[1]` rather than a bare `1`. */
+.markdown-body [data-footnote-ref]::before {
+  content: "[";
+}
+
+.markdown-body [data-footnote-ref]::after {
+  content: "]";
+}
+
 .markdown-body [data-footnote-backref] {
   color: var(--color-text-secondary);
   text-decoration: none;


### PR DESCRIPTION
Closes #150 (the visual half of the footnote regression on #14).

## Summary

remark-gfm emits the footnote reference as a bare number inside \`<sup>\`, so \`text[^1]\` rendered as \`text¹\`. GitHub renders the same source as \`text[1]\`.

## Fix

Pure CSS — \`::before\` / \`::after\` pseudo-elements on \`[data-footnote-ref]\` insert \`[\` and \`]\`. Same approach primer.css uses.

## Notes

- Independent of #145; they can land in either order. Both #145 and #149 must merge to fully resolve #150.
- 254 vitest tests pass, \`pnpm typecheck\` and \`pnpm check\` clean.
- [x] Manually verified light + dark themes.