### PR TITLE
feat(sync): scaffold pluggable backend trait + Git impl over libgit2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -458,6 +458,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1453,6 +1455,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,6 +1525,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 name = "glyph"
 version = "0.7.0"
 dependencies = [
+ "git2",
  "notify",
  "serde",
  "serde_json",
@@ -1522,6 +1539,8 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-window-state",
+ "tempfile",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
@@ -2031,6 +2050,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,6 +2180,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.4+1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,6 +2209,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2638,6 +2692,28 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4856,6 +4932,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,9 +26,14 @@ serde_json = "1"
 notify = "8"
 tauri-plugin-opener = "2.5.4"
 walkdir = "2.5.0"
+# Statically-linked libgit2 so end users don't need a system Git install.
+# `vendored-openssl` keeps SSH/HTTPS support self-contained too.
+git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2", "vendored-openssl"] }
+thiserror = "2"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }
+tempfile = "3"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"windows\"))".dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod commands;
 mod markdown;
 mod menu;
 mod menu_runtime;
+mod sync;
 mod watcher;
 
 use std::sync::{Arc, Mutex};

--- a/src-tauri/src/sync/backend.rs
+++ b/src-tauri/src/sync/backend.rs
@@ -1,0 +1,183 @@
+//! Pluggable sync backend interface.
+//!
+//! Every sync backend implements [`SyncBackend`] — Git today, WebDAV /
+//! S3 / Nextcloud / enterprise plans tomorrow. The trait deliberately
+//! mirrors a "batch sync" model (status + sync = pull/push) because
+//! that's what Approach B in issue #113 asks for and what every
+//! filesystem-backed sync target supports.
+//!
+//! ### Future: realtime collaboration backends
+//!
+//! Realtime collab (Yjs over WebSocket) does not fit the batch model —
+//! it needs continuous publish/subscribe semantics. When that backend
+//! lands it will get its own trait (e.g. `RealtimeSyncBackend`) instead
+//! of trying to stretch [`SyncBackend`] to cover both modes. UI code
+//! that wants to talk to "whatever's configured" will branch on
+//! [`BackendKind`].
+
+use serde::{Deserialize, Serialize};
+
+use super::error::SyncError;
+
+/// Which backend implementation a workspace is configured to use.
+///
+/// New variants get added here as backends ship — the rest of the code
+/// pattern-matches against this so the compiler tells us every
+/// dispatch site that needs updating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BackendKind {
+    /// `git2`-backed local repository plus `origin` remote.
+    Git,
+    // Reserved for future PRs — listed here so the enum stays the single
+    // source of truth for "what can a workspace sync to":
+    // Webdav,
+    // S3,
+    // Realtime,
+}
+
+/// What to do when local and remote disagree on the same file. v1 only
+/// applies to text files; binary attachments always prompt the user.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConflictPolicy {
+    /// Stop and surface every conflict in the UI for the user to resolve
+    /// manually. Default; matches what Obsidian Sync does.
+    #[default]
+    Prompt,
+    /// Take the remote version, drop local edits. For "I just want the
+    /// other device's state" cases.
+    PreferRemote,
+    /// Take the local version, push over the remote. Mirror of
+    /// PreferRemote for the other direction.
+    PreferLocal,
+}
+
+/// Inspect-only snapshot of "where is this workspace at relative to
+/// its remote?". Computed without writing anything so it can refresh
+/// cheaply (status bar polling, manual refresh button).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusReport {
+    pub kind: BackendKind,
+    /// `true` if the working tree has no uncommitted changes.
+    pub clean: bool,
+    /// Commits that exist locally but have not been pushed to the remote.
+    pub ahead: u32,
+    /// Commits that exist on the remote but have not been pulled.
+    pub behind: u32,
+    /// File paths (relative to the workspace root) that are currently in
+    /// a conflicting state from a previous sync attempt and still need
+    /// the user's attention.
+    pub conflicts: Vec<String>,
+    /// Unix-second timestamp of the last successful sync, if any. The
+    /// frontend renders this however it likes ("2 minutes ago", etc.).
+    pub last_sync_unix: Option<i64>,
+}
+
+/// Outcome of a single [`SyncBackend::sync`] call. Frontend renders a
+/// short summary ("3 changes pulled, 1 committed locally") and stashes
+/// the timestamp so the next status check can show it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncResult {
+    pub kind: BackendKind,
+    /// New commits pulled from the remote.
+    pub pulled_count: u32,
+    /// Local commits created for previously-uncommitted changes.
+    pub committed_count: u32,
+    /// Commits pushed to the remote.
+    pub pushed_count: u32,
+    /// Files that came back conflicting after the merge attempt; sync
+    /// returns successfully here so the UI can surface them, then the
+    /// next call will refuse to sync until they're resolved.
+    pub conflicts: Vec<String>,
+    /// Unix-second timestamp recorded at the end of the call.
+    pub completed_unix: i64,
+}
+
+/// What every batch sync backend must offer.
+///
+/// Implementations are **blocking** by design (libgit2 is sync, WebDAV
+/// PUT/GET is sync, etc.); Tauri command handlers wrap calls in
+/// `tokio::task::spawn_blocking` so the runtime thread stays free.
+/// Realtime backends will get their own async trait.
+pub trait SyncBackend: Send + Sync {
+    fn kind(&self) -> BackendKind;
+
+    /// Inspect-only — never writes to disk or the network.
+    fn status(&self) -> Result<StatusReport, SyncError>;
+
+    /// Stage local changes, commit, fetch remote, merge, push. Returns a
+    /// summary the frontend can show; surfaces conflicts via the
+    /// `conflicts` field so the UI can open the resolution panel.
+    fn sync(&self) -> Result<SyncResult, SyncError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_kind_serialises_kebab_case() {
+        let v = serde_json::to_value(BackendKind::Git).unwrap();
+        assert_eq!(v, serde_json::json!("git"));
+        let back: BackendKind = serde_json::from_value(serde_json::json!("git")).unwrap();
+        assert_eq!(back, BackendKind::Git);
+    }
+
+    #[test]
+    fn conflict_policy_serialises_and_round_trips() {
+        for policy in [
+            ConflictPolicy::Prompt,
+            ConflictPolicy::PreferRemote,
+            ConflictPolicy::PreferLocal,
+        ] {
+            let v = serde_json::to_value(policy).unwrap();
+            let round: ConflictPolicy = serde_json::from_value(v).unwrap();
+            assert_eq!(round, policy);
+        }
+    }
+
+    #[test]
+    fn conflict_policy_default_is_prompt() {
+        assert_eq!(ConflictPolicy::default(), ConflictPolicy::Prompt);
+    }
+
+    #[test]
+    fn status_report_serialises_camel_case() {
+        let r = StatusReport {
+            kind: BackendKind::Git,
+            clean: false,
+            ahead: 2,
+            behind: 1,
+            conflicts: vec!["a.md".into()],
+            last_sync_unix: Some(1_700_000_000),
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["kind"], "git");
+        assert_eq!(v["lastSyncUnix"], 1_700_000_000);
+        assert_eq!(v["conflicts"], serde_json::json!(["a.md"]));
+        assert_eq!(v["clean"], false);
+        assert_eq!(v["ahead"], 2);
+        assert_eq!(v["behind"], 1);
+    }
+
+    #[test]
+    fn sync_result_serialises_camel_case() {
+        let r = SyncResult {
+            kind: BackendKind::Git,
+            pulled_count: 3,
+            committed_count: 1,
+            pushed_count: 1,
+            conflicts: vec![],
+            completed_unix: 1_700_000_500,
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["kind"], "git");
+        assert_eq!(v["pulledCount"], 3);
+        assert_eq!(v["committedCount"], 1);
+        assert_eq!(v["pushedCount"], 1);
+        assert_eq!(v["completedUnix"], 1_700_000_500);
+    }
+}

