### PR TITLE
fix(viewer): drop the 60vh runway that fakes status-bar padding

### DIFF
--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -126,8 +126,16 @@ export function MarkdownViewer({
           onClose={handleSearchClose}
         />
       )}
-      <div ref={scrollRef} className="h-full overflow-y-auto">
-        <div ref={contentRef} className="markdown-body px-8 py-6 pb-[60vh]">
+      <div
+        ref={scrollRef}
+        className="h-full overflow-y-auto"
+        // Keep anchor targets a few pixels off the top edge when scrolled to
+        // via TOC / `#anchor`. Browsers cap scrollIntoView at maxScroll, so
+        // end-of-document targets land near the bottom of the viewport —
+        // no big empty padding under the content needed for that to work.
+        style={{ scrollPaddingTop: "16px" }}
+      >
+        <div ref={contentRef} className="markdown-body px-8 py-6">
           <ReactMarkdown
             remarkPlugins={remarkPlugins}
             rehypePlugins={rehypePlugins}

--- a/src/lib/scrollToHeading.ts
+++ b/src/lib/scrollToHeading.ts
@@ -1,12 +1,30 @@
-// Smooth-scrolls to a heading by id and notifies the outline so it can
+// Smooth-scrolls to an anchor by id and notifies the outline so it can
 // highlight the new active entry without waiting on the IntersectionObserver,
 // which lags during programmatic scrolls.
 const ACTIVE_HEADING_EVENT = "glyph:active-heading";
 
+// Pick `start` when the target can scroll to the top of its scroll container,
+// otherwise `end`. Prevents end-of-document targets (the last heading, footnote
+// refs) from disappearing into a half-scroll where the user can't tell whether
+// the click navigated.
+function autoBlock(target: HTMLElement): ScrollLogicalPosition {
+  let scroller: HTMLElement | null = target.parentElement;
+  while (scroller) {
+    const overflowY = getComputedStyle(scroller).overflowY;
+    if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") break;
+    scroller = scroller.parentElement;
+  }
+  if (!scroller) return "start";
+  const targetTopInScroller =
+    target.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop;
+  const maxScroll = scroller.scrollHeight - scroller.clientHeight;
+  return targetTopInScroller <= maxScroll ? "start" : "end";
+}
+
 export function scrollToHeading(id: string): boolean {
   const target = document.getElementById(id);
   if (!target) return false;
-  target.scrollIntoView({ behavior: "smooth", block: "start" });
+  target.scrollIntoView({ behavior: "smooth", block: autoBlock(target) });
   window.dispatchEvent(new CustomEvent(ACTIVE_HEADING_EVENT, { detail: { id } }));
   return true;
 }

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -33,6 +33,10 @@
   gap: 2px;
   margin-left: auto;
   padding: 0 4px;
+  /* Keep the toggle in the bar even if the tab list grows wide enough to
+   * fight for horizontal space (e.g. after a TOC scroll triggers a layout
+   * pass that re-measures the flex children). */
+  flex-shrink: 0;
 }
 
 .mode-toggle-btn {


### PR DESCRIPTION
Closes #154.

## Summary

The 60vh padding under every rendered document was creating two visible bugs at once:

1. Clicking a footnote ref (or the Footnotes TOC entry) parked the markdown body's bottom runway as a tall empty block above the status bar — looked like the bar had gained padding.
2. The same scroll path occasionally pushed the edit/view mode toggle out of the tab bar when the flex layout re-measured during the scroll.

## Fix

- Drop `pb-[60vh]` on the markdown body. End-of-document targets now scroll to wherever the natural document height allows — typically near the bottom of the viewport, which matches what the user described as a \"footer link on button view\" and is the standard browser anchor-link feel.
- Add `scroll-padding-top: 16px` to the scroll container so anchor targets earlier in the document still get a tiny breathing-room offset under the top edge.
- Pin `.mode-toggle` with `flex-shrink: 0` so the edit/view buttons can't be squeezed out of the tab bar after a layout pass triggered by scroll-induced re-render.

## Trade-off accepted

For headings *very* close to the end of a long document, TOC click can no longer pin the heading to the absolute top of the viewport — it lands wherever the scroll runway naturally allows. That's the cost of not painting 60% of viewport height as fake space, and it matches what every other markdown viewer does.

## Testing

- 271 vitest tests pass; \`pnpm typecheck\` and \`pnpm check\` clean.
- [x] Manually verified: clicking footnote refs and the Footnotes TOC entry no longer leaves a visible gap above the status bar; the mode toggle stays put.