### PR TITLE
fix(editor): give the split-view preview pane real height

### DIFF
--- a/src/components/editor/SplitView.test.tsx
+++ b/src/components/editor/SplitView.test.tsx
@@ -50,6 +50,20 @@ describe("SplitView", () => {
     expect(getByTestId("preview").textContent).toBe("v1");
   });
 
+  // Regression: the preview pane must be a flex column with `min-h-0` so the
+  // inner MarkdownViewer (which sizes itself with `flex-1` and positions its
+  // scrollable region absolutely) actually has a height. A plain block
+  // parent collapses to 0px and the preview appears empty.
+  it("renders the preview pane as a flex column so MarkdownViewer can stretch", () => {
+    const { getByTestId } = render(
+      <SplitView content="hello" onChange={() => {}} searchOpen={false} onSearchClose={() => {}} />,
+    );
+    const preview = getByTestId("split-view-preview");
+    expect(preview.className).toMatch(/\bflex\b/);
+    expect(preview.className).toMatch(/\bflex-col\b/);
+    expect(preview.className).toMatch(/\bmin-h-0\b/);
+  });
+
   it("syncs the preview from the content prop when it changes from outside", () => {
     const { getByTestId, rerender } = render(
       <SplitView

--- a/src/components/editor/SplitView.tsx
+++ b/src/components/editor/SplitView.tsx
@@ -49,9 +49,16 @@ export function SplitView({
     };
   }, []);
 
+  // The preview wrapper must be a flex column with `min-h-0` so that the
+  // inner MarkdownViewer (which sizes itself with `flex-1` and positions its
+  // scroll layer absolutely) gets a real height. A plain block parent
+  // collapses to 0px and the preview renders empty.
   return (
-    <div className="split-view">
-      <div className="split-view-editor">
+    <div className="split-view flex h-full w-full">
+      <div
+        data-testid="split-view-editor"
+        className="split-view-editor flex flex-1 min-w-0 min-h-0 overflow-hidden border-r border-[var(--color-border)]"
+      >
         <MarkdownEditor
           content={content}
           onChange={handleChange}
@@ -59,7 +66,10 @@ export function SplitView({
           workspaceRoot={workspaceRoot}
         />
       </div>
-      <div className="split-view-preview">
+      <div
+        data-testid="split-view-preview"
+        className="split-view-preview flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden"
+      >
         <MarkdownViewer
           content={previewContent}
           filePath={filePath}

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -8,25 +8,6 @@
   height: 100%;
 }
 
-.split-view {
-  display: flex;
-  height: 100%;
-  width: 100%;
-}
-
-.split-view-editor {
-  flex: 1;
-  min-width: 0;
-  border-right: 1px solid var(--color-border);
-  overflow: hidden;
-}
-
-.split-view-preview {
-  flex: 1;
-  min-width: 0;
-  overflow-y: auto;
-}
-
 .mode-toggle {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Split edit mode rendered the editor but no preview: the preview pane was a plain block container, so the inner `MarkdownViewer` (which sizes itself with `flex-1` and positions its scrollable region absolutely) collapsed to 0px.

## Changes

- Move the split-view layout from `.split-view*` CSS classes onto Tailwind utilities on the `SplitView` wrappers. The preview pane is now `flex flex-col min-w-0 min-h-0 overflow-hidden`, so `MarkdownViewer`'s `flex-1` actually stretches.
- Drop the now-unused `.split-view`, `.split-view-editor`, `.split-view-preview` rules from `src/styles/editor.css`.
- Add a regression test (`SplitView.test.tsx`) that asserts the preview pane's class list. The existing tests mocked `MarkdownViewer` away, which is why the layout regression went uncaught.

## Testing

- `pnpm test src/components/editor/SplitView.test.tsx` (4 passed)
- `pnpm typecheck`, `pnpm lint` (clean)
- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux (manually verified split mode renders the preview alongside the editor)