--- a/src-tauri/src/sync/config.rs
+++ b/src-tauri/src/sync/config.rs
@@ -13,6 +13,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::backend::{BackendKind, ConflictPolicy};
+use super::DEFAULT_REMOTE_BRANCH;
 
 /// What we keep on disk for a single workspace's sync setup.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -52,7 +53,7 @@ impl WorkspaceSyncConfig {
             workspace_path: workspace_path.into(),
             backend: BackendKind::Git,
             remote_url: String::new(),
-            remote_branch: "main".to_string(),
+            remote_branch: DEFAULT_REMOTE_BRANCH.to_string(),
             conflict_policy: ConflictPolicy::default(),
             auto_sync_seconds: None,
             author: None,
@@ -70,7 +71,7 @@ mod tests {
         assert_eq!(cfg.workspace_path, "/workspace/notes");
         assert_eq!(cfg.backend, BackendKind::Git);
         assert!(cfg.remote_url.is_empty());
-        assert_eq!(cfg.remote_branch, "main");
+        assert_eq!(cfg.remote_branch, DEFAULT_REMOTE_BRANCH);
         assert_eq!(cfg.conflict_policy, ConflictPolicy::Prompt);
         assert!(cfg.auto_sync_seconds.is_none());
         assert!(cfg.author.is_none());

--- a/src-tauri/src/sync/config.rs
+++ b/src-tauri/src/sync/config.rs
@@ -1,0 +1,120 @@
+//! Per-workspace sync configuration.
+//!
+//! Configuration lives outside the workspace folder (in the Tauri store
+//! plugin's app data dir) so users can opt into sync without polluting
+//! the repo with `.glyph/` files. The shape is one config per workspace
+//! root path.
+//!
+//! Credentials (PAT / SSH passphrase / etc.) are *not* in this struct —
+//! a follow-up PR routes them through the OS keychain via
+//! `tauri-plugin-stronghold` or `keyring-rs`. This struct only carries
+//! the bits we'd happily write to disk in plaintext.
+
+use serde::{Deserialize, Serialize};
+
+use super::backend::{BackendKind, ConflictPolicy};
+
+/// What we keep on disk for a single workspace's sync setup.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceSyncConfig {
+    /// Workspace root, absolute. Acts as the lookup key in the store.
+    pub workspace_path: String,
+    /// Which backend variant is configured.
+    pub backend: BackendKind,
+    /// Remote URL — `https://github.com/user/notes.git`, etc.
+    pub remote_url: String,
+    /// Branch we follow on the remote. Defaults to `main`.
+    pub remote_branch: String,
+    /// What to do when local and remote disagree on the same file.
+    pub conflict_policy: ConflictPolicy,
+    /// Auto-sync interval in seconds, or `None` to disable background
+    /// sync. The scheduler lives in a follow-up PR.
+    pub auto_sync_seconds: Option<u32>,
+    /// Author identity used for commits Glyph creates on the user's
+    /// behalf. Optional — falls back to libgit2's global config when
+    /// `None`.
+    pub author: Option<CommitIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitIdentity {
+    pub name: String,
+    pub email: String,
+}
+
+impl WorkspaceSyncConfig {
+    /// Default config for a brand new Git-backed workspace. Caller still
+    /// has to fill in `remote_url`.
+    pub fn new_git(workspace_path: impl Into<String>) -> Self {
+        Self {
+            workspace_path: workspace_path.into(),
+            backend: BackendKind::Git,
+            remote_url: String::new(),
+            remote_branch: "main".to_string(),
+            conflict_policy: ConflictPolicy::default(),
+            auto_sync_seconds: None,
+            author: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_git_defaults_to_main_branch_and_prompt_conflicts() {
+        let cfg = WorkspaceSyncConfig::new_git("/workspace/notes");
+        assert_eq!(cfg.workspace_path, "/workspace/notes");
+        assert_eq!(cfg.backend, BackendKind::Git);
+        assert!(cfg.remote_url.is_empty());
+        assert_eq!(cfg.remote_branch, "main");
+        assert_eq!(cfg.conflict_policy, ConflictPolicy::Prompt);
+        assert!(cfg.auto_sync_seconds.is_none());
+        assert!(cfg.author.is_none());
+    }
+
+    #[test]
+    fn round_trips_through_serde_camel_case() {
+        let cfg = WorkspaceSyncConfig {
+            workspace_path: "/w".to_string(),
+            backend: BackendKind::Git,
+            remote_url: "https://example.com/notes.git".to_string(),
+            remote_branch: "trunk".to_string(),
+            conflict_policy: ConflictPolicy::PreferRemote,
+            auto_sync_seconds: Some(300),
+            author: Some(CommitIdentity {
+                name: "Hamid".into(),
+                email: "h@example.com".into(),
+            }),
+        };
+        let v = serde_json::to_value(&cfg).unwrap();
+        assert_eq!(v["workspacePath"], "/w");
+        assert_eq!(v["remoteUrl"], "https://example.com/notes.git");
+        assert_eq!(v["remoteBranch"], "trunk");
+        assert_eq!(v["conflictPolicy"], "prefer-remote");
+        assert_eq!(v["autoSyncSeconds"], 300);
+        assert_eq!(v["author"]["name"], "Hamid");
+
+        let round: WorkspaceSyncConfig = serde_json::from_value(v).unwrap();
+        assert_eq!(round, cfg);
+    }
+
+    #[test]
+    fn deserialises_minimal_payload_omitting_optionals() {
+        let json = serde_json::json!({
+            "workspacePath": "/w",
+            "backend": "git",
+            "remoteUrl": "https://example.com/n.git",
+            "remoteBranch": "main",
+            "conflictPolicy": "prompt",
+            "autoSyncSeconds": null,
+            "author": null,
+        });
+        let cfg: WorkspaceSyncConfig = serde_json::from_value(json).unwrap();
+        assert!(cfg.auto_sync_seconds.is_none());
+        assert!(cfg.author.is_none());
+    }
+}

--- a/src-tauri/src/sync/error.rs
+++ b/src-tauri/src/sync/error.rs
@@ -1,0 +1,100 @@
+//! Common error type for every sync backend.
+//!
+//! Each variant is something the UI can act on:
+//! - `NotConfigured` → prompt the user to set up sync for this workspace.
+//! - `AuthFailed` → ask for credentials again.
+//! - `Network` → surface a retryable "couldn't reach the remote" notice.
+//! - `Conflict` → open the conflict-resolution UI (future PR).
+//! - `Io` and `Backend` → log and show a generic error.
+//!
+//! Backends should map their library-specific failures into these
+//! variants instead of leaking implementation-detail strings.
+
+use serde::Serialize;
+
+#[derive(Debug, thiserror::Error, Serialize)]
+#[serde(tag = "kind", content = "message", rename_all = "kebab-case")]
+pub enum SyncError {
+    #[error("sync is not configured for this workspace")]
+    NotConfigured,
+
+    #[error("authentication failed: {0}")]
+    AuthFailed(String),
+
+    #[error("network error: {0}")]
+    Network(String),
+
+    #[error("conflict in {} file(s); resolve before syncing again", .0.len())]
+    Conflict(Vec<String>),
+
+    #[error("repository is in a state we don't understand: {0}")]
+    InvalidState(String),
+
+    #[error("i/o error: {0}")]
+    Io(String),
+
+    #[error("backend error: {0}")]
+    Backend(String),
+}
+
+impl From<std::io::Error> for SyncError {
+    fn from(e: std::io::Error) -> Self {
+        SyncError::Io(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_messages_describe_each_variant() {
+        assert_eq!(
+            SyncError::NotConfigured.to_string(),
+            "sync is not configured for this workspace"
+        );
+        assert_eq!(
+            SyncError::AuthFailed("bad token".to_string()).to_string(),
+            "authentication failed: bad token"
+        );
+        assert_eq!(
+            SyncError::Network("timeout".to_string()).to_string(),
+            "network error: timeout"
+        );
+        assert_eq!(
+            SyncError::Conflict(vec!["a.md".to_string(), "b.md".to_string()]).to_string(),
+            "conflict in 2 file(s); resolve before syncing again"
+        );
+        assert_eq!(
+            SyncError::InvalidState("detached HEAD".to_string()).to_string(),
+            "repository is in a state we don't understand: detached HEAD"
+        );
+        assert_eq!(
+            SyncError::Io("disk full".to_string()).to_string(),
+            "i/o error: disk full"
+        );
+        assert_eq!(
+            SyncError::Backend("libgit2 boom".to_string()).to_string(),
+            "backend error: libgit2 boom"
+        );
+    }
+
+    #[test]
+    fn io_error_converts_via_from() {
+        let err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let sync_err: SyncError = err.into();
+        assert!(matches!(sync_err, SyncError::Io(msg) if msg.contains("missing")));
+    }
+
+    #[test]
+    fn serialises_to_tagged_object_for_the_frontend() {
+        let json = serde_json::to_value(SyncError::NotConfigured).unwrap();
+        assert_eq!(json["kind"], "not-configured");
+        let json = serde_json::to_value(SyncError::AuthFailed("nope".into())).unwrap();
+        assert_eq!(json["kind"], "auth-failed");
+        assert_eq!(json["message"], "nope");
+        let json = serde_json::to_value(SyncError::Conflict(vec!["x".into()])).unwrap();
+        assert_eq!(json["kind"], "conflict");
+        assert_eq!(json["message"], serde_json::json!(["x"]));
+    }
+}

--- a/src-tauri/src/sync/git.rs
+++ b/src-tauri/src/sync/git.rs
@@ -1,0 +1,728 @@
+//! Git-backed sync. Built on `git2` (statically-linked libgit2) so end
+//! users don't need a system `git` install — the entire backend ships
+//! inside the Glyph binary.
+//!
+//! Sync flow when [`GitBackend::sync`] is called:
+//!
+//! 1. Stage every change in the working tree (`git add -A`).
+//! 2. If there is anything staged, create a `glyph: auto-commit` commit
+//!    on the current branch using the configured author identity (or
+//!    libgit2's global config as a fallback).
+//! 3. Fetch the configured remote branch.
+//! 4. Fast-forward when possible. If fast-forward isn't possible, merge
+//!    the remote into the local branch with libgit2's merge analysis:
+//!    success → commit the merge; conflicts → surface them in
+//!    [`super::backend::SyncResult::conflicts`] and stop without pushing
+//!    so the user can resolve.
+//! 5. Push the local branch to the remote.
+//!
+//! Status is computed without touching the network: it counts dirty
+//! files in the index, then compares the current branch's tip against
+//! its upstream's last-known SHA for ahead / behind. The next sync call
+//! fetches and recomputes from real refs.
+//!
+//! Credentials: for v1 we only handle HTTPS + a static PAT-style token.
+//! SSH-agent / per-key flows land in a follow-up PR; the credential
+//! callback in this module is where they will attach.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use git2::{
+    BranchType, FetchOptions, MergeOptions, PushOptions, RemoteCallbacks, Repository, StatusOptions,
+};
+
+use super::backend::{BackendKind, StatusReport, SyncBackend, SyncResult};
+use super::config::WorkspaceSyncConfig;
+use super::error::SyncError;
+
+/// Default commit message Glyph uses when it auto-commits local
+/// changes during a sync. The user always sees a real "you wrote
+/// notes" history in their repo, but they don't have to author each
+/// commit by hand.
+const AUTO_COMMIT_MESSAGE: &str = "glyph: auto-commit local changes";
+/// What we call the merge commit when we have to reconcile remote.
+const MERGE_COMMIT_MESSAGE: &str = "glyph: merge remote changes";
+/// Remote name we look up; matches `git clone`'s default.
+const ORIGIN: &str = "origin";
+
+pub struct GitBackend {
+    config: WorkspaceSyncConfig,
+    /// Optional plaintext token used for HTTPS basic-auth. v1 hardcoded
+    /// to "x-access-token" username (GitHub / Codeberg / GitLab all
+    /// accept it). SSH key flow comes in a follow-up.
+    https_token: Option<String>,
+}
+
+impl GitBackend {
+    pub fn new(config: WorkspaceSyncConfig) -> Self {
+        Self {
+            config,
+            https_token: None,
+        }
+    }
+
+    /// Attach an HTTPS PAT/token. Used for private remotes; public
+    /// HTTPS clones don't need a token at all.
+    pub fn with_https_token(mut self, token: impl Into<String>) -> Self {
+        self.https_token = Some(token.into());
+        self
+    }
+
+    fn workspace(&self) -> &Path {
+        Path::new(&self.config.workspace_path)
+    }
+
+    /// Open the workspace as a Git repo. Surfaces a clear error if the
+    /// folder hasn't been `git init`'d / cloned yet — callers should
+    /// route that into the "set up sync" flow instead of treating it
+    /// as a generic failure.
+    fn open_repo(&self) -> Result<Repository, SyncError> {
+        Repository::open(self.workspace()).map_err(|e| {
+            if e.code() == git2::ErrorCode::NotFound {
+                SyncError::NotConfigured
+            } else {
+                SyncError::Backend(e.message().to_string())
+            }
+        })
+    }
+
+    /// Build the libgit2 credentials callback. Used for both fetch and
+    /// push. Tries the configured HTTPS token first, then falls back to
+    /// the libgit2 ssh-agent / default credentials so SSH-cloned repos
+    /// keep working too.
+    fn credentials_callbacks(&self) -> RemoteCallbacks<'_> {
+        let mut cb = RemoteCallbacks::new();
+        let token = self.https_token.clone();
+        cb.credentials(move |_url, username_from_url, allowed| {
+            // HTTPS basic auth — what `https://github.com/...` remotes
+            // expect. "x-access-token" is a magic GitHub PAT username
+            // but GitLab / Codeberg accept any non-empty username.
+            if allowed.is_user_pass_plaintext() {
+                if let Some(t) = token.as_ref() {
+                    return git2::Cred::userpass_plaintext("x-access-token", t);
+                }
+            }
+            // SSH agent (when configured).
+            if allowed.is_ssh_key() {
+                let user = username_from_url.unwrap_or("git");
+                return git2::Cred::ssh_key_from_agent(user);
+            }
+            git2::Cred::default()
+        });
+        cb
+    }
+
+    fn signature(&self) -> Result<git2::Signature<'static>, SyncError> {
+        if let Some(author) = &self.config.author {
+            return git2::Signature::now(&author.name, &author.email)
+                .map_err(|e| SyncError::Backend(e.message().to_string()));
+        }
+        // No explicit author configured — try git's global config.
+        let cfg = git2::Config::open_default()
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        let name = cfg
+            .get_string("user.name")
+            .unwrap_or_else(|_| "Glyph".to_string());
+        let email = cfg
+            .get_string("user.email")
+            .unwrap_or_else(|_| "glyph@localhost".to_string());
+        git2::Signature::now(&name, &email).map_err(|e| SyncError::Backend(e.message().to_string()))
+    }
+
+    /// True if the working tree differs from HEAD in any visible way.
+    fn working_tree_dirty(repo: &Repository) -> Result<bool, SyncError> {
+        let mut opts = StatusOptions::new();
+        opts.include_untracked(true);
+        opts.recurse_untracked_dirs(true);
+        let statuses = repo
+            .statuses(Some(&mut opts))
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        Ok(!statuses.is_empty())
+    }
+
+    /// Stage every change in the working tree (mirror of `git add -A`).
+    fn stage_all(repo: &Repository) -> Result<bool, SyncError> {
+        let mut index = repo
+            .index()
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        index
+            .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        index
+            .write()
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+
+        // Did the index actually move? Returns true when there is
+        // something staged that would produce a real commit.
+        let head_tree = match repo.head() {
+            Ok(head) => head
+                .peel_to_tree()
+                .map_err(|e| SyncError::Backend(e.message().to_string()))?,
+            Err(e) if e.code() == git2::ErrorCode::UnbornBranch => {
+                // No commits yet — anything in the index counts as a
+                // change.
+                return Ok(!index.is_empty());
+            }
+            Err(e) => return Err(SyncError::Backend(e.message().to_string())),
+        };
+        let index_tree_oid = index
+            .write_tree()
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        let index_tree = repo
+            .find_tree(index_tree_oid)
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        let diff = repo
+            .diff_tree_to_tree(Some(&head_tree), Some(&index_tree), None)
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        Ok(diff.deltas().len() > 0)
+    }
+
+    fn commit_index(
+        repo: &Repository,
+        signature: &git2::Signature<'_>,
+        message: &str,
+        parents: Vec<git2::Commit<'_>>,
+    ) -> Result<git2::Oid, SyncError> {
+        let mut index = repo
+            .index()
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        let tree_oid = index
+            .write_tree()
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        let tree = repo
+            .find_tree(tree_oid)
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        let parent_refs: Vec<&git2::Commit<'_>> = parents.iter().collect();
+        repo.commit(
+            Some("HEAD"),
+            signature,
+            signature,
+            message,
+            &tree,
+            &parent_refs,
+        )
+        .map_err(|e| SyncError::Backend(e.message().to_string()))
+    }
+
+    fn head_commit(repo: &Repository) -> Result<Option<git2::Commit<'_>>, SyncError> {
+        match repo.head() {
+            Ok(head) => head
+                .peel_to_commit()
+                .map(Some)
+                .map_err(|e| SyncError::Backend(e.message().to_string())),
+            Err(e) if e.code() == git2::ErrorCode::UnbornBranch => Ok(None),
+            Err(e) => Err(SyncError::Backend(e.message().to_string())),
+        }
+    }
+
+    /// Return (ahead, behind) of the local branch relative to its
+    /// remote-tracking branch. Returns (0, 0) when there is no upstream
+    /// configured yet (fresh init before the first push).
+    fn ahead_behind(repo: &Repository, branch_name: &str) -> Result<(u32, u32), SyncError> {
+        let local = match repo.find_branch(branch_name, BranchType::Local) {
+            Ok(b) => b,
+            Err(_) => return Ok((0, 0)),
+        };
+        let upstream_ref = format!("refs/remotes/{ORIGIN}/{branch_name}");
+        let upstream = match repo.find_reference(&upstream_ref) {
+            Ok(r) => r,
+            Err(_) => return Ok((0, 0)),
+        };
+        let local_oid = local
+            .get()
+            .target()
+            .ok_or_else(|| SyncError::InvalidState("local branch has no tip".into()))?;
+        let upstream_oid = upstream
+            .target()
+            .ok_or_else(|| SyncError::InvalidState("upstream ref has no tip".into()))?;
+        repo.graph_ahead_behind(local_oid, upstream_oid)
+            .map(|(a, b)| (a as u32, b as u32))
+            .map_err(|e| SyncError::Backend(e.message().to_string()))
+    }
+
+    fn collect_conflicts(repo: &Repository) -> Result<Vec<String>, SyncError> {
+        let mut out = Vec::new();
+        let index = repo
+            .index()
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        if !index.has_conflicts() {
+            return Ok(out);
+        }
+        let conflicts = index
+            .conflicts()
+            .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+        for entry in conflicts {
+            let entry = entry.map_err(|e| SyncError::Backend(e.message().to_string()))?;
+            // Prefer the "ours" path; fall back to "theirs"/"ancestor".
+            let path = entry
+                .our
+                .as_ref()
+                .or(entry.their.as_ref())
+                .or(entry.ancestor.as_ref())
+                .map(|e| String::from_utf8_lossy(&e.path).into_owned());
+            if let Some(p) = path {
+                out.push(p);
+            }
+        }
+        out.sort();
+        out.dedup();
+        Ok(out)
+    }
+
+    fn fetch_remote(&self, repo: &Repository) -> Result<(), SyncError> {
+        let mut remote = repo
+            .find_remote(ORIGIN)
+            .map_err(|_| SyncError::NotConfigured)?;
+        let mut opts = FetchOptions::new();
+        opts.remote_callbacks(self.credentials_callbacks());
+        let refspec = format!(
+            "refs/heads/{0}:refs/remotes/{ORIGIN}/{0}",
+            self.config.remote_branch
+        );
+        remote
+            .fetch(&[&refspec], Some(&mut opts), None)
+            .map_err(map_remote_error)?;
+        Ok(())
+    }
+
+    fn push_branch(&self, repo: &Repository) -> Result<(), SyncError> {
+        let mut remote = repo
+            .find_remote(ORIGIN)
+            .map_err(|_| SyncError::NotConfigured)?;
+        let mut opts = PushOptions::new();
+        opts.remote_callbacks(self.credentials_callbacks());
+        let refspec = format!("refs/heads/{0}:refs/heads/{0}", self.config.remote_branch);
+        remote
+            .push(&[&refspec], Some(&mut opts))
+            .map_err(map_remote_error)?;
+        Ok(())
+    }
+}
+
+impl SyncBackend for GitBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::Git
+    }
+
+    fn status(&self) -> Result<StatusReport, SyncError> {
+        let repo = self.open_repo()?;
+        let dirty = Self::working_tree_dirty(&repo)?;
+        let (ahead, behind) = Self::ahead_behind(&repo, &self.config.remote_branch)?;
+        let conflicts = Self::collect_conflicts(&repo)?;
+        Ok(StatusReport {
+            kind: BackendKind::Git,
+            clean: !dirty,
+            ahead,
+            behind,
+            conflicts,
+            last_sync_unix: None,
+        })
+    }
+
+    fn sync(&self) -> Result<SyncResult, SyncError> {
+        let repo = self.open_repo()?;
+        let signature = self.signature()?;
+
+        // Refuse to sync until existing conflicts are resolved — the
+        // user has to take action; we can't push or fast-forward over a
+        // conflicted index.
+        let existing_conflicts = Self::collect_conflicts(&repo)?;
+        if !existing_conflicts.is_empty() {
+            return Err(SyncError::Conflict(existing_conflicts));
+        }
+
+        // 1. Stage everything and commit if there's anything new.
+        let staged = Self::stage_all(&repo)?;
+        let mut committed_count = 0;
+        if staged {
+            let parents = match Self::head_commit(&repo)? {
+                Some(c) => vec![c],
+                None => vec![],
+            };
+            Self::commit_index(&repo, &signature, AUTO_COMMIT_MESSAGE, parents)?;
+            committed_count = 1;
+        }
+
+        // 2. Fetch the remote.
+        self.fetch_remote(&repo)?;
+
+        // 3. Analyse remote relative to local and reconcile.
+        let mut pulled_count = 0;
+        let upstream_ref = format!("refs/remotes/{ORIGIN}/{}", self.config.remote_branch);
+        if let Ok(upstream) = repo.find_reference(&upstream_ref) {
+            let upstream_commit = upstream
+                .peel_to_commit()
+                .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+            let upstream_oid = upstream_commit.id();
+            let upstream_annotated = repo
+                .find_annotated_commit(upstream_oid)
+                .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+            let (analysis, _) = repo
+                .merge_analysis(&[&upstream_annotated])
+                .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+
+            if analysis.is_up_to_date() {
+                // Local already contains everything from upstream — no-op.
+            } else if analysis.is_fast_forward() {
+                // Fast-forward: move local branch pointer to upstream
+                // and check out the new tree.
+                let local_ref_name = format!("refs/heads/{}", self.config.remote_branch);
+                let mut local_ref = repo
+                    .find_reference(&local_ref_name)
+                    .or_else(|_| repo.reference(&local_ref_name, upstream_oid, true, "ff init"))
+                    .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+                local_ref
+                    .set_target(upstream_oid, "glyph: fast-forward to upstream")
+                    .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+                repo.set_head(&local_ref_name)
+                    .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+                let mut co = git2::build::CheckoutBuilder::default();
+                co.force();
+                repo.checkout_head(Some(&mut co))
+                    .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+                pulled_count = 1;
+            } else {
+                // True merge needed.
+                let mut merge_opts = MergeOptions::new();
+                let mut checkout_opts = git2::build::CheckoutBuilder::new();
+                checkout_opts.allow_conflicts(true);
+                repo.merge(
+                    &[&upstream_annotated],
+                    Some(&mut merge_opts),
+                    Some(&mut checkout_opts),
+                )
+                .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+
+                let conflicts = Self::collect_conflicts(&repo)?;
+                if !conflicts.is_empty() {
+                    // Leave the repo in the merging state so the user
+                    // can resolve. Skip push.
+                    return Ok(SyncResult {
+                        kind: BackendKind::Git,
+                        pulled_count: 0,
+                        committed_count,
+                        pushed_count: 0,
+                        conflicts,
+                        completed_unix: now_unix(),
+                    });
+                }
+
+                // No conflicts — write the merge commit.
+                let head = Self::head_commit(&repo)?
+                    .ok_or_else(|| SyncError::InvalidState("HEAD missing during merge".into()))?;
+                Self::commit_index(
+                    &repo,
+                    &signature,
+                    MERGE_COMMIT_MESSAGE,
+                    vec![head, upstream_commit],
+                )?;
+                repo.cleanup_state()
+                    .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+                pulled_count = 1;
+            }
+        }
+
+        // 4. Push the (possibly newly-extended) local branch.
+        let (ahead, _) = Self::ahead_behind(&repo, &self.config.remote_branch)?;
+        let mut pushed_count = 0;
+        if ahead > 0 || committed_count > 0 {
+            self.push_branch(&repo)?;
+            pushed_count = ahead.max(committed_count);
+        }
+
+        Ok(SyncResult {
+            kind: BackendKind::Git,
+            pulled_count,
+            committed_count,
+            pushed_count,
+            conflicts: vec![],
+            completed_unix: now_unix(),
+        })
+    }
+}
+
+fn map_remote_error(e: git2::Error) -> SyncError {
+    let msg = e.message().to_string();
+    match e.class() {
+        git2::ErrorClass::Net | git2::ErrorClass::Http => SyncError::Network(msg),
+        git2::ErrorClass::Ssh | git2::ErrorClass::Callback => SyncError::AuthFailed(msg),
+        _ if msg.contains("authentication") || msg.contains("auth") => SyncError::AuthFailed(msg),
+        _ => SyncError::Backend(msg),
+    }
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Initialise a new git repository at `path` with the default branch
+/// set to the supplied name. Convenience wrapper around `git2::Repository::init_opts`.
+pub fn init_repo(path: &Path, default_branch: &str) -> Result<PathBuf, SyncError> {
+    let mut opts = git2::RepositoryInitOptions::new();
+    opts.initial_head(default_branch);
+    Repository::init_opts(path, &opts).map_err(|e| SyncError::Backend(e.message().to_string()))?;
+    Ok(path.to_path_buf())
+}
+
+/// Add an `origin` remote pointing at `url` to a repository at `path`.
+pub fn set_origin(path: &Path, url: &str) -> Result<(), SyncError> {
+    let repo = Repository::open(path).map_err(|e| SyncError::Backend(e.message().to_string()))?;
+    match repo.find_remote(ORIGIN) {
+        Ok(_) => repo.remote_set_url(ORIGIN, url),
+        Err(_) => repo.remote(ORIGIN, url).map(|_| ()),
+    }
+    .map_err(|e| SyncError::Backend(e.message().to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Build a self-contained Git test harness:
+    /// - `remote/` is a bare repository acting as the cloud
+    /// - `local/` clones from it, with the working tree we'll mutate
+    /// - returns the [`TempDir`] (drop = cleanup), the workspace path,
+    ///   and a backend wired up to it
+    struct Fixture {
+        _tmp: TempDir,
+        workspace: PathBuf,
+        remote: PathBuf,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let tmp = TempDir::new().unwrap();
+            let remote = tmp.path().join("remote.git");
+            git2::Repository::init_bare(&remote).unwrap();
+            let workspace = tmp.path().join("local");
+            fs::create_dir_all(&workspace).unwrap();
+            init_repo(&workspace, "main").unwrap();
+            set_origin(&workspace, remote.to_str().unwrap()).unwrap();
+            // libgit2 needs *some* author identity for commits.
+            let cfg_path = workspace.join(".git/config");
+            let mut cfg = git2::Config::open(&cfg_path).unwrap();
+            cfg.set_str("user.name", "Test User").unwrap();
+            cfg.set_str("user.email", "test@example.com").unwrap();
+            Self {
+                _tmp: tmp,
+                workspace,
+                remote,
+            }
+        }
+
+        fn backend(&self) -> GitBackend {
+            let mut cfg = WorkspaceSyncConfig::new_git(self.workspace.to_string_lossy());
+            cfg.remote_url = self.remote.to_string_lossy().into();
+            cfg.author = Some(super::super::config::CommitIdentity {
+                name: "Test User".into(),
+                email: "test@example.com".into(),
+            });
+            GitBackend::new(cfg)
+        }
+
+        fn write_file(&self, name: &str, contents: &str) {
+            fs::write(self.workspace.join(name), contents).unwrap();
+        }
+    }
+
+    #[test]
+    fn open_repo_errors_with_not_configured_when_workspace_isnt_a_repo() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = WorkspaceSyncConfig::new_git(tmp.path().to_string_lossy());
+        let backend = GitBackend::new(cfg);
+        let err = backend.status().unwrap_err();
+        assert!(matches!(err, SyncError::NotConfigured), "got: {err:?}");
+    }
+
+    #[test]
+    fn status_is_clean_on_a_fresh_repo() {
+        let f = Fixture::new();
+        let status = f.backend().status().unwrap();
+        assert!(status.clean);
+        assert_eq!(status.ahead, 0);
+        assert_eq!(status.behind, 0);
+        assert!(status.conflicts.is_empty());
+    }
+
+    #[test]
+    fn status_reports_dirty_when_files_are_modified() {
+        let f = Fixture::new();
+        f.write_file("notes.md", "# hi");
+        let status = f.backend().status().unwrap();
+        assert!(!status.clean);
+    }
+
+    #[test]
+    fn sync_commits_and_pushes_local_changes() {
+        let f = Fixture::new();
+        f.write_file("notes.md", "# hello\n");
+        let result = f.backend().sync().unwrap();
+        assert_eq!(result.kind, BackendKind::Git);
+        assert_eq!(result.committed_count, 1);
+        assert_eq!(result.pulled_count, 0);
+        assert_eq!(result.pushed_count, 1);
+        assert!(result.conflicts.is_empty());
+
+        // The bare remote should now contain the commit.
+        let remote = Repository::open_bare(&f.remote).unwrap();
+        let head = remote.find_reference("refs/heads/main").unwrap();
+        let commit = head.peel_to_commit().unwrap();
+        assert_eq!(commit.message().unwrap(), AUTO_COMMIT_MESSAGE);
+    }
+
+    #[test]
+    fn sync_with_no_local_changes_is_a_noop() {
+        let f = Fixture::new();
+        // Seed a commit so HEAD exists.
+        f.write_file("seed.md", "# seed\n");
+        f.backend().sync().unwrap();
+        // Second call should report no work.
+        let result = f.backend().sync().unwrap();
+        assert_eq!(result.committed_count, 0);
+        assert_eq!(result.pulled_count, 0);
+        assert_eq!(result.pushed_count, 0);
+    }
+
+    #[test]
+    fn sync_fast_forwards_when_remote_advanced() {
+        // Set up: workspace A and workspace B both clone from `remote`.
+        // A commits + pushes; B sync should fast-forward.
+        let f = Fixture::new();
+        f.write_file("a.md", "# a\n");
+        f.backend().sync().unwrap();
+
+        // Clone a second working copy from the same bare remote.
+        let other = f._tmp.path().join("other");
+        Repository::clone(f.remote.to_str().unwrap(), &other).unwrap();
+        let mut other_cfg = WorkspaceSyncConfig::new_git(other.to_string_lossy());
+        other_cfg.remote_url = f.remote.to_string_lossy().into();
+        other_cfg.author = Some(super::super::config::CommitIdentity {
+            name: "Other User".into(),
+            email: "other@example.com".into(),
+        });
+        let other_backend = GitBackend::new(other_cfg);
+
+        // Now write a new file in A, push it.
+        f.write_file("b.md", "# b\n");
+        f.backend().sync().unwrap();
+
+        // B should fast-forward and pick up b.md.
+        let result = other_backend.sync().unwrap();
+        assert_eq!(result.pulled_count, 1);
+        assert!(other.join("b.md").exists());
+    }
+
+    #[test]
+    fn sync_records_a_completed_timestamp() {
+        let f = Fixture::new();
+        f.write_file("a.md", "# a\n");
+        let result = f.backend().sync().unwrap();
+        assert!(result.completed_unix > 0);
+    }
+
+    #[test]
+    fn map_remote_error_classifies_network_and_auth_errors() {
+        // We can't easily fabricate libgit2 Errors of arbitrary class,
+        // but we can confirm the unclassified fallback at least.
+        let e = git2::Error::from_str("authentication required");
+        let mapped = map_remote_error(e);
+        assert!(matches!(mapped, SyncError::AuthFailed(_)));
+    }
+
+    #[test]
+    fn init_repo_creates_a_repository_with_the_requested_default_branch() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path(), "trunk").unwrap();
+        let repo = Repository::open(tmp.path()).unwrap();
+        // HEAD points at refs/heads/trunk on a fresh repo even before
+        // the first commit.
+        let head = repo.find_reference("HEAD").unwrap();
+        assert_eq!(head.symbolic_target(), Some("refs/heads/trunk"));
+    }
+
+    #[test]
+    fn set_origin_creates_then_updates_the_remote_url() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path(), "main").unwrap();
+        set_origin(tmp.path(), "https://example.com/a.git").unwrap();
+        set_origin(tmp.path(), "https://example.com/b.git").unwrap();
+        let repo = Repository::open(tmp.path()).unwrap();
+        let remote = repo.find_remote("origin").unwrap();
+        assert_eq!(remote.url(), Some("https://example.com/b.git"));
+    }
+
+    #[test]
+    fn signature_falls_back_to_global_config_when_no_author_in_workspace_config() {
+        let f = Fixture::new();
+        let mut backend = f.backend();
+        backend.config.author = None;
+        let sig = backend.signature().unwrap();
+        assert!(!sig.name().unwrap().is_empty());
+        assert!(!sig.email().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sync_surfaces_conflicts_and_does_not_push() {
+        // Two clones diverge on the same file → second sync hits a
+        // merge conflict.
+        let f = Fixture::new();
+        f.write_file("notes.md", "line one\nline two\n");
+        f.backend().sync().unwrap();
+
+        // Second clone, edits the same line.
+        let other = f._tmp.path().join("other");
+        Repository::clone(f.remote.to_str().unwrap(), &other).unwrap();
+        let mut other_cfg = WorkspaceSyncConfig::new_git(other.to_string_lossy());
+        other_cfg.remote_url = f.remote.to_string_lossy().into();
+        other_cfg.author = Some(super::super::config::CommitIdentity {
+            name: "Other".into(),
+            email: "o@e.com".into(),
+        });
+        let other_backend = GitBackend::new(other_cfg);
+        fs::write(other.join("notes.md"), "line one\nFROM OTHER\n").unwrap();
+        other_backend.sync().unwrap();
+
+        // First workspace edits the same file too, then tries to sync.
+        f.write_file("notes.md", "line one\nFROM FIRST\n");
+        let result = f.backend().sync().unwrap();
+        assert!(
+            !result.conflicts.is_empty(),
+            "expected conflicts, got {result:?}"
+        );
+        assert!(result.conflicts.iter().any(|p| p.ends_with("notes.md")));
+        assert_eq!(result.pushed_count, 0, "must not push while conflicted");
+    }
+
+    #[test]
+    fn sync_refuses_to_run_while_workspace_still_has_unresolved_conflicts() {
+        // Same setup as above, but call sync twice in a row without
+        // resolving the conflict — second call should error out instead
+        // of trying to "merge again".
+        let f = Fixture::new();
+        f.write_file("notes.md", "line one\n");
+        f.backend().sync().unwrap();
+
+        let other = f._tmp.path().join("other");
+        Repository::clone(f.remote.to_str().unwrap(), &other).unwrap();
+        let mut other_cfg = WorkspaceSyncConfig::new_git(other.to_string_lossy());
+        other_cfg.remote_url = f.remote.to_string_lossy().into();
+        other_cfg.author = Some(super::super::config::CommitIdentity {
+            name: "Other".into(),
+            email: "o@e.com".into(),
+        });
+        fs::write(other.join("notes.md"), "OTHER\n").unwrap();
+        GitBackend::new(other_cfg).sync().unwrap();
+
+        f.write_file("notes.md", "MINE\n");
+        f.backend().sync().unwrap(); // leaves conflict in index
+        let err = f.backend().sync().unwrap_err();
+        assert!(matches!(err, SyncError::Conflict(_)), "got {err:?}");
+    }
+}

--- a/src-tauri/src/sync/git.rs
+++ b/src-tauri/src/sync/git.rs
@@ -500,10 +500,19 @@ mod tests {
         fn new() -> Self {
             let tmp = TempDir::new().unwrap();
             let remote = tmp.path().join("remote.git");
-            git2::Repository::init_bare(&remote).unwrap();
+            // `init_bare` alone honours the runner's `init.defaultBranch`
+            // config — GitHub Actions hosts default to "master" because
+            // they don't set `init.defaultBranch`, which makes
+            // `Repository::clone` resolve HEAD to a non-existent branch
+            // and breaks the merge scenarios below. Pin via init_opts so
+            // the fixture is deterministic regardless of host config.
+            let mut opts = git2::RepositoryInitOptions::new();
+            opts.bare(true);
+            opts.initial_head(super::super::DEFAULT_REMOTE_BRANCH);
+            git2::Repository::init_opts(&remote, &opts).unwrap();
             let workspace = tmp.path().join("local");
             fs::create_dir_all(&workspace).unwrap();
-            init_repo(&workspace, "main").unwrap();
+            init_repo(&workspace, super::super::DEFAULT_REMOTE_BRANCH).unwrap();
             set_origin(&workspace, remote.to_str().unwrap()).unwrap();
             // libgit2 needs *some* author identity for commits.
             let cfg_path = workspace.join(".git/config");
@@ -650,7 +659,7 @@ mod tests {
     #[test]
     fn set_origin_creates_then_updates_the_remote_url() {
         let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path(), "main").unwrap();
+        init_repo(tmp.path(), super::super::DEFAULT_REMOTE_BRANCH).unwrap();
         set_origin(tmp.path(), "https://example.com/a.git").unwrap();
         set_origin(tmp.path(), "https://example.com/b.git").unwrap();
         let repo = Repository::open(tmp.path()).unwrap();

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -1,0 +1,20 @@
+//! Workspace sync. See [`backend::SyncBackend`] for the contract every
+//! backend must honour, and [`git::GitBackend`] for the Git-over-libgit2
+//! implementation that ships in v1.
+//!
+//! This module ships standalone in this PR — no Tauri commands invoke
+//! it yet. The follow-up PR layers in the IPC surface and the
+//! settings UI. `dead_code` is allowed at the module level so the trait
+//! / config / git impl can land + be tested without spurious warnings
+//! about "no caller".
+
+#![allow(dead_code, unused_imports)]
+
+mod backend;
+mod config;
+mod error;
+pub mod git;
+
+pub use backend::{BackendKind, ConflictPolicy, StatusReport, SyncBackend, SyncResult};
+pub use config::{CommitIdentity, WorkspaceSyncConfig};
+pub use error::SyncError;

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -18,3 +18,9 @@ pub mod git;
 pub use backend::{BackendKind, ConflictPolicy, StatusReport, SyncBackend, SyncResult};
 pub use config::{CommitIdentity, WorkspaceSyncConfig};
 pub use error::SyncError;
+
+/// Default branch name Glyph uses for new workspaces and as the canonical
+/// branch in test fixtures. Centralised here so every call site stays in
+/// lockstep — change it once and both the `WorkspaceSyncConfig` default and
+/// every fixture's `init_repo` / `init_bare` agree.
+pub const DEFAULT_REMOTE_BRANCH: &str = "main";


### PR DESCRIPTION
First PR in the cloud-sync feature branch (#113). Lands the foundation; subsequent PRs in this series target the same \`feature/cloud-sync\` branch so \`main\` only sees the feature when it's complete.

## What's in this PR

- \`src-tauri/src/sync/\` module with:
  - \`error::SyncError\` (serde-tagged for the frontend)
  - \`backend::SyncBackend\` trait + \`BackendKind\` / \`StatusReport\` / \`SyncResult\` / \`ConflictPolicy\`
  - \`config::WorkspaceSyncConfig\` (per-workspace setup)
  - \`git::GitBackend\` over \`git2\` with **statically-linked libgit2** so end users never need a system \`git\` install
- 24 new tests covering every public surface — local bare-repo fixtures, no network

No UI, no Tauri commands, no scheduler. Those come in follow-up PRs against the same feature branch.

## Sync flow (GitBackend::sync)

1. Stage every working-tree change (\`git add -A\`)
2. Auto-commit if anything moved
3. Fetch \`origin/<branch>\`
4. Fast-forward when possible; otherwise merge → if conflicts arise, surface them in \`SyncResult.conflicts\` and refuse to push
5. Push the local branch

Status report is computed without touching the network so the UI can poll it cheaply.

## Why a feature branch

This is a multi-PR feature. Stacking against \`feature/cloud-sync\` lets each PR stay small/reviewable while keeping \`main\` clean until everything ships together.

## Test plan

- [x] \`cargo test --lib\` — 113 tests pass (24 new)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\` clean
- [x] Frontend pre-flight (typecheck, lint, vitest) clean — frontend untouched

## Roadmap (follow-up PRs against this branch)

- Tauri commands (\`sync_status\`, \`sync_run\`, \`sync_init\`, \`sync_set_config\`)
- Settings UI: per-workspace sync setup, remote URL, conflict-policy picker
- Credentials in OS keychain (tauri-plugin-stronghold or keyring-rs)
- Background sync scheduler (with the autoSyncSeconds config field)
- Conflict-resolution UI (side-by-side merge for markdown)
- WebDAV backend
- Eventually: realtime collab backend (separate trait)

Refs #113