### PR TITLE
feat(editor): undo/redo for in-document edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - Table of Contents sidebar with active heading tracking
 - Print & PDF export — `Cmd/Ctrl+P` with configurable page breaks, optional TOC, and theme-color control
 - Live reload — file watcher auto-updates on external changes
+- Undo / redo for in-document edits — `Cmd/Ctrl+Z` and `Cmd/Ctrl+Shift+Z` reverse task-list checkbox toggles and other programmatic edits per tab
 - Drag and drop markdown files or folders to open
 - File associations — double-click `.md` files to open in Glyph
 - CLI support — `glyph README.md` opens a file; `glyph ~/notes/` opens a folder as a workspace
@@ -192,6 +193,8 @@ cd src-tauri && cargo clippy    # Lint Rust
 | `Cmd+=` / `Ctrl+=` | Zoom in |
 | `Cmd+-` / `Ctrl+-` | Zoom out |
 | `Cmd+0` / `Ctrl+0` | Reset zoom |
+| `Cmd+Z` / `Ctrl+Z` | Undo last in-document edit (e.g. task checkbox toggle) |
+| `Cmd+Shift+Z` / `Ctrl+Shift+Z` (also `Ctrl+Y` on Windows/Linux) | Redo |
 | `Cmd+B` / `Ctrl+B` | Toggle files sidebar |
 | `Cmd+\` / `Ctrl+\` | Toggle outline sidebar |
 | `Cmd+,` / `Ctrl+,` | Settings |

--- a/samples/README.md
+++ b/samples/README.md
@@ -239,6 +239,7 @@ In the editor or split view, typing `[[` opens a popup with workspace files. Kee
 | `Cmd+F` | Find in document |
 | `Cmd+=` / `Cmd+-` | Zoom in / out |
 | `Cmd+0` | Reset zoom |
+| `Cmd+Z` / `Cmd+Shift+Z` | Undo / redo task checkbox toggles |
 | `Cmd+B` | Toggle sidebar |
 | `Cmd+,` | Settings |
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,26 +1,27 @@
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { type AIAction, useAI } from "@/hooks/useAI";
+import { useAutoSave } from "@/hooks/useAutoSave";
+import { useContextMenu } from "@/hooks/useContextMenu";
+import { useDocumentUndoRedo } from "@/hooks/useDocumentUndoRedo";
 import { useNativeMenuState } from "@/hooks/useNativeMenuState";
-import { type AIAction, useAI } from "../hooks/useAI";
-import { useAutoSave } from "../hooks/useAutoSave";
-import { useContextMenu } from "../hooks/useContextMenu";
-import { usePlatform } from "../hooks/usePlatform";
-import { usePrint } from "../hooks/usePrint";
-import { useSettings } from "../hooks/useSettings";
-import { useTableOfContents } from "../hooks/useTableOfContents";
-import { activeFileOf, useTabs } from "../hooks/useTabs";
-import { useTaskList } from "../hooks/useTaskList";
-import { useTheme } from "../hooks/useTheme";
-import { useTTS } from "../hooks/useTTS";
-import { filterBacklinks } from "../lib/backlinks";
-import { ZOOM_DEFAULT, ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from "../lib/settings";
+import { usePlatform } from "@/hooks/usePlatform";
+import { usePrint } from "@/hooks/usePrint";
+import { useSettings } from "@/hooks/useSettings";
+import { useTableOfContents } from "@/hooks/useTableOfContents";
+import { activeFileOf, useTabs } from "@/hooks/useTabs";
+import { useTaskList } from "@/hooks/useTaskList";
+import { useTheme } from "@/hooks/useTheme";
+import { useTTS } from "@/hooks/useTTS";
+import { filterBacklinks } from "@/lib/backlinks";
+import { ZOOM_DEFAULT, ZOOM_MAX, ZOOM_MIN, ZOOM_STEP } from "@/lib/settings";
 // Code theme CSS (inline imports for production compatibility)
-import glyphThemeCSS from "../styles/highlight.css?inline";
-import githubThemeCSS from "../styles/highlight-github.css?inline";
-import monokaiThemeCSS from "../styles/highlight-monokai.css?inline";
-import nordThemeCSS from "../styles/highlight-nord.css?inline";
-import solarizedDarkThemeCSS from "../styles/highlight-solarized-dark.css?inline";
-import solarizedLightThemeCSS from "../styles/highlight-solarized-light.css?inline";
+import glyphThemeCSS from "@/styles/highlight.css?inline";
+import githubThemeCSS from "@/styles/highlight-github.css?inline";
+import monokaiThemeCSS from "@/styles/highlight-monokai.css?inline";
+import nordThemeCSS from "@/styles/highlight-nord.css?inline";
+import solarizedDarkThemeCSS from "@/styles/highlight-solarized-dark.css?inline";
+import solarizedLightThemeCSS from "@/styles/highlight-solarized-light.css?inline";
 import { MarkdownEditor, SplitView } from "./editor/lazyEditor";
 import { EmptyState } from "./layout/EmptyState";
 import { Sidebar } from "./layout/Sidebar";
@@ -64,6 +65,8 @@ export function App() {
     updateEditContent,
     markSaved,
     toggleTask,
+    undoEdit,
+    redoEdit,
     saveScrollPosition,
     openFileDialog,
   } = useTabs({
@@ -184,6 +187,8 @@ export function App() {
   );
 
   const { handleToggle: handleTaskToggle } = useTaskList({ activeTabId, toggleTask });
+
+  useDocumentUndoRedo({ activeTabId, platform, onUndo: undoEdit, onRedo: redoEdit });
 
   // Close the active tab (used by File → Close Folder which doubles as close-tab
   // when the active tab is a folder; Cmd+W still closes the window).

--- a/src/hooks/useDocumentUndoRedo.test.ts
+++ b/src/hooks/useDocumentUndoRedo.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useDocumentUndoRedo } from "./useDocumentUndoRedo";
+
+function dispatch(init: KeyboardEventInit, target?: Element) {
+  const event = new KeyboardEvent("keydown", { ...init, bubbles: true, cancelable: true });
+  // KeyboardEvent.target is read-only after dispatch; tests need to assert from
+  // a chosen element, so override the getter.
+  Object.defineProperty(event, "target", { value: target ?? document.body });
+  document.dispatchEvent(event);
+  return event;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("useDocumentUndoRedo", () => {
+  it("calls onUndo for Cmd+Z on macOS when focus is outside the editor", () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    renderHook(() =>
+      useDocumentUndoRedo({ activeTabId: "tab-1", platform: "macos", onUndo, onRedo }),
+    );
+    const event = dispatch({ key: "z", metaKey: true });
+    expect(onUndo).toHaveBeenCalledWith("tab-1");
+    expect(onRedo).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("calls onRedo for Shift+Cmd+Z", () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    renderHook(() =>
+      useDocumentUndoRedo({ activeTabId: "tab-1", platform: "macos", onUndo, onRedo }),
+    );
+    dispatch({ key: "z", metaKey: true, shiftKey: true });
+    expect(onRedo).toHaveBeenCalledWith("tab-1");
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+
+  it("defers to CodeMirror when focus is inside .cm-editor", () => {
+    const editor = document.createElement("div");
+    editor.className = "cm-editor";
+    const input = document.createElement("textarea");
+    editor.appendChild(input);
+    document.body.appendChild(editor);
+
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    renderHook(() =>
+      useDocumentUndoRedo({ activeTabId: "tab-1", platform: "macos", onUndo, onRedo }),
+    );
+    const event = dispatch({ key: "z", metaKey: true }, input);
+    expect(onUndo).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("is a no-op when no tab is active", () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    renderHook(() => useDocumentUndoRedo({ activeTabId: null, platform: "macos", onUndo, onRedo }));
+    dispatch({ key: "z", metaKey: true });
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+
+  it("ignores keys that do not match either shortcut", () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    renderHook(() =>
+      useDocumentUndoRedo({ activeTabId: "tab-1", platform: "macos", onUndo, onRedo }),
+    );
+    dispatch({ key: "a", metaKey: true });
+    dispatch({ key: "z" }); // no modifier
+    expect(onUndo).not.toHaveBeenCalled();
+    expect(onRedo).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDocumentUndoRedo.ts
+++ b/src/hooks/useDocumentUndoRedo.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import type { Platform } from "@/hooks/usePlatform";
+import { KEYBOARD_EVENT, matchesRedoShortcut, matchesUndoShortcut } from "@/lib/keyboard";
+
+interface UseDocumentUndoRedoOptions {
+  activeTabId: string | null;
+  platform: Platform;
+  onUndo: (tabId: string) => void;
+  onRedo: (tabId: string) => void;
+}
+
+// Global keyboard shortcut for programmatic-edit undo/redo (task toggles,
+// future rename refactors). CodeMirror keeps its own history for typed
+// input; we defer to it whenever focus is inside the editor pane.
+export function useDocumentUndoRedo({
+  activeTabId,
+  platform,
+  onUndo,
+  onRedo,
+}: UseDocumentUndoRedoOptions) {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const isUndo = matchesUndoShortcut(event, platform);
+      const isRedo = !isUndo && matchesRedoShortcut(event, platform);
+      if (!isUndo && !isRedo) return;
+      const target = event.target as Element | null;
+      if (target?.closest(".cm-editor")) return;
+      if (!activeTabId) return;
+      event.preventDefault();
+      if (isUndo) onUndo(activeTabId);
+      else onRedo(activeTabId);
+    };
+    document.addEventListener(KEYBOARD_EVENT.KeyDown, onKeyDown);
+    return () => document.removeEventListener(KEYBOARD_EVENT.KeyDown, onKeyDown);
+  }, [activeTabId, platform, onUndo, onRedo]);
+}

--- a/src/hooks/useTabs.test.tsx
+++ b/src/hooks/useTabs.test.tsx
@@ -323,6 +323,149 @@ describe("useTabs file operations", () => {
     }
   });
 
+  it("toggleTask in view mode writes to disk and records an undoable edit", async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(invoke).mockImplementation(
+      makeInvoker({
+        read_file: async () => "- [ ] task",
+        write_file: writeFile as unknown as Invoker,
+      }) as typeof invoke,
+    );
+    const { result } = renderHook(() => useTabs(defaultOptions()));
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/p/tasks.md");
+    });
+    const tabId = result.current.tabs[0].id;
+
+    await act(async () => {
+      await result.current.toggleTask(tabId, 1);
+    });
+    expect(writeFile).toHaveBeenCalledWith("write_file", {
+      path: "/p/tasks.md",
+      content: "- [x] task",
+    });
+    if (result.current.tabs[0].kind === "file") {
+      expect(result.current.tabs[0].file.content).toBe("- [x] task");
+    }
+
+    await act(async () => {
+      await result.current.undoEdit(tabId);
+    });
+    expect(writeFile).toHaveBeenLastCalledWith("write_file", {
+      path: "/p/tasks.md",
+      content: "- [ ] task",
+    });
+    if (result.current.tabs[0].kind === "file") {
+      expect(result.current.tabs[0].file.content).toBe("- [ ] task");
+    }
+
+    await act(async () => {
+      await result.current.redoEdit(tabId);
+    });
+    if (result.current.tabs[0].kind === "file") {
+      expect(result.current.tabs[0].file.content).toBe("- [x] task");
+    }
+  });
+
+  it("toggleTask in edit mode mutates editContent and is undoable", async () => {
+    vi.mocked(invoke).mockImplementation(
+      makeInvoker({
+        read_file: async () => "- [ ] task",
+      }) as typeof invoke,
+    );
+    const { result } = renderHook(() => useTabs(defaultOptions({ defaultEditorMode: "edit" })));
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/p/tasks.md");
+    });
+    const tabId = result.current.tabs[0].id;
+
+    await act(async () => {
+      await result.current.toggleTask(tabId, 1);
+    });
+    if (result.current.tabs[0].kind === "file") {
+      expect(result.current.tabs[0].file.editContent).toBe("- [x] task");
+      expect(result.current.tabs[0].file.dirty).toBe(true);
+    }
+
+    await act(async () => {
+      await result.current.undoEdit(tabId);
+    });
+    if (result.current.tabs[0].kind === "file") {
+      expect(result.current.tabs[0].file.editContent).toBe("- [ ] task");
+    }
+  });
+
+  it("undoEdit is a no-op when there is no history", async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(invoke).mockImplementation(
+      makeInvoker({
+        read_file: async () => "- [ ] task",
+        write_file: writeFile as unknown as Invoker,
+      }) as typeof invoke,
+    );
+    const { result } = renderHook(() => useTabs(defaultOptions()));
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/p/tasks.md");
+    });
+    const tabId = result.current.tabs[0].id;
+
+    await act(async () => {
+      await result.current.undoEdit(tabId);
+    });
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("an external file-changed reload drops the undo stack", async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+    let body = "- [ ] task";
+    const fileChanged = captureListener("file-changed");
+    vi.mocked(invoke).mockImplementation(
+      makeInvoker({
+        read_file: async () => body,
+        write_file: writeFile as unknown as Invoker,
+      }) as typeof invoke,
+    );
+
+    const { result } = renderHook(() => useTabs(defaultOptions({ autoReload: true })));
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/p/tasks.md");
+    });
+    const tabId = result.current.tabs[0].id;
+
+    await act(async () => {
+      await result.current.toggleTask(tabId, 1);
+    });
+    writeFile.mockClear();
+
+    // Skip past the self-save grace window (1500ms) so the file-changed event
+    // is treated as a true external reload rather than the echo of our write.
+    const realNow = Date.now;
+    const offset = 5000;
+    Date.now = () => realNow() + offset;
+    try {
+      body = "EXTERNAL EDIT";
+      await act(async () => {
+        fileChanged.handler?.({ payload: "/p/tasks.md" });
+        await new Promise((r) => setTimeout(r, 350));
+      });
+    } finally {
+      Date.now = realNow;
+    }
+
+    await act(async () => {
+      await result.current.undoEdit(tabId);
+    });
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
   it("saveScrollPosition + setActiveTab persists scrollTop to the leaving tab", async () => {
     const { result } = renderHook(() => useTabs(defaultOptions()));
     await waitFor(() => expect(result.current.initializing).toBe(false));

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -2,10 +2,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { WikilinkRef } from "../lib/backlinks";
-import { MARKDOWN_EXTENSIONS } from "../lib/markdownExtensions";
-import type { EditorMode } from "../lib/settings";
-import { toggleTaskAtLine } from "../lib/taskList";
+import type { WikilinkRef } from "@/lib/backlinks";
+import { emptyHistory, popRedo, popUndo, pushEntry, type TabHistory } from "@/lib/editHistory";
+import { MARKDOWN_EXTENSIONS } from "@/lib/markdownExtensions";
+import type { EditorMode } from "@/lib/settings";
+import { toggleTaskAtLine } from "@/lib/taskList";
 
 interface FileMetadata {
   name: string;
@@ -374,6 +375,7 @@ export function useTabs(options: UseTabsOptions) {
         invoke("unwatch_file", { path: tab.file.path }).catch(() => {});
       }
       scrollRefsMap.current.delete(id);
+      editHistory.current.delete(id);
       setWorkspaceIndex((prevIdx) => {
         if (!(id in prevIdx)) return prevIdx;
         const next = { ...prevIdx };
@@ -457,6 +459,10 @@ export function useTabs(options: UseTabsOptions) {
   const selfSaveTimes = useRef<Map<string, number>>(new Map());
   const SELF_SAVE_GRACE_MS = 1500;
 
+  // Per-tab undo/redo stack for programmatic edits (task toggles, future
+  // rename refactors). The editor's own history covers typed input.
+  const editHistory = useRef<Map<string, TabHistory>>(new Map());
+
   const markSaved = useCallback(
     (id: string, content: string) => {
       updateActiveFile(id, (f) => {
@@ -467,9 +473,37 @@ export function useTabs(options: UseTabsOptions) {
     [updateActiveFile],
   );
 
-  // Toggle a checklist item by source line number. In view mode the change
-  // writes straight to disk; in edit/split mode it updates editContent so the
-  // editor reflects the toggle and auto-save flushes it as usual.
+  // Apply a programmatic edit. In view mode writes straight to disk (with the
+  // self-save grace so the file-watcher doesn't re-enter); in edit/split mode
+  // it updates editContent so auto-save flushes it. Used by toggleTask and the
+  // undo/redo applier.
+  const applyProgrammaticEdit = useCallback(
+    async (id: string, next: string): Promise<boolean> => {
+      const tab = stateRef.current.tabs.find((t) => t.id === id);
+      if (!tab) return false;
+      const file = activeFileOf(tab);
+      if (!file) return false;
+
+      if (file.mode !== "view") {
+        updateActiveFile(id, (f) => ({ ...f, editContent: next, dirty: true }));
+        return true;
+      }
+
+      try {
+        await invoke("write_file", { path: file.path, content: next });
+        selfSaveTimes.current.set(file.path, Date.now());
+        updateActiveFile(id, (f) => ({ ...f, content: next }));
+        return true;
+      } catch (err) {
+        console.error("Failed to apply edit:", err);
+        return false;
+      }
+    },
+    [updateActiveFile],
+  );
+
+  // Toggle a checklist item by source line number. Pushes the change onto the
+  // tab's history stack so it can be undone.
   const toggleTask = useCallback(
     async (id: string, line: number) => {
       const tab = stateRef.current.tabs.find((t) => t.id === id);
@@ -482,20 +516,37 @@ export function useTabs(options: UseTabsOptions) {
       const next = toggleTaskAtLine(source, line);
       if (next === source) return;
 
-      if (isEditing) {
-        updateActiveFile(id, (f) => ({ ...f, editContent: next, dirty: true }));
-        return;
-      }
-
-      try {
-        await invoke("write_file", { path: file.path, content: next });
-        selfSaveTimes.current.set(file.path, Date.now());
-        updateActiveFile(id, (f) => ({ ...f, content: next }));
-      } catch (err) {
-        console.error("Failed to toggle task:", err);
+      const applied = await applyProgrammaticEdit(id, next);
+      if (applied) {
+        const current = editHistory.current.get(id) ?? emptyHistory();
+        editHistory.current.set(id, pushEntry(current, { before: source, after: next }));
       }
     },
-    [updateActiveFile],
+    [applyProgrammaticEdit],
+  );
+
+  const undoEdit = useCallback(
+    async (id: string) => {
+      const history = editHistory.current.get(id);
+      if (!history) return;
+      const result = popUndo(history);
+      if (!result) return;
+      const applied = await applyProgrammaticEdit(id, result.entry.before);
+      if (applied) editHistory.current.set(id, result.next);
+    },
+    [applyProgrammaticEdit],
+  );
+
+  const redoEdit = useCallback(
+    async (id: string) => {
+      const history = editHistory.current.get(id);
+      if (!history) return;
+      const result = popRedo(history);
+      if (!result) return;
+      const applied = await applyProgrammaticEdit(id, result.entry.after);
+      if (applied) editHistory.current.set(id, result.next);
+    },
+    [applyProgrammaticEdit],
   );
 
   const saveScrollPosition = useCallback(
@@ -612,6 +663,9 @@ export function useTabs(options: UseTabsOptions) {
             tabs: prev.tabs.map((t) => {
               const f = activeFileOf(t);
               if (!f || f.path !== changedPath) return t;
+              // External reload invalidates our edit history — replaying old
+              // diffs against changed content is unsafe.
+              editHistory.current.delete(t.id);
               const next: FileState = { ...f, content, metadata };
               return t.kind === "folder" ? { ...t, file: next } : { ...t, file: next };
             }),
@@ -690,6 +744,8 @@ export function useTabs(options: UseTabsOptions) {
     updateEditContent,
     markSaved,
     toggleTask,
+    undoEdit,
+    redoEdit,
     saveScrollPosition,
     openFileDialog,
   };

--- a/src/lib/editHistory.test.ts
+++ b/src/lib/editHistory.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { emptyHistory, MAX_HISTORY_ENTRIES, popRedo, popUndo, pushEntry } from "./editHistory";
+
+describe("editHistory", () => {
+  it("starts with empty undo and redo stacks", () => {
+    expect(emptyHistory()).toEqual({ undo: [], redo: [] });
+  });
+
+  it("pushes entries onto the undo stack and clears redo", () => {
+    const h0 = emptyHistory();
+    const h1 = pushEntry(h0, { before: "a", after: "b" });
+    expect(h1.undo).toHaveLength(1);
+    expect(h1.redo).toHaveLength(0);
+
+    // Simulate an undo so redo has content
+    const popped = popUndo(h1)!;
+    expect(popped.entry).toEqual({ before: "a", after: "b" });
+    expect(popped.next.redo).toHaveLength(1);
+
+    // A fresh push should clear the redo stack
+    const h2 = pushEntry(popped.next, { before: "x", after: "y" });
+    expect(h2.redo).toHaveLength(0);
+  });
+
+  it("caps the undo stack at MAX_HISTORY_ENTRIES, dropping oldest", () => {
+    let h = emptyHistory();
+    for (let i = 0; i < MAX_HISTORY_ENTRIES + 5; i++) {
+      h = pushEntry(h, { before: `b${i}`, after: `a${i}` });
+    }
+    expect(h.undo).toHaveLength(MAX_HISTORY_ENTRIES);
+    // Oldest 5 dropped, so first remaining is b5
+    expect(h.undo[0].before).toBe("b5");
+    expect(h.undo[h.undo.length - 1].before).toBe(`b${MAX_HISTORY_ENTRIES + 4}`);
+  });
+
+  it("popUndo moves the entry to the redo stack", () => {
+    const h0 = pushEntry(emptyHistory(), { before: "a", after: "b" });
+    const result = popUndo(h0)!;
+    expect(result.entry).toEqual({ before: "a", after: "b" });
+    expect(result.next.undo).toHaveLength(0);
+    expect(result.next.redo).toEqual([{ before: "a", after: "b" }]);
+  });
+
+  it("popUndo returns null when the undo stack is empty", () => {
+    expect(popUndo(emptyHistory())).toBeNull();
+  });
+
+  it("popRedo moves the entry back onto the undo stack", () => {
+    const h0 = pushEntry(emptyHistory(), { before: "a", after: "b" });
+    const undone = popUndo(h0)!.next;
+    const result = popRedo(undone)!;
+    expect(result.entry).toEqual({ before: "a", after: "b" });
+    expect(result.next.undo).toEqual([{ before: "a", after: "b" }]);
+    expect(result.next.redo).toHaveLength(0);
+  });
+
+  it("popRedo returns null when the redo stack is empty", () => {
+    expect(popRedo(emptyHistory())).toBeNull();
+  });
+});

--- a/src/lib/editHistory.ts
+++ b/src/lib/editHistory.ts
@@ -1,0 +1,40 @@
+// Per-tab undo/redo stack for programmatic edits that originate outside the
+// editor (task-list toggles, future rename refactors). The CodeMirror editor
+// keeps its own history for typed input; this stack only covers writes that
+// bypass it.
+
+export interface EditEntry {
+  before: string;
+  after: string;
+}
+
+export interface TabHistory {
+  undo: EditEntry[];
+  redo: EditEntry[];
+}
+
+export const MAX_HISTORY_ENTRIES = 50;
+
+export function emptyHistory(): TabHistory {
+  return { undo: [], redo: [] };
+}
+
+export function pushEntry(history: TabHistory, entry: EditEntry): TabHistory {
+  const undo = [...history.undo, entry];
+  if (undo.length > MAX_HISTORY_ENTRIES) undo.shift();
+  return { undo, redo: [] };
+}
+
+export function popUndo(history: TabHistory): { entry: EditEntry; next: TabHistory } | null {
+  if (history.undo.length === 0) return null;
+  const undo = history.undo.slice(0, -1);
+  const entry = history.undo[history.undo.length - 1];
+  return { entry, next: { undo, redo: [...history.redo, entry] } };
+}
+
+export function popRedo(history: TabHistory): { entry: EditEntry; next: TabHistory } | null {
+  if (history.redo.length === 0) return null;
+  const redo = history.redo.slice(0, -1);
+  const entry = history.redo[history.redo.length - 1];
+  return { entry, next: { undo: [...history.undo, entry], redo } };
+}

--- a/src/lib/keyboard.test.ts
+++ b/src/lib/keyboard.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { KEYBOARD_EVENT, matchesRedoShortcut, matchesUndoShortcut } from "./keyboard";
+
+function makeEvent(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent(KEYBOARD_EVENT.KeyDown, init);
+}
+
+describe("matchesUndoShortcut", () => {
+  it("matches Cmd+Z on macOS", () => {
+    expect(matchesUndoShortcut(makeEvent({ key: "z", metaKey: true }), "macos")).toBe(true);
+  });
+
+  it("matches Ctrl+Z on windows and linux", () => {
+    expect(matchesUndoShortcut(makeEvent({ key: "z", ctrlKey: true }), "windows")).toBe(true);
+    expect(matchesUndoShortcut(makeEvent({ key: "z", ctrlKey: true }), "linux")).toBe(true);
+  });
+
+  it("rejects Cmd+Z when shift or alt are held", () => {
+    expect(
+      matchesUndoShortcut(makeEvent({ key: "z", metaKey: true, shiftKey: true }), "macos"),
+    ).toBe(false);
+    expect(matchesUndoShortcut(makeEvent({ key: "z", metaKey: true, altKey: true }), "macos")).toBe(
+      false,
+    );
+  });
+
+  it("rejects unrelated keys", () => {
+    expect(matchesUndoShortcut(makeEvent({ key: "a", metaKey: true }), "macos")).toBe(false);
+  });
+
+  it("rejects the wrong platform modifier", () => {
+    expect(matchesUndoShortcut(makeEvent({ key: "z", ctrlKey: true }), "macos")).toBe(false);
+    expect(matchesUndoShortcut(makeEvent({ key: "z", metaKey: true }), "windows")).toBe(false);
+  });
+});
+
+describe("matchesRedoShortcut", () => {
+  it("matches Shift+Cmd+Z on macOS", () => {
+    expect(
+      matchesRedoShortcut(makeEvent({ key: "z", metaKey: true, shiftKey: true }), "macos"),
+    ).toBe(true);
+  });
+
+  it("matches Shift+Ctrl+Z and Ctrl+Y on windows and linux", () => {
+    expect(
+      matchesRedoShortcut(makeEvent({ key: "z", ctrlKey: true, shiftKey: true }), "windows"),
+    ).toBe(true);
+    expect(matchesRedoShortcut(makeEvent({ key: "y", ctrlKey: true }), "windows")).toBe(true);
+    expect(matchesRedoShortcut(makeEvent({ key: "y", ctrlKey: true }), "linux")).toBe(true);
+  });
+
+  it("does not match Cmd+Y on macOS (reserved by the OS)", () => {
+    expect(matchesRedoShortcut(makeEvent({ key: "y", metaKey: true }), "macos")).toBe(false);
+  });
+
+  it("rejects plain Cmd+Z without shift", () => {
+    expect(matchesRedoShortcut(makeEvent({ key: "z", metaKey: true }), "macos")).toBe(false);
+  });
+});

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -1,0 +1,28 @@
+import type { Platform } from "@/hooks/usePlatform";
+import { isMac } from "@/lib/platform";
+
+export const KEYBOARD_EVENT = {
+  KeyDown: "keydown",
+} as const;
+
+const Key = {
+  Z: "z",
+  Y: "y",
+} as const;
+
+function hasPlatformModifier(event: KeyboardEvent, platform: Platform): boolean {
+  return isMac(platform) ? event.metaKey : event.ctrlKey;
+}
+
+export function matchesUndoShortcut(event: KeyboardEvent, platform: Platform): boolean {
+  if (!hasPlatformModifier(event, platform) || event.altKey || event.shiftKey) return false;
+  return event.key.toLowerCase() === Key.Z;
+}
+
+export function matchesRedoShortcut(event: KeyboardEvent, platform: Platform): boolean {
+  if (!hasPlatformModifier(event, platform) || event.altKey) return false;
+  const key = event.key.toLowerCase();
+  if (key === Key.Z && event.shiftKey) return true;
+  // Ctrl+Y is the Windows/Linux convention for redo; macOS uses Shift+Cmd+Z.
+  return !isMac(platform) && key === Key.Y && !event.shiftKey;
+}


### PR DESCRIPTION
## Summary

Adds a per-tab undo/redo stack for programmatic edits made outside the editor (today: task-list checkbox toggles; next: rename refactors). Without this, view-mode toggles wrote to disk with no recovery path, and edit-mode programmatic patches arrived in CodeMirror as opaque changes.

Closes #152

## Changes

- `src/lib/editHistory.ts` + test — pure per-tab `{ undo, redo }` stack capped at 50 entries.
- `src/lib/keyboard.ts` + test — `KEYBOARD_EVENT` constants and platform-aware `matchesUndoShortcut` / `matchesRedoShortcut` helpers (Cmd+Z on macOS, Ctrl+Z and Ctrl+Y on Win/Linux).
- `src/hooks/useTabs.ts` — `toggleTask` records onto the active tab's history; new `undoEdit` / `redoEdit` apply through the same write path as the original change (view-mode `write_file` with self-save grace, edit/split `editContent`). History clears on `closeTab` and on external file-changed reloads.
- `src/hooks/useDocumentUndoRedo.ts` + test — global keydown listener that calls `undoEdit` / `redoEdit` on the active tab and defers to CodeMirror when focus is inside `.cm-editor`.
- `src/components/App.tsx` — calls the new hook (single line); switched local imports to the `@/` alias.
- `README.md`, `samples/README.md` — feature bullet + shortcut row.

## Testing

- `pnpm typecheck` clean
- `pnpm check` (Biome) clean
- `pnpm test` — 439 tests pass (16 new across editHistory, keyboard, useTabs, useDocumentUndoRedo)

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux (WSL2)

## Test plan

- [ ] In view mode, click a `- [ ]` checkbox so it flips to `- [x]`. Press `Cmd/Ctrl+Z` — the checkbox and file content revert.
- [ ] `Cmd/Ctrl+Shift+Z` (or `Ctrl+Y` on Win/Linux) re-applies the toggle.
- [ ] Switch to split mode, toggle a checkbox in the rendered pane, then undo with focus outside the editor — editor pane updates accordingly.
- [ ] With focus inside the editor, `Cmd/Ctrl+Z` should still drive CodeMirror's own history (not the document stack).
- [ ] Modify the file externally → next undo is a no-op (stack cleared).
- [ ] Close the tab → reopening starts with an empty stack.