### PR TITLE
ci: fail the job when codecov upload fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
           files: coverage/lcov.info
           flags: frontend
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   test-rust:
     name: Test (Rust)
@@ -117,6 +118,7 @@ jobs:
           files: coverage-rust.lcov
           flags: rust
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   clippy:
     name: Clippy


### PR DESCRIPTION
## Summary

Both Test (Frontend) and Test (Rust) currently swallow codecov upload failures. The action exits 0 even when the upload fails (missing token, network error, repo not activated), so the CI step shows green while codecov receives nothing. That left the README badge serving a 403 with no visible cause in CI.

Set `fail_ci_if_error: true` on both upload steps so any future upload problem surfaces immediately on the PR check.

> Note: this will start failing CI until `CODECOV_TOKEN` is configured in repo secrets and the repo is activated on codecov.io. Land that first, then merge this.

## Changes

- `.github/workflows/ci.yml`: add `fail_ci_if_error: true` to both `codecov/codecov-action@v6` steps.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Verified by the PR's own CI run.