### PR TITLE
test(rust): extract pure helpers from menu/watcher/lib and cover them

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,0 +1,119 @@
+use std::path::{Path, PathBuf};
+
+/// Resolve a CLI-supplied path against the working directory. Returns the
+/// canonicalized path if it points at something on disk, otherwise `None`.
+///
+/// Resolution order:
+/// 1. Empty / blank input → None.
+/// 2. Absolute path → canonicalize as-is.
+/// 3. Relative path → try `cwd/path`, then `cwd/../path` (covers `cargo tauri
+///    dev` running from `src-tauri/`). If neither exists, fall back to the
+///    cwd-relative variant so canonicalize can still report a meaningful error.
+pub fn resolve_initial_path(path_str: &str, cwd: &Path) -> Option<PathBuf> {
+    if path_str.is_empty() {
+        return None;
+    }
+    let path = Path::new(path_str);
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        let from_cwd = cwd.join(path);
+        if from_cwd.exists() {
+            from_cwd
+        } else {
+            let from_parent = cwd.join("..").join(path);
+            if from_parent.exists() {
+                from_parent
+            } else {
+                from_cwd
+            }
+        }
+    };
+    absolute.canonicalize().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_tmp(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "glyph_cli_test_{}_{}_{}",
+            name,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn empty_input_returns_none() {
+        assert!(resolve_initial_path("", Path::new("/tmp")).is_none());
+    }
+
+    #[test]
+    fn nonexistent_path_returns_none() {
+        let cwd = unique_tmp("missing");
+        let result = resolve_initial_path("does_not_exist.md", &cwd);
+        assert!(result.is_none());
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn absolute_existing_file_is_canonicalized() {
+        let cwd = unique_tmp("abs_file");
+        let file = cwd.join("notes.md");
+        fs::write(&file, "x").unwrap();
+
+        let resolved = resolve_initial_path(file.to_string_lossy().as_ref(), Path::new("/"))
+            .expect("should resolve");
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            file.canonicalize().unwrap()
+        );
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn relative_path_resolves_against_cwd() {
+        let cwd = unique_tmp("rel_cwd");
+        let file = cwd.join("readme.md");
+        fs::write(&file, "x").unwrap();
+
+        let resolved = resolve_initial_path("readme.md", &cwd).expect("should resolve");
+        assert_eq!(resolved, file.canonicalize().unwrap());
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn relative_path_falls_back_to_parent_when_cwd_misses() {
+        // Simulates `cargo tauri dev` running with cwd=src-tauri/ but the user
+        // passed a path that lives in the repo root one level up.
+        let root = unique_tmp("rel_parent_root");
+        fs::write(root.join("notes.md"), "x").unwrap();
+        let inner = root.join("src-tauri");
+        fs::create_dir_all(&inner).unwrap();
+
+        let resolved = resolve_initial_path("notes.md", &inner).expect("should resolve via parent");
+        assert_eq!(resolved, root.join("notes.md").canonicalize().unwrap());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn resolves_to_a_directory_path_too() {
+        let cwd = unique_tmp("rel_dir");
+        let sub = cwd.join("workspace");
+        fs::create_dir_all(&sub).unwrap();
+
+        let resolved = resolve_initial_path("workspace", &cwd).expect("should resolve");
+        assert!(resolved.is_dir());
+        assert_eq!(resolved, sub.canonicalize().unwrap());
+        let _ = fs::remove_dir_all(&cwd);
+    }
+}

--- a/src-tauri/src/commands/directory.rs
+++ b/src-tauri/src/commands/directory.rs
@@ -149,7 +149,10 @@ mod tests {
         assert!(names.contains(&"subdir"));
         assert!(names.contains(&"readme.md"));
         assert!(names.contains(&"notes.markdown"));
-        assert!(!names.contains(&"image.png"), "non-markdown files filtered out");
+        assert!(
+            !names.contains(&"image.png"),
+            "non-markdown files filtered out"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -213,7 +216,13 @@ mod tests {
         result.sort();
         let names: Vec<String> = result
             .iter()
-            .map(|p| Path::new(p).file_name().unwrap().to_string_lossy().to_string())
+            .map(|p| {
+                Path::new(p)
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            })
             .collect();
         assert!(names.contains(&"root.md".to_string()));
         assert!(names.contains(&"a.md".to_string()));
@@ -237,7 +246,13 @@ mod tests {
         let result = list_markdown_files(dir.to_string_lossy().to_string()).unwrap();
         let names: Vec<String> = result
             .iter()
-            .map(|p| Path::new(p).file_name().unwrap().to_string_lossy().to_string())
+            .map(|p| {
+                Path::new(p)
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            })
             .collect();
         assert_eq!(names, vec!["keep.md".to_string()]);
 

--- a/src-tauri/src/commands/wikilinks.rs
+++ b/src-tauri/src/commands/wikilinks.rs
@@ -154,7 +154,11 @@ mod tests {
     #[test]
     fn scan_wikilinks_finds_basic_targets() {
         let dir = unique_tmp("scan_basic");
-        fs::write(dir.join("a.md"), "Read [[B]] today.\nAlso [[B|the second]].\n").unwrap();
+        fs::write(
+            dir.join("a.md"),
+            "Read [[B]] today.\nAlso [[B|the second]].\n",
+        )
+        .unwrap();
         fs::write(dir.join("b.md"), "no links here").unwrap();
 
         let mut refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
@@ -206,7 +210,11 @@ mod tests {
     #[test]
     fn scan_wikilinks_records_line_and_snippet() {
         let dir = unique_tmp("scan_meta");
-        fs::write(dir.join("a.md"), "line one\nline two has [[Target#section|alias]] here\n").unwrap();
+        fs::write(
+            dir.join("a.md"),
+            "line one\nline two has [[Target#section|alias]] here\n",
+        )
+        .unwrap();
 
         let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
         assert_eq!(refs.len(), 1);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,12 +1,13 @@
+mod cli;
 mod commands;
 mod markdown;
 mod menu;
 mod watcher;
 
 use std::sync::{Arc, Mutex};
-use tauri::{DragDropEvent, Emitter, Manager, WindowEvent};
 #[cfg(target_os = "macos")]
 use tauri::RunEvent;
+use tauri::{DragDropEvent, Emitter, Manager, WindowEvent};
 use tauri_plugin_cli::CliExt;
 use watcher::FileWatcherState;
 
@@ -22,7 +23,9 @@ pub fn run() {
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
-        .manage(FileWatcherState(Arc::new(Mutex::new(std::collections::HashMap::new()))))
+        .manage(FileWatcherState(Arc::new(Mutex::new(
+            std::collections::HashMap::new(),
+        ))))
         .manage(commands::InitialFile(Mutex::new(None)))
         .manage(commands::InitialFolder(Mutex::new(None)))
         .setup(|app| {
@@ -33,41 +36,17 @@ pub fn run() {
             if let Ok(matches) = app.cli().matches() {
                 if let Some(file_arg) = matches.args.get("file") {
                     if let Some(path_str) = file_arg.value.as_str() {
-                        if !path_str.is_empty() {
-                            let path = std::path::Path::new(path_str);
-                            let absolute = if path.is_absolute() {
-                                path.to_path_buf()
+                        let cwd = std::env::current_dir().unwrap_or_default();
+                        if let Some(canonical) = cli::resolve_initial_path(path_str, &cwd) {
+                            let abs_str = canonical.to_string_lossy().to_string();
+                            if canonical.is_dir() {
+                                let state = app.state::<commands::InitialFolder>();
+                                let mut guard = state.0.lock().unwrap();
+                                *guard = Some(abs_str);
                             } else {
-                                // Try current dir first, then TAURI_INVOKE_ORIGIN or parent
-                                let from_cwd = std::env::current_dir()
-                                    .unwrap_or_default()
-                                    .join(path);
-                                if from_cwd.exists() {
-                                    from_cwd
-                                } else {
-                                    // In dev mode, cwd is src-tauri/ — try parent
-                                    let from_parent = std::env::current_dir()
-                                        .unwrap_or_default()
-                                        .join("..")
-                                        .join(path);
-                                    if from_parent.exists() {
-                                        from_parent
-                                    } else {
-                                        from_cwd
-                                    }
-                                }
-                            };
-                            if let Ok(canonical) = absolute.canonicalize() {
-                                let abs_str = canonical.to_string_lossy().to_string();
-                                if canonical.is_dir() {
-                                    let state = app.state::<commands::InitialFolder>();
-                                    let mut guard = state.0.lock().unwrap();
-                                    *guard = Some(abs_str);
-                                } else {
-                                    let state = app.state::<commands::InitialFile>();
-                                    let mut guard = state.0.lock().unwrap();
-                                    *guard = Some(abs_str);
-                                }
+                                let state = app.state::<commands::InitialFile>();
+                                let mut guard = state.0.lock().unwrap();
+                                *guard = Some(abs_str);
                             }
                         }
                     }
@@ -118,7 +97,11 @@ pub fn run() {
                 if let Ok(path) = url.to_file_path() {
                     let path_str = path.to_string_lossy().to_string();
                     let is_folder = path.is_dir();
-                    let event_name = if is_folder { "open-folder" } else { "open-file" };
+                    let event_name = if is_folder {
+                        "open-folder"
+                    } else {
+                        "open-file"
+                    };
 
                     // Try to emit to the frontend (works if webview is ready)
                     let emitted = _app_handle.emit(event_name, &path_str).is_ok();
@@ -127,11 +110,13 @@ pub fn run() {
                     // (cold-launch via Finder open-with).
                     if emitted {
                         if is_folder {
-                            if let Some(state) = _app_handle.try_state::<commands::InitialFolder>() {
+                            if let Some(state) = _app_handle.try_state::<commands::InitialFolder>()
+                            {
                                 let mut guard = state.0.lock().unwrap();
                                 *guard = Some(path_str);
                             }
-                        } else if let Some(state) = _app_handle.try_state::<commands::InitialFile>() {
+                        } else if let Some(state) = _app_handle.try_state::<commands::InitialFile>()
+                        {
                             let mut guard = state.0.lock().unwrap();
                             *guard = Some(path_str);
                         }

--- a/src-tauri/src/markdown.rs
+++ b/src-tauri/src/markdown.rs
@@ -75,7 +75,9 @@ mod tests {
     #[test]
     fn with_directory_path() {
         assert!(is_markdown_file(Path::new("/home/user/docs/README.md")));
-        assert!(is_markdown_file(Path::new("./relative/path/notes.markdown")));
+        assert!(is_markdown_file(Path::new(
+            "./relative/path/notes.markdown"
+        )));
     }
 
     #[test]

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -40,12 +40,14 @@ pub fn build_menu(app: &App) -> tauri::Result<tauri::menu::Menu<Wry>> {
         .build()?;
 
     // View menu
-    let toggle_files_sidebar = MenuItemBuilder::with_id("toggle-files-sidebar", "Toggle Files Sidebar")
-        .accelerator("CmdOrCtrl+B")
-        .build(handle)?;
-    let toggle_outline_sidebar = MenuItemBuilder::with_id("toggle-outline-sidebar", "Toggle Outline Sidebar")
-        .accelerator("CmdOrCtrl+\\")
-        .build(handle)?;
+    let toggle_files_sidebar =
+        MenuItemBuilder::with_id("toggle-files-sidebar", "Toggle Files Sidebar")
+            .accelerator("CmdOrCtrl+B")
+            .build(handle)?;
+    let toggle_outline_sidebar =
+        MenuItemBuilder::with_id("toggle-outline-sidebar", "Toggle Outline Sidebar")
+            .accelerator("CmdOrCtrl+\\")
+            .build(handle)?;
 
     let zoom_in = MenuItemBuilder::with_id("zoom-in", "Zoom In")
         .accelerator("CmdOrCtrl+=")
@@ -76,14 +78,11 @@ pub fn build_menu(app: &App) -> tauri::Result<tauri::menu::Menu<Wry>> {
         .build()?;
 
     // AI menu
-    let ai_summarize = MenuItemBuilder::with_id("ai-summarize", "Summarize Document")
-        .build(handle)?;
-    let ai_explain = MenuItemBuilder::with_id("ai-explain", "Explain Document")
-        .build(handle)?;
-    let ai_simplify = MenuItemBuilder::with_id("ai-simplify", "Simplify Document")
-        .build(handle)?;
-    let ai_read_aloud = MenuItemBuilder::with_id("ai-read-aloud", "Read Aloud")
-        .build(handle)?;
+    let ai_summarize =
+        MenuItemBuilder::with_id("ai-summarize", "Summarize Document").build(handle)?;
+    let ai_explain = MenuItemBuilder::with_id("ai-explain", "Explain Document").build(handle)?;
+    let ai_simplify = MenuItemBuilder::with_id("ai-simplify", "Simplify Document").build(handle)?;
+    let ai_read_aloud = MenuItemBuilder::with_id("ai-read-aloud", "Read Aloud").build(handle)?;
 
     let ai_menu = SubmenuBuilder::new(handle, "AI")
         .item(&ai_summarize)
@@ -171,64 +170,148 @@ pub fn build_menu(app: &App) -> tauri::Result<tauri::menu::Menu<Wry>> {
     Ok(menu)
 }
 
+/// Action a menu item triggers. `CloseWindow` is handled specially because it
+/// touches the window directly; every other entry just emits an event to the
+/// frontend. Keeping this as a pure mapping makes the wiring testable without
+/// booting a Tauri app.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MenuAction {
+    Emit(&'static str),
+    EmitWithPayload(&'static str, &'static str),
+    CloseWindow,
+}
+
+pub fn menu_action(id: &str) -> Option<MenuAction> {
+    Some(match id {
+        "open" => MenuAction::Emit("menu-open-file"),
+        "open-folder" => MenuAction::Emit("menu-open-folder"),
+        "close-tab" => MenuAction::Emit("menu-close-tab"),
+        "reset-view" => MenuAction::Emit("menu-reset-view"),
+        "print" => MenuAction::Emit("menu-print"),
+        "close" => MenuAction::CloseWindow,
+        "toggle-files-sidebar" => MenuAction::Emit("menu-toggle-files-sidebar"),
+        "toggle-outline-sidebar" => MenuAction::Emit("menu-toggle-outline-sidebar"),
+        "open-settings" => MenuAction::Emit("menu-open-settings"),
+        "ai-summarize" => MenuAction::EmitWithPayload("menu-ai-action", "summarize"),
+        "ai-explain" => MenuAction::EmitWithPayload("menu-ai-action", "explain"),
+        "ai-simplify" => MenuAction::EmitWithPayload("menu-ai-action", "simplify"),
+        "ai-read-aloud" => MenuAction::Emit("menu-ai-read-aloud"),
+        "zoom-in" => MenuAction::Emit("menu-zoom-in"),
+        "zoom-out" => MenuAction::Emit("menu-zoom-out"),
+        "actual-size" => MenuAction::Emit("menu-zoom-reset"),
+        "find" => MenuAction::Emit("menu-find"),
+        "toggle-edit" => MenuAction::Emit("menu-toggle-edit"),
+        _ => return None,
+    })
+}
+
 pub fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
-    match event.id().as_ref() {
-        "open" => {
-            let _ = app.emit("menu-open-file", ());
+    match menu_action(event.id().as_ref()) {
+        Some(MenuAction::Emit(name)) => {
+            let _ = app.emit(name, ());
         }
-        "open-folder" => {
-            let _ = app.emit("menu-open-folder", ());
+        Some(MenuAction::EmitWithPayload(name, payload)) => {
+            let _ = app.emit(name, payload);
         }
-        "close-tab" => {
-            let _ = app.emit("menu-close-tab", ());
-        }
-        "reset-view" => {
-            let _ = app.emit("menu-reset-view", ());
-        }
-        "print" => {
-            let _ = app.emit("menu-print", ());
-        }
-        "close" => {
+        Some(MenuAction::CloseWindow) => {
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.close();
             }
         }
-        "toggle-files-sidebar" => {
-            let _ = app.emit("menu-toggle-files-sidebar", ());
-        }
-        "toggle-outline-sidebar" => {
-            let _ = app.emit("menu-toggle-outline-sidebar", ());
-        }
-        "open-settings" => {
-            let _ = app.emit("menu-open-settings", ());
-        }
-        "ai-summarize" => {
-            let _ = app.emit("menu-ai-action", "summarize");
-        }
-        "ai-explain" => {
-            let _ = app.emit("menu-ai-action", "explain");
-        }
-        "ai-simplify" => {
-            let _ = app.emit("menu-ai-action", "simplify");
-        }
-        "ai-read-aloud" => {
-            let _ = app.emit("menu-ai-read-aloud", ());
-        }
-        "zoom-in" => {
-            let _ = app.emit("menu-zoom-in", ());
-        }
-        "zoom-out" => {
-            let _ = app.emit("menu-zoom-out", ());
-        }
-        "actual-size" => {
-            let _ = app.emit("menu-zoom-reset", ());
-        }
-        "find" => {
-            let _ = app.emit("menu-find", ());
-        }
-        "toggle-edit" => {
-            let _ = app.emit("menu-toggle-edit", ());
-        }
-        _ => {}
+        None => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_id_yields_no_action() {
+        assert!(menu_action("does-not-exist").is_none());
+        assert!(menu_action("").is_none());
+    }
+
+    #[test]
+    fn close_id_maps_to_close_window() {
+        assert_eq!(menu_action("close"), Some(MenuAction::CloseWindow));
+    }
+
+    #[test]
+    fn file_menu_emits() {
+        assert_eq!(
+            menu_action("open"),
+            Some(MenuAction::Emit("menu-open-file"))
+        );
+        assert_eq!(
+            menu_action("open-folder"),
+            Some(MenuAction::Emit("menu-open-folder"))
+        );
+        assert_eq!(menu_action("print"), Some(MenuAction::Emit("menu-print")));
+        assert_eq!(
+            menu_action("close-tab"),
+            Some(MenuAction::Emit("menu-close-tab"))
+        );
+        assert_eq!(
+            menu_action("open-settings"),
+            Some(MenuAction::Emit("menu-open-settings"))
+        );
+    }
+
+    #[test]
+    fn view_menu_emits() {
+        assert_eq!(
+            menu_action("toggle-files-sidebar"),
+            Some(MenuAction::Emit("menu-toggle-files-sidebar"))
+        );
+        assert_eq!(
+            menu_action("toggle-outline-sidebar"),
+            Some(MenuAction::Emit("menu-toggle-outline-sidebar"))
+        );
+        assert_eq!(
+            menu_action("toggle-edit"),
+            Some(MenuAction::Emit("menu-toggle-edit"))
+        );
+        assert_eq!(
+            menu_action("zoom-in"),
+            Some(MenuAction::Emit("menu-zoom-in"))
+        );
+        assert_eq!(
+            menu_action("zoom-out"),
+            Some(MenuAction::Emit("menu-zoom-out"))
+        );
+        assert_eq!(
+            menu_action("actual-size"),
+            Some(MenuAction::Emit("menu-zoom-reset"))
+        );
+        assert_eq!(
+            menu_action("reset-view"),
+            Some(MenuAction::Emit("menu-reset-view"))
+        );
+    }
+
+    #[test]
+    fn edit_menu_emits() {
+        assert_eq!(menu_action("find"), Some(MenuAction::Emit("menu-find")));
+    }
+
+    #[test]
+    fn ai_menu_emits_action_payloads() {
+        assert_eq!(
+            menu_action("ai-summarize"),
+            Some(MenuAction::EmitWithPayload("menu-ai-action", "summarize"))
+        );
+        assert_eq!(
+            menu_action("ai-explain"),
+            Some(MenuAction::EmitWithPayload("menu-ai-action", "explain"))
+        );
+        assert_eq!(
+            menu_action("ai-simplify"),
+            Some(MenuAction::EmitWithPayload("menu-ai-action", "simplify"))
+        );
+        assert_eq!(
+            menu_action("ai-read-aloud"),
+            Some(MenuAction::Emit("menu-ai-read-aloud"))
+        );
     }
 }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -6,6 +6,21 @@ use tauri::{AppHandle, Emitter, Manager};
 
 pub struct FileWatcherState(pub Arc<Mutex<HashMap<String, RecommendedWatcher>>>);
 
+/// A directory watch should fire when a markdown file or a sub-directory is
+/// added, removed, renamed, or modified. Everything else (e.g. attribute-only
+/// changes, non-markdown sibling files) is filtered out so the frontend isn't
+/// flooded with refreshes. Extracted as a pure helper so we can test the
+/// filter without booting a Tauri app.
+pub fn is_relevant_directory_change(event: &Event) -> bool {
+    matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Remove(_) | EventKind::Modify(_)
+    ) && event
+        .paths
+        .iter()
+        .any(|p| crate::is_markdown_file(p) || p.is_dir())
+}
+
 #[tauri::command]
 pub fn watch_file(path: String, app: AppHandle) -> Result<(), String> {
     let state = app.state::<FileWatcherState>();
@@ -59,16 +74,7 @@ pub fn watch_directory(path: String, app: AppHandle) -> Result<(), String> {
     let watched_path = path.clone();
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
         if let Ok(event) = res {
-            // Emit when markdown files are added/removed/renamed/modified, or when
-            // any directory entry changes (so subfolders show up immediately).
-            let relevant = match event.kind {
-                EventKind::Create(_) | EventKind::Remove(_) | EventKind::Modify(_) => event
-                    .paths
-                    .iter()
-                    .any(|p| crate::is_markdown_file(p) || p.is_dir()),
-                _ => false,
-            };
-            if relevant {
+            if is_relevant_directory_change(&event) {
                 let _ = app_handle.emit("directory-changed", &watched_path);
             }
         }
@@ -89,4 +95,94 @@ pub fn unwatch_directory(path: String, app: AppHandle) -> Result<(), String> {
     let mut watchers = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
     watchers.remove(&path);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{CreateKind, ModifyKind, RemoveKind};
+    use std::path::PathBuf;
+
+    fn event(kind: EventKind, paths: Vec<PathBuf>) -> Event {
+        Event {
+            kind,
+            paths,
+            attrs: Default::default(),
+        }
+    }
+
+    #[test]
+    fn relevant_when_markdown_file_is_created() {
+        let e = event(
+            EventKind::Create(CreateKind::File),
+            vec![PathBuf::from("/p/notes.md")],
+        );
+        assert!(is_relevant_directory_change(&e));
+    }
+
+    #[test]
+    fn relevant_when_markdown_file_is_removed() {
+        let e = event(
+            EventKind::Remove(RemoveKind::File),
+            vec![PathBuf::from("/p/notes.md")],
+        );
+        assert!(is_relevant_directory_change(&e));
+    }
+
+    #[test]
+    fn relevant_when_markdown_file_is_modified() {
+        let e = event(
+            EventKind::Modify(ModifyKind::Any),
+            vec![PathBuf::from("/p/notes.md")],
+        );
+        assert!(is_relevant_directory_change(&e));
+    }
+
+    #[test]
+    fn not_relevant_for_non_markdown_files() {
+        let e = event(
+            EventKind::Create(CreateKind::File),
+            vec![
+                PathBuf::from("/p/image.png"),
+                PathBuf::from("/p/binary.bin"),
+            ],
+        );
+        assert!(!is_relevant_directory_change(&e));
+    }
+
+    #[test]
+    fn not_relevant_for_access_or_other_event_kinds() {
+        let e = event(
+            EventKind::Access(notify::event::AccessKind::Read),
+            vec![PathBuf::from("/p/notes.md")],
+        );
+        assert!(!is_relevant_directory_change(&e));
+
+        let other = event(EventKind::Other, vec![PathBuf::from("/p/notes.md")]);
+        assert!(!is_relevant_directory_change(&other));
+    }
+
+    #[test]
+    fn relevant_for_directory_create_even_if_not_markdown() {
+        let dir = std::env::temp_dir().join(format!(
+            "glyph_watcher_test_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let e = event(EventKind::Create(CreateKind::Folder), vec![dir.clone()]);
+        assert!(is_relevant_directory_change(&e));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn not_relevant_when_paths_are_empty() {
+        let e = event(EventKind::Create(CreateKind::File), vec![]);
+        assert!(!is_relevant_directory_change(&e));
+    }
 }


### PR DESCRIPTION
## Summary

Lifts Rust coverage by making the parts of the backend that used to depend on a real Tauri \`AppHandle\` unit-testable. Three small, behavior-preserving extractions plus 18 new tests.

Total Rust test count: **41 → 60**.

## Changes

Pure-helper extractions (logic identical, just moved):

- \`menu::menu_action(id) -> Option<MenuAction>\` — id-to-action mapping. \`handle_menu_event\` now consults it and performs the side effect (\`app.emit(...)\` / window close) in a single thin match.
- \`watcher::is_relevant_directory_change(&Event) -> bool\` — predicate the directory watch closure used to inline. Same condition: a Create/Remove/Modify event whose paths include a markdown file or a directory.
- \`cli::resolve_initial_path(path_str, cwd) -> Option<PathBuf>\` — new module owning the CLI argument resolution (absolute / cwd / cwd-parent / canonicalize). \`lib.rs\`'s setup hook now calls it. Same resolution order, same fallback behavior.

New tests:

- \`menu\`: 6 tests covering every id mapping, the \`CloseWindow\` special case, and the unknown-id None path.
- \`watcher\`: 7 tests covering create / remove / modify on markdown files, non-markdown filtering, Access/Other event-kind rejection, directory create, and empty-paths.
- \`cli\`: 5 tests covering empty input, non-existent paths, absolute paths, cwd-relative resolution, the \`cargo tauri dev\` parent-directory fallback, and directory resolution.

Also picks up a \`cargo fmt\` pass over the existing test bodies (whitespace only, no semantic change).

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

\`cd src-tauri && cargo test\` → 60 passed; 0 failed.
\`cargo clippy --tests -- -D warnings\` → clean.

Toward #171.