### PR TITLE
chore(ci): clean up workflow deprecations and lint annotations

### DIFF
--- a/.claude/rules/ci-hygiene.md
+++ b/.claude/rules/ci-hygiene.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - ".github/workflows/**/*.yml"
+  - "src/**/*.{ts,tsx}"
+  - "biome.json"
+---
+
+# CI Hygiene Rules
+
+Keep the GitHub Actions "Annotations" panel clean. Warnings and notices are real findings, not background noise.
+
+- Treat every `##[warning]` and `##[notice]` annotation as a fix-it item, not a TODO. The Lint job runs Biome with `--error-on-warnings`, so any new warning fails CI.
+- Apply Biome's suggested fix for lint findings instead of suppressing them (e.g. `useOptionalChain`, `useIndexOf`).
+- When GitHub flags an action as targeting a deprecated Node.js version, bump the action to the major version that ships on the current Node runtime. Examples: `pnpm/action-setup@v5+`, `actions/upload-artifact@v5+`, `codecov/codecov-action@v6+` (the v6 bump pulls in `actions/github-script@v8`).
+- Update every workflow in `.github/workflows/` in the same pass, not just the file that triggered the alert.
+- Don't disable rules or filter annotations to silence warnings. If a rule genuinely doesn't fit the codebase, change it in `biome.json` with a justification, not inline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,23 +35,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Biome lint
-        run: npx @biomejs/biome lint --reporter=github src/
+        run: npx @biomejs/biome lint --error-on-warnings --reporter=github src/
       - name: Biome format check
-        run: npx @biomejs/biome format --reporter=github src/
+        run: npx @biomejs/biome format --error-on-warnings --reporter=github src/
 
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -76,14 +76,14 @@ jobs:
         run: pnpm test:coverage
       - name: Upload coverage report (artifact)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: frontend-coverage
           path: coverage/
           retention-days: 14
       - name: Upload frontend coverage
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: coverage/lcov.info
           flags: frontend
@@ -112,7 +112,7 @@ jobs:
         run: cargo llvm-cov --lcov --output-path ../coverage-rust.lcov
       - name: Upload Rust coverage
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: coverage-rust.lcov
           flags: rust
@@ -158,7 +158,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/dependabot-tauri-npm-sync.yml
+++ b/.github/workflows/dependabot-tauri-npm-sync.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # Glyph
 
 [![CI](https://github.com/hamidfzm/glyph/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/hamidfzm/glyph/actions/workflows/ci.yml)
+[![Release](https://github.com/hamidfzm/glyph/actions/workflows/release.yml/badge.svg)](https://github.com/hamidfzm/glyph/actions/workflows/release.yml)
+[![CodeQL](https://github.com/hamidfzm/glyph/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/hamidfzm/glyph/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/hamidfzm/glyph/graph/badge.svg)](https://codecov.io/gh/hamidfzm/glyph)
+[![Latest release](https://img.shields.io/github/v/release/hamidfzm/glyph?sort=semver)](https://github.com/hamidfzm/glyph/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/hamidfzm/glyph/total?color=blue)](https://github.com/hamidfzm/glyph/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![Tauri v2](https://img.shields.io/badge/Tauri-v2-24c8db?logo=tauri)](https://v2.tauri.app)
+[![React 19](https://img.shields.io/badge/React-19-61dafb?logo=react&logoColor=white)](https://react.dev)
+[![Code style: Biome](https://img.shields.io/badge/code_style-biome-60a5fa?logo=biome)](https://biomejs.dev)
 
 A modern, cross-platform markdown viewer and editor with platform-native styling.
 
@@ -261,7 +269,3 @@ Glyph is built around speed, native feel, and offline-first usage. The tables be
 Legend: ✅ supported · ⚠️ partial / inconsistent · ❌ not supported · plugin = third-party · planned = on roadmap
 
 Note on "WYSIWYG / inline preview": Glyph's editor has split-view live preview and styled markdown tokens (bold/italic render as bold/italic in source), but markdown markers remain visible — Typora-style fully inline rendering is not implemented.
-
-## License
-
-[MIT](LICENSE)

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -313,7 +313,7 @@ export function App() {
   const renderContent = () => {
     if (!activeTab) return null;
     const file = activeFileOf(activeTab);
-    if (!file || !file.content) return null;
+    if (!file?.content) return null;
 
     const editorContent = file.editContent ?? file.content;
 

--- a/src/components/layout/FileTree.test.tsx
+++ b/src/components/layout/FileTree.test.tsx
@@ -28,8 +28,8 @@ describe("FileTree", () => {
     const buttons = screen.getAllByRole("button");
     // First button is the root header (none — it's an h3) so first interactive: subdir, then post.md
     const labels = buttons.map((b) => b.textContent?.trim());
-    const subdirIdx = labels.findIndex((t) => t === "subdir");
-    const fileIdx = labels.findIndex((t) => t === "post.md");
+    const subdirIdx = labels.indexOf("subdir");
+    const fileIdx = labels.indexOf("post.md");
     expect(subdirIdx).toBeGreaterThanOrEqual(0);
     expect(fileIdx).toBeGreaterThan(subdirIdx);
   });


### PR DESCRIPTION
## Summary

Clean up every warning and notice surfacing in the GitHub Actions Annotations panel, and make the Lint job fail on future warnings so they don't pile up again.

## Changes

- **Action version bumps** to clear `Node.js 20 is deprecated` warnings:
  - `pnpm/action-setup@v4` → `v5`
  - `actions/upload-artifact@v4` → `v5`
  - `codecov/codecov-action@v5` → `v6` (pulls in `actions/github-script@v8`)
- **Biome `--error-on-warnings`** added to the Lint job (lint and format steps) so any future warning fails CI.
- **Lint fixes** for findings Biome currently flags:
  - `useOptionalChain` in `src/components/App.tsx`
  - `useIndexOf` (x2) in `src/components/layout/FileTree.test.tsx`
- **`.claude/rules/ci-hygiene.md`**: persist the policy in the repo so future contributors (and agents) treat annotations as fix-it items, not noise.
- **README badges**: add Release, CodeQL, latest release, downloads, license, Tauri v2, React 19, and Biome badges. Drop the redundant `## License` section at the bottom (license now linked via badge).

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Verified locally: `pnpm lint` and `pnpm typecheck` both clean. CI on the branch will exercise every workflow file touched.