### PR TITLE
feat(sync): Tauri command surface + managed state

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1541,6 +1541,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "walkdir",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,9 @@ thiserror = "2"
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }
 tempfile = "3"
+# `#[tokio::test]` macro for async unit tests. Tauri already pulls tokio
+# in transitively; we only need the macro / runtime entry points here.
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"windows\"))".dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,7 @@ pub fn run() {
         ))))
         .manage(commands::InitialFile(Mutex::new(None)))
         .manage(commands::InitialFolder(Mutex::new(None)))
+        .manage(sync::SyncState::new())
         .setup(|app| {
             let (menu, menu_refs) = menu::build_menu(app)?;
             app.set_menu(menu)?;
@@ -142,6 +143,15 @@ pub fn run() {
             watcher::watch_directory,
             watcher::unwatch_directory,
             menu_runtime::set_menu_state,
+            sync::commands::sync_set_config,
+            sync::commands::sync_get_config,
+            sync::commands::sync_remove_config,
+            sync::commands::sync_set_token,
+            sync::commands::sync_clear_token,
+            sync::commands::sync_init_repo,
+            sync::commands::sync_clone_remote,
+            sync::commands::sync_status,
+            sync::commands::sync_run,
         ])
         .build(tauri::generate_context!())
         .expect("error while building Glyph");

--- a/src-tauri/src/sync/backend.rs
+++ b/src-tauri/src/sync/backend.rs
@@ -56,7 +56,7 @@ pub enum ConflictPolicy {
 /// Inspect-only snapshot of "where is this workspace at relative to
 /// its remote?". Computed without writing anything so it can refresh
 /// cheaply (status bar polling, manual refresh button).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusReport {
     pub kind: BackendKind,
@@ -78,7 +78,7 @@ pub struct StatusReport {
 /// Outcome of a single [`SyncBackend::sync`] call. Frontend renders a
 /// short summary ("3 changes pulled, 1 committed locally") and stashes
 /// the timestamp so the next status check can show it.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncResult {
     pub kind: BackendKind,

--- a/src-tauri/src/sync/commands.rs
+++ b/src-tauri/src/sync/commands.rs
@@ -1,130 +1,25 @@
 //! Tauri command surface for cloud sync.
 //!
-//! Layout choice: every `#[tauri::command]` is a thin wrapper around a
-//! pure async helper (`run_sync_inner`, `run_status_inner`, etc.). The
-//! helpers take a plain `&SyncState` reference instead of Tauri's
-//! `State<'_, T>` wrapper so tests can drive them directly without
-//! standing up a full Tauri runtime. The wrappers only do
-//! `helper(&state, …).await`.
-//!
-//! All blocking work (libgit2 calls) is dispatched through
-//! `tauri::async_runtime::spawn_blocking` so the Tauri async runtime thread stays
-//! free.
-
-use std::path::PathBuf;
+//! Every function in this file is a thin `#[tauri::command]` wrapper
+//! around an async helper in [`super::ops`]. The proc-macro emits IPC
+//! marshalling code that isn't reachable from a direct function call,
+//! so this file is excluded from codecov coverage; the real logic lives
+//! in `ops.rs` and is fully tested there.
 
 use tauri::State;
 
 use super::backend::{StatusReport, SyncResult};
 use super::config::WorkspaceSyncConfig;
 use super::error::SyncError;
-use super::git;
+use super::ops;
 use super::state::SyncState;
-use super::DEFAULT_REMOTE_BRANCH;
-
-// -- Pure helpers (testable without Tauri) -----------------------------------
-
-/// Persist (or replace) the sync config for the workspace it names.
-pub fn set_config_inner(state: &SyncState, config: WorkspaceSyncConfig) {
-    state.set_config(config);
-}
-
-/// Look up the stored config for a workspace. `None` is a clean "not
-/// configured yet" signal, distinct from an error.
-pub fn get_config_inner(state: &SyncState, workspace_path: &str) -> Option<WorkspaceSyncConfig> {
-    state.get_config(workspace_path)
-}
-
-/// Forget a workspace's config (e.g. user disabled sync for it).
-pub fn remove_config_inner(state: &SyncState, workspace_path: &str) {
-    state.remove_config(workspace_path);
-}
-
-/// Stash a credential token in memory for `workspace_path`. The OS-keychain
-/// PR replaces this implementation; the call signature stays the same.
-pub fn set_token_inner(state: &SyncState, workspace_path: String, token: String) {
-    state.set_token(workspace_path, token);
-}
-
-pub fn clear_token_inner(state: &SyncState, workspace_path: &str) {
-    state.clear_token(workspace_path);
-}
-
-/// Initialise a fresh repository at `workspace_path` with `default_branch`
-/// as HEAD. Sets `origin` to `remote_url` when one is supplied so the
-/// follow-up `sync_run` call can push to it.
-pub async fn init_repo_inner(
-    workspace_path: String,
-    default_branch: Option<String>,
-    remote_url: Option<String>,
-) -> Result<(), SyncError> {
-    tauri::async_runtime::spawn_blocking(move || {
-        let branch = default_branch.unwrap_or_else(|| DEFAULT_REMOTE_BRANCH.to_string());
-        let path = PathBuf::from(&workspace_path);
-        git::init_repo(&path, &branch)?;
-        if let Some(url) = remote_url {
-            git::set_origin(&path, &url)?;
-        }
-        Ok(())
-    })
-    .await
-    .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
-}
-
-/// Clone `remote_url` into `workspace_path`. Destination must not exist
-/// yet (libgit2 rule). When `token` is provided it's used as HTTPS
-/// basic-auth.
-pub async fn clone_remote_inner(
-    workspace_path: String,
-    remote_url: String,
-    token: Option<String>,
-) -> Result<(), SyncError> {
-    tauri::async_runtime::spawn_blocking(move || {
-        git::clone_repo(
-            &remote_url,
-            &PathBuf::from(&workspace_path),
-            token.as_deref(),
-        )
-        .map(|_| ())
-    })
-    .await
-    .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
-}
-
-/// Build the configured backend for `workspace_path` and ask it for its
-/// status. Errors with `NotConfigured` when no config has been stored
-/// yet — the frontend interprets that as "show the setup CTA".
-pub async fn run_status_inner(
-    state: &SyncState,
-    workspace_path: &str,
-) -> Result<StatusReport, SyncError> {
-    let backend = state.build_backend(workspace_path)?;
-    tauri::async_runtime::spawn_blocking(move || backend.status())
-        .await
-        .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
-}
-
-/// Build the configured backend and run a full sync (stage → commit →
-/// fetch → merge → push). Conflicts come back via `SyncResult.conflicts`,
-/// not as an error — the frontend opens the conflict UI for those.
-pub async fn run_sync_inner(
-    state: &SyncState,
-    workspace_path: &str,
-) -> Result<SyncResult, SyncError> {
-    let backend = state.build_backend(workspace_path)?;
-    tauri::async_runtime::spawn_blocking(move || backend.sync())
-        .await
-        .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
-}
-
-// -- Tauri command wrappers --------------------------------------------------
 
 #[tauri::command]
 pub async fn sync_set_config(
     config: WorkspaceSyncConfig,
     state: State<'_, SyncState>,
 ) -> Result<(), SyncError> {
-    set_config_inner(&state, config);
+    ops::set_config(&state, config);
     Ok(())
 }
 
@@ -133,7 +28,7 @@ pub async fn sync_get_config(
     workspace_path: String,
     state: State<'_, SyncState>,
 ) -> Result<Option<WorkspaceSyncConfig>, SyncError> {
-    Ok(get_config_inner(&state, &workspace_path))
+    Ok(ops::get_config(&state, &workspace_path))
 }
 
 #[tauri::command]
@@ -141,7 +36,7 @@ pub async fn sync_remove_config(
     workspace_path: String,
     state: State<'_, SyncState>,
 ) -> Result<(), SyncError> {
-    remove_config_inner(&state, &workspace_path);
+    ops::remove_config(&state, &workspace_path);
     Ok(())
 }
 
@@ -151,7 +46,7 @@ pub async fn sync_set_token(
     token: String,
     state: State<'_, SyncState>,
 ) -> Result<(), SyncError> {
-    set_token_inner(&state, workspace_path, token);
+    ops::set_token(&state, workspace_path, token);
     Ok(())
 }
 
@@ -160,7 +55,7 @@ pub async fn sync_clear_token(
     workspace_path: String,
     state: State<'_, SyncState>,
 ) -> Result<(), SyncError> {
-    clear_token_inner(&state, &workspace_path);
+    ops::clear_token(&state, &workspace_path);
     Ok(())
 }
 
@@ -170,7 +65,7 @@ pub async fn sync_init_repo(
     default_branch: Option<String>,
     remote_url: Option<String>,
 ) -> Result<(), SyncError> {
-    init_repo_inner(workspace_path, default_branch, remote_url).await
+    ops::init_repo(workspace_path, default_branch, remote_url).await
 }
 
 #[tauri::command]
@@ -179,7 +74,7 @@ pub async fn sync_clone_remote(
     remote_url: String,
     token: Option<String>,
 ) -> Result<(), SyncError> {
-    clone_remote_inner(workspace_path, remote_url, token).await
+    ops::clone_remote(workspace_path, remote_url, token).await
 }
 
 #[tauri::command]
@@ -187,7 +82,7 @@ pub async fn sync_status(
     workspace_path: String,
     state: State<'_, SyncState>,
 ) -> Result<StatusReport, SyncError> {
-    run_status_inner(&state, &workspace_path).await
+    ops::run_status(&state, &workspace_path).await
 }
 
 #[tauri::command]
@@ -195,19 +90,28 @@ pub async fn sync_run(
     workspace_path: String,
     state: State<'_, SyncState>,
 ) -> Result<SyncResult, SyncError> {
-    run_sync_inner(&state, &workspace_path).await
+    ops::run_sync(&state, &workspace_path).await
 }
 
 #[cfg(test)]
 mod tests {
+    //! Each wrapper is one line of `ops::* (...).await`, but they still
+    //! need exercising so the `pub async fn ...` body line is covered.
+    //! Tests build a mock app, register `SyncState`, and call the
+    //! wrappers directly via `Manager::state()`. Real IPC routing (the
+    //! proc-macro-emitted `__cmd__sync_*` marshalling) is not reached
+    //! here — that's framework code we can't drive without spinning up
+    //! a webview, and covering it isn't this PR's goal.
     use super::*;
     use crate::sync::backend::{BackendKind, ConflictPolicy};
     use crate::sync::config::CommitIdentity;
     use std::fs;
+    use tauri::test::mock_app;
+    use tauri::Manager;
     use tempfile::TempDir;
 
-    /// Reusable harness mirroring git::tests::Fixture so the command
-    /// tests have a real bare-repo backend to drive.
+    use crate::sync::DEFAULT_REMOTE_BRANCH;
+
     struct Workspace {
         tmp: TempDir,
         workspace_path: String,
@@ -234,7 +138,7 @@ mod tests {
                 workspace_path: self.workspace_path.clone(),
                 backend: BackendKind::Git,
                 remote_url: self.remote_path.clone(),
-                remote_branch: DEFAULT_REMOTE_BRANCH.to_string(),
+                remote_branch: DEFAULT_REMOTE_BRANCH.into(),
                 conflict_policy: ConflictPolicy::Prompt,
                 auto_sync_seconds: None,
                 author: Some(CommitIdentity {
@@ -246,123 +150,92 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn init_repo_inner_creates_a_repo_with_origin_set() {
+    async fn sync_set_config_wrapper_writes_into_managed_state() {
+        let app = mock_app();
+        app.manage(SyncState::new());
         let ws = Workspace::new();
-        init_repo_inner(
-            ws.workspace_path.clone(),
-            None,
-            Some(ws.remote_path.clone()),
-        )
-        .await
-        .unwrap();
-
-        let repo = git2::Repository::open(&ws.workspace_path).unwrap();
-        let remote = repo.find_remote("origin").unwrap();
-        assert_eq!(remote.url(), Some(ws.remote_path.as_str()));
-        // Default branch defaults to DEFAULT_REMOTE_BRANCH when caller
-        // passes None.
-        let head = repo.find_reference("HEAD").unwrap();
+        sync_set_config(ws.config(), app.state::<SyncState>())
+            .await
+            .unwrap();
         assert_eq!(
-            head.symbolic_target(),
-            Some(format!("refs/heads/{DEFAULT_REMOTE_BRANCH}").as_str())
+            app.state::<SyncState>()
+                .get_config(&ws.workspace_path)
+                .unwrap()
+                .workspace_path,
+            ws.workspace_path
         );
     }
 
     #[tokio::test]
-    async fn init_repo_inner_respects_an_explicit_default_branch() {
-        let ws = Workspace::new();
-        init_repo_inner(ws.workspace_path.clone(), Some("trunk".into()), None)
+    async fn sync_get_config_wrapper_returns_none_when_unconfigured() {
+        let app = mock_app();
+        app.manage(SyncState::new());
+        let result = sync_get_config("/missing".into(), app.state::<SyncState>())
             .await
             .unwrap();
-        let repo = git2::Repository::open(&ws.workspace_path).unwrap();
-        let head = repo.find_reference("HEAD").unwrap();
-        assert_eq!(head.symbolic_target(), Some("refs/heads/trunk"));
+        assert!(result.is_none());
     }
 
     #[tokio::test]
-    async fn run_status_inner_errors_when_no_config_is_set() {
+    async fn sync_get_config_wrapper_returns_the_stored_config() {
+        let app = mock_app();
+        app.manage(SyncState::new());
         let ws = Workspace::new();
-        let state = SyncState::new();
-        let err = run_status_inner(&state, &ws.workspace_path)
+        app.state::<SyncState>().set_config(ws.config());
+        let result = sync_get_config(ws.workspace_path.clone(), app.state::<SyncState>())
             .await
-            .unwrap_err();
-        assert!(matches!(err, SyncError::NotConfigured));
+            .unwrap()
+            .expect("config present");
+        assert_eq!(result.workspace_path, ws.workspace_path);
     }
 
     #[tokio::test]
-    async fn run_sync_inner_errors_when_no_config_is_set() {
+    async fn sync_remove_config_wrapper_drops_the_entry() {
+        let app = mock_app();
+        app.manage(SyncState::new());
         let ws = Workspace::new();
-        let state = SyncState::new();
-        let err = run_sync_inner(&state, &ws.workspace_path)
+        app.state::<SyncState>().set_config(ws.config());
+        sync_remove_config(ws.workspace_path.clone(), app.state::<SyncState>())
             .await
-            .unwrap_err();
-        assert!(matches!(err, SyncError::NotConfigured));
+            .unwrap();
+        assert!(app
+            .state::<SyncState>()
+            .get_config(&ws.workspace_path)
+            .is_none());
     }
 
     #[tokio::test]
-    async fn run_status_inner_errors_when_config_set_but_repo_is_missing() {
-        // Config says "look at this path" but the path isn't a git repo.
-        // Backend should bubble up NotConfigured (the git open path).
-        let tmp = TempDir::new().unwrap();
-        let state = SyncState::new();
-        let config = WorkspaceSyncConfig {
-            workspace_path: tmp.path().to_string_lossy().into(),
-            backend: BackendKind::Git,
-            remote_url: String::new(),
-            remote_branch: DEFAULT_REMOTE_BRANCH.into(),
-            conflict_policy: ConflictPolicy::Prompt,
-            auto_sync_seconds: None,
-            author: None,
-        };
-        let path = config.workspace_path.clone();
-        set_config_inner(&state, config);
-        let err = run_status_inner(&state, &path).await.unwrap_err();
-        assert!(matches!(err, SyncError::NotConfigured));
+    async fn sync_set_token_and_clear_wrappers_round_trip() {
+        let app = mock_app();
+        app.manage(SyncState::new());
+        sync_set_token("/w".into(), "tok".into(), app.state::<SyncState>())
+            .await
+            .unwrap();
+        assert_eq!(
+            app.state::<SyncState>().get_token("/w").as_deref(),
+            Some("tok")
+        );
+        sync_clear_token("/w".into(), app.state::<SyncState>())
+            .await
+            .unwrap();
+        assert!(app.state::<SyncState>().get_token("/w").is_none());
     }
 
     #[tokio::test]
-    async fn full_init_then_sync_round_trip() {
-        // 1. init_repo creates the local repo + origin
-        // 2. write a file
-        // 3. sync_run commits + pushes
-        // 4. status_inner reports a clean working tree
+    async fn sync_init_repo_wrapper_creates_a_repo() {
         let ws = Workspace::new();
-        let state = SyncState::new();
-
-        init_repo_inner(
-            ws.workspace_path.clone(),
-            None,
-            Some(ws.remote_path.clone()),
-        )
-        .await
-        .unwrap();
-
-        fs::write(
-            std::path::Path::new(&ws.workspace_path).join("notes.md"),
-            "# hello\n",
-        )
-        .unwrap();
-
-        set_config_inner(&state, ws.config());
-
-        let result = run_sync_inner(&state, &ws.workspace_path).await.unwrap();
-        assert_eq!(result.kind, BackendKind::Git);
-        assert_eq!(result.committed_count, 1);
-        assert_eq!(result.pushed_count, 1);
-        assert!(result.conflicts.is_empty());
-
-        let status = run_status_inner(&state, &ws.workspace_path).await.unwrap();
-        assert!(status.clean);
-        assert_eq!(status.ahead, 0);
-        assert_eq!(status.behind, 0);
+        sync_init_repo(ws.workspace_path.clone(), None, None)
+            .await
+            .unwrap();
+        assert!(std::path::Path::new(&ws.workspace_path)
+            .join(".git")
+            .exists());
     }
 
     #[tokio::test]
-    async fn clone_remote_inner_populates_a_fresh_workspace_from_the_remote() {
-        // Seed the remote by syncing from another workspace, then clone
-        // into a new path and confirm the file landed.
+    async fn sync_clone_remote_wrapper_populates_a_workspace() {
         let ws = Workspace::new();
-        init_repo_inner(
+        sync_init_repo(
             ws.workspace_path.clone(),
             None,
             Some(ws.remote_path.clone()),
@@ -374,36 +247,61 @@ mod tests {
             "# seed\n",
         )
         .unwrap();
-        let state = SyncState::new();
-        set_config_inner(&state, ws.config());
-        run_sync_inner(&state, &ws.workspace_path).await.unwrap();
+        let app = mock_app();
+        app.manage(SyncState::new());
+        app.state::<SyncState>().set_config(ws.config());
+        sync_run(ws.workspace_path.clone(), app.state::<SyncState>())
+            .await
+            .unwrap();
 
-        let dest = ws.tmp.path().join("clone-into-me");
-        clone_remote_inner(dest.to_string_lossy().into(), ws.remote_path.clone(), None)
+        let dest = ws.tmp.path().join("clone-via-wrapper");
+        sync_clone_remote(dest.to_string_lossy().into(), ws.remote_path.clone(), None)
             .await
             .unwrap();
         assert!(dest.join("seed.md").exists());
     }
 
     #[tokio::test]
-    async fn config_set_then_get_round_trips_through_the_command_helpers() {
+    async fn sync_status_wrapper_returns_a_status_report() {
+        let app = mock_app();
+        app.manage(SyncState::new());
         let ws = Workspace::new();
-        let state = SyncState::new();
-        assert!(get_config_inner(&state, &ws.workspace_path).is_none());
-        set_config_inner(&state, ws.config());
-        let cfg = get_config_inner(&state, &ws.workspace_path).unwrap();
-        assert_eq!(cfg.workspace_path, ws.workspace_path);
-        assert_eq!(cfg.backend, BackendKind::Git);
-        remove_config_inner(&state, &ws.workspace_path);
-        assert!(get_config_inner(&state, &ws.workspace_path).is_none());
+        sync_init_repo(
+            ws.workspace_path.clone(),
+            None,
+            Some(ws.remote_path.clone()),
+        )
+        .await
+        .unwrap();
+        app.state::<SyncState>().set_config(ws.config());
+        let status = sync_status(ws.workspace_path.clone(), app.state::<SyncState>())
+            .await
+            .unwrap();
+        assert!(status.clean);
     }
 
     #[tokio::test]
-    async fn token_set_clear_round_trip() {
-        let state = SyncState::new();
-        set_token_inner(&state, "/ws".into(), "tok".into());
-        assert_eq!(state.get_token("/ws").as_deref(), Some("tok"));
-        clear_token_inner(&state, "/ws");
-        assert!(state.get_token("/ws").is_none());
+    async fn sync_run_wrapper_pushes_local_changes() {
+        let app = mock_app();
+        app.manage(SyncState::new());
+        let ws = Workspace::new();
+        sync_init_repo(
+            ws.workspace_path.clone(),
+            None,
+            Some(ws.remote_path.clone()),
+        )
+        .await
+        .unwrap();
+        fs::write(
+            std::path::Path::new(&ws.workspace_path).join("a.md"),
+            "# a\n",
+        )
+        .unwrap();
+        app.state::<SyncState>().set_config(ws.config());
+        let result = sync_run(ws.workspace_path.clone(), app.state::<SyncState>())
+            .await
+            .unwrap();
+        assert_eq!(result.committed_count, 1);
+        assert_eq!(result.pushed_count, 1);
     }
 }

--- a/src-tauri/src/sync/commands.rs
+++ b/src-tauri/src/sync/commands.rs
@@ -1,0 +1,409 @@
+//! Tauri command surface for cloud sync.
+//!
+//! Layout choice: every `#[tauri::command]` is a thin wrapper around a
+//! pure async helper (`run_sync_inner`, `run_status_inner`, etc.). The
+//! helpers take a plain `&SyncState` reference instead of Tauri's
+//! `State<'_, T>` wrapper so tests can drive them directly without
+//! standing up a full Tauri runtime. The wrappers only do
+//! `helper(&state, …).await`.
+//!
+//! All blocking work (libgit2 calls) is dispatched through
+//! `tauri::async_runtime::spawn_blocking` so the Tauri async runtime thread stays
+//! free.
+
+use std::path::PathBuf;
+
+use tauri::State;
+
+use super::backend::{StatusReport, SyncResult};
+use super::config::WorkspaceSyncConfig;
+use super::error::SyncError;
+use super::git;
+use super::state::SyncState;
+use super::DEFAULT_REMOTE_BRANCH;
+
+// -- Pure helpers (testable without Tauri) -----------------------------------
+
+/// Persist (or replace) the sync config for the workspace it names.
+pub fn set_config_inner(state: &SyncState, config: WorkspaceSyncConfig) {
+    state.set_config(config);
+}
+
+/// Look up the stored config for a workspace. `None` is a clean "not
+/// configured yet" signal, distinct from an error.
+pub fn get_config_inner(state: &SyncState, workspace_path: &str) -> Option<WorkspaceSyncConfig> {
+    state.get_config(workspace_path)
+}
+
+/// Forget a workspace's config (e.g. user disabled sync for it).
+pub fn remove_config_inner(state: &SyncState, workspace_path: &str) {
+    state.remove_config(workspace_path);
+}
+
+/// Stash a credential token in memory for `workspace_path`. The OS-keychain
+/// PR replaces this implementation; the call signature stays the same.
+pub fn set_token_inner(state: &SyncState, workspace_path: String, token: String) {
+    state.set_token(workspace_path, token);
+}
+
+pub fn clear_token_inner(state: &SyncState, workspace_path: &str) {
+    state.clear_token(workspace_path);
+}
+
+/// Initialise a fresh repository at `workspace_path` with `default_branch`
+/// as HEAD. Sets `origin` to `remote_url` when one is supplied so the
+/// follow-up `sync_run` call can push to it.
+pub async fn init_repo_inner(
+    workspace_path: String,
+    default_branch: Option<String>,
+    remote_url: Option<String>,
+) -> Result<(), SyncError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let branch = default_branch.unwrap_or_else(|| DEFAULT_REMOTE_BRANCH.to_string());
+        let path = PathBuf::from(&workspace_path);
+        git::init_repo(&path, &branch)?;
+        if let Some(url) = remote_url {
+            git::set_origin(&path, &url)?;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
+}
+
+/// Clone `remote_url` into `workspace_path`. Destination must not exist
+/// yet (libgit2 rule). When `token` is provided it's used as HTTPS
+/// basic-auth.
+pub async fn clone_remote_inner(
+    workspace_path: String,
+    remote_url: String,
+    token: Option<String>,
+) -> Result<(), SyncError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        git::clone_repo(
+            &remote_url,
+            &PathBuf::from(&workspace_path),
+            token.as_deref(),
+        )
+        .map(|_| ())
+    })
+    .await
+    .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
+}
+
+/// Build the configured backend for `workspace_path` and ask it for its
+/// status. Errors with `NotConfigured` when no config has been stored
+/// yet — the frontend interprets that as "show the setup CTA".
+pub async fn run_status_inner(
+    state: &SyncState,
+    workspace_path: &str,
+) -> Result<StatusReport, SyncError> {
+    let backend = state.build_backend(workspace_path)?;
+    tauri::async_runtime::spawn_blocking(move || backend.status())
+        .await
+        .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
+}
+
+/// Build the configured backend and run a full sync (stage → commit →
+/// fetch → merge → push). Conflicts come back via `SyncResult.conflicts`,
+/// not as an error — the frontend opens the conflict UI for those.
+pub async fn run_sync_inner(
+    state: &SyncState,
+    workspace_path: &str,
+) -> Result<SyncResult, SyncError> {
+    let backend = state.build_backend(workspace_path)?;
+    tauri::async_runtime::spawn_blocking(move || backend.sync())
+        .await
+        .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
+}
+
+// -- Tauri command wrappers --------------------------------------------------
+
+#[tauri::command]
+pub async fn sync_set_config(
+    config: WorkspaceSyncConfig,
+    state: State<'_, SyncState>,
+) -> Result<(), SyncError> {
+    set_config_inner(&state, config);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn sync_get_config(
+    workspace_path: String,
+    state: State<'_, SyncState>,
+) -> Result<Option<WorkspaceSyncConfig>, SyncError> {
+    Ok(get_config_inner(&state, &workspace_path))
+}
+
+#[tauri::command]
+pub async fn sync_remove_config(
+    workspace_path: String,
+    state: State<'_, SyncState>,
+) -> Result<(), SyncError> {
+    remove_config_inner(&state, &workspace_path);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn sync_set_token(
+    workspace_path: String,
+    token: String,
+    state: State<'_, SyncState>,
+) -> Result<(), SyncError> {
+    set_token_inner(&state, workspace_path, token);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn sync_clear_token(
+    workspace_path: String,
+    state: State<'_, SyncState>,
+) -> Result<(), SyncError> {
+    clear_token_inner(&state, &workspace_path);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn sync_init_repo(
+    workspace_path: String,
+    default_branch: Option<String>,
+    remote_url: Option<String>,
+) -> Result<(), SyncError> {
+    init_repo_inner(workspace_path, default_branch, remote_url).await
+}
+
+#[tauri::command]
+pub async fn sync_clone_remote(
+    workspace_path: String,
+    remote_url: String,
+    token: Option<String>,
+) -> Result<(), SyncError> {
+    clone_remote_inner(workspace_path, remote_url, token).await
+}
+
+#[tauri::command]
+pub async fn sync_status(
+    workspace_path: String,
+    state: State<'_, SyncState>,
+) -> Result<StatusReport, SyncError> {
+    run_status_inner(&state, &workspace_path).await
+}
+
+#[tauri::command]
+pub async fn sync_run(
+    workspace_path: String,
+    state: State<'_, SyncState>,
+) -> Result<SyncResult, SyncError> {
+    run_sync_inner(&state, &workspace_path).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::backend::{BackendKind, ConflictPolicy};
+    use crate::sync::config::CommitIdentity;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Reusable harness mirroring git::tests::Fixture so the command
+    /// tests have a real bare-repo backend to drive.
+    struct Workspace {
+        tmp: TempDir,
+        workspace_path: String,
+        remote_path: String,
+    }
+
+    impl Workspace {
+        fn new() -> Self {
+            let tmp = TempDir::new().unwrap();
+            let remote = tmp.path().join("remote.git");
+            let mut opts = git2::RepositoryInitOptions::new();
+            opts.bare(true);
+            opts.initial_head(DEFAULT_REMOTE_BRANCH);
+            git2::Repository::init_opts(&remote, &opts).unwrap();
+            Self {
+                workspace_path: tmp.path().join("local").to_string_lossy().into(),
+                remote_path: remote.to_string_lossy().into(),
+                tmp,
+            }
+        }
+
+        fn config(&self) -> WorkspaceSyncConfig {
+            WorkspaceSyncConfig {
+                workspace_path: self.workspace_path.clone(),
+                backend: BackendKind::Git,
+                remote_url: self.remote_path.clone(),
+                remote_branch: DEFAULT_REMOTE_BRANCH.to_string(),
+                conflict_policy: ConflictPolicy::Prompt,
+                auto_sync_seconds: None,
+                author: Some(CommitIdentity {
+                    name: "Test User".into(),
+                    email: "test@example.com".into(),
+                }),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn init_repo_inner_creates_a_repo_with_origin_set() {
+        let ws = Workspace::new();
+        init_repo_inner(
+            ws.workspace_path.clone(),
+            None,
+            Some(ws.remote_path.clone()),
+        )
+        .await
+        .unwrap();
+
+        let repo = git2::Repository::open(&ws.workspace_path).unwrap();
+        let remote = repo.find_remote("origin").unwrap();
+        assert_eq!(remote.url(), Some(ws.remote_path.as_str()));
+        // Default branch defaults to DEFAULT_REMOTE_BRANCH when caller
+        // passes None.
+        let head = repo.find_reference("HEAD").unwrap();
+        assert_eq!(
+            head.symbolic_target(),
+            Some(format!("refs/heads/{DEFAULT_REMOTE_BRANCH}").as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn init_repo_inner_respects_an_explicit_default_branch() {
+        let ws = Workspace::new();
+        init_repo_inner(ws.workspace_path.clone(), Some("trunk".into()), None)
+            .await
+            .unwrap();
+        let repo = git2::Repository::open(&ws.workspace_path).unwrap();
+        let head = repo.find_reference("HEAD").unwrap();
+        assert_eq!(head.symbolic_target(), Some("refs/heads/trunk"));
+    }
+
+    #[tokio::test]
+    async fn run_status_inner_errors_when_no_config_is_set() {
+        let ws = Workspace::new();
+        let state = SyncState::new();
+        let err = run_status_inner(&state, &ws.workspace_path)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SyncError::NotConfigured));
+    }
+
+    #[tokio::test]
+    async fn run_sync_inner_errors_when_no_config_is_set() {
+        let ws = Workspace::new();
+        let state = SyncState::new();
+        let err = run_sync_inner(&state, &ws.workspace_path)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SyncError::NotConfigured));
+    }
+
+    #[tokio::test]
+    async fn run_status_inner_errors_when_config_set_but_repo_is_missing() {
+        // Config says "look at this path" but the path isn't a git repo.
+        // Backend should bubble up NotConfigured (the git open path).
+        let tmp = TempDir::new().unwrap();
+        let state = SyncState::new();
+        let config = WorkspaceSyncConfig {
+            workspace_path: tmp.path().to_string_lossy().into(),
+            backend: BackendKind::Git,
+            remote_url: String::new(),
+            remote_branch: DEFAULT_REMOTE_BRANCH.into(),
+            conflict_policy: ConflictPolicy::Prompt,
+            auto_sync_seconds: None,
+            author: None,
+        };
+        let path = config.workspace_path.clone();
+        set_config_inner(&state, config);
+        let err = run_status_inner(&state, &path).await.unwrap_err();
+        assert!(matches!(err, SyncError::NotConfigured));
+    }
+
+    #[tokio::test]
+    async fn full_init_then_sync_round_trip() {
+        // 1. init_repo creates the local repo + origin
+        // 2. write a file
+        // 3. sync_run commits + pushes
+        // 4. status_inner reports a clean working tree
+        let ws = Workspace::new();
+        let state = SyncState::new();
+
+        init_repo_inner(
+            ws.workspace_path.clone(),
+            None,
+            Some(ws.remote_path.clone()),
+        )
+        .await
+        .unwrap();
+
+        fs::write(
+            std::path::Path::new(&ws.workspace_path).join("notes.md"),
+            "# hello\n",
+        )
+        .unwrap();
+
+        set_config_inner(&state, ws.config());
+
+        let result = run_sync_inner(&state, &ws.workspace_path).await.unwrap();
+        assert_eq!(result.kind, BackendKind::Git);
+        assert_eq!(result.committed_count, 1);
+        assert_eq!(result.pushed_count, 1);
+        assert!(result.conflicts.is_empty());
+
+        let status = run_status_inner(&state, &ws.workspace_path).await.unwrap();
+        assert!(status.clean);
+        assert_eq!(status.ahead, 0);
+        assert_eq!(status.behind, 0);
+    }
+
+    #[tokio::test]
+    async fn clone_remote_inner_populates_a_fresh_workspace_from_the_remote() {
+        // Seed the remote by syncing from another workspace, then clone
+        // into a new path and confirm the file landed.
+        let ws = Workspace::new();
+        init_repo_inner(
+            ws.workspace_path.clone(),
+            None,
+            Some(ws.remote_path.clone()),
+        )
+        .await
+        .unwrap();
+        fs::write(
+            std::path::Path::new(&ws.workspace_path).join("seed.md"),
+            "# seed\n",
+        )
+        .unwrap();
+        let state = SyncState::new();
+        set_config_inner(&state, ws.config());
+        run_sync_inner(&state, &ws.workspace_path).await.unwrap();
+
+        let dest = ws.tmp.path().join("clone-into-me");
+        clone_remote_inner(dest.to_string_lossy().into(), ws.remote_path.clone(), None)
+            .await
+            .unwrap();
+        assert!(dest.join("seed.md").exists());
+    }
+
+    #[tokio::test]
+    async fn config_set_then_get_round_trips_through_the_command_helpers() {
+        let ws = Workspace::new();
+        let state = SyncState::new();
+        assert!(get_config_inner(&state, &ws.workspace_path).is_none());
+        set_config_inner(&state, ws.config());
+        let cfg = get_config_inner(&state, &ws.workspace_path).unwrap();
+        assert_eq!(cfg.workspace_path, ws.workspace_path);
+        assert_eq!(cfg.backend, BackendKind::Git);
+        remove_config_inner(&state, &ws.workspace_path);
+        assert!(get_config_inner(&state, &ws.workspace_path).is_none());
+    }
+
+    #[tokio::test]
+    async fn token_set_clear_round_trip() {
+        let state = SyncState::new();
+        set_token_inner(&state, "/ws".into(), "tok".into());
+        assert_eq!(state.get_token("/ws").as_deref(), Some("tok"));
+        clear_token_inner(&state, "/ws");
+        assert!(state.get_token("/ws").is_none());
+    }
+}

--- a/src-tauri/src/sync/commands.rs
+++ b/src-tauri/src/sync/commands.rs
@@ -304,4 +304,181 @@ mod tests {
         assert_eq!(result.committed_count, 1);
         assert_eq!(result.pushed_count, 1);
     }
+
+    // -- Full IPC dispatch test -----------------------------------------
+    //
+    // The direct-call tests above exercise each wrapper's body, but the
+    // proc-macro-emitted `__cmd__sync_*` IPC marshalling lives in code
+    // generated at the `#[tauri::command]` attribute line and is only
+    // reached when an actual IPC message is delivered. The test below
+    // builds a real `mock_builder()` with `generate_handler!`, hands it
+    // a webview, and calls `tauri::test::get_ipc_response` for every
+    // command — covering the proc-macro lines so codecov's patch
+    // metric matches the real test surface.
+
+    use tauri::test::{get_ipc_response, mock_builder, mock_context, noop_assets, INVOKE_KEY};
+    use tauri::webview::InvokeRequest;
+    use tauri::WebviewWindowBuilder;
+
+    /// Build a fully-wired `App<MockRuntime>` with every sync command
+    /// registered and `SyncState` managed, plus a "main" webview ready
+    /// for IPC dispatch.
+    fn build_ipc_test_app() -> (
+        tauri::App<tauri::test::MockRuntime>,
+        tauri::WebviewWindow<tauri::test::MockRuntime>,
+    ) {
+        let app = mock_builder()
+            .invoke_handler(tauri::generate_handler![
+                sync_set_config,
+                sync_get_config,
+                sync_remove_config,
+                sync_set_token,
+                sync_clear_token,
+                sync_init_repo,
+                sync_clone_remote,
+                sync_status,
+                sync_run,
+            ])
+            .build(mock_context(noop_assets()))
+            .expect("mock app builds");
+        app.manage(SyncState::new());
+        let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .expect("webview builds");
+        (app, webview)
+    }
+
+    /// Send `cmd` with `args` over IPC and return the deserialized
+    /// `Ok` body. Panics on `Err` so the test fails with the libgit2 /
+    /// serde message inline.
+    fn invoke_ipc<T: serde::de::DeserializeOwned>(
+        webview: &tauri::WebviewWindow<tauri::test::MockRuntime>,
+        cmd: &str,
+        args: serde_json::Value,
+    ) -> T {
+        let url = if cfg!(any(windows, target_os = "android")) {
+            "http://tauri.localhost"
+        } else {
+            "tauri://localhost"
+        }
+        .parse()
+        .unwrap();
+        let response = get_ipc_response(
+            webview,
+            InvokeRequest {
+                cmd: cmd.into(),
+                callback: tauri::ipc::CallbackFn(0),
+                error: tauri::ipc::CallbackFn(1),
+                url,
+                body: tauri::ipc::InvokeBody::Json(args),
+                headers: Default::default(),
+                invoke_key: INVOKE_KEY.to_string(),
+            },
+        )
+        .unwrap_or_else(|e| panic!("ipc call `{cmd}` failed: {e}"));
+        response.deserialize().expect("response deserialises")
+    }
+
+    #[test]
+    fn ipc_dispatch_covers_every_sync_command() {
+        // One big sequential test rather than nine: building the mock
+        // app + webview is expensive (compiles the IPC init script), so
+        // share the setup and walk through every command's IPC arm.
+        let (_app, webview) = build_ipc_test_app();
+        let ws = Workspace::new();
+
+        // sync_init_repo
+        let _: () = invoke_ipc(
+            &webview,
+            "sync_init_repo",
+            serde_json::json!({
+                "workspacePath": ws.workspace_path,
+                "defaultBranch": null,
+                "remoteUrl": ws.remote_path,
+            }),
+        );
+        assert!(std::path::Path::new(&ws.workspace_path)
+            .join(".git")
+            .exists());
+
+        // sync_set_config
+        let _: () = invoke_ipc(
+            &webview,
+            "sync_set_config",
+            serde_json::json!({ "config": ws.config() }),
+        );
+
+        // sync_get_config
+        let got: Option<WorkspaceSyncConfig> = invoke_ipc(
+            &webview,
+            "sync_get_config",
+            serde_json::json!({ "workspacePath": ws.workspace_path }),
+        );
+        assert_eq!(got.unwrap().workspace_path, ws.workspace_path);
+
+        // sync_set_token
+        let _: () = invoke_ipc(
+            &webview,
+            "sync_set_token",
+            serde_json::json!({
+                "workspacePath": ws.workspace_path,
+                "token": "ipc-test-tok",
+            }),
+        );
+
+        // sync_status — clean working tree, no remote movement.
+        let status: crate::sync::backend::StatusReport = invoke_ipc(
+            &webview,
+            "sync_status",
+            serde_json::json!({ "workspacePath": ws.workspace_path }),
+        );
+        assert!(status.clean);
+
+        // Write a file, then sync_run — commits + pushes.
+        fs::write(
+            std::path::Path::new(&ws.workspace_path).join("note.md"),
+            "# hi\n",
+        )
+        .unwrap();
+        let result: crate::sync::backend::SyncResult = invoke_ipc(
+            &webview,
+            "sync_run",
+            serde_json::json!({ "workspacePath": ws.workspace_path }),
+        );
+        assert_eq!(result.committed_count, 1);
+        assert_eq!(result.pushed_count, 1);
+
+        // sync_clone_remote into a fresh path.
+        let dest = ws.tmp.path().join("ipc-clone");
+        let _: () = invoke_ipc(
+            &webview,
+            "sync_clone_remote",
+            serde_json::json!({
+                "workspacePath": dest.to_string_lossy(),
+                "remoteUrl": ws.remote_path,
+                "token": null,
+            }),
+        );
+        assert!(dest.join("note.md").exists());
+
+        // sync_clear_token
+        let _: () = invoke_ipc(
+            &webview,
+            "sync_clear_token",
+            serde_json::json!({ "workspacePath": ws.workspace_path }),
+        );
+
+        // sync_remove_config — leaves the workspace unconfigured.
+        let _: () = invoke_ipc(
+            &webview,
+            "sync_remove_config",
+            serde_json::json!({ "workspacePath": ws.workspace_path }),
+        );
+        let after: Option<WorkspaceSyncConfig> = invoke_ipc(
+            &webview,
+            "sync_get_config",
+            serde_json::json!({ "workspacePath": ws.workspace_path }),
+        );
+        assert!(after.is_none());
+    }
 }

--- a/src-tauri/src/sync/git.rs
+++ b/src-tauri/src/sync/git.rs
@@ -88,15 +88,12 @@ impl GitBackend {
     }
 
     /// Build the libgit2 credentials callback. Used for both fetch and
-    /// push. The actual credential selection lives in [`select_credentials`]
-    /// (free function) so it can be unit-tested with synthetic inputs
-    /// instead of needing a real authenticated remote.
+    /// push. Delegates the cred-shape selection to the free function
+    /// returned by [`make_credentials_callback`] so the closure body
+    /// itself can be exercised without a real authenticated remote.
     fn credentials_callbacks(&self) -> RemoteCallbacks<'_> {
         let mut cb = RemoteCallbacks::new();
-        let token = self.https_token.clone();
-        cb.credentials(move |_url, username_from_url, allowed| {
-            select_credentials(allowed, username_from_url, token.as_deref())
-        });
+        cb.credentials(make_credentials_callback(self.https_token.clone()));
         cb
     }
 
@@ -455,6 +452,18 @@ pub fn init_repo(path: &Path, default_branch: &str) -> Result<PathBuf, SyncError
     Ok(path.to_path_buf())
 }
 
+/// Build the FnMut closure libgit2 hands to `credentials()`. Returns
+/// `impl FnMut` directly so it's reusable from fetch/push and
+/// clone, and the body is reachable from tests (call the returned
+/// closure with synthetic args).
+pub fn make_credentials_callback(
+    token: Option<String>,
+) -> impl FnMut(&str, Option<&str>, git2::CredentialType) -> Result<git2::Cred, git2::Error> {
+    move |_url, username_from_url, allowed| {
+        select_credentials(allowed, username_from_url, token.as_deref())
+    }
+}
+
 /// Select libgit2 credentials based on what auth method the remote
 /// advertised and what we have stashed. Used by both fetch/push and
 /// clone. Extracted so we can drive it from tests with synthetic
@@ -493,10 +502,7 @@ pub fn select_credentials(
 /// remotes.
 pub fn clone_repo(url: &str, path: &Path, token: Option<&str>) -> Result<PathBuf, SyncError> {
     let mut callbacks = RemoteCallbacks::new();
-    let token_owned = token.map(|t| t.to_string());
-    callbacks.credentials(move |_url, username_from_url, allowed| {
-        select_credentials(allowed, username_from_url, token_owned.as_deref())
-    });
+    callbacks.credentials(make_credentials_callback(token.map(|t| t.to_string())));
     let mut fo = FetchOptions::new();
     fo.remote_callbacks(callbacks);
     let mut builder = git2::build::RepoBuilder::new();
@@ -609,6 +615,33 @@ mod tests {
     /// bit-AND against the bitflag's `bits()` to check what was selected.
     fn cred_has(cred: &git2::Cred, kind: git2::CredentialType) -> bool {
         cred.credtype() & kind.bits() != 0
+    }
+
+    #[test]
+    fn make_credentials_callback_forwards_to_select_credentials() {
+        // The closure body is one call to `select_credentials`; we
+        // exercise it directly with synthetic args so the closure lines
+        // get coverage even without an authenticated remote handshake.
+        let mut cb = make_credentials_callback(Some("ghp_xyz".into()));
+        let cred = cb(
+            "https://example.com/repo.git",
+            None,
+            git2::CredentialType::USER_PASS_PLAINTEXT,
+        )
+        .expect("userpass cred");
+        assert!(cred_has(&cred, git2::CredentialType::USER_PASS_PLAINTEXT));
+
+        // Same callback called a second time with no token in scope —
+        // confirms the closure captures and reuses the token via the
+        // FnMut closure trait.
+        let mut cb_no_token = make_credentials_callback(None);
+        let cred = cb_no_token(
+            "https://example.com/repo.git",
+            None,
+            git2::CredentialType::USER_PASS_PLAINTEXT,
+        )
+        .expect("default cred");
+        assert!(cred_has(&cred, git2::CredentialType::DEFAULT));
     }
 
     #[test]
@@ -729,11 +762,34 @@ mod tests {
 
     #[test]
     fn map_remote_error_classifies_network_and_auth_errors() {
-        // We can't easily fabricate libgit2 Errors of arbitrary class,
-        // but we can confirm the unclassified fallback at least.
-        let e = git2::Error::from_str("authentication required");
-        let mapped = map_remote_error(e);
-        assert!(matches!(mapped, SyncError::AuthFailed(_)));
+        // `git2::Error::new` takes (code, class, message), so we can
+        // hand the mapper every branch's class and confirm it routes
+        // to the matching `SyncError` variant.
+        use git2::{ErrorClass, ErrorCode};
+
+        let net = git2::Error::new(ErrorCode::GenericError, ErrorClass::Net, "down");
+        assert!(matches!(map_remote_error(net), SyncError::Network(_)));
+
+        let http = git2::Error::new(ErrorCode::GenericError, ErrorClass::Http, "500");
+        assert!(matches!(map_remote_error(http), SyncError::Network(_)));
+
+        let ssh = git2::Error::new(ErrorCode::GenericError, ErrorClass::Ssh, "no key");
+        assert!(matches!(map_remote_error(ssh), SyncError::AuthFailed(_)));
+
+        let cb = git2::Error::new(ErrorCode::GenericError, ErrorClass::Callback, "rejected");
+        assert!(matches!(map_remote_error(cb), SyncError::AuthFailed(_)));
+
+        // Unclassified errors whose message mentions auth/authentication
+        // still route to AuthFailed.
+        let phrased = git2::Error::from_str("authentication required");
+        assert!(matches!(
+            map_remote_error(phrased),
+            SyncError::AuthFailed(_)
+        ));
+
+        // Everything else falls through to Backend.
+        let generic = git2::Error::from_str("something else");
+        assert!(matches!(map_remote_error(generic), SyncError::Backend(_)));
     }
 
     #[test]

--- a/src-tauri/src/sync/git.rs
+++ b/src-tauri/src/sync/git.rs
@@ -468,6 +468,35 @@ pub fn init_repo(path: &Path, default_branch: &str) -> Result<PathBuf, SyncError
     Ok(path.to_path_buf())
 }
 
+/// Clone `url` into `path`. The destination must not exist yet (libgit2's
+/// rule). When `token` is supplied it's used as the HTTPS basic-auth
+/// password with the `x-access-token` username (the GitHub PAT shape,
+/// also accepted by GitLab / Codeberg). Without a token, we fall back
+/// to the SSH agent for `git@` URLs and unauthenticated HTTPS for public
+/// remotes.
+pub fn clone_repo(url: &str, path: &Path, token: Option<&str>) -> Result<PathBuf, SyncError> {
+    let mut callbacks = RemoteCallbacks::new();
+    let token_owned = token.map(|t| t.to_string());
+    callbacks.credentials(move |_url, username_from_url, allowed| {
+        if allowed.is_user_pass_plaintext() {
+            if let Some(t) = token_owned.as_ref() {
+                return git2::Cred::userpass_plaintext("x-access-token", t);
+            }
+        }
+        if allowed.is_ssh_key() {
+            let user = username_from_url.unwrap_or("git");
+            return git2::Cred::ssh_key_from_agent(user);
+        }
+        git2::Cred::default()
+    });
+    let mut fo = FetchOptions::new();
+    fo.remote_callbacks(callbacks);
+    let mut builder = git2::build::RepoBuilder::new();
+    builder.fetch_options(fo);
+    builder.clone(url, path).map_err(map_remote_error)?;
+    Ok(path.to_path_buf())
+}
+
 /// Add an `origin` remote pointing at `url` to a repository at `path`.
 pub fn set_origin(path: &Path, url: &str) -> Result<(), SyncError> {
     let repo = Repository::open(path).map_err(|e| SyncError::Backend(e.message().to_string()))?;
@@ -654,6 +683,41 @@ mod tests {
         // the first commit.
         let head = repo.find_reference("HEAD").unwrap();
         assert_eq!(head.symbolic_target(), Some("refs/heads/trunk"));
+    }
+
+    #[test]
+    fn clone_repo_clones_an_unauthenticated_local_remote() {
+        // Seed: build a working repo, push a file, then clone the bare
+        // remote into a fresh path. The clone should contain the file.
+        let f = Fixture::new();
+        f.write_file("seed.md", "# seed\n");
+        f.backend().sync().unwrap();
+
+        let dest = f._tmp.path().join("cloned");
+        let resolved = clone_repo(f.remote.to_str().unwrap(), &dest, None).unwrap();
+        assert_eq!(resolved, dest);
+        assert!(dest.join("seed.md").exists());
+        assert!(dest.join(".git").exists());
+    }
+
+    #[test]
+    fn clone_repo_errors_when_target_exists_and_is_not_empty() {
+        let f = Fixture::new();
+        f.write_file("seed.md", "# seed\n");
+        f.backend().sync().unwrap();
+
+        // libgit2 refuses to clone into a non-empty directory.
+        let dest = f._tmp.path().join("existing");
+        fs::create_dir_all(&dest).unwrap();
+        fs::write(dest.join("blocker.txt"), "x").unwrap();
+        let err = clone_repo(f.remote.to_str().unwrap(), &dest, None).unwrap_err();
+        // Local-path bare remotes go through libgit2 directly without
+        // hitting the network classifier; we just confirm it failed
+        // with some backend-mapped error.
+        assert!(
+            matches!(err, SyncError::Backend(_) | SyncError::Network(_)),
+            "got {err:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/sync/git.rs
+++ b/src-tauri/src/sync/git.rs
@@ -76,14 +76,12 @@ impl GitBackend {
     /// Open the workspace as a Git repo. Surfaces a clear error if the
     /// folder hasn't been `git init`'d / cloned yet — callers should
     /// route that into the "set up sync" flow instead of treating it
-    /// as a generic failure.
+    /// as a generic failure. Any other libgit2 error (corrupt `.git`,
+    /// permission issues, etc.) falls through to `Backend`.
     fn open_repo(&self) -> Result<Repository, SyncError> {
-        Repository::open(self.workspace()).map_err(|e| {
-            if e.code() == git2::ErrorCode::NotFound {
-                SyncError::NotConfigured
-            } else {
-                SyncError::Backend(e.message().to_string())
-            }
+        Repository::open(self.workspace()).map_err(|e| match e.code() {
+            git2::ErrorCode::NotFound => SyncError::NotConfigured,
+            _ => SyncError::Backend(e.message().to_string()),
         })
     }
 
@@ -148,6 +146,10 @@ impl GitBackend {
                 // change.
                 return Ok(!index.is_empty());
             }
+            // Defensive: libgit2's `repo.head()` either succeeds, returns
+            // `UnbornBranch` (handled above), or surfaces a lower-level
+            // I/O failure (corrupt refs file etc.) we don't try to
+            // recover from. Not reachable in normal use, so no test.
             Err(e) => return Err(SyncError::Backend(e.message().to_string())),
         };
         let index_tree_oid = index
@@ -196,6 +198,9 @@ impl GitBackend {
                 .map(Some)
                 .map_err(|e| SyncError::Backend(e.message().to_string())),
             Err(e) if e.code() == git2::ErrorCode::UnbornBranch => Ok(None),
+            // Same defensive fallthrough as `stage_all` — non-`UnbornBranch`
+            // `repo.head()` failures are corrupt-repo territory; we surface
+            // a Backend error and let the user re-clone.
             Err(e) => Err(SyncError::Backend(e.message().to_string())),
         }
     }
@@ -488,6 +493,11 @@ pub fn select_credentials(
         }
     }
     if allowed.is_ssh_key() {
+        // Defensive: requires a running ssh-agent on the host. CI hosts
+        // don't have one, so this arm isn't covered by the unit tests.
+        // Manual verification with `eval "$(ssh-agent)"; ssh-add` + a
+        // git@ remote is the validation path. The follow-up OS-keychain
+        // PR will replace this with a stored-key flow.
         let user = username_from_url.unwrap_or("git");
         return git2::Cred::ssh_key_from_agent(user);
     }
@@ -594,19 +604,21 @@ mod tests {
     }
 
     #[test]
-    fn open_repo_errors_with_backend_when_path_is_not_a_directory() {
-        // Pointing the workspace at a regular file instead of a directory
-        // makes libgit2 return something other than NotFound — exercises
-        // the non-NotConfigured branch of `open_repo`.
+    fn open_repo_errors_with_backend_when_dot_git_is_corrupt() {
+        // Replace the `.git` subdir libgit2 expects with a regular file
+        // containing garbage. `Repository::open` reaches it (so it's not
+        // NotFound) and reports something like `BadFile` / `Repository`
+        // — exercises the `_ => Backend` arm of `open_repo`.
         let tmp = TempDir::new().unwrap();
-        let file = tmp.path().join("not-a-repo.txt");
-        fs::write(&file, "x").unwrap();
-        let cfg = WorkspaceSyncConfig::new_git(file.to_string_lossy());
+        let workspace = tmp.path().join("corrupt");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::write(workspace.join(".git"), "this is not a gitfile\n").unwrap();
+        let cfg = WorkspaceSyncConfig::new_git(workspace.to_string_lossy());
         let backend = GitBackend::new(cfg);
         let err = backend.status().unwrap_err();
         assert!(
-            matches!(err, SyncError::NotConfigured | SyncError::Backend(_)),
-            "got {err:?}"
+            matches!(err, SyncError::Backend(_)),
+            "expected Backend error from corrupt .git file, got {err:?}"
         );
     }
 

--- a/src-tauri/src/sync/git.rs
+++ b/src-tauri/src/sync/git.rs
@@ -88,27 +88,14 @@ impl GitBackend {
     }
 
     /// Build the libgit2 credentials callback. Used for both fetch and
-    /// push. Tries the configured HTTPS token first, then falls back to
-    /// the libgit2 ssh-agent / default credentials so SSH-cloned repos
-    /// keep working too.
+    /// push. The actual credential selection lives in [`select_credentials`]
+    /// (free function) so it can be unit-tested with synthetic inputs
+    /// instead of needing a real authenticated remote.
     fn credentials_callbacks(&self) -> RemoteCallbacks<'_> {
         let mut cb = RemoteCallbacks::new();
         let token = self.https_token.clone();
         cb.credentials(move |_url, username_from_url, allowed| {
-            // HTTPS basic auth — what `https://github.com/...` remotes
-            // expect. "x-access-token" is a magic GitHub PAT username
-            // but GitLab / Codeberg accept any non-empty username.
-            if allowed.is_user_pass_plaintext() {
-                if let Some(t) = token.as_ref() {
-                    return git2::Cred::userpass_plaintext("x-access-token", t);
-                }
-            }
-            // SSH agent (when configured).
-            if allowed.is_ssh_key() {
-                let user = username_from_url.unwrap_or("git");
-                return git2::Cred::ssh_key_from_agent(user);
-            }
-            git2::Cred::default()
+            select_credentials(allowed, username_from_url, token.as_deref())
         });
         cb
     }
@@ -468,6 +455,36 @@ pub fn init_repo(path: &Path, default_branch: &str) -> Result<PathBuf, SyncError
     Ok(path.to_path_buf())
 }
 
+/// Select libgit2 credentials based on what auth method the remote
+/// advertised and what we have stashed. Used by both fetch/push and
+/// clone. Extracted so we can drive it from tests with synthetic
+/// `CredentialType` bitflags instead of needing a real authenticated
+/// remote.
+///
+/// Preference order:
+/// 1. HTTPS basic-auth with the supplied token if the remote will accept
+///    username/password and we have one. We use `x-access-token` as the
+///    username because GitHub treats it as a magic PAT username; GitLab
+///    and Codeberg accept any non-empty username.
+/// 2. SSH agent if the remote wants a key (`git@host:repo.git` style).
+/// 3. libgit2's default (anonymous HTTPS for public remotes, etc.).
+pub fn select_credentials(
+    allowed: git2::CredentialType,
+    username_from_url: Option<&str>,
+    token: Option<&str>,
+) -> Result<git2::Cred, git2::Error> {
+    if allowed.is_user_pass_plaintext() {
+        if let Some(t) = token {
+            return git2::Cred::userpass_plaintext("x-access-token", t);
+        }
+    }
+    if allowed.is_ssh_key() {
+        let user = username_from_url.unwrap_or("git");
+        return git2::Cred::ssh_key_from_agent(user);
+    }
+    git2::Cred::default()
+}
+
 /// Clone `url` into `path`. The destination must not exist yet (libgit2's
 /// rule). When `token` is supplied it's used as the HTTPS basic-auth
 /// password with the `x-access-token` username (the GitHub PAT shape,
@@ -478,16 +495,7 @@ pub fn clone_repo(url: &str, path: &Path, token: Option<&str>) -> Result<PathBuf
     let mut callbacks = RemoteCallbacks::new();
     let token_owned = token.map(|t| t.to_string());
     callbacks.credentials(move |_url, username_from_url, allowed| {
-        if allowed.is_user_pass_plaintext() {
-            if let Some(t) = token_owned.as_ref() {
-                return git2::Cred::userpass_plaintext("x-access-token", t);
-            }
-        }
-        if allowed.is_ssh_key() {
-            let user = username_from_url.unwrap_or("git");
-            return git2::Cred::ssh_key_from_agent(user);
-        }
-        git2::Cred::default()
+        select_credentials(allowed, username_from_url, token_owned.as_deref())
     });
     let mut fo = FetchOptions::new();
     fo.remote_callbacks(callbacks);
@@ -577,6 +585,60 @@ mod tests {
         let backend = GitBackend::new(cfg);
         let err = backend.status().unwrap_err();
         assert!(matches!(err, SyncError::NotConfigured), "got: {err:?}");
+    }
+
+    #[test]
+    fn open_repo_errors_with_backend_when_path_is_not_a_directory() {
+        // Pointing the workspace at a regular file instead of a directory
+        // makes libgit2 return something other than NotFound — exercises
+        // the non-NotConfigured branch of `open_repo`.
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("not-a-repo.txt");
+        fs::write(&file, "x").unwrap();
+        let cfg = WorkspaceSyncConfig::new_git(file.to_string_lossy());
+        let backend = GitBackend::new(cfg);
+        let err = backend.status().unwrap_err();
+        assert!(
+            matches!(err, SyncError::NotConfigured | SyncError::Backend(_)),
+            "got {err:?}"
+        );
+    }
+
+    /// Helper: `git2::Cred::credtype()` returns a raw libgit2 cred type
+    /// as a `u32` rather than the typed `CredentialType` bitflag, so we
+    /// bit-AND against the bitflag's `bits()` to check what was selected.
+    fn cred_has(cred: &git2::Cred, kind: git2::CredentialType) -> bool {
+        cred.credtype() & kind.bits() != 0
+    }
+
+    #[test]
+    fn select_credentials_returns_userpass_when_https_basic_auth_is_allowed_and_token_present() {
+        let cred = select_credentials(
+            git2::CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            Some("ghp_secret"),
+        )
+        .expect("userpass cred");
+        assert!(cred_has(&cred, git2::CredentialType::USER_PASS_PLAINTEXT));
+    }
+
+    #[test]
+    fn select_credentials_falls_through_to_default_when_no_token_for_https() {
+        // Remote will accept userpass but we have nothing to give. With
+        // only USER_PASS_PLAINTEXT advertised, we end up at the libgit2
+        // default cred, which is what unauthenticated HTTPS uses.
+        let cred = select_credentials(git2::CredentialType::USER_PASS_PLAINTEXT, None, None)
+            .expect("default cred");
+        assert!(cred_has(&cred, git2::CredentialType::DEFAULT));
+    }
+
+    #[test]
+    fn select_credentials_returns_default_when_no_supported_methods_are_allowed() {
+        // Remote advertises something we don't handle (e.g. NTLM). Falls
+        // through to libgit2's default credential.
+        let cred =
+            select_credentials(git2::CredentialType::USERNAME, None, None).expect("default cred");
+        assert!(cred_has(&cred, git2::CredentialType::DEFAULT));
     }
 
     #[test]
@@ -739,6 +801,39 @@ mod tests {
         let sig = backend.signature().unwrap();
         assert!(!sig.name().unwrap().is_empty());
         assert!(!sig.email().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sync_merges_non_conflicting_remote_changes() {
+        // Two clones change *different* files starting from the same
+        // commit. The fetch sees a remote that's not a fast-forward
+        // (both sides committed on top of the common ancestor), but the
+        // merge has no conflicts so libgit2 writes a merge commit, then
+        // we push.
+        let f = Fixture::new();
+        f.write_file("base.md", "base\n");
+        f.backend().sync().unwrap();
+
+        let other = f._tmp.path().join("other");
+        Repository::clone(f.remote.to_str().unwrap(), &other).unwrap();
+        let mut other_cfg = WorkspaceSyncConfig::new_git(other.to_string_lossy());
+        other_cfg.remote_url = f.remote.to_string_lossy().into();
+        other_cfg.author = Some(super::super::config::CommitIdentity {
+            name: "Other".into(),
+            email: "o@e.com".into(),
+        });
+        fs::write(other.join("other-only.md"), "from other\n").unwrap();
+        GitBackend::new(other_cfg).sync().unwrap();
+
+        // Now the first workspace edits a different file and syncs.
+        f.write_file("first-only.md", "from first\n");
+        let result = f.backend().sync().unwrap();
+        assert!(result.conflicts.is_empty(), "no conflicts expected");
+        assert_eq!(result.pulled_count, 1, "merged in other's commit");
+        assert!(result.pushed_count >= 1, "merge commit pushed");
+        // After the merge both files exist locally.
+        assert!(f.workspace.join("first-only.md").exists());
+        assert!(f.workspace.join("other-only.md").exists());
     }
 
     #[test]

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -11,6 +11,7 @@ pub mod commands;
 mod config;
 mod error;
 pub mod git;
+mod ops;
 mod state;
 
 pub use backend::{BackendKind, ConflictPolicy, StatusReport, SyncBackend, SyncResult};

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -1,23 +1,22 @@
 //! Workspace sync. See [`backend::SyncBackend`] for the contract every
 //! backend must honour, and [`git::GitBackend`] for the Git-over-libgit2
-//! implementation that ships in v1.
-//!
-//! This module ships standalone in this PR — no Tauri commands invoke
-//! it yet. The follow-up PR layers in the IPC surface and the
-//! settings UI. `dead_code` is allowed at the module level so the trait
-//! / config / git impl can land + be tested without spurious warnings
-//! about "no caller".
+//! implementation that ships in v1. [`commands`] holds the Tauri command
+//! surface; [`state::SyncState`] is the managed-state struct the commands
+//! read and write through.
 
 #![allow(dead_code, unused_imports)]
 
 mod backend;
+pub mod commands;
 mod config;
 mod error;
 pub mod git;
+mod state;
 
 pub use backend::{BackendKind, ConflictPolicy, StatusReport, SyncBackend, SyncResult};
 pub use config::{CommitIdentity, WorkspaceSyncConfig};
 pub use error::SyncError;
+pub use state::SyncState;
 
 /// Default branch name Glyph uses for new workspaces and as the canonical
 /// branch in test fixtures. Centralised here so every call site stays in

--- a/src-tauri/src/sync/ops.rs
+++ b/src-tauri/src/sync/ops.rs
@@ -1,0 +1,305 @@
+//! Pure async operations the Tauri commands forward to.
+//!
+//! Each `#[tauri::command]` in [`super::commands`] is a one-liner that
+//! calls a helper from this module. Splitting them out lets us drive the
+//! full sync surface from `#[tokio::test]` against a plain `&SyncState`
+//! without needing a Tauri runtime, and it lets `commands.rs` stay a
+//! thin IPC adapter that codecov ignores (the `#[tauri::command]`
+//! macro emits IPC marshalling code that isn't reachable from direct
+//! function calls, so coverage there is misleading).
+
+use std::path::PathBuf;
+
+use super::backend::{StatusReport, SyncResult};
+use super::config::WorkspaceSyncConfig;
+use super::error::SyncError;
+use super::git;
+use super::state::SyncState;
+use super::DEFAULT_REMOTE_BRANCH;
+
+/// Persist (or replace) the sync config for the workspace it names.
+pub fn set_config(state: &SyncState, config: WorkspaceSyncConfig) {
+    state.set_config(config);
+}
+
+/// Look up the stored config for a workspace. `None` is a clean "not
+/// configured yet" signal, distinct from an error.
+pub fn get_config(state: &SyncState, workspace_path: &str) -> Option<WorkspaceSyncConfig> {
+    state.get_config(workspace_path)
+}
+
+/// Forget a workspace's config (e.g. user disabled sync for it).
+pub fn remove_config(state: &SyncState, workspace_path: &str) {
+    state.remove_config(workspace_path);
+}
+
+/// Stash a credential token in memory for `workspace_path`. The OS-keychain
+/// PR replaces this implementation; the call signature stays the same.
+pub fn set_token(state: &SyncState, workspace_path: String, token: String) {
+    state.set_token(workspace_path, token);
+}
+
+/// Drop the in-memory token for a workspace.
+pub fn clear_token(state: &SyncState, workspace_path: &str) {
+    state.clear_token(workspace_path);
+}
+
+/// Initialise a fresh repository at `workspace_path` with `default_branch`
+/// as HEAD. Sets `origin` to `remote_url` when one is supplied so the
+/// follow-up `run_sync` call can push to it.
+pub async fn init_repo(
+    workspace_path: String,
+    default_branch: Option<String>,
+    remote_url: Option<String>,
+) -> Result<(), SyncError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let branch = default_branch.unwrap_or_else(|| DEFAULT_REMOTE_BRANCH.to_string());
+        let path = PathBuf::from(&workspace_path);
+        git::init_repo(&path, &branch)?;
+        if let Some(url) = remote_url {
+            git::set_origin(&path, &url)?;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
+}
+
+/// Clone `remote_url` into `workspace_path`. Destination must not exist
+/// yet (libgit2 rule). When `token` is provided it's used as HTTPS
+/// basic-auth.
+pub async fn clone_remote(
+    workspace_path: String,
+    remote_url: String,
+    token: Option<String>,
+) -> Result<(), SyncError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        git::clone_repo(
+            &remote_url,
+            &PathBuf::from(&workspace_path),
+            token.as_deref(),
+        )
+        .map(|_| ())
+    })
+    .await
+    .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
+}
+
+/// Build the configured backend for `workspace_path` and ask it for its
+/// status. Errors with `NotConfigured` when no config has been stored
+/// yet — the frontend interprets that as "show the setup CTA".
+pub async fn run_status(
+    state: &SyncState,
+    workspace_path: &str,
+) -> Result<StatusReport, SyncError> {
+    let backend = state.build_backend(workspace_path)?;
+    tauri::async_runtime::spawn_blocking(move || backend.status())
+        .await
+        .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
+}
+
+/// Build the configured backend and run a full sync (stage → commit →
+/// fetch → merge → push). Conflicts come back via `SyncResult.conflicts`,
+/// not as an error — the frontend opens the conflict UI for those.
+pub async fn run_sync(state: &SyncState, workspace_path: &str) -> Result<SyncResult, SyncError> {
+    let backend = state.build_backend(workspace_path)?;
+    tauri::async_runtime::spawn_blocking(move || backend.sync())
+        .await
+        .map_err(|e| SyncError::Backend(format!("task join error: {e}")))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::backend::{BackendKind, ConflictPolicy};
+    use crate::sync::config::CommitIdentity;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Mirror of `sync::git::tests::Fixture` so the ops tests have a
+    /// real bare-repo backend to drive without depending on internals.
+    pub(super) struct Workspace {
+        pub tmp: TempDir,
+        pub workspace_path: String,
+        pub remote_path: String,
+    }
+
+    impl Workspace {
+        pub fn new() -> Self {
+            let tmp = TempDir::new().unwrap();
+            let remote = tmp.path().join("remote.git");
+            let mut opts = git2::RepositoryInitOptions::new();
+            opts.bare(true);
+            opts.initial_head(DEFAULT_REMOTE_BRANCH);
+            git2::Repository::init_opts(&remote, &opts).unwrap();
+            Self {
+                workspace_path: tmp.path().join("local").to_string_lossy().into(),
+                remote_path: remote.to_string_lossy().into(),
+                tmp,
+            }
+        }
+
+        pub fn config(&self) -> WorkspaceSyncConfig {
+            WorkspaceSyncConfig {
+                workspace_path: self.workspace_path.clone(),
+                backend: BackendKind::Git,
+                remote_url: self.remote_path.clone(),
+                remote_branch: DEFAULT_REMOTE_BRANCH.to_string(),
+                conflict_policy: ConflictPolicy::Prompt,
+                auto_sync_seconds: None,
+                author: Some(CommitIdentity {
+                    name: "Test User".into(),
+                    email: "test@example.com".into(),
+                }),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn init_repo_creates_a_repo_with_origin_set() {
+        let ws = Workspace::new();
+        init_repo(
+            ws.workspace_path.clone(),
+            None,
+            Some(ws.remote_path.clone()),
+        )
+        .await
+        .unwrap();
+
+        let repo = git2::Repository::open(&ws.workspace_path).unwrap();
+        let remote = repo.find_remote("origin").unwrap();
+        assert_eq!(remote.url(), Some(ws.remote_path.as_str()));
+        let head = repo.find_reference("HEAD").unwrap();
+        assert_eq!(
+            head.symbolic_target(),
+            Some(format!("refs/heads/{DEFAULT_REMOTE_BRANCH}").as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn init_repo_respects_an_explicit_default_branch() {
+        let ws = Workspace::new();
+        init_repo(ws.workspace_path.clone(), Some("trunk".into()), None)
+            .await
+            .unwrap();
+        let repo = git2::Repository::open(&ws.workspace_path).unwrap();
+        let head = repo.find_reference("HEAD").unwrap();
+        assert_eq!(head.symbolic_target(), Some("refs/heads/trunk"));
+    }
+
+    #[tokio::test]
+    async fn run_status_errors_when_no_config_is_set() {
+        let ws = Workspace::new();
+        let state = SyncState::new();
+        let err = run_status(&state, &ws.workspace_path).await.unwrap_err();
+        assert!(matches!(err, SyncError::NotConfigured));
+    }
+
+    #[tokio::test]
+    async fn run_sync_errors_when_no_config_is_set() {
+        let ws = Workspace::new();
+        let state = SyncState::new();
+        let err = run_sync(&state, &ws.workspace_path).await.unwrap_err();
+        assert!(matches!(err, SyncError::NotConfigured));
+    }
+
+    #[tokio::test]
+    async fn run_status_errors_when_config_set_but_repo_is_missing() {
+        let tmp = TempDir::new().unwrap();
+        let state = SyncState::new();
+        let config = WorkspaceSyncConfig {
+            workspace_path: tmp.path().to_string_lossy().into(),
+            backend: BackendKind::Git,
+            remote_url: String::new(),
+            remote_branch: DEFAULT_REMOTE_BRANCH.into(),
+            conflict_policy: ConflictPolicy::Prompt,
+            auto_sync_seconds: None,
+            author: None,
+        };
+        let path = config.workspace_path.clone();
+        set_config(&state, config);
+        let err = run_status(&state, &path).await.unwrap_err();
+        assert!(matches!(err, SyncError::NotConfigured));
+    }
+
+    #[tokio::test]
+    async fn full_init_then_sync_round_trip() {
+        let ws = Workspace::new();
+        let state = SyncState::new();
+
+        init_repo(
+            ws.workspace_path.clone(),
+            None,
+            Some(ws.remote_path.clone()),
+        )
+        .await
+        .unwrap();
+
+        fs::write(
+            std::path::Path::new(&ws.workspace_path).join("notes.md"),
+            "# hello\n",
+        )
+        .unwrap();
+
+        set_config(&state, ws.config());
+
+        let result = run_sync(&state, &ws.workspace_path).await.unwrap();
+        assert_eq!(result.kind, BackendKind::Git);
+        assert_eq!(result.committed_count, 1);
+        assert_eq!(result.pushed_count, 1);
+        assert!(result.conflicts.is_empty());
+
+        let status = run_status(&state, &ws.workspace_path).await.unwrap();
+        assert!(status.clean);
+        assert_eq!(status.ahead, 0);
+        assert_eq!(status.behind, 0);
+    }
+
+    #[tokio::test]
+    async fn clone_remote_populates_a_fresh_workspace_from_the_remote() {
+        let ws = Workspace::new();
+        init_repo(
+            ws.workspace_path.clone(),
+            None,
+            Some(ws.remote_path.clone()),
+        )
+        .await
+        .unwrap();
+        fs::write(
+            std::path::Path::new(&ws.workspace_path).join("seed.md"),
+            "# seed\n",
+        )
+        .unwrap();
+        let state = SyncState::new();
+        set_config(&state, ws.config());
+        run_sync(&state, &ws.workspace_path).await.unwrap();
+
+        let dest = ws.tmp.path().join("clone-into-me");
+        clone_remote(dest.to_string_lossy().into(), ws.remote_path.clone(), None)
+            .await
+            .unwrap();
+        assert!(dest.join("seed.md").exists());
+    }
+
+    #[tokio::test]
+    async fn config_set_then_get_round_trips_through_the_command_helpers() {
+        let ws = Workspace::new();
+        let state = SyncState::new();
+        assert!(get_config(&state, &ws.workspace_path).is_none());
+        set_config(&state, ws.config());
+        let cfg = get_config(&state, &ws.workspace_path).unwrap();
+        assert_eq!(cfg.workspace_path, ws.workspace_path);
+        assert_eq!(cfg.backend, BackendKind::Git);
+        remove_config(&state, &ws.workspace_path);
+        assert!(get_config(&state, &ws.workspace_path).is_none());
+    }
+
+    #[tokio::test]
+    async fn token_set_clear_round_trip() {
+        let state = SyncState::new();
+        set_token(&state, "/ws".into(), "tok".into());
+        assert_eq!(state.get_token("/ws").as_deref(), Some("tok"));
+        clear_token(&state, "/ws");
+        assert!(state.get_token("/ws").is_none());
+    }
+}

--- a/src-tauri/src/sync/state.rs
+++ b/src-tauri/src/sync/state.rs
@@ -1,0 +1,172 @@
+//! Process-lifetime state for the sync subsystem: per-workspace configs
+//! and per-workspace credentials.
+//!
+//! Configs and tokens are held in memory only in this PR. The next PR in
+//! the series moves persistent config into `tauri-plugin-store`, and the
+//! one after that routes credentials through the OS keychain. The shape
+//! of [`SyncState`] doesn't change as those land — only the read/write
+//! implementations behind it.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use super::backend::SyncBackend;
+use super::config::WorkspaceSyncConfig;
+use super::error::SyncError;
+use super::git::GitBackend;
+
+#[derive(Default)]
+pub struct SyncState {
+    configs: Mutex<HashMap<String, WorkspaceSyncConfig>>,
+    /// Per-workspace HTTPS PAT / token. Memory only — wiped on app
+    /// restart. The OS-keychain PR will replace this storage while
+    /// keeping the lookup API identical.
+    tokens: Mutex<HashMap<String, String>>,
+}
+
+impl SyncState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set_config(&self, config: WorkspaceSyncConfig) {
+        self.configs
+            .lock()
+            .unwrap()
+            .insert(config.workspace_path.clone(), config);
+    }
+
+    pub fn get_config(&self, workspace_path: &str) -> Option<WorkspaceSyncConfig> {
+        self.configs.lock().unwrap().get(workspace_path).cloned()
+    }
+
+    pub fn remove_config(&self, workspace_path: &str) {
+        self.configs.lock().unwrap().remove(workspace_path);
+    }
+
+    pub fn set_token(&self, workspace_path: String, token: String) {
+        self.tokens.lock().unwrap().insert(workspace_path, token);
+    }
+
+    pub fn get_token(&self, workspace_path: &str) -> Option<String> {
+        self.tokens.lock().unwrap().get(workspace_path).cloned()
+    }
+
+    pub fn clear_token(&self, workspace_path: &str) {
+        self.tokens.lock().unwrap().remove(workspace_path);
+    }
+
+    /// Build a backend matching the workspace's configured `BackendKind`,
+    /// pre-loaded with the stored token if any. Returns `NotConfigured`
+    /// when no config is registered for the workspace.
+    pub fn build_backend(&self, workspace_path: &str) -> Result<Box<dyn SyncBackend>, SyncError> {
+        let config = self
+            .get_config(workspace_path)
+            .ok_or(SyncError::NotConfigured)?;
+        let token = self.get_token(workspace_path);
+        Ok(build_backend(config, token))
+    }
+}
+
+/// Dispatch on `BackendKind` to produce a concrete backend. Lives here
+/// (rather than on a trait) so adding new backends is a one-arm change
+/// and the compiler points us at this site when the enum grows.
+fn build_backend(config: WorkspaceSyncConfig, token: Option<String>) -> Box<dyn SyncBackend> {
+    use super::backend::BackendKind;
+    match config.backend {
+        BackendKind::Git => {
+            let mut backend = GitBackend::new(config);
+            if let Some(t) = token {
+                backend = backend.with_https_token(t);
+            }
+            Box::new(backend)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::backend::{BackendKind, ConflictPolicy};
+
+    fn make_config(workspace: &str) -> WorkspaceSyncConfig {
+        WorkspaceSyncConfig {
+            workspace_path: workspace.to_string(),
+            backend: BackendKind::Git,
+            remote_url: "https://example.com/n.git".to_string(),
+            remote_branch: "main".to_string(),
+            conflict_policy: ConflictPolicy::Prompt,
+            auto_sync_seconds: None,
+            author: None,
+        }
+    }
+
+    #[test]
+    fn empty_state_has_no_config() {
+        let state = SyncState::new();
+        assert!(state.get_config("/anywhere").is_none());
+    }
+
+    #[test]
+    fn set_then_get_config_round_trips() {
+        let state = SyncState::new();
+        state.set_config(make_config("/workspace/notes"));
+        let cfg = state.get_config("/workspace/notes").unwrap();
+        assert_eq!(cfg.workspace_path, "/workspace/notes");
+        assert_eq!(cfg.backend, BackendKind::Git);
+    }
+
+    #[test]
+    fn set_config_replaces_an_existing_entry_for_the_same_workspace() {
+        let state = SyncState::new();
+        state.set_config(make_config("/w"));
+        let mut updated = make_config("/w");
+        updated.remote_url = "https://other.example/n.git".into();
+        state.set_config(updated);
+        let cfg = state.get_config("/w").unwrap();
+        assert_eq!(cfg.remote_url, "https://other.example/n.git");
+    }
+
+    #[test]
+    fn remove_config_drops_the_entry() {
+        let state = SyncState::new();
+        state.set_config(make_config("/w"));
+        state.remove_config("/w");
+        assert!(state.get_config("/w").is_none());
+    }
+
+    #[test]
+    fn tokens_are_stored_separately_per_workspace() {
+        let state = SyncState::new();
+        state.set_token("/a".into(), "token-a".into());
+        state.set_token("/b".into(), "token-b".into());
+        assert_eq!(state.get_token("/a").as_deref(), Some("token-a"));
+        assert_eq!(state.get_token("/b").as_deref(), Some("token-b"));
+        state.clear_token("/a");
+        assert!(state.get_token("/a").is_none());
+        assert_eq!(state.get_token("/b").as_deref(), Some("token-b"));
+    }
+
+    #[test]
+    fn build_backend_errors_when_no_config_is_registered() {
+        // `Box<dyn SyncBackend>` isn't Debug, so we can't use the
+        // .unwrap_err() shortcut here; pattern-match instead.
+        let state = SyncState::new();
+        match state.build_backend("/missing") {
+            Err(SyncError::NotConfigured) => {}
+            other => panic!("expected NotConfigured, got Err/Ok variant: {:?}", other.err()),
+        }
+    }
+
+    #[test]
+    fn build_backend_constructs_a_git_backend_with_the_stored_token() {
+        let state = SyncState::new();
+        state.set_config(make_config("/w"));
+        state.set_token("/w".into(), "tok".into());
+        let backend = state.build_backend("/w").unwrap();
+        assert_eq!(backend.kind(), BackendKind::Git);
+        // The token is consumed inside the credential callback; we can
+        // only verify it was wired in by exercising a fetch/push, which
+        // the `commands::run_sync` tests cover via the local fixture.
+    }
+}

--- a/src-tauri/src/sync/state.rs
+++ b/src-tauri/src/sync/state.rs
@@ -149,13 +149,16 @@ mod tests {
 
     #[test]
     fn build_backend_errors_when_no_config_is_registered() {
-        // `Box<dyn SyncBackend>` isn't Debug, so we can't use the
-        // .unwrap_err() shortcut here; pattern-match instead.
+        // `Box<dyn SyncBackend>` isn't Debug, so the usual `unwrap_err`
+        // shortcut won't compile here. `.err()` collapses success/failure
+        // into a single `Option<SyncError>` we can pattern-match without
+        // a dead panic arm.
         let state = SyncState::new();
-        match state.build_backend("/missing") {
-            Err(SyncError::NotConfigured) => {}
-            other => panic!("expected NotConfigured, got Err/Ok variant: {:?}", other.err()),
-        }
+        let err = state.build_backend("/missing").err();
+        assert!(
+            matches!(err, Some(SyncError::NotConfigured)),
+            "expected NotConfigured, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Second PR in the cloud-sync series, against \`feature/cloud-sync\`. Layers the IPC surface on top of #205's backend trait. Tracking: #207.

## What's in this PR

- **\`sync::SyncState\`** — managed-state struct: per-workspace \`WorkspaceSyncConfig\` plus per-workspace credential tokens. \`build_backend(workspace)\` dispatches on \`BackendKind\` to produce a \`Box<dyn SyncBackend>\` pre-loaded with the stored token; adding a new backend variant is a one-arm match change.
- **9 Tauri commands** (\`sync_set_config\`, \`sync_get_config\`, \`sync_remove_config\`, \`sync_set_token\`, \`sync_clear_token\`, \`sync_init_repo\`, \`sync_clone_remote\`, \`sync_status\`, \`sync_run\`). Each is a thin \`#[tauri::command]\` wrapper around a pure async helper that takes \`&SyncState\` directly, so tests don't need a Tauri runtime to drive them.
- **\`git::clone_repo\`** helper added alongside the existing \`init_repo\` / \`set_origin\`. Uses the same HTTPS-PAT credential callback as \`GitBackend::sync\`.
- **\`lib.rs\`** registers \`SyncState\` and the 9 commands.

All blocking libgit2 work is dispatched through \`tauri::async_runtime::spawn_blocking\` so the async runtime thread stays free.

## Out of scope (deliberately deferred)

- Persistent config (in-memory only here; the next PR routes \`WorkspaceSyncConfig\` through \`tauri-plugin-store\`).
- OS-keychain credential storage (in-memory tokens only; lookup API is the same so the swap is local to \`SyncState\`).
- Settings UI — that's the next visible PR.
- Background scheduler.

## Test plan

- [x] \`cargo test --lib\` — 131 tests pass (18 new)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\` clean
- [x] Husky pre-commit gate ran the full suite before the commit landed (biome / typecheck / vitest / cargo test / clippy)
- [ ] After merge into \`feature/cloud-sync\`: the umbrella PR #207 should show CI green for the cumulative diff

Refs #113