### PR TITLE
fix(cli): fall back to argv when tauri-plugin-cli loses the path on Windows

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -64,6 +64,27 @@ pub fn classify_initial_arg(path_str: &str, cwd: &Path) -> Option<InitialOpenAct
     classify_resolved_path(&canonical)
 }
 
+/// Pick the initial path to open at first launch from the two sources we
+/// have available, in order:
+///
+/// 1. `plugin_path` — the value `tauri-plugin-cli` parsed out of its
+///    configured args. Works when the OS hands us the file via association,
+///    or when the user runs the binary directly.
+/// 2. `env_args` — the raw process argv, scanned by [`pick_path_arg`]. This
+///    is the Windows-friendly path: `pnpm tauri dev -- samples` can land
+///    `samples` in argv without ever populating the plugin's matches, so we
+///    fall back to argv when the plugin yields nothing.
+pub fn initial_open_action(
+    plugin_path: Option<&str>,
+    env_args: &[String],
+    cwd: &Path,
+) -> Option<InitialOpenAction> {
+    let path_str = plugin_path
+        .map(str::to_string)
+        .or_else(|| pick_path_arg(env_args).map(str::to_string))?;
+    classify_initial_arg(&path_str, cwd)
+}
+
 /// The frontend event a second-instance launch should fire on the running
 /// window, plus the absolute path payload. Returned by [`second_instance_event`].
 #[derive(Debug, PartialEq, Eq)]
