### PR TITLE
style(cli): reformat test line to satisfy rustfmt

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -462,8 +462,7 @@ mod tests {
         fs::create_dir_all(&argv_target).unwrap();
 
         let env_args = vec!["glyph".to_string(), "from-argv".to_string()];
-        let result =
-            initial_open_action(Some("from-plugin"), &env_args, &cwd).expect("classifies");
+        let result = initial_open_action(Some("from-plugin"), &env_args, &cwd).expect("classifies");
         assert!(
             matches!(&result, InitialOpenAction::Folder(p) if p.ends_with("from-plugin")),
             "expected the plugin-supplied path to win, got {result:?}"


### PR DESCRIPTION
## Summary

`cargo fmt --check` — run by the lint-staged pre-commit hook over the whole `src-tauri` crate — fails on `main` against current stable rustfmt, blocking any Rust-staging commit locally. A single statement in `cli.rs` tests was split across two lines, but rustfmt now fits it on one (it lands at exactly the 100-column max width).

This is a hygiene fix that unblocks the local pre-commit hook. CI does not run `cargo fmt`, so this only affects contributors committing Rust changes locally.

## Changes

- Collapse the two-line `let result = …` statement in `cli.rs` tests onto one line so `cargo fmt --check` is green.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

`cargo fmt --check`, `cargo test --lib` (91 passed), and `cargo clippy --all-targets -- -D warnings` all pass.