### PR TITLE
fix(context-menu): drop ambiguous "Toggle Sidebar" entry

### DIFF
--- a/.claude/rules/cleanup.md
+++ b/.claude/rules/cleanup.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "src/**/*.{ts,tsx,css}"
+  - "src-tauri/src/**/*.rs"
+---
+
+# Cleanup Rules
+
+When you remove a feature, delete a section, or refactor, finish the job. Half-removed code is worse than no change: it confuses readers, fails lints later, and rots into bugs.
+
+In the same commit as the removal, also delete or update:
+
+- **Callers and prop drilling.** If a function, hook, or component is gone, remove every import, every call site, and every type field that referenced it (props, context values, action objects, settings keys, event payloads).
+- **Tests.** Drop `*.test.ts`/`*.test.tsx` cases and mocks that exercise the removed code. Don't leave a `skip` or a comment, just delete.
+- **Types and enums.** Prune fields, variants, and union members that no caller writes anymore. If an interface only had one consumer and that consumer is gone, the interface goes too.
+- **Settings.** Remove now-unused entries from `src/lib/settings.ts` defaults, types, and the `SettingsModal` UI. If migration is needed for users with old persisted values, do it in the same PR.
+- **Menu items, shortcuts, and capabilities.** Drop entries from `src-tauri/src/menu.rs`, accelerators in `src/lib/keyboard.ts`, and capability grants in `src-tauri/capabilities/*.json` that no longer have a handler.
+- **Rust commands.** Remove `#[tauri::command]` functions whose only callers were the deleted frontend code, and prune them from `tauri::generate_handler![…]`.
+- **Styles.** Delete CSS classes, custom properties, and `data-*` selectors used only by the removed UI. Remove the corresponding `@import` in `src/styles/app.css` if a whole file goes.
+- **Docs.** Update `README.md`, `samples/README.md`, and any rule files that referenced the removed behaviour. If the change drops a keyboard shortcut, remove the row from the shortcuts table.
+- **Dependencies.** If a package or crate is no longer used after the change, remove it from `package.json` / `Cargo.toml` and refresh the lockfiles.
+
+Verify with the toolchain, not by eye: run `pnpm typecheck`, `pnpm lint`, and `cargo check` before opening the PR. Biome's `noUnusedImports` and `noUnusedVariables` plus `cargo`'s dead-code warnings catch most leftovers; treat any new warning as a blocker.
+
+Refactors get the same rule: when you replace `oldThing` with `newThing`, delete `oldThing` and every adaptor or compatibility shim once the migration is finished. Don't leave deprecated paths "just in case". If a follow-up really must exist, file an issue and link it, don't drop a `// TODO`.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -132,11 +132,11 @@ export function AppShell() {
   );
   useMenuEvents(menuHandlers);
 
