### PR TITLE
fix(chocolatey): create Start Menu and Desktop shortcuts after MSI install

### DIFF
--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -11,3 +11,48 @@ $packageArgs = @{
 }
 
 Install-ChocolateyPackage @packageArgs
+
+# The Tauri WiX template should create Start Menu / Desktop shortcuts, but
+# we've seen MSI installs land Glyph in Program Files without surfacing it
+# in the Start Menu or Apps list (#188). Install shortcuts defensively from
+# the Chocolatey side so `choco install glyph` always leaves the app
+# discoverable. Idempotent: rerunning the install replaces the .lnks.
+
+# Locate the installed Glyph.exe. Prefer the registry uninstall key
+# (authoritative even if MSI changes install directory in the future) and
+# fall back to the Tauri default `Program Files\Glyph` per-machine path.
+$exePath = $null
+$keys = Get-UninstallRegistryKey -SoftwareName 'Glyph*'
+foreach ($key in $keys) {
+  $candidateDir = $key.InstallLocation
+  if ($candidateDir -and (Test-Path (Join-Path $candidateDir 'Glyph.exe'))) {
+    $exePath = Join-Path $candidateDir 'Glyph.exe'
+    break
+  }
+}
+if (-not $exePath) {
+  $fallback = Join-Path $env:ProgramFiles 'Glyph\Glyph.exe'
+  if (Test-Path $fallback) { $exePath = $fallback }
+}
+
+if ($exePath) {
+  $workingDir = Split-Path -Parent $exePath
+
+  $startMenuShortcut = Join-Path $env:ProgramData 'Microsoft\Windows\Start Menu\Programs\Glyph.lnk'
+  Install-ChocolateyShortcut `
+    -ShortcutFilePath $startMenuShortcut `
+    -TargetPath $exePath `
+    -WorkingDirectory $workingDir `
+    -Description 'Cross-platform markdown viewer' `
+    -IconLocation $exePath
+
+  $desktopShortcut = Join-Path $env:Public 'Desktop\Glyph.lnk'
+  Install-ChocolateyShortcut `
+    -ShortcutFilePath $desktopShortcut `
+    -TargetPath $exePath `
+    -WorkingDirectory $workingDir `
+    -Description 'Cross-platform markdown viewer' `
+    -IconLocation $exePath
+} else {
+  Write-Warning "Glyph.exe was not found after MSI install. Skipping shortcut creation."
+}

--- a/chocolatey/tools/chocolateyuninstall.ps1
+++ b/chocolatey/tools/chocolateyuninstall.ps1
@@ -14,3 +14,15 @@ if ($key.Count -eq 1) {
     Uninstall-ChocolateyPackage @packageArgs
   }
 }
+
+# Remove the Start Menu and Desktop shortcuts created by the install script.
+# Silent so a missing shortcut (e.g. user deleted it manually) is not an error.
+$shortcuts = @(
+  (Join-Path $env:ProgramData 'Microsoft\Windows\Start Menu\Programs\Glyph.lnk'),
+  (Join-Path $env:Public 'Desktop\Glyph.lnk')
+)
+foreach ($lnk in $shortcuts) {
+  if (Test-Path -LiteralPath $lnk) {
+    Remove-Item -LiteralPath $lnk -Force -ErrorAction SilentlyContinue
+  }
+}


### PR DESCRIPTION
## Summary

- After \`choco install glyph\`, Glyph landed in Program Files but never appeared in the Start Menu or Apps list, leaving users with no way to launch it short of finding the exe by hand (#188).
- The Tauri WiX template's \`ShortcutsFeature\` is supposed to register Start Menu / Desktop shortcuts during MSI install, but the result has been unreliable in practice. Rather than wait on a Tauri-side fix and another release cycle, this PR adds a defensive Chocolatey-side step that runs after \`Install-ChocolateyPackage\`:
  - Looks up the install directory from the registry uninstall key (authoritative); falls back to the Tauri per-machine default of \`Program Files\\Glyph\`.
  - Drops a \`Glyph.lnk\` into \`ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\` and \`Public\\Desktop\` via \`Install-ChocolateyShortcut\`.
- The uninstall script removes both \`.lnk\`s alongside the MSI uninstall. Operations are idempotent, so repeated installs/upgrades cleanly replace the shortcuts.

## Test plan

- [ ] On a clean Win 11 VM, \`choco install glyph -y\` then verify:
  - [ ] \"Glyph\" appears when typed into Start Menu search
  - [ ] \"Glyph\" appears in Settings → Apps
  - [ ] A Glyph shortcut is on the Desktop (or at least the Public Desktop folder for shared use)
  - [ ] Clicking each shortcut launches the app
- [ ] \`choco uninstall glyph -y\` removes both shortcuts
- [ ] Reinstall over an existing install does not duplicate shortcuts

## Notes / follow-ups

- Long-term it would be cleaner to fix this in the WiX template at the Tauri-bundle layer so the bare MSI installer works without Chocolatey's help, but that needs Windows-VM iteration we don't currently have. The Chocolatey-side fix is additive — when the bundle-layer issue is resolved, the registered shortcuts will simply be replaced by identical ones.

Closes #188