### PR TITLE
fix(test): load Windows lib-test binary by embedding ComCtl32 v6

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -4,7 +4,33 @@ use std::path::PathBuf;
 
 fn main() {
     generate_md_extensions();
+    embed_comctl32_v6_in_test_binaries();
     tauri_build::build();
+}
+
+/// Embed the ComCtl32 v6 (Common-Controls 6.0.0.0) manifest dependency when
+/// linking on Windows.
+///
+/// Tauri embeds this manifest into the shipped `glyph.exe` so the modern
+/// (WinSxS) ComCtl32 v6 is loaded. The cargo unit-test harness binary, however,
+/// gets no such manifest, so it binds to the legacy System32 ComCtl32 v5.82 —
+/// which lacks `TaskDialogIndirect`, a v6-only export that `rfd` (pulled in via
+/// `tauri-plugin-dialog`) statically imports. The result is a load-time
+/// `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139) crash before any test runs.
+///
+/// `cargo:rustc-link-arg` is the only directive that reaches the lib unit-test
+/// harness (the `-tests` variant covers `[[test]]` integration targets only,
+/// which this crate has none of). It also applies to the shipped binary and the
+/// cdylib, but both already declare (or are agnostic to) the v6 dependency, so
+/// the duplicate is merged harmlessly by the linker.
+fn embed_comctl32_v6_in_test_binaries() {
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        println!(
+            "cargo:rustc-link-arg=/MANIFESTDEPENDENCY:type='win32' \
+             name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+             processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'"
+        );
+    }
 }
 
 /// Single source of truth for the supported markdown extensions:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,11 +238,14 @@ mod tests {
         let bucket: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let sink = Arc::clone(&bucket);
         app_handle.listen(event, move |evt| {
-            // emit() serialises the payload as JSON; the raw payload string
-            // wraps the path in quotes which we strip for easier asserts.
-            let raw = evt.payload().to_string();
-            let trimmed = raw.trim_matches('"').to_string();
-            sink.lock().unwrap().push(trimmed);
+            // emit() serialises the payload as a JSON string. Deserialise it so
+            // platform-specific escaping is undone — on Windows the path's
+            // backslashes are JSON-escaped (`C:\\dir`), so naive quote-trimming
+            // would leave doubled separators and break `canonicalize`.
+            let payload = evt.payload();
+            let path = serde_json::from_str::<String>(payload)
+                .unwrap_or_else(|_| payload.trim_matches('"').to_string());
+            sink.lock().unwrap().push(path);
         });
         bucket
     }


### PR DESCRIPTION
## Summary

`cargo test --lib` crashes at load on Windows with `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139) **before any test runs**. This affects every Windows contributor and the pre-commit hook's `cargo test --lib` gate.

Root cause: Tauri embeds the `Microsoft.Windows.Common-Controls` 6.0.0.0 manifest only in the shipped `glyph.exe`, not in the cargo unit-test harness binary. Without it, the test exe binds to the legacy System32 ComCtl32 v5.82, which lacks `TaskDialogIndirect` — a v6-only export that `rfd` (pulled in via `tauri-plugin-dialog`) statically imports.

The fix emits a Windows-only `/MANIFESTDEPENDENCY` linker arg from `build.rs` so the v6 dependency is embedded when linking. It applies to test/dev binaries; the shipped app already gets the manifest from Tauri, so the duplicate is merged harmlessly.

> **Note:** This PR is stacked on #239 (rustfmt fix) so the local pre-commit hook passes. Once #239 merges, I'll rebase this onto `main` and retarget the base branch.

## Changes

- `build.rs`: emit `cargo:rustc-link-arg=/MANIFESTDEPENDENCY:…Common-Controls 6.0.0.0…` on Windows so the lib-test harness loads ComCtl32 v6.
- `lib.rs`: fix a latent test bug surfaced once the harness could finally run on Windows — `capture_event` trimmed quotes off the emitted JSON payload without unescaping it, leaving Windows path backslashes doubled so `canonicalize` rejected them. Deserialise the payload as JSON instead.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

`cargo test --lib` now loads and passes all 91 tests (was: crash before test 1). `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass.