### PR TITLE
fix(ci): produce byte-identical orig.tar.gz across PPA series

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,11 +452,23 @@ jobs:
           SERIES="${{ matrix.series }}"
           DATE=$(date -R)
 
-          # Set up source tree
-          mkdir -p /tmp/glyph-${VERSION}/debian
+          # Set up pristine source tree (no debian/ yet)
+          mkdir -p /tmp/glyph-${VERSION}
           cp -r /tmp/glyph-extracted/* /tmp/glyph-${VERSION}/
 
-          # Copy debian packaging files with version/date substitution
+          # Build orig tarball BEFORE adding debian/, with reproducible flags so
+          # every series in the matrix produces a byte-identical file. Launchpad
+          # rejects re-uploads of orig.tar.gz with differing contents.
+          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct "$GITHUB_REF_NAME")
+          tar --sort=name \
+              --mtime="@${SOURCE_DATE_EPOCH}" \
+              --owner=0 --group=0 --numeric-owner \
+              -cf - -C /tmp "glyph-${VERSION}" \
+            | gzip -n > /tmp/glyph_${VERSION}.orig.tar.gz
+
+          # Now add debian/ packaging (series-specific changelog lives here, but
+          # debuild ships it as the separate .debian.tar.xz, not in orig.tar.gz).
+          mkdir -p /tmp/glyph-${VERSION}/debian
           cp ppa/debian/control /tmp/glyph-${VERSION}/debian/
           cp ppa/debian/rules /tmp/glyph-${VERSION}/debian/
 
@@ -478,10 +490,7 @@ jobs:
           sed -e "s/{{VERSION}}/$VERSION/g" -e "s/{{SERIES}}/$SERIES/g" -e "s/{{DATE}}/$DATE/g" \
             ppa/debian/changelog > /tmp/glyph-${VERSION}/debian/changelog
 
-          # Create orig tarball
-          tar czf /tmp/glyph_${VERSION}.orig.tar.gz -C /tmp glyph-${VERSION}
-
-          # Build source package
+          # Build source package (picks up the orig.tar.gz we created above)
           cd /tmp/glyph-${VERSION}
           DEBUILD_LINTIAN=no debuild -S -sa -d -k"$GPG_KEY_ID"
       - name: Upload to PPA


### PR DESCRIPTION
## Summary

The Launchpad PPA upload for 0.6.0 noble was rejected with:

> File glyph_0.6.0.orig.tar.gz already exists in Glyph, but uploaded version has different contents.

The `publish-ppa` matrix builds jammy and noble in parallel and constructed `orig.tar.gz` **after** copying a series-specific `debian/changelog` into the source tree. Each runner therefore uploaded an `orig.tar.gz` with the same filename but different bytes. Launchpad accepted the first arrival and rejected the second.

## Changes

- Build `orig.tar.gz` before adding `debian/`, so the tarball is pristine upstream source only.
- Use reproducible `tar` flags (`--sort=name`, fixed `--mtime` from the tag commit, stable owner/group, `gzip -n`) so every series produces a byte-identical tarball.
- Series-specific packaging still ships in the separate `.debian.tar.xz` that `debuild -S` emits, which is the standard Debian layout.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Cannot be fully tested without cutting a release. Suggested verification path: land this, then cut 0.6.1 via the Create Release workflow and confirm both jammy and noble accept the upload on Launchpad.