@@ -430,6 +451,60 @@ mod tests {
         let resolved = resolve_initial_path("notes.md", &inner).expect("should resolve via parent");
         assert_eq!(resolved, root.join("notes.md").canonicalize().unwrap());
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn initial_open_action_prefers_plugin_value_over_argv() {
+        let cwd = unique_tmp("ioa_pref");
+        let plugin_target = cwd.join("from-plugin");
+        let argv_target = cwd.join("from-argv");
+        fs::create_dir_all(&plugin_target).unwrap();
+        fs::create_dir_all(&argv_target).unwrap();
+
+        let env_args = vec!["glyph".to_string(), "from-argv".to_string()];
+        let result =
+            initial_open_action(Some("from-plugin"), &env_args, &cwd).expect("classifies");
+        assert!(
+            matches!(&result, InitialOpenAction::Folder(p) if p.ends_with("from-plugin")),
+            "expected the plugin-supplied path to win, got {result:?}"
+        );
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn initial_open_action_falls_back_to_argv_when_plugin_is_empty() {
+        // This is the Windows path: tauri-plugin-cli's `file` arg is
+        // None / null because pnpm's arg forwarding bypassed it, but the
+        // positional arg is still in argv. The fallback must pick it up.
+        let cwd = unique_tmp("ioa_fallback");
+        let target = cwd.join("samples");
+        fs::create_dir_all(&target).unwrap();
+
+        let env_args = vec!["glyph".to_string(), "samples".to_string()];
+        let result = initial_open_action(None, &env_args, &cwd).expect("classifies via argv");
+        assert!(
+            matches!(&result, InitialOpenAction::Folder(p) if p.ends_with("samples")),
+            "expected argv fallback to find samples, got {result:?}"
+        );
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn initial_open_action_returns_none_when_neither_source_yields_a_path() {
+        let cwd = unique_tmp("ioa_none");
+        let env_args = vec!["glyph".to_string(), "--verbose".to_string()];
+        assert!(initial_open_action(None, &env_args, &cwd).is_none());
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn initial_open_action_returns_none_when_path_does_not_exist() {
+        // Plugin and argv agree on a path, but it isn't there. Should be
+        // None (and the caller decides whether to log).
+        let cwd = unique_tmp("ioa_missing");
+        let env_args = vec!["glyph".to_string(), "nope".to_string()];
+        assert!(initial_open_action(Some("nope"), &env_args, &cwd).is_none());
+        let _ = fs::remove_dir_all(&cwd);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,27 +84,35 @@ pub fn run() {
             app.manage(menu_refs);
 
             // Parse CLI arguments and store the initial file/folder. The pure
-            // classification logic lives in `cli::classify_initial_arg` (tested
+            // selection + classification logic lives in `cli` (tested
             // there); this block is the thin Tauri-runtime adapter that maps
             // each variant to managed state or a warning.
-            if let Ok(matches) = app.cli().matches() {
-                if let Some(file_arg) = matches.args.get("file") {
-                    if let Some(path_str) = file_arg.value.as_str() {
-                        let cwd = std::env::current_dir().unwrap_or_default();
-                        match cli::classify_initial_arg(path_str, &cwd) {
-                            Some(cli::InitialOpenAction::Folder(p)) => {
-                                *app.state::<commands::InitialFolder>().0.lock().unwrap() = Some(p);
-                            }
-                            Some(cli::InitialOpenAction::File(p)) => {
-                                *app.state::<commands::InitialFile>().0.lock().unwrap() = Some(p);
-                            }
-                            Some(cli::InitialOpenAction::RejectedNotMarkdown(p)) => {
-                                eprintln!("Refusing to open non-markdown file: {p}");
-                            }
-                            None => {}
-                        }
-                    }
+            //
+            // We pass both the `tauri-plugin-cli` value and raw `std::env::args()`
+            // into `cli::initial_open_action`; the helper prefers the plugin
+            // (so OS file-association launches still work) and falls back to
+            // argv. The fallback is what makes `pnpm tauri dev -- samples`
+            // work on Windows: pnpm's arg forwarding can land the positional
+            // arg in argv without ever populating the plugin's matches.
+            let cwd = std::env::current_dir().unwrap_or_default();
+            let plugin_path: Option<String> = app
+                .cli()
+                .matches()
+                .ok()
+                .and_then(|m| m.args.get("file").cloned())
+                .and_then(|a| a.value.as_str().map(str::to_string));
+            let env_args: Vec<String> = std::env::args().collect();
+            match cli::initial_open_action(plugin_path.as_deref(), &env_args, &cwd) {
+                Some(cli::InitialOpenAction::Folder(p)) => {
+                    *app.state::<commands::InitialFolder>().0.lock().unwrap() = Some(p);
                 }
+                Some(cli::InitialOpenAction::File(p)) => {
+                    *app.state::<commands::InitialFile>().0.lock().unwrap() = Some(p);
+                }
+                Some(cli::InitialOpenAction::RejectedNotMarkdown(p)) => {
+                    eprintln!("Refusing to open non-markdown file: {p}");
+                }
+                None => {}
             }
             Ok(())
         })


### PR DESCRIPTION
## Summary

On Windows, `pnpm tauri dev -- samples` boots the app into the empty state instead of opening the `samples` workspace. The cause: `tauri-plugin-cli`'s `file` match ends up null, so the inline `as_str()` check returns `None` and the whole CLI block falls through silently. The positional arg is still in the binary's `std::env::args()`, but we never look there.

## Changes

- Added `cli::initial_open_action(plugin_path, env_args, cwd)` — a pure helper that prefers the plugin value (so OS file-association launches keep working) and falls back to `pick_path_arg(env_args)` when the plugin yields nothing.
- Rewired the Tauri `setup()` block to call the helper, so the resolution logic is unit-tested instead of embedded in runtime plumbing.
- Added 4 cli tests: plugin-wins-over-argv, argv-fallback-when-plugin-empty, neither-source-yields-a-path, plugin-and-argv-agree-but-missing-on-disk.

## Caveats

I cannot reproduce on Windows from this machine, so the diagnosis is by code inspection. The fix is safe regardless (the fallback only kicks in when the plugin yields nothing on every platform), but please verify on Windows that `pnpm tauri dev -- samples` now opens the workspace.

## Testing

- `cargo test --lib cli::` (30 passed, 4 new)
- `cargo check`, `cargo clippy -- -D warnings` (clean)
- [ ] Tested on macOS
- [ ] Tested on Windows (the actual repro case — please verify)
- [x] Tested on Linux (the existing flow is unchanged when the plugin works)