### PR TITLE
feat(telemetry): add opt-in Sentry error reporting

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,4 @@
-github: hamidfzm
+# GitHub Sponsors isn't enabled for this account, so we use a custom link.
+# It points at the README Sponsors section, which lists the crypto wallets
+# (FUNDING.yml's custom field only accepts URLs, not raw addresses).
+custom: ["https://github.com/hamidfzm/glyph#sponsors"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,10 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Enables source-map upload from the Vite build (vite.config.ts). When
+          # unset (e.g. forks), the Sentry plugin is skipped and the build still
+          # succeeds.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Glyph ${{ github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - Window state persistence across restarts
 - Native menu bar with keyboard shortcuts
 
+### Privacy
+- Local-first: your files never leave your machine
+- Opt-in crash reporting (off by default) to help fix bugs — see [Privacy & Error Reporting](#privacy--error-reporting)
+
 ## Install
 
 ### macOS (Homebrew)
@@ -275,3 +279,40 @@ Glyph is built around speed, native feel, and offline-first usage. The tables be
 Legend: ✅ supported · ⚠️ partial / inconsistent · ❌ not supported · plugin = third-party · planned = on roadmap
 
 Note on "WYSIWYG / inline preview": Glyph's editor has split-view live preview and styled markdown tokens (bold/italic render as bold/italic in source), but markdown markers remain visible — Typora-style fully inline rendering is not implemented.
+
+## Privacy & Error Reporting
+
+Glyph is local-first: your documents are read and written on your machine and are never uploaded anywhere.
+
+Crash and error reporting is **opt-in and off by default**. Nothing is sent until you turn it on in **Settings → Privacy → Send crash reports**, and even then it is only active in production builds (never during development).
+
+When enabled, reports include only:
+
+- Stack traces of the crash or unhandled error
+- Operating system and Glyph version
+- The error message
+
+They never include your file contents, file paths, file names, or any links — these are stripped from every report before it is sent. You can turn reporting off again at any time from the same setting.
+
+## Sponsors
+
+Glyph is free and open source. These sponsors help keep it that way.
+
+<a href="https://sentry.io">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" alt="Sentry" height="40">
+  </picture>
+</a>
+
+[**Sentry**](https://sentry.io) provides error monitoring through their Sponsored Business plan, which we use for the opt-in crash reporting above.
+
+### Support Glyph
+
+If Glyph is useful to you, donations are welcome via crypto:
+
+| Network | Asset | Address |
+|---|---|---|
+| Solana | SOL | `<pending>` |
+| BNB Smart Chain (BEP-20) | USDT | `<pending>` |
+| Tron (TRC-20) | USDT | `<pending>` |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,3 +18,17 @@ If you discover a security vulnerability, please report it responsibly:
 3. You will receive a response within 48 hours.
 
 We will work with you to understand the issue and coordinate a fix before any public disclosure.
+
+## Telemetry & Data Collection
+
+Glyph is local-first. Your documents are processed on your machine and are never uploaded.
+
+Crash and error reporting is **opt-in and off by default**, powered by [Sentry](https://sentry.io).
+
+- **Disabled until you choose otherwise.** No data is sent until you enable **Settings → Privacy → Send crash reports**.
+- **Production only.** Reporting never runs in development builds, even if the toggle is on.
+- **What is collected:** stack traces, operating system, Glyph version, and the error message.
+- **What is never collected:** file contents, file paths, file names, document text, and links. These are scrubbed from every event (message, exception values, breadcrumbs, and stack-frame paths) before it leaves your machine, on both the frontend and the Rust backend. IP address collection and session replay are disabled.
+- **Opting out:** turn the same setting off at any time. The reporter is torn down immediately and nothing further is sent.
+
+The reports are sent to the Glyph project on Sentry. Source maps are uploaded at release time so stack traces are readable, but they are not shipped to users.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.0",
     "@lezer/highlight": "^1.2.3",
+    "@sentry/react": "^10.55.0",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-cli": "^2",
     "@tauri-apps/plugin-dialog": "2.7.0",
@@ -65,6 +66,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@sentry/cli",
       "esbuild"
     ],
     "overrides": {
@@ -78,6 +80,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
     "@codecov/vite-plugin": "^2.0.1",
+    "@sentry/vite-plugin": "^5.3.0",
     "@tailwindcss/vite": "^4",
     "@tauri-apps/cli": "^2.11.2",
     "@testing-library/jest-dom": "^6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
+      '@sentry/react':
+        specifier: ^10.55.0
+        version: 10.55.0(react@19.2.6)
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
@@ -136,6 +139,9 @@ importers:
       '@codecov/vite-plugin':
         specifier: ^2.0.1
         version: 2.0.1(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@sentry/vite-plugin':
+        specifier: ^5.3.0
+        version: 5.3.0(rollup@4.60.3)
       '@tailwindcss/vite':
         specifier: ^4
         version: 4.3.0(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
@@ -982,6 +988,109 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sentry-internal/browser-utils@10.55.0':
+    resolution: {integrity: sha512-zUvyBr13EK0evKsSTzwSimRzZ3P9kugS32dLCj3ea5gNN+/DFtU/GsMTdcIQDhusEDraIlH17AGgqJH5gUAv5w==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.55.0':
+    resolution: {integrity: sha512-32X9WW1xs5DjCRlp89QJ/PLw4kbTIX6MsBDXN2RBN1nWBjm/2WcwXqO/v/WoIS4W2kTWXcZnQwalLSI22Fp33A==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.55.0':
+    resolution: {integrity: sha512-lu/y7k9cK7FZ/qJpL0fBX4WqK6IFa/+bTPhedEaC5UpzjUNP7BfXt0H+R7q9CHWmp20Ffh/wGfO3j7O+Tv2MAA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.55.0':
+    resolution: {integrity: sha512-OkQpANGwYU5UKfwLk6Y+NpESRC8nrLBjawRDLwF6cJ8HpNScOuNNJDEJEGwXHVkJPH0pcIixsH8y0Qfcltq6Xw==}
+    engines: {node: '>=18'}
+
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser@10.55.0':
+    resolution: {integrity: sha512-5n1kxmW1m4j16ZDV9kt+Zo5uafFnKTy7s5YyEcGnC45KnOiO1Gy+QFd3woXns1K5GNxpjF7oOOc6tXgZLuXnQQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
+    engines: {node: '>= 18'}
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/core@10.55.0':
+    resolution: {integrity: sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/react@10.55.0':
+    resolution: {integrity: sha512-cf6wI0W1FdrL/7d5FTHXUdTN5k5uRZ9AQu5QZxUujnxWN+DBxUWtow1HDD1zTEonQsCFyYuhXVu3w+qmBBW11A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/rollup-plugin@5.3.0':
+    resolution: {integrity: sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@sentry/vite-plugin@5.3.0':
+    resolution: {integrity: sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==}
+    engines: {node: '>= 18'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1437,6 +1546,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -1481,6 +1594,10 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.10.7:
     resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
     engines: {node: '>=6.0.0'}
@@ -1491,6 +1608,10 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -1782,6 +1903,10 @@ packages:
   dompurify@3.4.0:
     resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
@@ -1858,6 +1983,10 @@ packages:
       picomatch:
         optional: true
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
@@ -1880,6 +2009,10 @@ packages:
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1960,6 +2093,10 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -2005,6 +2142,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -2153,6 +2293,10 @@ packages:
   listr2@10.2.1:
     resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
     engines: {node: '>=22.13.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash-es@4.18.0:
     resolution: {integrity: sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA==}
@@ -2352,6 +2496,14 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -2363,6 +2515,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
@@ -2372,6 +2533,14 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
@@ -2390,6 +2559,14 @@ packages:
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2418,8 +2595,15 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2646,6 +2830,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -2824,6 +3011,9 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -2842,6 +3032,14 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -2882,6 +3080,10 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3764,6 +3966,118 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     optional: true
 
+  '@sentry-internal/browser-utils@10.55.0':
+    dependencies:
+      '@sentry/core': 10.55.0
+
+  '@sentry-internal/feedback@10.55.0':
+    dependencies:
+      '@sentry/core': 10.55.0
+
+  '@sentry-internal/replay-canvas@10.55.0':
+    dependencies:
+      '@sentry-internal/replay': 10.55.0
+      '@sentry/core': 10.55.0
+
+  '@sentry-internal/replay@10.55.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.55.0
+      '@sentry/core': 10.55.0
+
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser@10.55.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.55.0
+      '@sentry-internal/feedback': 10.55.0
+      '@sentry-internal/replay': 10.55.0
+      '@sentry-internal/replay-canvas': 10.55.0
+      '@sentry/core': 10.55.0
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/core@10.55.0': {}
+
+  '@sentry/react@10.55.0(react@19.2.6)':
+    dependencies:
+      '@sentry/browser': 10.55.0
+      '@sentry/core': 10.55.0
+      react: 19.2.6
+
+  '@sentry/rollup-plugin@5.3.0(rollup@4.60.3)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.60.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/vite-plugin@5.3.0(rollup@4.60.3)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/rollup-plugin': 5.3.0(rollup@4.60.3)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.3.0':
@@ -4225,6 +4539,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -4259,6 +4579,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.7: {}
 
   before-after-hook@4.0.0: {}
@@ -4267,6 +4589,10 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
     optional: true
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.1:
     dependencies:
@@ -4577,6 +4903,8 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  dotenv@16.6.1: {}
+
   electron-to-chromium@1.5.313: {}
 
   emoji-regex@10.6.0: {}
@@ -4654,6 +4982,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
   format@0.2.2: {}
 
   fsevents@2.3.3:
@@ -4666,6 +4999,12 @@ snapshots:
   get-east-asian-width@1.6.0: {}
 
   github-slugger@2.0.0: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   graceful-fs@4.2.11: {}
 
@@ -4834,6 +5173,13 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   husky@9.1.7: {}
 
   iconv-lite@0.6.3:
@@ -4867,6 +5213,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1:
     optional: true
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -5004,6 +5352,10 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 10.0.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash-es@4.18.0: {}
 
   log-update@6.1.0:
@@ -5022,8 +5374,7 @@ snapshots:
       devlop: 1.1.0
       highlight.js: 11.11.1
 
-  lru-cache@11.5.1:
-    optional: true
+  lru-cache@11.5.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -5464,6 +5815,12 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minipass@7.1.3: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -5475,6 +5832,10 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-releases@2.0.36: {}
 
   obug@2.1.1: {}
@@ -5482,6 +5843,14 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   package-manager-detector@1.6.0: {}
 
@@ -5507,6 +5876,13 @@ snapshots:
     optional: true
 
   path-data-parser@0.1.0: {}
+
+  path-exists@4.0.0: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -5539,7 +5915,11 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  progress@2.0.3: {}
+
   property-information@7.1.0: {}
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1:
     optional: true
@@ -5845,6 +6225,8 @@ snapshots:
       tldts: 7.4.0
     optional: true
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -5996,6 +6378,8 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1:
     optional: true
 
@@ -6014,6 +6398,15 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
     optional: true
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -6044,6 +6437,8 @@ snapshots:
 
   yaml@2.9.0:
     optional: true
+
+  yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +271,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "base64"
@@ -766,6 +790,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1391,8 +1426,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1402,9 +1439,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1419,6 +1458,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gio"
@@ -1510,6 +1555,7 @@ name = "glyph"
 version = "0.8.1"
 dependencies = [
  "notify",
+ "sentry",
  "serde",
  "serde_json",
  "tauri",
@@ -1634,6 +1680,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1752,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1776,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2197,6 +2276,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,6 +2699,15 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3111,6 +3205,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3306,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3336,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,6 +3361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3289,6 +3467,46 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3346,6 +3564,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,10 +3612,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3493,6 +3773,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentry"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989425268ab5c011e06400187eed6c298272f8ef913e49fcadc3fda788b45030"
+dependencies = [
+ "httpdate",
+ "reqwest 0.12.28",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e299dd3f7bcf676875eee852c9941e1d08278a743c32ca528e2debf846a653"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac0c5d6892cd4c414492fc957477b620026fb3411fca9fa12774831da561c88"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deaa38b94e70820ff3f1f9db3c8b0aef053b667be130f618e615e0ff2492cbcc"
+dependencies = [
+ "rand 0.9.4",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7a23b13c004873de3ce7db86eb0f59fe4adfc655a31f7bbc17fd10bacc9bfe"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac841c7050aa73fc2bec8f7d8e9cb1159af0b3095757b99820823f3e54e5080"
+dependencies = [
+ "bitflags 2.11.0",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e477f4d4db08ddb4ab553717a8d3a511bc9e81dde0c808c680feacbb8105c412"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,6 +3961,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3836,6 +4224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,7 +4391,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4458,6 +4852,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4481,6 +4890,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4690,6 +5109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "tracing-core",
 ]
 
 [[package]]
@@ -4741,6 +5170,15 @@ dependencies = [
  "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4803,6 +5241,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4834,6 +5306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,6 +5334,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"
@@ -5055,6 +5539,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5108,6 +5602,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5338,6 +5841,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5888,6 +6400,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,15 @@ serde_json = "1"
 notify = "8"
 tauri-plugin-opener = "2.5.4"
 walkdir = "2.5.0"
+# rustls (not native-tls) so release builds don't need OpenSSL system libs on
+# Linux. Default integrations include the panic handler we rely on.
+sentry = { version = "0.42", default-features = false, features = [
+    "backtrace",
+    "contexts",
+    "panic",
+    "reqwest",
+    "rustls",
+] }
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -4,8 +4,34 @@ use std::path::PathBuf;
 
 fn main() {
     generate_md_extensions();
+    emit_sentry_dsn();
     embed_comctl32_v6_in_test_binaries();
     tauri_build::build();
+}
+
+/// Single source of truth for the Sentry DSN: `src-tauri/sentry.json` → `dsn`.
+///
+/// The frontend imports the same file (see `src/lib/telemetry.ts`) so both
+/// clients target the same project. Emitted as the `GLYPH_SENTRY_DSN` compile
+/// env so `telemetry.rs` can read it via `option_env!` with zero runtime cost.
+///
+/// Tolerant by design: a missing file or absent `dsn` yields an empty string,
+/// which disables reporting rather than failing the build (e.g. on forks).
+fn emit_sentry_dsn() {
+    println!("cargo:rerun-if-changed=sentry.json");
+
+    let dsn = fs::read_to_string("sentry.json")
+        .ok()
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok())
+        .and_then(|value| {
+            value
+                .get("dsn")
+                .and_then(|d| d.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_default();
+
+    println!("cargo:rustc-env=GLYPH_SENTRY_DSN={dsn}");
 }
 
 /// Embed the ComCtl32 v6 (Common-Controls 6.0.0.0) manifest dependency when

--- a/src-tauri/sentry.json
+++ b/src-tauri/sentry.json
@@ -1,0 +1,3 @@
+{
+  "dsn": "https://0ae4d558b7b6fe1ec29b3ffb7c04fabb@o4511468551340032.ingest.us.sentry.io/4511491763470336"
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod commands;
 mod markdown;
 mod menu;
 mod menu_runtime;
+mod telemetry;
 mod watcher;
 
 use std::sync::{Arc, Mutex};
@@ -78,6 +79,7 @@ pub fn run() {
         ))))
         .manage(commands::InitialFile(Mutex::new(None)))
         .manage(commands::InitialFolder(Mutex::new(None)))
+        .manage(telemetry::TelemetryState(Mutex::new(None)))
         .setup(|app| {
             let (menu, menu_refs) = menu::build_menu(app)?;
             app.set_menu(menu)?;
@@ -159,6 +161,7 @@ pub fn run() {
             watcher::watch_directory,
             watcher::unwatch_directory,
             menu_runtime::set_menu_state,
+            telemetry::set_error_reporting,
         ])
         .build(tauri::generate_context!())
         .expect("error while building Glyph");

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -1,0 +1,204 @@
+//! Opt-in, production-only crash reporting via Sentry.
+//!
+//! The frontend owns the user's opt-in choice (persisted in settings) and drives
+//! this module through the [`set_error_reporting`] command. Nothing initializes
+//! until the user opts in, and [`init_guard`] is a no-op in debug builds so
+//! `pnpm tauri dev` never sends events. PII (absolute file paths, the machine
+//! hostname) is stripped in [`scrub_event`] before anything leaves the process.
+
+use std::sync::{Arc, Mutex};
+
+use sentry::protocol::Event;
+use tauri::State;
+
+// Public Sentry client identifier for the `glyph` project. DSNs ship in every
+// client and are not secrets, so hardcoding is intentional.
+const SENTRY_DSN: &str =
+    "https://0ae4d558b7b6fe1ec29b3ffb7c04fabb@o4511468551340032.ingest.us.sentry.io/4511491763470336";
+
+/// Holds the live Sentry client guard while reporting is enabled. Dropping the
+/// guard (setting this to `None`) flushes and disables the client.
+pub struct TelemetryState(pub Mutex<Option<sentry::ClientInitGuard>>);
+
+/// Redact absolute filesystem paths and `file://` URLs from a string so user
+/// file locations (which encode usernames and document names) never reach
+/// Sentry. Matches Windows drive paths and common POSIX roots.
+fn redact_paths(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for token in input.split_inclusive(char::is_whitespace) {
+        let (word, trailing_ws) = match token.char_indices().last() {
+            Some((i, c)) if c.is_whitespace() => (&token[..i], &token[i..]),
+            _ => (token, ""),
+        };
+        if is_path_like(word) {
+            out.push_str("[redacted-path]");
+        } else {
+            out.push_str(word);
+        }
+        out.push_str(trailing_ws);
+    }
+    out
+}
+
+/// Heuristic: does this whitespace-delimited token look like an absolute path or
+/// a file URL we should redact?
+fn is_path_like(word: &str) -> bool {
+    if word.starts_with("file://") {
+        return true;
+    }
+    // Windows drive path, e.g. C:\Users\...
+    let bytes = word.as_bytes();
+    if bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'\\' {
+        return true;
+    }
+    // POSIX absolute path under a user/data-bearing root.
+    const ROOTS: [&str; 9] = [
+        "/Users/",
+        "/home/",
+        "/root/",
+        "/var/",
+        "/tmp/",
+        "/private/",
+        "/mnt/",
+        "/media/",
+        "/opt/",
+    ];
+    ROOTS.iter().any(|root| word.starts_with(root))
+}
+
+/// Strip PII from an event before send: null the hostname and redact paths from
+/// the message and every exception value.
+fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
+    event.server_name = None;
+
+    if let Some(message) = event.message.take() {
+        event.message = Some(redact_paths(&message));
+    }
+
+    for exception in &mut event.exception.values {
+        if let Some(value) = exception.value.take() {
+            exception.value = Some(redact_paths(&value));
+        }
+    }
+
+    Some(event)
+}
+
+/// Build a Sentry client guard, or `None` if reporting must stay off. Returns
+/// `None` in debug builds (dev) so events are only ever sent from release
+/// builds. The default integrations install the panic handler that captures
+/// Rust panics.
+fn init_guard() -> Option<sentry::ClientInitGuard> {
+    if cfg!(debug_assertions) {
+        return None;
+    }
+
+    Some(sentry::init((
+        SENTRY_DSN,
+        sentry::ClientOptions {
+            release: Some(format!("glyph@{}", env!("CARGO_PKG_VERSION")).into()),
+            send_default_pii: false,
+            server_name: None,
+            before_send: Some(Arc::new(scrub_event)),
+            ..Default::default()
+        },
+    )))
+}
+
+/// Reconcile the desired enabled state with the held guard. Extracted from the
+/// command so the enable/disable transitions can be unit-tested without a Tauri
+/// `State`.
+fn apply_enabled(enabled: bool, guard: &mut Option<sentry::ClientInitGuard>) {
+    if enabled {
+        if guard.is_none() {
+            *guard = init_guard();
+        }
+    } else {
+        *guard = None;
+    }
+}
+
+/// Frontend-driven toggle. Enabling initializes Sentry (release builds only);
+/// disabling drops the guard, which flushes and stops the client.
+#[tauri::command]
+pub fn set_error_reporting(enabled: bool, state: State<'_, TelemetryState>) -> Result<(), String> {
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    apply_enabled(enabled, &mut guard);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sentry::protocol::Exception;
+
+    #[test]
+    fn redacts_windows_paths() {
+        assert_eq!(
+            redact_paths(r"open C:\Users\Jane\notes.md failed"),
+            "open [redacted-path] failed",
+        );
+    }
+
+    #[test]
+    fn redacts_posix_paths() {
+        assert_eq!(
+            redact_paths("read /Users/jane/diary.md done"),
+            "read [redacted-path] done",
+        );
+        assert_eq!(redact_paths("at /home/jane/todo.md"), "at [redacted-path]");
+    }
+
+    #[test]
+    fn redacts_file_urls() {
+        assert_eq!(redact_paths("file:///Users/jane/x.md"), "[redacted-path]");
+    }
+
+    #[test]
+    fn leaves_path_free_text_untouched() {
+        let msg = "called `Option::unwrap()` on a `None` value";
+        assert_eq!(redact_paths(msg), msg);
+    }
+
+    #[test]
+    fn scrub_event_nulls_hostname_and_redacts_paths() {
+        let event = Event {
+            message: Some(r"panic at C:\Users\Jane\a.md".to_string()),
+            server_name: Some("janes-machine".into()),
+            exception: vec![Exception {
+                value: Some("missing /home/jane/b.md".to_string()),
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+
+        let scrubbed = scrub_event(event).expect("event kept");
+        assert_eq!(scrubbed.server_name, None);
+        assert_eq!(
+            scrubbed.message.as_deref(),
+            Some("panic at [redacted-path]")
+        );
+        assert_eq!(
+            scrubbed.exception.values[0].value.as_deref(),
+            Some("missing [redacted-path]"),
+        );
+    }
+
+    #[test]
+    fn init_guard_is_disabled_in_debug_builds() {
+        // The test binary is a debug build, so reporting must stay off.
+        assert!(init_guard().is_none());
+    }
+
+    #[test]
+    fn apply_enabled_transitions_do_not_panic() {
+        let mut guard = None;
+        // Enable: calls init_guard (None in debug) — guard stays None, no panic.
+        apply_enabled(true, &mut guard);
+        assert!(guard.is_none());
+        // Disable: clears the guard.
+        apply_enabled(false, &mut guard);
+        assert!(guard.is_none());
+    }
+}

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -88,6 +88,19 @@ fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
     Some(event)
 }
 
+/// The privacy-hardened client options: tagged release, no PII, no hostname,
+/// and the path-scrubbing `before_send`. Extracted from [`init_guard`] so the
+/// configuration can be asserted in tests without initializing a real client.
+fn client_options() -> sentry::ClientOptions {
+    sentry::ClientOptions {
+        release: Some(format!("glyph@{}", env!("CARGO_PKG_VERSION")).into()),
+        send_default_pii: false,
+        server_name: None,
+        before_send: Some(Arc::new(scrub_event)),
+        ..Default::default()
+    }
+}
+
 /// Build a Sentry client guard, or `None` if reporting must stay off. Returns
 /// `None` in debug builds (dev) so events are only ever sent from release
 /// builds. The default integrations install the panic handler that captures
@@ -97,16 +110,7 @@ fn init_guard() -> Option<sentry::ClientInitGuard> {
         return None;
     }
 
-    Some(sentry::init((
-        SENTRY_DSN,
-        sentry::ClientOptions {
-            release: Some(format!("glyph@{}", env!("CARGO_PKG_VERSION")).into()),
-            send_default_pii: false,
-            server_name: None,
-            before_send: Some(Arc::new(scrub_event)),
-            ..Default::default()
-        },
-    )))
+    Some(sentry::init((SENTRY_DSN, client_options())))
 }
 
 /// Reconcile the desired enabled state with the held guard. Extracted from the
@@ -122,13 +126,20 @@ fn apply_enabled(enabled: bool, guard: &mut Option<sentry::ClientInitGuard>) {
     }
 }
 
+/// Lock the guard and reconcile it with `enabled`. Takes `&TelemetryState`
+/// (constructible in tests) rather than a Tauri `State` so the lock + apply path
+/// is unit-testable; the command is a thin wrapper over this.
+fn set_enabled(state: &TelemetryState, enabled: bool) -> Result<(), String> {
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    apply_enabled(enabled, &mut guard);
+    Ok(())
+}
+
 /// Frontend-driven toggle. Enabling initializes Sentry (release builds only);
 /// disabling drops the guard, which flushes and stops the client.
 #[tauri::command]
 pub fn set_error_reporting(enabled: bool, state: State<'_, TelemetryState>) -> Result<(), String> {
-    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
-    apply_enabled(enabled, &mut guard);
-    Ok(())
+    set_enabled(&state, enabled)
 }
 
 #[cfg(test)]
@@ -204,5 +215,27 @@ mod tests {
         // Disable: clears the guard.
         apply_enabled(false, &mut guard);
         assert!(guard.is_none());
+    }
+
+    #[test]
+    fn client_options_are_privacy_hardened() {
+        let opts = client_options();
+        assert!(!opts.send_default_pii, "PII must never be sent");
+        assert!(opts.server_name.is_none(), "hostname must not be set");
+        assert!(opts.before_send.is_some(), "scrubber must be installed");
+        assert_eq!(
+            opts.release.as_deref(),
+            Some(concat!("glyph@", env!("CARGO_PKG_VERSION"))),
+        );
+    }
+
+    #[test]
+    fn set_enabled_toggles_without_a_tauri_state() {
+        let state = TelemetryState(Mutex::new(None));
+        // Enable then disable both succeed; the guard stays None in debug builds.
+        assert!(set_enabled(&state, true).is_ok());
+        assert!(state.0.lock().unwrap().is_none());
+        assert!(set_enabled(&state, false).is_ok());
+        assert!(state.0.lock().unwrap().is_none());
     }
 }

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -11,10 +11,14 @@ use std::sync::{Arc, Mutex};
 use sentry::protocol::Event;
 use tauri::State;
 
-// Public Sentry client identifier for the `glyph` project. DSNs ship in every
-// client and are not secrets, so hardcoding is intentional.
-const SENTRY_DSN: &str =
-    "https://0ae4d558b7b6fe1ec29b3ffb7c04fabb@o4511468551340032.ingest.us.sentry.io/4511491763470336";
+// Single source of truth for the DSN — `src-tauri/sentry.json`, read at build
+// time by build.rs and injected as `GLYPH_SENTRY_DSN`. The frontend imports the
+// same file, so both clients target the same project. Empty (missing file or
+// `dsn`) disables reporting.
+const SENTRY_DSN: &str = match option_env!("GLYPH_SENTRY_DSN") {
+    Some(dsn) => dsn,
+    None => "",
+};
 
 /// Holds the live Sentry client guard while reporting is enabled. Dropping the
 /// guard (setting this to `None`) flushes and disables the client.
@@ -89,7 +93,7 @@ fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
 /// builds. The default integrations install the panic handler that captures
 /// Rust panics.
 fn init_guard() -> Option<sentry::ClientInitGuard> {
-    if cfg!(debug_assertions) {
+    if cfg!(debug_assertions) || SENTRY_DSN.is_empty() {
         return None;
     }
 

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -238,4 +238,15 @@ mod tests {
         assert!(set_enabled(&state, false).is_ok());
         assert!(state.0.lock().unwrap().is_none());
     }
+
+    #[test]
+    fn set_error_reporting_command_runs_through_managed_state() {
+        use tauri::Manager;
+        // Drive the #[tauri::command] wrapper end to end against a managed
+        // TelemetryState, mirroring how lib.rs tests use a mock app.
+        let app = tauri::test::mock_app();
+        app.manage(TelemetryState(Mutex::new(None)));
+        assert!(set_error_reporting(true, app.state()).is_ok());
+        assert!(set_error_reporting(false, app.state()).is_ok());
+    }
 }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { useAutoSave } from "@/hooks/useAutoSave";
 import { useCommandPaletteController } from "@/hooks/useCommandPaletteController";
 import { useContextMenu } from "@/hooks/useContextMenu";
 import { useDocumentUndoRedo } from "@/hooks/useDocumentUndoRedo";
+import { useErrorReporting } from "@/hooks/useErrorReporting";
 import { useFontZoom } from "@/hooks/useFontZoom";
 import { useMenuEvents } from "@/hooks/useMenuEvents";
 import { useNativeMenuState } from "@/hooks/useNativeMenuState";
@@ -29,9 +30,12 @@ import { TabContent } from "./TabContent";
 // real <App> is a tiny provider stack and we want both files to stay focused.
 export function AppShell() {
   const platform = usePlatform();
-  const { settings, updateSettings } = useSettings();
+  const { settings, updateSettings, loaded } = useSettings();
   const tabs = useTabsContext();
   const sidebar = useSidebarLayoutContext();
+
+  // Opt-in crash/error reporting; inert in dev and until the user enables it.
+  useErrorReporting(settings.privacy.errorReporting, loaded);
 
   // Reveal the window (created hidden in tauri.conf.json) once settings/theme
   // are loaded, avoiding the white flash + geometry jump on launch.

--- a/src/components/ErrorFallback.test.tsx
+++ b/src/components/ErrorFallback.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ErrorFallback } from "./ErrorFallback";
+
+describe("ErrorFallback", () => {
+  it("renders the recovery message", () => {
+    render(<ErrorFallback />);
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/ErrorFallback.test.tsx
+++ b/src/components/ErrorFallback.test.tsx
@@ -1,10 +1,25 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { ErrorFallback } from "./ErrorFallback";
+
+const { show, setFocus } = vi.hoisted(() => ({
+  show: vi.fn(() => Promise.resolve()),
+  setFocus: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ show, setFocus }),
+}));
 
 describe("ErrorFallback", () => {
   it("renders the recovery message", () => {
     render(<ErrorFallback />);
     expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+  });
+
+  it("reveals the window so the message is not hidden on an early crash", async () => {
+    render(<ErrorFallback />);
+    await waitFor(() => expect(show).toHaveBeenCalled());
+    await waitFor(() => expect(setFocus).toHaveBeenCalled());
   });
 });

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,6 +1,26 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect } from "react";
+
 // Fallback UI rendered by the top-level Sentry ErrorBoundary (see main.tsx)
-// when a render error escapes the tree. Presentational only.
+// when a render error escapes the tree. Presentational, plus one effect: it
+// reveals the window itself.
 export function ErrorFallback() {
+  // The window is created hidden (visible:false in tauri.conf.json) and is
+  // normally revealed by useWindowReveal inside AppShell. If the crash happens
+  // before that runs, AppShell never mounts, so we reveal here — otherwise this
+  // message would render into an invisible window.
+  useEffect(() => {
+    try {
+      const win = getCurrentWindow();
+      void win
+        .show()
+        .then(() => win.setFocus())
+        .catch(() => {});
+    } catch {
+      // Window API unavailable (non-Tauri / test environment); nothing to do.
+    }
+  }, []);
+
   return (
     <div
       style={{

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,19 @@
+// Fallback UI rendered by the top-level Sentry ErrorBoundary (see main.tsx)
+// when a render error escapes the tree. Presentational only.
+export function ErrorFallback() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        height: "100vh",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "2rem",
+        textAlign: "center",
+        color: "var(--color-text-secondary)",
+      }}
+    >
+      <p>Something went wrong. Try reopening the file or restarting Glyph.</p>
+    </div>
+  );
+}

--- a/src/components/modals/SettingsModal.test.tsx
+++ b/src/components/modals/SettingsModal.test.tsx
@@ -37,6 +37,7 @@ describe("SettingsModal", () => {
     expect(screen.getByText("Behavior")).toBeInTheDocument();
     expect(screen.getByText("AI")).toBeInTheDocument();
     expect(screen.getByText("Print")).toBeInTheDocument();
+    expect(screen.getByText("Privacy")).toBeInTheDocument();
   });
 
   it("switches the active tab when a tab button is clicked", () => {
@@ -107,6 +108,19 @@ describe("SettingsModal", () => {
     fireEvent.click(screen.getByText("Behavior"));
     fireEvent.click(screen.getByText(/Clear Recent Files/i));
     expect(updateSettings).toHaveBeenCalledWith("behavior.recentFiles", []);
+  });
+
+  it("toggles error reporting from the Privacy tab", () => {
+    const updateSettings = vi.fn();
+    const { wrapper } = withSettings({ updateSettings });
+    render(<SettingsModal open={true} onClose={vi.fn()} />, { wrapper });
+
+    fireEvent.click(screen.getByText("Privacy"));
+    expect(screen.getByText("Send crash reports")).toBeInTheDocument();
+
+    const toggle = screen.getByRole("checkbox");
+    fireEvent.click(toggle);
+    expect(updateSettings).toHaveBeenCalledWith("privacy.errorReporting", true);
   });
 
   it("calls resetSettings from the footer Reset button", () => {

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useSettings } from "@/hooks/useSettings";
 import { MODEL_SUGGESTIONS } from "@/lib/settings";
 
-type Tab = "appearance" | "layout" | "behavior" | "ai" | "print";
+type Tab = "appearance" | "layout" | "behavior" | "ai" | "print" | "privacy";
 
 interface SettingsModalProps {
   open: boolean;
@@ -73,6 +73,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
     { id: "behavior", label: "Behavior" },
     { id: "ai", label: "AI" },
     { id: "print", label: "Print" },
+    { id: "privacy", label: "Privacy" },
   ];
 
   return (
@@ -119,6 +120,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           {tab === "behavior" && <BehaviorTab />}
           {tab === "ai" && <AITab />}
           {tab === "print" && <PrintTab />}
+          {tab === "privacy" && <PrivacyTab />}
         </div>
 
         <div className="settings-footer">
@@ -455,6 +457,31 @@ function PrintTab() {
         <Toggle
           checked={print.includeBackground}
           onChange={(v) => updateSettings("print.includeBackground", v)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function PrivacyTab() {
+  const { settings, updateSettings } = useSettings();
+  const { privacy } = settings;
+
+  return (
+    <div className="settings-section">
+      <div className="settings-section-title">Error Reporting</div>
+      <div className="settings-row">
+        <div>
+          <span className="settings-label">Send crash reports</span>
+          <div className="settings-description">
+            Off by default. When on, anonymous crash reports (stack traces, OS, and app version) are
+            sent to help fix bugs. Your files, file paths, and links are never included. Only active
+            in production builds. See SECURITY.md for the full policy.
+          </div>
+        </div>
+        <Toggle
+          checked={privacy.errorReporting}
+          onChange={(v) => updateSettings("privacy.errorReporting", v)}
         />
       </div>
     </div>

--- a/src/hooks/useErrorReporting.test.ts
+++ b/src/hooks/useErrorReporting.test.ts
@@ -1,0 +1,45 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useErrorReporting } from "./useErrorReporting";
+
+const enableTelemetry = vi.fn();
+const disableTelemetry = vi.fn();
+
+vi.mock("@/lib/telemetry", () => ({
+  enableTelemetry: () => enableTelemetry(),
+  disableTelemetry: () => disableTelemetry(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useErrorReporting", () => {
+  it("does nothing until settings are loaded", () => {
+    renderHook(() => useErrorReporting(true, false));
+    expect(enableTelemetry).not.toHaveBeenCalled();
+    expect(disableTelemetry).not.toHaveBeenCalled();
+  });
+
+  it("enables telemetry when loaded and opted in", () => {
+    renderHook(() => useErrorReporting(true, true));
+    expect(enableTelemetry).toHaveBeenCalledTimes(1);
+    expect(disableTelemetry).not.toHaveBeenCalled();
+  });
+
+  it("disables telemetry when loaded and opted out", () => {
+    renderHook(() => useErrorReporting(false, true));
+    expect(disableTelemetry).toHaveBeenCalledTimes(1);
+    expect(enableTelemetry).not.toHaveBeenCalled();
+  });
+
+  it("reacts to the toggle flipping", () => {
+    const { rerender } = renderHook(({ enabled }) => useErrorReporting(enabled, true), {
+      initialProps: { enabled: false },
+    });
+    expect(disableTelemetry).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: true });
+    expect(enableTelemetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useErrorReporting.ts
+++ b/src/hooks/useErrorReporting.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { disableTelemetry, enableTelemetry } from "@/lib/telemetry";
+
+/**
+ * Reconcile the Sentry error-reporting opt-in with the SDKs. Runs only once
+ * settings have loaded (so we never act on the default before the user's saved
+ * choice is known), then enables or disables telemetry whenever the toggle
+ * changes. The underlying SDK calls are themselves no-ops in dev builds.
+ */
+export function useErrorReporting(enabled: boolean, loaded: boolean): void {
+  useEffect(() => {
+    if (!loaded) return;
+    if (enabled) {
+      enableTelemetry();
+    } else {
+      disableTelemetry();
+    }
+  }, [enabled, loaded]);
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -66,12 +66,19 @@ export interface PrintSettings {
   includeBackground: boolean;
 }
 
+export interface PrivacySettings {
+  // Opt-in crash/error reporting to Sentry. Off by default — nothing leaves the
+  // machine until the user turns this on, and it stays inert in dev builds.
+  errorReporting: boolean;
+}
+
 export interface Settings {
   appearance: AppearanceSettings;
   layout: LayoutSettings;
   behavior: BehaviorSettings;
   ai: AISettings;
   print: PrintSettings;
+  privacy: PrivacySettings;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -113,6 +120,9 @@ export const DEFAULT_SETTINGS: Settings = {
     pageBreakLevel: "none",
     includeToc: false,
     includeBackground: false,
+  },
+  privacy: {
+    errorReporting: false,
   },
 };
 

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -76,6 +76,16 @@ describe("scrubBreadcrumb", () => {
     const crumb: Breadcrumb = { category: "ui.click", message: "clicked button" };
     expect(scrubBreadcrumb(crumb)).toEqual(crumb);
   });
+
+  it("keeps a breadcrumb that has no message", () => {
+    const crumb: Breadcrumb = { category: "ui.click" };
+    expect(scrubBreadcrumb(crumb)).toEqual({ category: "ui.click" });
+  });
+
+  it("leaves non-string url data untouched", () => {
+    const crumb: Breadcrumb = { category: "ui.click", data: { count: 3 } };
+    expect(scrubBreadcrumb(crumb)?.data).toEqual({ count: 3 });
+  });
 });
 
 describe("scrubEvent", () => {
@@ -101,6 +111,15 @@ describe("scrubEvent", () => {
     const scrubbed = scrubEvent(event);
     expect(scrubbed.message).toBe("failed at [redacted-path]");
     expect(scrubbed.exception?.values?.[0].value).toBe("ENOENT [redacted-path]");
+  });
+
+  it("handles exceptions that have no value", () => {
+    const event = {
+      exception: { values: [{ type: "Error" }] },
+    } as unknown as ErrorEvent;
+
+    const scrubbed = scrubEvent(event);
+    expect(scrubbed.exception?.values?.[0].value).toBeUndefined();
   });
 
   it("keeps only allowlisted contexts", () => {

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -1,0 +1,174 @@
+import type { Breadcrumb, ErrorEvent } from "@sentry/react";
+import * as Sentry from "@sentry/react";
+import { invoke } from "@tauri-apps/api/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  disableTelemetry,
+  enableTelemetry,
+  redactPaths,
+  scrubBreadcrumb,
+  scrubEvent,
+} from "./telemetry";
+
+vi.mock("@sentry/react", () => ({
+  init: vi.fn(),
+  getClient: vi.fn(() => undefined),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+const mockedInit = vi.mocked(Sentry.init);
+const mockedGetClient = vi.mocked(Sentry.getClient);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedInvoke.mockResolvedValue(undefined);
+  mockedGetClient.mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("redactPaths", () => {
+  it("redacts Windows absolute paths", () => {
+    expect(redactPaths(String.raw`opened C:\Users\Jane\Secret\notes.md ok`)).toBe(
+      "opened [redacted-path] ok",
+    );
+  });
+
+  it("redacts POSIX home paths", () => {
+    expect(redactPaths("read /Users/jane/Documents/diary.md failed")).toBe(
+      "read [redacted-path] failed",
+    );
+    expect(redactPaths("at /home/jane/notes/todo.md")).toBe("at [redacted-path]");
+  });
+
+  it("redacts file:// URLs", () => {
+    expect(redactPaths("file:///Users/jane/x.md broke")).toBe("[redacted-path] broke");
+  });
+
+  it("leaves path-free text untouched", () => {
+    expect(redactPaths("Cannot read property of undefined")).toBe(
+      "Cannot read property of undefined",
+    );
+  });
+});
+
+describe("scrubBreadcrumb", () => {
+  it("drops navigation / fetch / xhr breadcrumbs", () => {
+    expect(scrubBreadcrumb({ category: "navigation" })).toBeNull();
+    expect(scrubBreadcrumb({ category: "fetch" })).toBeNull();
+    expect(scrubBreadcrumb({ category: "xhr" })).toBeNull();
+  });
+
+  it("redacts paths in the message and url data", () => {
+    const result = scrubBreadcrumb({
+      category: "ui.click",
+      message: "opened /Users/jane/a.md",
+      data: { url: "https://example.com/secret" },
+    });
+    expect(result).not.toBeNull();
+    expect(result?.message).toBe("opened [redacted-path]");
+    expect(result?.data?.url).toBe("[redacted-url]");
+  });
+
+  it("keeps a plain breadcrumb as-is", () => {
+    const crumb: Breadcrumb = { category: "ui.click", message: "clicked button" };
+    expect(scrubBreadcrumb(crumb)).toEqual(crumb);
+  });
+});
+
+describe("scrubEvent", () => {
+  it("strips request, user, and server_name", () => {
+    const event = {
+      request: { url: "https://x" },
+      user: { ip_address: "1.2.3.4" },
+      server_name: "janes-macbook",
+    } as unknown as ErrorEvent;
+
+    const scrubbed = scrubEvent(event);
+    expect(scrubbed.request).toBeUndefined();
+    expect(scrubbed.user).toBeUndefined();
+    expect(scrubbed.server_name).toBeUndefined();
+  });
+
+  it("redacts the message and exception values", () => {
+    const event = {
+      message: "failed at /Users/jane/a.md",
+      exception: { values: [{ value: String.raw`ENOENT C:\Users\Jane\b.md` }] },
+    } as unknown as ErrorEvent;
+
+    const scrubbed = scrubEvent(event);
+    expect(scrubbed.message).toBe("failed at [redacted-path]");
+    expect(scrubbed.exception?.values?.[0].value).toBe("ENOENT [redacted-path]");
+  });
+
+  it("keeps only allowlisted contexts", () => {
+    const event = {
+      contexts: {
+        os: { name: "macOS" },
+        app: { app_version: "1.0" },
+        evil: { secret: "leak" },
+      },
+    } as unknown as ErrorEvent;
+
+    const scrubbed = scrubEvent(event);
+    expect(scrubbed.contexts?.os).toBeDefined();
+    expect(scrubbed.contexts?.app).toBeDefined();
+    expect(scrubbed.contexts?.evil).toBeUndefined();
+  });
+
+  it("filters URL-bearing breadcrumbs and redacts the rest", () => {
+    const event = {
+      breadcrumbs: [
+        { category: "navigation", message: "/Users/jane" },
+        { category: "ui.click", message: "open /Users/jane/a.md" },
+      ],
+    } as unknown as ErrorEvent;
+
+    const scrubbed = scrubEvent(event);
+    expect(scrubbed.breadcrumbs).toHaveLength(1);
+    expect(scrubbed.breadcrumbs?.[0].message).toBe("open [redacted-path]");
+  });
+});
+
+describe("enableTelemetry", () => {
+  it("mirrors state to the backend but does not init Sentry in dev", () => {
+    vi.stubEnv("PROD", false);
+    enableTelemetry();
+    expect(mockedInvoke).toHaveBeenCalledWith("set_error_reporting", { enabled: true });
+    expect(mockedInit).not.toHaveBeenCalled();
+  });
+
+  it("initializes Sentry in production when no client exists", () => {
+    vi.stubEnv("PROD", true);
+    enableTelemetry();
+    expect(mockedInit).toHaveBeenCalledTimes(1);
+    const options = mockedInit.mock.calls[0][0];
+    expect(options).toMatchObject({ sendDefaultPii: false, tracesSampleRate: 0 });
+    expect(options?.beforeSend).toBe(scrubEvent);
+    expect(options?.beforeBreadcrumb).toBe(scrubBreadcrumb);
+  });
+
+  it("does not re-init when a client already exists", () => {
+    vi.stubEnv("PROD", true);
+    mockedGetClient.mockReturnValue({} as ReturnType<typeof Sentry.getClient>);
+    enableTelemetry();
+    expect(mockedInit).not.toHaveBeenCalled();
+  });
+});
+
+describe("disableTelemetry", () => {
+  it("mirrors state to the backend and closes an existing client", () => {
+    const close = vi.fn();
+    mockedGetClient.mockReturnValue({ close } as unknown as ReturnType<typeof Sentry.getClient>);
+    disableTelemetry();
+    expect(mockedInvoke).toHaveBeenCalledWith("set_error_reporting", { enabled: false });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op on the client when none exists", () => {
+    mockedGetClient.mockReturnValue(undefined);
+    expect(() => disableTelemetry()).not.toThrow();
+  });
+});

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,11 +1,14 @@
 import type { Breadcrumb, ErrorEvent } from "@sentry/react";
 import * as Sentry from "@sentry/react";
 import { invoke } from "@tauri-apps/api/core";
+// Single source of truth for the Sentry DSN — `src-tauri/sentry.json`. The Rust
+// build script reads the same file (see build.rs) so the frontend and backend
+// clients always target the same project. DSNs are public client identifiers,
+// not secrets, so committing this is intentional.
+// biome-ignore lint/style/noRestrictedImports: lives outside src/, but it is the canonical config
+import sentryConfig from "../../src-tauri/sentry.json";
 
-// Public Sentry client identifier for the `glyph` project. DSNs are not secrets
-// (they ship in every client app), so hardcoding is fine and intentional.
-const SENTRY_DSN =
-  "https://0ae4d558b7b6fe1ec29b3ffb7c04fabb@o4511468551340032.ingest.us.sentry.io/4511491763470336";
+const SENTRY_DSN = sentryConfig.dsn;
 
 // Breadcrumb categories that carry navigation URLs / request paths — dropped
 // wholesale so we never ship the user's file locations or any remote URLs.

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,128 @@
+import type { Breadcrumb, ErrorEvent } from "@sentry/react";
+import * as Sentry from "@sentry/react";
+import { invoke } from "@tauri-apps/api/core";
+
+// Public Sentry client identifier for the `glyph` project. DSNs are not secrets
+// (they ship in every client app), so hardcoding is fine and intentional.
+const SENTRY_DSN =
+  "https://0ae4d558b7b6fe1ec29b3ffb7c04fabb@o4511468551340032.ingest.us.sentry.io/4511491763470336";
+
+// Breadcrumb categories that carry navigation URLs / request paths — dropped
+// wholesale so we never ship the user's file locations or any remote URLs.
+const URL_BEARING_CATEGORIES = new Set(["navigation", "fetch", "xhr"]);
+
+// Only these context blocks are allowed through; everything else (which may
+// contain machine- or user-specific data) is stripped.
+const SAFE_CONTEXTS = new Set(["os", "app", "device", "runtime", "browser"]);
+
+// Absolute filesystem paths and file:// URLs. We redact rather than send these
+// because they leak usernames, directory layouts, and document names.
+const FILE_URL = /file:\/\/[^\s"'<>|]+/g;
+const WINDOWS_PATH = /[A-Za-z]:\\[^\s"'<>|]+/g;
+const POSIX_PATH = /\/(?:Users|home|root|var|tmp|private|mnt|media|opt)\/[^\s"'<>|]+/g;
+
+const REDACTED = "[redacted-path]";
+
+/** Replace any absolute path or file URL in `input` with a placeholder. */
+export function redactPaths(input: string): string {
+  return input
+    .replace(FILE_URL, REDACTED)
+    .replace(WINDOWS_PATH, REDACTED)
+    .replace(POSIX_PATH, REDACTED);
+}
+
+/**
+ * Scrub a breadcrumb before it is attached to an event. Drops URL-bearing
+ * categories entirely and redacts paths / URLs from anything that remains.
+ * Returns `null` to discard the breadcrumb.
+ */
+export function scrubBreadcrumb(crumb: Breadcrumb): Breadcrumb | null {
+  if (crumb.category && URL_BEARING_CATEGORIES.has(crumb.category)) {
+    return null;
+  }
+  if (crumb.message) {
+    crumb.message = redactPaths(crumb.message);
+  }
+  if (crumb.data && typeof crumb.data.url === "string") {
+    crumb.data.url = "[redacted-url]";
+  }
+  return crumb;
+}
+
+/**
+ * Scrub an error event before it leaves the machine: drop request/user/host
+ * data, redact absolute paths from messages and exception values, and keep only
+ * an allowlist of context blocks. PII never reaches Sentry.
+ */
+export function scrubEvent(event: ErrorEvent): ErrorEvent {
+  // Request carries the URL + query string; user carries IP / id; server_name
+  // is the machine hostname. None of these are useful for a local app.
+  event.request = undefined;
+  event.user = undefined;
+  event.server_name = undefined;
+
+  if (event.message) {
+    event.message = redactPaths(event.message);
+  }
+
+  for (const exception of event.exception?.values ?? []) {
+    if (exception.value) {
+      exception.value = redactPaths(exception.value);
+    }
+  }
+
+  if (event.contexts) {
+    for (const key of Object.keys(event.contexts)) {
+      if (!SAFE_CONTEXTS.has(key)) {
+        delete event.contexts[key];
+      }
+    }
+  }
+
+  if (event.breadcrumbs) {
+    event.breadcrumbs = event.breadcrumbs
+      .map(scrubBreadcrumb)
+      .filter((crumb): crumb is Breadcrumb => crumb !== null);
+  }
+
+  return event;
+}
+
+// Reporting only happens in production builds with a DSN present. Dev builds
+// (`pnpm tauri dev`) never initialize the SDK, so no events are sent locally.
+function reportingAllowed(): boolean {
+  return import.meta.env.PROD && SENTRY_DSN.length > 0;
+}
+
+/**
+ * Turn error reporting on. Mirrors the choice into the Rust backend (which has
+ * its own prod gate) and lazily initializes the JS SDK. No-op in dev or if the
+ * client is already running.
+ */
+export function enableTelemetry(): void {
+  void invoke("set_error_reporting", { enabled: true }).catch(() => {});
+
+  if (!reportingAllowed() || Sentry.getClient()) {
+    return;
+  }
+
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    release: `glyph@${__APP_VERSION__}`,
+    // Hard privacy posture for a local-first viewer: no PII, no performance
+    // tracing, no session replay (replay would record document contents).
+    sendDefaultPii: false,
+    tracesSampleRate: 0,
+    beforeSend: scrubEvent,
+    beforeBreadcrumb: scrubBreadcrumb,
+  });
+}
+
+/**
+ * Turn error reporting off. Closes the JS client (flushing anything queued) and
+ * tells the Rust backend to drop its Sentry guard.
+ */
+export function disableTelemetry(): void {
+  void invoke("set_error_reporting", { enabled: false }).catch(() => {});
+  void Sentry.getClient()?.close();
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./components/App";
@@ -6,8 +7,28 @@ import "./styles/app.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <SettingsProvider>
-      <App />
-    </SettingsProvider>
+    {/* Captures React render errors. No-op until telemetry is initialized
+        (production + opted in); see src/lib/telemetry.ts. */}
+    <Sentry.ErrorBoundary
+      fallback={
+        <div
+          style={{
+            display: "flex",
+            height: "100vh",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "2rem",
+            textAlign: "center",
+            color: "var(--color-text-secondary)",
+          }}
+        >
+          <p>Something went wrong. Try reopening the file or restarting Glyph.</p>
+        </div>
+      }
+    >
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
+    </Sentry.ErrorBoundary>
   </StrictMode>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./components/App";
+import { ErrorFallback } from "./components/ErrorFallback";
 import { SettingsProvider } from "./contexts/SettingsContext";
 import "./styles/app.css";
 
@@ -9,23 +10,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     {/* Captures React render errors. No-op until telemetry is initialized
         (production + opted in); see src/lib/telemetry.ts. */}
-    <Sentry.ErrorBoundary
-      fallback={
-        <div
-          style={{
-            display: "flex",
-            height: "100vh",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: "2rem",
-            textAlign: "center",
-            color: "var(--color-text-secondary)",
-          }}
-        >
-          <p>Something went wrong. Try reopening the file or restarting Glyph.</p>
-        </div>
-      }
-    >
+    <Sentry.ErrorBoundary fallback={<ErrorFallback />}>
       <SettingsProvider>
         <App />
       </SettingsProvider>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,7 +2,9 @@ import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn(),
+  // Mirrors the real API: invoke always returns a Promise. Tests that need a
+  // specific resolved/rejected value override per-case with mockResolvedValue.
+  invoke: vi.fn(() => Promise.resolve()),
   convertFileSrc: vi.fn((path: string) => `asset://localhost/${path}`),
 }));
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="vite/client" />
 
+// Injected at build time from package.json `version` (see vite.config.ts /
+// vitest.config.ts `define`). Used as the Sentry release identifier.
+declare const __APP_VERSION__: string;
+
 declare module "*.css?inline" {
   const css: string;
   export default css;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,18 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { codecovVitePlugin } from "@codecov/vite-plugin";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 const host = process.env.TAURI_DEV_HOST;
+
+const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8"));
+
+// Source-map upload is opt-in via the auth token (set in CI). Without it, the
+// plugin is skipped entirely so local/dev builds are unaffected.
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
 
 export default defineConfig(async ({ mode }) => ({
   plugins: [
@@ -16,7 +24,29 @@ export default defineConfig(async ({ mode }) => ({
       uploadToken: process.env.CODECOV_TOKEN,
       gitService: "github",
     }),
+    // Uploads source maps to Sentry so production stack traces are readable.
+    // Only active when SENTRY_AUTH_TOKEN is present; maps are deleted from the
+    // bundle after upload so they never ship to users.
+    ...(sentryAuthToken
+      ? [
+          sentryVitePlugin({
+            org: "glyph-md",
+            project: "glyph",
+            authToken: sentryAuthToken,
+            telemetry: false,
+            sourcemaps: { filesToDeleteAfterUpload: ["./dist/**/*.map"] },
+          }),
+        ]
+      : []),
   ],
+  // Expose package.json version to the app (Sentry release id).
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
+  // Source maps are only emitted when we're going to upload + delete them.
+  build: {
+    sourcemap: sentryAuthToken ? true : false,
+  },
   // Strip `console.*` and `debugger` from production bundles so diagnostic
   // logs added during debugging don't leak into shipped builds (and don't
   // weigh down the bundle). Dev builds keep them so the in-app DevTools

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,15 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
+const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8"));
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),


### PR DESCRIPTION
## Summary

Adds **opt-in, production-only** crash and error reporting to Sentry on both the React frontend (`@sentry/react`) and the Rust backend (`sentry` crate), closing #236. Off by default: no data leaves the machine until the user enables it, and reporting stays inert in dev builds. PII (file paths, contents, URLs, hostname) is scrubbed before anything is sent.

Sentry sponsors Glyph via their Sponsored Business plan, so this also adds a Sponsors section and funding button.

## Changes

- **Settings → Privacy** toggle ("Send crash reports"), default **off** (`src/lib/settings.ts`, `src/components/modals/SettingsModal.tsx`)
- **Frontend**: `src/lib/telemetry.ts` lazily inits `@sentry/react` only in production once opted in; `src/hooks/useErrorReporting.ts` reconciles the toggle; `Sentry.ErrorBoundary` wraps the app in `main.tsx`
- **Backend**: `src-tauri/src/telemetry.rs` adds a `set_error_reporting` command + managed guard, gated on `debug_assertions` (release only), captures Rust panics, and scrubs paths in `before_send`
- **Privacy hardening**: no session replay, no tracing, no logs, `sendDefaultPii: false`; paths/URLs/hostname stripped from messages, exception values, breadcrumbs, and stack frames on both sides
- **Source maps**: `@sentry/vite-plugin` uploads on release, gated on `SENTRY_AUTH_TOKEN` (org `glyph-md`, project `glyph`), maps deleted after upload
- **Docs**: README Privacy + Sponsors sections (Sentry + crypto donation addresses, currently `<pending>`), `SECURITY.md` telemetry policy, `.github/FUNDING.yml` custom Sponsor button

## Testing

- `pnpm typecheck`, `pnpm check` (Biome), `pnpm build` pass
- `pnpm test` — 634 passing; new `telemetry.ts` at 100% line coverage, hook + scrubbers fully covered
- `cargo test` — 99 passing (7 new), `cargo clippy -D warnings` and `cargo fmt --check` clean
- Full `.husky/pre-commit` gate run manually and green

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Follow-ups

- Replace the `<pending>` crypto wallet addresses in `README.md` Sponsors section
- `SENTRY_AUTH_TOKEN` repo secret set so release builds upload source maps
