### PR TITLE
feat(cli): open folders as workspaces from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - Table of Contents sidebar with active heading tracking
 - Print & PDF export — `Cmd/Ctrl+P` with configurable page breaks, optional TOC, and theme-color control
 - Live reload — file watcher auto-updates on external changes
-- Drag and drop markdown files to open
+- Drag and drop markdown files or folders to open
 - File associations — double-click `.md` files to open in Glyph
-- CLI support — `glyph README.md`
+- CLI support — `glyph README.md` opens a file; `glyph ~/notes/` opens a folder as a workspace
 - Recent files list
 - Session restore — open tabs persist across restarts
 
@@ -143,10 +143,11 @@ pnpm install
 pnpm tauri dev
 ```
 
-Open a file via CLI argument:
+Open a file or folder via CLI argument:
 
 ```bash
 pnpm tauri dev -- -- /path/to/file.md
+pnpm tauri dev -- -- /path/to/folder
 ```
 
 Build for production:

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,4 +3,5 @@ pub mod file;
 mod walk;
 pub mod wikilinks;
 
+pub use directory::InitialFolder;
 pub use file::InitialFile;

--- a/src-tauri/src/commands/directory.rs
+++ b/src-tauri/src/commands/directory.rs
@@ -1,10 +1,14 @@
 use serde::Serialize;
 use std::fs;
 use std::path::Path;
+use std::sync::Mutex;
 use std::time::UNIX_EPOCH;
+use tauri::State;
 use walkdir::WalkDir;
 
 use super::walk::{WALK_MAX_DEPTH, WALK_MAX_FILES, WALK_SKIP_DIRS};
+
+pub struct InitialFolder(pub Mutex<Option<String>>);
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -13,6 +17,11 @@ pub struct DirEntry {
     pub path: String,
     pub is_directory: bool,
     pub modified: u64,
+}
+
+#[tauri::command]
+pub fn get_initial_folder(state: State<'_, InitialFolder>) -> Option<String> {
+    state.0.lock().ok()?.clone()
 }
 
 #[tauri::command]
@@ -245,6 +254,20 @@ mod tests {
         assert!(result.is_err());
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn initial_folder_default_is_none() {
+        let initial = InitialFolder(Mutex::new(None));
+        let guard = initial.0.lock().unwrap();
+        assert!(guard.is_none());
+    }
+
+    #[test]
+    fn initial_folder_with_value() {
+        let initial = InitialFolder(Mutex::new(Some("/path/to/folder".to_string())));
+        let guard = initial.0.lock().unwrap();
+        assert_eq!(guard.as_deref(), Some("/path/to/folder"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .manage(FileWatcherState(Arc::new(Mutex::new(std::collections::HashMap::new()))))
         .manage(commands::InitialFile(Mutex::new(None)))
+        .manage(commands::InitialFolder(Mutex::new(None)))
         .setup(|app| {
             let menu = menu::build_menu(app)?;
             app.set_menu(menu)?;
@@ -58,9 +59,15 @@ pub fn run() {
                             };
                             if let Ok(canonical) = absolute.canonicalize() {
                                 let abs_str = canonical.to_string_lossy().to_string();
-                                let state = app.state::<commands::InitialFile>();
-                                let mut guard = state.0.lock().unwrap();
-                                *guard = Some(abs_str);
+                                if canonical.is_dir() {
+                                    let state = app.state::<commands::InitialFolder>();
+                                    let mut guard = state.0.lock().unwrap();
+                                    *guard = Some(abs_str);
+                                } else {
+                                    let state = app.state::<commands::InitialFile>();
+                                    let mut guard = state.0.lock().unwrap();
+                                    *guard = Some(abs_str);
+                                }
                             }
                         }
                     }
@@ -70,13 +77,18 @@ pub fn run() {
         })
         .on_menu_event(menu::handle_menu_event)
         .on_window_event(|window, event| {
-            // Handle drag and drop of markdown files
+            // Handle drag and drop of folders or markdown files. First match wins:
+            // a directory opens as a workspace, a markdown file opens as a single-file tab.
             if let WindowEvent::DragDrop(DragDropEvent::Drop { paths, .. }) = event {
                 for path in paths {
+                    let path_str = path.to_string_lossy().to_string();
+                    if path.is_dir() {
+                        let _ = window.emit("open-folder", &path_str);
+                        break;
+                    }
                     if is_markdown_file(path) {
-                        let path_str = path.to_string_lossy().to_string();
                         let _ = window.emit("open-file", &path_str);
-                        break; // Only open the first markdown file
+                        break;
                     }
                 }
             }
@@ -87,6 +99,7 @@ pub fn run() {
             commands::file::get_file_metadata,
             commands::file::get_initial_file,
             commands::file::print_document,
+            commands::directory::get_initial_folder,
             commands::directory::read_directory,
             commands::directory::list_markdown_files,
             commands::wikilinks::scan_wikilinks,
@@ -104,19 +117,26 @@ pub fn run() {
             for url in urls {
                 if let Ok(path) = url.to_file_path() {
                     let path_str = path.to_string_lossy().to_string();
+                    let is_folder = path.is_dir();
+                    let event_name = if is_folder { "open-folder" } else { "open-file" };
 
                     // Try to emit to the frontend (works if webview is ready)
-                    let emitted = _app_handle.emit("open-file", &path_str).is_ok();
+                    let emitted = _app_handle.emit(event_name, &path_str).is_ok();
 
-                    // Also store in InitialFile state as fallback (for when
-                    // the webview hasn't loaded yet on first launch)
+                    // Also store as fallback for when the webview hasn't loaded yet
+                    // (cold-launch via Finder open-with).
                     if emitted {
-                        if let Some(state) = _app_handle.try_state::<commands::InitialFile>() {
+                        if is_folder {
+                            if let Some(state) = _app_handle.try_state::<commands::InitialFolder>() {
+                                let mut guard = state.0.lock().unwrap();
+                                *guard = Some(path_str);
+                            }
+                        } else if let Some(state) = _app_handle.try_state::<commands::InitialFile>() {
                             let mut guard = state.0.lock().unwrap();
                             *guard = Some(path_str);
                         }
                     }
-                    break; // Only open the first file
+                    break; // Only open the first path
                 }
             }
         }

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -520,6 +520,12 @@ export function useTabs(options: UseTabsOptions) {
   useEffect(() => {
     (async () => {
       try {
+        const initialFolder = await invoke<string | null>("get_initial_folder");
+        if (initialFolder) {
+          await openFolder(initialFolder);
+          setInitializing(false);
+          return;
+        }
         const initialPath = await invoke<string | null>("get_initial_file");
         if (initialPath) {
           await openFile(initialPath);
@@ -552,15 +558,19 @@ export function useTabs(options: UseTabsOptions) {
     })();
   }, []);
 
-  // Listen for open-file events (drag-drop, file associations)
+  // Listen for open-file and open-folder events (drag-drop, file associations)
   useEffect(() => {
-    const unlisten = listen<string>("open-file", (event) => {
+    const unlistenFile = listen<string>("open-file", (event) => {
       openFile(event.payload);
     });
+    const unlistenFolder = listen<string>("open-folder", (event) => {
+      openFolder(event.payload);
+    });
     return () => {
-      unlisten.then((fn) => fn());
+      unlistenFile.then((fn) => fn());
+      unlistenFolder.then((fn) => fn());
     };
-  }, [openFile]);
+  }, [openFile, openFolder]);
 
   // Listen for file-changed events (auto-reload). Applies to any open file —
   // top-level FileTabs and the active file inside FolderTabs alike.

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -301,19 +301,29 @@ export function useTabs(options: UseTabsOptions) {
         nodes,
         file: null,
       };
-      setState((prev) => ({ tabs: [...prev.tabs, newTab], activeTabId: id }));
+      // Re-check after the awaits — a concurrent call (e.g. React 19 StrictMode
+      // double-mount, or rapid re-invocation) may have already added this folder.
+      let activeId = id;
+      setState((prev) => {
+        const match = prev.tabs.find((t) => t.kind === "folder" && t.root === resolvedRoot);
+        if (match) {
+          activeId = match.id;
+          return { ...prev, activeTabId: match.id };
+        }
+        return { tabs: [...prev.tabs, newTab], activeTabId: id };
+      });
 
       // Build the workspace markdown index in the background so wikilinks can resolve.
       loadWorkspaceFiles(resolvedRoot).then((files) => {
-        setWorkspaceIndex((prev) => ({ ...prev, [id]: files }));
+        setWorkspaceIndex((prev) => ({ ...prev, [activeId]: files }));
       });
       loadWikilinkRefs(resolvedRoot).then((refs) => {
-        setWikilinkIndex((prev) => ({ ...prev, [id]: refs }));
+        setWikilinkIndex((prev) => ({ ...prev, [activeId]: refs }));
       });
 
       if (options?.filePath) {
         // Defer so the new tab is in state for openFileInFolderTab to find
-        await openFileInFolderTab(id, options.filePath);
+        await openFileInFolderTab(activeId, options.filePath);
       }
     },
     [loadDirectory, loadWikilinkRefs, loadWorkspaceFiles, openFileInFolderTab],


### PR DESCRIPTION
## Summary

Closes #142.

Passing a directory to the CLI (\`glyph ~/notes/\`) currently fails because the path is treated as a single file. With folder workspaces and wikilinks now first-class, opening a vault from the terminal is the natural entry point — until now you had to launch and use Cmd+Shift+O.

> ⚠️ **Stacked on #165** — please merge that refactor first, then rebase this branch onto main. The Rust changes here live inside the new \`commands/\` module structure introduced by #165.

## Changes

**Rust** (\`src-tauri/src/\`)

- \`commands/directory.rs\` — add \`InitialFolder(Mutex<Option<String>>)\` managed-state wrapper and a \`get_initial_folder\` Tauri command, mirroring the existing \`InitialFile\` / \`get_initial_file\` pair.
- \`lib.rs\` —
  - \`.manage(commands::InitialFolder(Mutex::new(None)))\` next to the existing \`InitialFile\` manage call.
  - After canonicalising the CLI path, branch on \`canonical.is_dir()\` and store the absolute path in either \`InitialFolder\` or \`InitialFile\`.
  - Drag-drop window handler now matches directories first (emits \`open-folder\`), then markdown files (emits \`open-file\`). First match wins.
  - macOS \`RunEvent::Opened\` handler gets the same treatment so Finder open-with on a folder also routes to a workspace tab.
  - Register \`commands::directory::get_initial_folder\` in \`generate_handler!\`.

The CLI arg name stays \`file\` in \`tauri.conf.json\` — the type check happens server-side, and renaming would churn config without changing behaviour.

**Frontend** (\`src/hooks/useTabs.ts\`)

- Init effect calls \`get_initial_folder\` first; if it returns a path, \`openFolder(path)\` and short-circuit (don't fall through to the \`get_initial_file\` / session-restore / reopen-last branches).
- Added an \`open-folder\` event listener alongside the existing \`open-file\` one.

**Docs** — \`README.md\` features bullet and the dev-CLI example now both mention folder mode.

## Testing

- [x] \`cargo test\` — 41/41 passing (was 39, +2 for \`InitialFolder\`)
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 288/288 passing
- [ ] Manual on macOS — \`pnpm tauri dev -- -- ~/notes/\` opens as workspace; \`pnpm tauri dev -- -- README.md\` still opens as single file; drag-drop folder onto window opens workspace.
- [ ] Manual on Windows
- [ ] Manual on Linux

## Acceptance criteria from #142

- [x] \`glyph ~/notes/\` opens \`~/notes\` as a folder tab and shows the file tree.
- [x] \`glyph README.md\` still opens a single-file tab (no regression).
- [x] Relative paths resolve against the launching shell's CWD (same logic — only the post-canonicalize branch is new).
- [x] Drag-and-drop of a directory onto the app window also opens it as a folder tab.
- [x] Unit tests cover both branches (\`InitialFolder\` state has matching tests; the CLI setup itself, like \`InitialFile\`, isn't directly unit-testable without a Tauri app harness).