### PR TITLE
docs: add per-OS dev prerequisites to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,58 @@ Thanks for your interest in contributing!
 ## Development Setup
 
 ```bash
-# Prerequisites: Node.js (see .nvmrc), pnpm, Rust stable
+# Prerequisites: Node.js (see .nvmrc), pnpm, Rust stable, plus platform deps (below)
 git clone https://github.com/hamidfzm/glyph.git
 cd glyph
 nvm use          # or fnm use — reads .nvmrc
 pnpm install     # also installs the Husky git hooks via `prepare`
 pnpm tauri dev
+```
+
+### Platform prerequisites
+
+Glyph is built on [Tauri v2](https://v2.tauri.app/), which needs a system toolchain in addition to Node.js, pnpm, and Rust. See [Tauri's prerequisites page](https://v2.tauri.app/start/prerequisites/) for the canonical list. Quick reference per OS:
+
+**Windows** (via [Chocolatey](https://chocolatey.org/install), run PowerShell as Administrator):
+
+```powershell
+choco install -y visualstudio2022buildtools visualstudio2022-workload-vctools rustup.install nvm pnpm
+# WebView2 ships with Windows 10 1803+ and Windows 11. If missing:
+choco install -y webview2-runtime
+```
+
+After `rustup.install`, open a new shell and run `rustup default stable-msvc`. Then `nvm install` (reads `.nvmrc`) and `pnpm install`.
+
+**macOS**:
+
+```bash
+xcode-select --install                          # Command Line Tools
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+brew install node pnpm                          # or use nvm/fnm for Node
+```
+
+**Linux, Debian / Ubuntu**:
+
+```bash
+sudo apt update
+sudo apt install -y libwebkit2gtk-4.1-dev build-essential curl wget file \
+  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+# Install Node via nvm/fnm (reads .nvmrc), then `npm i -g pnpm`
+```
+
+**Linux, Fedora**:
+
+```bash
+sudo dnf install -y webkit2gtk4.1-devel openssl-devel curl wget file \
+  libappindicator-gtk3-devel librsvg2-devel libxdo-devel gcc gcc-c++ make
+```
+
+**Linux, Arch**:
+
+```bash
+sudo pacman -S --needed webkit2gtk-4.1 base-devel curl wget file openssl \
+  appmenu-gtk-module libappindicator-gtk3 librsvg xdotool
 ```
 
 ### Git hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,15 @@ choco install -y webview2-runtime
 
 After `rustup.install`, open a new shell and run `rustup default stable-msvc`. Then `nvm install` (reads `.nvmrc`) and `pnpm install`.
 
+> **Important:** Use the `stable-msvc` Rust toolchain, not `stable-gnu`. If MSYS2 is on your PATH (or rustup picked the GNU host during install), builds fail with errors like `C:\msys64\usr\bin\dlltool.exe ... Permission denied` when compiling `getrandom`, `parking_lot_core`, or `windows-sys`, especially if your user folder contains a space (e.g. `C:\Users\Jane Doe\...`), because MinGW's `dlltool` does not handle spaces in paths. Run `rustup show` to confirm the default host is `x86_64-pc-windows-msvc`. To switch:
+>
+> ```powershell
+> rustup toolchain install stable-msvc
+> rustup default stable-msvc
+> rustup set default-host x86_64-pc-windows-msvc
+> cd src-tauri; cargo clean   # remove gnu-built artifacts before rebuilding
+> ```
+
 **macOS**:
 
 ```bash


### PR DESCRIPTION
## Summary

CONTRIBUTING.md listed "Node.js, pnpm, Rust stable" as the only prerequisites, but Tauri v2 also needs a platform-specific system toolchain (WebView2 + MSVC on Windows, Xcode CLT on macOS, webkit2gtk + friends on Linux). New contributors hit confusing build errors without it.

## Changes

- Added a **Platform prerequisites** subsection under *Development Setup* with copy-pasteable install commands for:
  - Windows (Chocolatey: `visualstudio2022buildtools`, `visualstudio2022-workload-vctools`, `rustup.install`, `nvm`, `pnpm`, `webview2-runtime`)
  - macOS (`xcode-select --install`, rustup, Homebrew for node/pnpm)
  - Linux: Debian/Ubuntu, Fedora, Arch (package lists from Tauri's official prereqs page)
- Linked to https://v2.tauri.app/start/prerequisites/ as the canonical source.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows (Chocolatey command verified, `webview2-runtime` is the correct package id, `microsoft-edge-webview2-runtime` does not exist on the community feed)
- [ ] Tested on Linux

Docs-only change, no code paths touched.