-  // Context menu (Win/Linux only) — uses files-sidebar toggle for the legacy 'toggleSidebar' slot
+  // Context menu (Win/Linux only): text-content actions only. Sidebar/menu/zoom
+  // commands have their own keyboard shortcuts and titlebar buttons.
   const contextMenuActions = useMemo(
     () => ({
       openFileDialog,
-      toggleSidebar: sidebar.toggleFiles,
       ttsSpeak: tts.speak,
       ttsStop: tts.stop,
       ttsSpeaking: tts.speaking,
@@ -145,14 +145,7 @@ export function AppShell() {
       aiConfigured: aiController.configured,
       content: displayContent,
     }),
-    [
-      openFileDialog,
-      sidebar.toggleFiles,
-      tts,
-      handleAIActionFromMenu,
-      aiController.configured,
-      displayContent,
-    ],
+    [openFileDialog, tts, handleAIActionFromMenu, aiController.configured, displayContent],
   );
   useContextMenu(platform, contextMenuActions);
 

--- a/src/hooks/useContextMenu.test.tsx
+++ b/src/hooks/useContextMenu.test.tsx
@@ -155,9 +155,7 @@ describe("useContextMenu", () => {
 
   it("removes its listener on unmount", async () => {
     const removeSpy = vi.spyOn(document, "removeEventListener");
-    const { unmount } = renderHook(() =>
-      useContextMenu("linux", { openFileDialog: vi.fn() }),
-    );
+    const { unmount } = renderHook(() => useContextMenu("linux", { openFileDialog: vi.fn() }));
 
     act(() => {
       unmount();

--- a/src/hooks/useContextMenu.test.tsx
+++ b/src/hooks/useContextMenu.test.tsx
@@ -46,7 +46,7 @@ afterEach(() => {
 
 describe("useContextMenu", () => {
   it("attaches no contextmenu listener on macOS (defers to native)", async () => {
-    const actions = { openFileDialog: vi.fn(), toggleSidebar: vi.fn() };
+    const actions = { openFileDialog: vi.fn() };
     renderHook(() => useContextMenu("macos", actions));
 
     await fireContextMenu();
@@ -56,15 +56,15 @@ describe("useContextMenu", () => {
   });
 
   it("attaches no contextmenu listener on unknown platforms", async () => {
-    const actions = { openFileDialog: vi.fn(), toggleSidebar: vi.fn() };
+    const actions = { openFileDialog: vi.fn() };
     renderHook(() => useContextMenu("unknown", actions));
 
     await fireContextMenu();
     expect(menuItems).toHaveLength(0);
   });
 
-  it("builds a default menu (Copy, SelectAll, Open File, Toggle Sidebar) on Linux", async () => {
-    const actions = { openFileDialog: vi.fn(), toggleSidebar: vi.fn() };
+  it("builds a default menu (Copy, SelectAll, Open File) on Linux", async () => {
+    const actions = { openFileDialog: vi.fn() };
     renderHook(() => useContextMenu("linux", actions));
 
     await fireContextMenu();
@@ -73,7 +73,7 @@ describe("useContextMenu", () => {
     expect(labels).toContain("Copy");
     expect(labels).toContain("SelectAll");
     expect(labels.some((l) => l?.includes("Open File"))).toBe(true);
-    expect(labels).toContain("Toggle Sidebar");
+    expect(labels).not.toContain("Toggle Sidebar");
     expect(popupSpy).toHaveBeenCalled();
   });
 
@@ -82,7 +82,6 @@ describe("useContextMenu", () => {
     renderHook(() =>
       useContextMenu("linux", {
         openFileDialog: vi.fn(),
-        toggleSidebar: vi.fn(),
         ttsAvailable: true,
         ttsSpeaking: false,
         ttsSpeak,
@@ -103,7 +102,6 @@ describe("useContextMenu", () => {
     renderHook(() =>
       useContextMenu("linux", {
         openFileDialog: vi.fn(),
-        toggleSidebar: vi.fn(),
         ttsAvailable: true,
         ttsSpeaking: true,
         ttsStop,
@@ -124,7 +122,6 @@ describe("useContextMenu", () => {
     renderHook(() =>
       useContextMenu("linux", {
         openFileDialog: vi.fn(),
-        toggleSidebar: vi.fn(),
         aiConfigured: true,
         aiAction,
         content: "doc body",
@@ -146,23 +143,20 @@ describe("useContextMenu", () => {
     expect(aiAction).toHaveBeenCalledWith("summarize", "doc body");
   });
 
-  it("Open File and Toggle Sidebar fire the provided actions when invoked", async () => {
+  it("Open File fires the provided action when invoked", async () => {
     const openFileDialog = vi.fn();
-    const toggleSidebar = vi.fn();
-    renderHook(() => useContextMenu("linux", { openFileDialog, toggleSidebar }));
+    renderHook(() => useContextMenu("linux", { openFileDialog }));
 
     await fireContextMenu();
 
     menuItems.find((i) => i.text?.startsWith("Open File"))?.action?.();
-    menuItems.find((i) => i.text === "Toggle Sidebar")?.action?.();
     expect(openFileDialog).toHaveBeenCalled();
-    expect(toggleSidebar).toHaveBeenCalled();
   });
 
   it("removes its listener on unmount", async () => {
     const removeSpy = vi.spyOn(document, "removeEventListener");
     const { unmount } = renderHook(() =>
-      useContextMenu("linux", { openFileDialog: vi.fn(), toggleSidebar: vi.fn() }),
+      useContextMenu("linux", { openFileDialog: vi.fn() }),
     );
 
     act(() => {

--- a/src/hooks/useContextMenu.ts
+++ b/src/hooks/useContextMenu.ts
@@ -3,7 +3,6 @@ import type { Platform } from "./usePlatform";
 
 interface ContextMenuActions {
   openFileDialog: () => void;
-  toggleSidebar: () => void;
   ttsSpeak?: (text: string) => void;
   ttsStop?: () => void;
   ttsSpeaking?: boolean;
@@ -111,18 +110,12 @@ export function useContextMenu(platform: Platform, actions: ContextMenuActions) 
         }
       }
 
-      // Open File + Toggle Sidebar
+      // Open File
       items.push(await PredefinedMenuItem.new({ item: "Separator" }));
       items.push(
         await MenuItem.new({
           text: "Open File\u2026",
           action: () => actions.openFileDialog(),
-        }),
-      );
-      items.push(
-        await MenuItem.new({
-          text: "Toggle Sidebar",
-          action: () => actions.toggleSidebar(),
         }),
       );
 


### PR DESCRIPTION
## Summary

- The right-click context menu had a \"Toggle Sidebar\" item left over from before the files/outline sidebar split. It was ambiguous (which sidebar?), redundant with the keyboard shortcut, the View menu, and the titlebar buttons, and unreliable because the Tauri \`Menu\` wrapper can be GC'd between \`popup()\` resolving and the user clicking, dropping the action callback.
- Removes the entry and the now-dead \`toggleSidebar\` wiring from \`AppShell\`, \`useContextMenu\`, and its tests.
- Adds \`.claude/rules/cleanup.md\` so future removals propagate through callers, tests, types, settings, menus, Rust commands, styles, docs, and dependencies in the same commit.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` (480 tests pass)
- [ ] Right-click in the markdown view on Windows / Linux: menu shows Copy / Select All / (Search Google / Read Aloud / AI as applicable) / Open File, no Toggle Sidebar entry
- [ ] macOS still defers to the native WebView menu (unchanged)