### PR TITLE
ci: run gates on PRs to every branch, not just main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
 on:
+  # Push: only protect `main`. Feature branches use PR runs for
+  # validation; direct pushes to feature branches don't need their own
+  # CI fire.
   push:
     branches: [main]
+  # PR: every PR runs the gate regardless of target branch so stacked
+  # PRs against `feature/*` get the same checks as PRs to `main`.
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,10 +1,14 @@
 name: Security
 
 on:
+  # Push: only `main` so the weekly run is the source of truth for
+  # feature-branch security findings. Direct pushes to feature branches
+  # are still covered by their PR run.
   push:
     branches: [main]
+  # PR: any target branch (PRs to `feature/*` get the same scan as PRs
+  # to `main`).
   pull_request:
-    branches: [main]
   schedule:
     - cron: "0 6 * * 1" # Weekly on Monday at 6am UTC
 


### PR DESCRIPTION
## Summary

PRs targeting \`feature/cloud-sync\` (PR #205) currently show **zero checks** because both \`ci.yml\` and \`security.yml\` filter \`pull_request:\` to \`branches: [main]\`. Stacked PRs against a long-lived feature branch need the same gate as PRs to \`main\`.

## Change

- \`ci.yml\` and \`security.yml\`: drop the \`branches:\` filter from \`pull_request:\`. GitHub's default kicks in — every PR fires, regardless of target branch, and re-runs on every push to the PR's head branch via the implicit \`synchronize\` activity type.
- \`push:\` keeps \`branches: [main]\` so direct pushes to a feature branch don't double up with the PR run (the PR's \`synchronize\` event already covers that).

## Test plan

- [x] After merge: PR #205 (targeting \`feature/cloud-sync\`) re-runs and shows Lint / Typecheck / Test (Frontend) / Test (Rust) / Clippy / CodeQL / Cargo Audit / npm Audit / PR title check
- [ ] Pushing a new commit to that PR's branch triggers a fresh CI run
- [ ] Existing main-targeted PRs are unaffected (still trigger as before)