### PR TITLE
fix(tabs): stop nesting the close <button> inside the tab <button>

### DIFF
--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -144,4 +144,14 @@ describe("TabBar", () => {
     });
     expect(screen.queryByLabelText("View mode")).not.toBeInTheDocument();
   });
+
+  // Regression: <button> cannot be a descendant of <button> per the HTML
+  // spec, and React 19 logs a hydration error when it sees it. The close
+  // button used to sit inside the tab activate button; now it's a sibling.
+  it("does not nest a button inside another button", () => {
+    const { container } = renderTabBar({ tabs: makeTabs(2), activeTabId: "tab-0" });
+    for (const button of container.querySelectorAll("button")) {
+      expect(button.querySelector("button")).toBeNull();
+    }
+  });
 });

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -32,13 +32,14 @@ export function TabBar() {
           const dirty = file?.dirty ?? false;
           const label = tabLabel(tab);
           return (
-            <button
+            // Wrapper is a div, not a button, so the close <button> below it
+            // is a valid sibling instead of an HTML-invalid nested button.
+            // Click-to-activate lives on the inner `tab-activate` button.
+            <div
               key={tab.id}
-              type="button"
               className="tab-item"
               data-active={tab.id === activeTabId || undefined}
               data-tab-kind={tab.kind}
-              onClick={() => onActivate(tab.id)}
               onAuxClick={(e) => {
                 if (e.button === 1) {
                   e.preventDefault();
@@ -47,18 +48,22 @@ export function TabBar() {
               }}
               title={tabPathOf(tab)}
             >
-              {dirty && <span className="tab-dirty-dot" />}
-              {tab.kind === "folder" && <FolderIcon className="opacity-70 -ml-0.5" />}
-              <span className="tab-label">{label}</span>
+              <button
+                type="button"
+                className="tab-activate"
+                onClick={() => onActivate(tab.id)}
+                aria-label={label}
+              >
+                {dirty && <span className="tab-dirty-dot" />}
+                {tab.kind === "folder" && <FolderIcon className="opacity-70 -ml-0.5" />}
+                <span className="tab-label">{label}</span>
+              </button>
               <button
                 type="button"
                 className="tab-close"
                 tabIndex={-1}
                 aria-label={`Close ${label}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onClose(tab.id);
-                }}
+                onClick={() => onClose(tab.id)}
               >
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
                   <path
@@ -69,7 +74,7 @@ export function TabBar() {
                   />
                 </svg>
               </button>
-            </button>
+            </div>
           );
         })}
       </div>

--- a/src/styles/tabs.css
+++ b/src/styles/tabs.css
@@ -26,14 +26,11 @@
   font-size: 12px;
   color: var(--color-text-secondary);
   background: none;
-  border: none;
   border-right: 1px solid var(--color-border);
-  cursor: pointer;
   white-space: nowrap;
   min-width: 0;
   max-width: 200px;
   transition: background 0.1s ease, color 0.1s ease;
-  font-family: inherit;
 }
 
 .tab-item:hover {
@@ -44,6 +41,26 @@
   background: var(--color-surface);
   color: var(--color-text-primary);
   font-weight: 500;
+}
+
+/* Click target for "switch to this tab". A transparent button so the
+ * close <button> next to it is a sibling, not a descendant — invalid
+ * HTML and a React hydration error otherwise. */
+.tab-activate {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  min-width: 0;
+  flex: 1;
+  text-align: left;
 }
 
 .tab-label {


### PR DESCRIPTION
## Summary

React 19 logged a hydration error every time TabBar mounted:

> In HTML, `<button>` cannot be a descendant of `<button>`. This will cause a hydration error.

The outer tab `<button>` held both the "switch to this tab" `onClick` handler and a nested close `<button>`, which violates the HTML spec.

## Changes

Restructure the tab item:

- Outer element is now a `<div className="tab-item">` — the visual container with hover / active styling and the middle-click handler.
- A new `<button className="tab-activate">` is the click target for switching tabs (takes `flex: 1` inside the div).
- The existing `<button className="tab-close">` is now a sibling of `tab-activate`, not a child — so no more button-in-button.

Visuals are unchanged: padding, gap, hover background, active background, dirty-dot, folder-icon and label all keep their styles. The new `.tab-activate` rule explicitly clears the default button appearance so the inner button is invisible to the user.

## Tests

Regression test in `TabBar.test.tsx` asserts no `<button>` rendered by TabBar has another `<button>` as a descendant. All 9 TabBar tests pass, plus the full 575-test suite.

## Testing

- `pnpm test src/components/layout/TabBar.test.tsx` (9 passed)
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (all green)
- Manually clicked a tab label (activates), clicked the X (closes), middle-clicked the tab body (closes) — all still work.
- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux