### PR TITLE
ci(release): show version in workflow run name

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,5 @@
 name: Create Release
+run-name: Create Release v${{ inputs.version }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

The "Create Release" workflow currently lists every run with the generic name "Create Release", so the run history has no way to tell `0.5.0` from `0.7.0` without opening each run. This PR sets `run-name` so the input version is part of the run title.

## Changes

- `.github/workflows/create-release.yml`: add `run-name: Create Release v${{ inputs.version }}`

Each dispatch now shows up as e.g. **"Create Release v0.7.1"** in the Actions list. Existing runs are not affected; only new runs use the dynamic name.

## Testing

Verified syntax against GitHub's `run-name` reference. The expression resolves the workflow input at dispatch time, so the title is set before the first job runs. No code paths inside the workflow change.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

(Platform checkboxes left unchecked: this is a CI metadata change and does not run on user machines.)