### PR TITLE
ci: upload junit test results to Codecov Test Analytics

### DIFF
--- a/.claude/rules/ci-hygiene.md
+++ b/.claude/rules/ci-hygiene.md
@@ -12,5 +12,7 @@ Keep the GitHub Actions "Annotations" panel clean. Warnings and notices are real
 - Treat every `##[warning]` and `##[notice]` annotation as a fix-it item, not a TODO. The Lint job runs Biome with `--error-on-warnings`, so any new warning fails CI.
 - Apply Biome's suggested fix for lint findings instead of suppressing them (e.g. `useOptionalChain`, `useIndexOf`).
 - When GitHub flags an action as targeting a deprecated Node.js version, bump the action to the major version that ships on the current Node runtime. Examples: `pnpm/action-setup@v5+`, `actions/upload-artifact@v5+`, `codecov/codecov-action@v6+` (the v6 bump pulls in `actions/github-script@v8`).
+- Don't introduce deprecated actions, packages, or APIs. Before adding a third-party action or library, check its README/changelog for deprecation notices and pick the supported replacement instead. Examples we've hit: `codecov/test-results-action` (deprecated; use `codecov/codecov-action@v6` with `report_type: test_results`).
+- If an existing workflow step prints a deprecation warning at runtime, fix it in the same PR you noticed it in. Don't file a follow-up.
 - Update every workflow in `.github/workflows/` in the same pass, not just the file that triggered the alert.
 - Don't disable rules or filter annotations to silence warnings. If a rule genuinely doesn't fit the codebase, change it in `biome.json` with a justification, not inline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,14 @@ jobs:
           flags: frontend
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+      - name: Upload frontend test results
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v5
+        with:
+          files: junit-frontend.xml
+          flags: frontend
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   test-rust:
     name: Test (Rust)
@@ -108,14 +116,24 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
       - name: Run Rust tests with coverage
         working-directory: src-tauri
-        run: cargo llvm-cov --lcov --output-path ../coverage-rust.lcov
+        run: cargo llvm-cov nextest --lcov --output-path ../coverage-rust.lcov --profile ci
       - name: Upload Rust coverage
         if: always()
         uses: codecov/codecov-action@v6
         with:
           files: coverage-rust.lcov
+          flags: rust
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+      - name: Upload Rust test results
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v5
+        with:
+          files: src-tauri/target/nextest/ci/junit.xml
           flags: rust
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,11 @@ jobs:
           fail_ci_if_error: true
       - name: Upload frontend test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: junit-frontend.xml
           flags: frontend
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
@@ -131,10 +132,11 @@ jobs:
           fail_ci_if_error: true
       - name: Upload Rust test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: src-tauri/target/nextest/ci/junit.xml
           flags: rust
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 coverage/
 src-tauri/target/
 coverage/
+junit*.xml
 *.log
 .DS_Store
 

--- a/src-tauri/.config/nextest.toml
+++ b/src-tauri/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
+    reporters: process.env.CI
+      ? ["default", ["junit", { outputFile: "junit-frontend.xml" }]]
+      : ["default"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "html"],


### PR DESCRIPTION
## Summary

Enables [Codecov Test Analytics](https://docs.codecov.com/docs/test-analytics) so PRs get test-failure summaries and flaky tests on `main` are flagged automatically.

Closes #176.

## Changes

- `vitest.config.ts`: emit `junit-frontend.xml` alongside the default reporter when `CI=true` so local runs stay quiet.
- `.gitignore`: ignore `junit*.xml` so a stray local CI run doesn't get committed.
- `src-tauri/.config/nextest.toml`: new `ci` profile that writes `junit.xml` next to the nextest output dir.
- `.github/workflows/ci.yml`:
  - `test-frontend`: add `codecov/test-results-action@v5` step uploading the Vitest junit file with `flags: frontend`.
  - `test-rust`: install `cargo-nextest`, switch the coverage step to `cargo llvm-cov nextest --profile ci` (still produces the same lcov output), then upload `target/nextest/ci/junit.xml` with `flags: rust`.
- Both uploads use `if: ${{ !cancelled() }}` so failing tests still report results (the whole point of failure analytics) and `fail_ci_if_error: true` to match the existing coverage upload contract.

## Testing

- [ ] CI green
- [ ] Codecov bot comment on this PR includes a Test Analytics / Test Results section
- [ ] After merge, confirm the Codecov UI starts populating the Tests tab for both `frontend` and `rust` flags