### PR TITLE
chore: gitignore the regenerated windows-schema.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ junit*.xml
 # Claude Code local settings (keep .claude/ committed, ignore local overrides)
 .claude/settings.local.json
 
-# Linux-only Tauri ACL schema (regenerated locally on Linux builds; only the
-# macOS / desktop schemas are tracked upstream).
+# Platform-specific Tauri ACL schemas (regenerated locally per-host by
+# `tauri dev` / `tauri build`; only the cross-platform `desktop-schema.json`
+# and `macOS-schema.json` are tracked upstream).
 src-tauri/gen/schemas/linux-schema.json
+src-tauri/gen/schemas/windows-schema.json


### PR DESCRIPTION
## Summary

`tauri dev` / `tauri build` regenerates the platform-specific ACL schema for whatever host you're running on, so a Linux/WSL developer ends up with both `linux-schema.json` and `windows-schema.json` as untracked files under `src-tauri/gen/schemas/`. `linux-schema.json` is already ignored; this just adds the matching entry for Windows and generalises the comment.

## Changes

- `.gitignore`: ignore `src-tauri/gen/schemas/windows-schema.json` alongside the existing `linux-schema.json` line, and reword the comment so it describes the policy in general (only `desktop-schema.json` and `macOS-schema.json` are tracked upstream).

## Testing

- [x] No code changes; nothing to test beyond `git status` showing the file is now ignored.