### PR TITLE
feat: render Jupyter notebooks (.ipynb)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - Wikilink autocomplete — type `[[` in a folder workspace to pick from existing notes; Tab/Enter to insert
 
 ### Viewer
+- Jupyter notebooks — open `.ipynb` files directly; markdown cells render with full markdown (math, code, diagrams), code cells are syntax-highlighted, and image, HTML, plain-text, and colourised stream/traceback outputs show under each cell with `In [n]:` / `Out [n]:` prompts (read-only)
 - Folder / workspace tabs — open a folder as a tab; browse `.md` files in the sidebar tree; right-click a file to open it in a new top-level tab
 - Multiple files in tabs — open, switch, close, middle-click to close
 - Command palette — `Cmd/Ctrl+K` to fuzzy-jump to any workspace file, document heading, or app action
@@ -60,9 +61,9 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - Print & PDF export — `Cmd/Ctrl+P` with configurable page breaks, optional TOC, and theme-color control
 - Live reload — file watcher auto-updates on external changes
 - Undo / redo for in-document edits — `Cmd/Ctrl+Z` and `Cmd/Ctrl+Shift+Z` reverse task-list checkbox toggles and other programmatic edits per tab
-- Drag and drop markdown files or folders to open
+- Drag and drop markdown files, notebooks, or folders to open
 - File associations — double-click `.md` files to open in Glyph
-- CLI support — `glyph README.md` opens a file; `glyph ~/notes/` opens a folder as a workspace
+- CLI support — `glyph README.md` opens a file; `glyph notebook.ipynb` opens a notebook; `glyph ~/notes/` opens a folder as a workspace
 - Recent files list
 - Session restore — open tabs persist across restarts
 
@@ -223,6 +224,7 @@ Glyph is built around speed, native feel, and offline-first usage. The tables be
 | GitHub-style alerts | ✅ | ✅ | ⚠️ | ❌ | ❌ | ⚠️ | ✅ |
 | YAML frontmatter | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ |
 | Emoji shortcodes | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | plugin |
+| Jupyter notebooks (`.ipynb`) | ✅ | plugin | ❌ | ❌ | ❌ | ❌ | ✅ |
 
 ### Editing
 

--- a/samples/Notebook.ipynb
+++ b/samples/Notebook.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Jupyter Notebook Demo\n\nGlyph renders `.ipynb` files directly. **Markdown cells** support the full markdown feature set, including inline math like $e^{i\\pi} + 1 = 0$ and block math:\n\n$$\\int_0^\\infty e^{-x^2}\\,dx = \\frac{\\sqrt{\\pi}}{2}$$\n\n...and Mermaid diagrams:\n\n```mermaid\nflowchart LR\n  A[Read .ipynb] --> B{Cell type}\n  B -->|markdown| C[MarkdownContent]\n  B -->|code| D[Highlighted source]\n  D --> E[Outputs]\n```"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "values = np.arange(5)\n",
+    "print('values:', values)\n",
+    "values.sum()"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "values: [0 1 2 3 4]\n"
+     ]
+    },
+    {
+     "output_type": "execute_result",
+     "execution_count": 1,
+     "data": {
+      "text/plain": [
+       "10"
+      ]
+     },
+     "metadata": {}
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Rich outputs\n",
+    "\n",
+    "Outputs render under each cell by their richest available representation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "source": [
+    "from IPython.display import HTML\n",
+    "HTML('<strong>HTML output</strong> is sanitised, then rendered.')"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "execution_count": 2,
+     "data": {
+      "text/html": [
+       "<strong>HTML output</strong> is sanitised, then rendered."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {}
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "plt.plot(values, values ** 2)\n",
+    "plt.show()"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAS0lEQVR4nJXCERZCAQAF0bemOI7j4fhzHMdxHMfxLKs1zD13J0x3xnQXTHfFdGC6G6Y7MN0d0z0w3RPTvTDdG9N9MN0X0/0wnZj+AaZenxAbfTPKAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {}
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "source": [
+    "1 / 0"
+   ],
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "ZeroDivisionError",
+     "evalue": "division by zero",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[4], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;241m1\u001b[39m \u001b[38;5;241m/\u001b[39m \u001b[38;5;241m0\u001b[39m",
+      "\u001b[0;31mZeroDivisionError\u001b[0m: division by zero"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Raw cells are shown verbatim, without markdown processing."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -24,6 +24,7 @@ This document demonstrates all the rendering features supported by Glyph. The YA
 - [Raw HTML](#raw-html)
 - [Images](#images)
 - [Links](#links)
+- [Jupyter Notebooks](#jupyter-notebooks)
 - [Keyboard Shortcuts](#keyboard-shortcuts)
 
 ## Frontmatter
@@ -262,6 +263,16 @@ When you have the `samples/` folder open, the **Backlinks** section under the fi
 ### Wikilink autocomplete
 
 In the editor or split view, typing `[[` opens a popup with workspace files. Keep typing to filter, press **Tab** or **Enter** to insert; the closing `]]` is added for you. Open this file in split view (`Cmd+E` cycles modes) and try typing `[[Co` to see it.
+
+## Jupyter Notebooks
+
+Glyph opens `.ipynb` files directly — no Jupyter required. Open `Notebook.ipynb` from the file tree (or run `glyph samples/Notebook.ipynb`) to see it. Notebooks are read-only and render each cell in order:
+
+- **Markdown cells** get the full markdown pipeline above — math, code, Mermaid, alerts, the lot.
+- **Code cells** are syntax-highlighted using the notebook's kernel language, with an `In [n]:` prompt in the gutter.
+- **Outputs** render under their cell by richest type: images (`image/png`, `image/jpeg`, `image/svg+xml`), sanitised HTML, markdown, and plain text. Stream output and exception tracebacks keep their ANSI colours instead of showing raw escape codes. An `Out [n]:` prompt marks execution results.
+
+Interactive outputs (Plotly, Vega, Jupyter widgets) aren't rendered yet — they show a short placeholder. Notebooks can't be edited in Glyph, so the mode toggle stays read-only: **view** shows the rendered cells, **edit** shows the raw `.ipynb` JSON as a syntax-highlighted source view, and **split** shows the JSON source and rendered cells side by side.
 
 ---
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::markdown::is_markdown_file;
+use crate::is_supported_file;
 
 /// Pick the first non-flag argument from a second-instance argv. The slice is
 /// expected to be the full argv including the program name at index 0, which
@@ -26,12 +26,12 @@ pub enum InitialOpenAction {
     Folder(String),
     /// Open as a single markdown file. Inner is the absolute path.
     File(String),
-    /// Path exists and resolves, but is not a markdown file (e.g. `.txt`,
-    /// `.html`). The caller should log a warning and skip it rather than
-    /// forwarding it to the renderer, which would otherwise treat the
-    /// content as markdown and allow embedded HTML / JS through the
+    /// Path exists and resolves, but is not a supported document (markdown or
+    /// `.ipynb`) — e.g. `.txt`, `.html`. The caller should log a warning and
+    /// skip it rather than forwarding it to the renderer, which would otherwise
+    /// treat the content as markdown and allow embedded HTML / JS through the
     /// sanitizer. Inner is the absolute path for the log message.
-    RejectedNotMarkdown(String),
+    RejectedUnsupported(String),
 }
 
 /// Classify a path that's already been resolved to a canonical absolute form.
@@ -45,10 +45,10 @@ pub fn classify_resolved_path(canonical: &Path) -> Option<InitialOpenAction> {
     if canonical.is_dir() {
         Some(InitialOpenAction::Folder(abs))
     } else if canonical.is_file() {
-        if is_markdown_file(canonical) {
+        if is_supported_file(canonical) {
             Some(InitialOpenAction::File(abs))
         } else {
-            Some(InitialOpenAction::RejectedNotMarkdown(abs))
+            Some(InitialOpenAction::RejectedUnsupported(abs))
         }
     } else {
         None
@@ -109,7 +109,7 @@ pub fn second_instance_event(argv: &[String], cwd: &Path) -> Option<SecondInstan
             event_name: "open-file",
             path,
         }),
-        InitialOpenAction::RejectedNotMarkdown(_) => None,
+        InitialOpenAction::RejectedUnsupported(_) => None,
     }
 }
 
@@ -271,7 +271,7 @@ mod tests {
         let actions = [
             InitialOpenAction::Folder("/workspace".to_string()),
             InitialOpenAction::File("/workspace/notes.md".to_string()),
-            InitialOpenAction::RejectedNotMarkdown("/workspace/evil.txt".to_string()),
+            InitialOpenAction::RejectedUnsupported("/workspace/evil.txt".to_string()),
         ];
         for action in &actions {
             let formatted = format!("{action:?}");
@@ -310,8 +310,8 @@ mod tests {
         fs::write(&file, "<script>alert('x')</script>").unwrap();
         let result = classify_resolved_path(&file.canonicalize().unwrap()).expect("classifies");
         assert!(
-            matches!(&result, InitialOpenAction::RejectedNotMarkdown(p) if p.ends_with("evil.txt")),
-            "expected RejectedNotMarkdown ending in evil.txt, got {result:?}"
+            matches!(&result, InitialOpenAction::RejectedUnsupported(p) if p.ends_with("evil.txt")),
+            "expected RejectedUnsupported ending in evil.txt, got {result:?}"
         );
         let _ = fs::remove_dir_all(&cwd);
     }
@@ -360,7 +360,7 @@ mod tests {
         let file = cwd.join("evil.txt");
         fs::write(&file, "x").unwrap();
         let result = classify_initial_arg("evil.txt", &cwd).expect("classifies");
-        assert!(matches!(result, InitialOpenAction::RejectedNotMarkdown(_)));
+        assert!(matches!(result, InitialOpenAction::RejectedUnsupported(_)));
         let _ = fs::remove_dir_all(&cwd);
     }
 
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn second_instance_event_returns_none_for_non_markdown_files() {
-        // Covers the RejectedNotMarkdown -> None arm in second_instance_event:
+        // Covers the RejectedUnsupported -> None arm in second_instance_event:
         // a second instance pointed at evil.txt should not fire any event.
         let cwd = unique_tmp("si_txt");
         let file = cwd.join("evil.txt");

--- a/src-tauri/src/commands/directory.rs
+++ b/src-tauri/src/commands/directory.rs
@@ -41,7 +41,7 @@ pub fn read_directory(path: String) -> Result<Vec<DirEntry>, String> {
             Err(_) => continue,
         };
         let is_directory = metadata.is_dir();
-        if !is_directory && !crate::is_markdown_file(&entry_path) {
+        if !is_directory && !crate::is_supported_file(&entry_path) {
             continue;
         }
         let modified = metadata
@@ -97,7 +97,7 @@ pub fn list_markdown_files(path: String) -> Result<Vec<String>, String> {
             continue;
         }
         let p = entry.path();
-        if !crate::is_markdown_file(p) {
+        if !crate::is_supported_file(p) {
             continue;
         }
         if results.len() >= WALK_MAX_FILES {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod commands;
 mod markdown;
 mod menu;
 mod menu_runtime;
+mod notebook;
 mod telemetry;
 mod watcher;
 
@@ -14,6 +15,7 @@ use tauri_plugin_cli::CliExt;
 use watcher::FileWatcherState;
 
 pub use markdown::is_markdown_file;
+pub use notebook::{is_notebook_file, is_supported_file};
 
 /// Handle a second-instance launch: refocus the main window and forward the
 /// file/folder argument (if any) to the frontend via the same `open-file` /
@@ -121,8 +123,8 @@ pub fn run() {
                 Some(cli::InitialOpenAction::File(p)) => {
                     *app.state::<commands::InitialFile>().0.lock().unwrap() = Some(p);
                 }
-                Some(cli::InitialOpenAction::RejectedNotMarkdown(p)) => {
-                    eprintln!("Refusing to open non-markdown file: {p}");
+                Some(cli::InitialOpenAction::RejectedUnsupported(p)) => {
+                    eprintln!("Refusing to open unsupported file type: {p}");
                 }
                 None => {}
             }
@@ -139,7 +141,7 @@ pub fn run() {
                         let _ = window.emit("open-folder", &path_str);
                         break;
                     }
-                    if is_markdown_file(path) {
+                    if is_supported_file(path) {
                         let _ = window.emit("open-file", &path_str);
                         break;
                     }
@@ -194,10 +196,10 @@ pub fn run() {
                         }
                         break;
                     }
-                    Some(cli::InitialOpenAction::RejectedNotMarkdown(p)) => {
-                        eprintln!("Refusing to open non-markdown file: {p}");
+                    Some(cli::InitialOpenAction::RejectedUnsupported(p)) => {
+                        eprintln!("Refusing to open unsupported file type: {p}");
                         // Keep scanning the URL list — the user may have
-                        // dropped a mix of markdown and non-markdown files.
+                        // dropped a mix of supported and unsupported files.
                     }
                     None => {}
                 }

--- a/src-tauri/src/notebook.rs
+++ b/src-tauri/src/notebook.rs
@@ -1,0 +1,55 @@
+use std::path::Path;
+
+/// Jupyter notebooks always use the `.ipynb` extension, so — unlike the
+/// markdown list generated from `tauri.conf.json` — this is a fixed check.
+///
+/// Notebooks are intentionally NOT registered as an OS file association (only
+/// markdown is, via `tauri.conf.json` → `bundle.fileAssociations`). They open
+/// via the CLI, the open dialog, drag-and-drop, and the workspace file tree —
+/// all of which gate on this function. The frontend mirror is
+/// `src/lib/notebookExtensions.ts`.
+pub fn is_notebook_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("ipynb"))
+        .unwrap_or(false)
+}
+
+/// Any document Glyph can open: a markdown file or a Jupyter notebook. Used by
+/// the open-gating paths (CLI args, drag-drop, file-tree walking) so both
+/// document types reach the renderer while everything else is rejected.
+pub fn is_supported_file(path: &Path) -> bool {
+    crate::is_markdown_file(path) || is_notebook_file(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipynb_is_a_notebook() {
+        assert!(is_notebook_file(Path::new("analysis.ipynb")));
+        assert!(is_notebook_file(Path::new("/home/u/Untitled.IPYNB")));
+    }
+
+    #[test]
+    fn other_extensions_are_not_notebooks() {
+        assert!(!is_notebook_file(Path::new("readme.md")));
+        assert!(!is_notebook_file(Path::new("data.json")));
+        assert!(!is_notebook_file(Path::new("noext")));
+        assert!(!is_notebook_file(Path::new("")));
+    }
+
+    #[test]
+    fn supported_covers_markdown_and_notebooks() {
+        assert!(is_supported_file(Path::new("README.md")));
+        assert!(is_supported_file(Path::new("notes.markdown")));
+        assert!(is_supported_file(Path::new("analysis.ipynb")));
+    }
+
+    #[test]
+    fn supported_rejects_other_types() {
+        assert!(!is_supported_file(Path::new("image.png")));
+        assert!(!is_supported_file(Path::new("main.rs")));
+    }
+}

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -274,12 +274,23 @@ describe("App", () => {
       listeners["menu-find"]?.({ payload: undefined });
     });
 
-    // menu-toggle-edit: cycles view → edit. The lazy editor mock renders for
-    // edit mode, so its appearance confirms setTabMode fired.
+    // menu-toggle-edit cycles view → edit → split → view. Each step renders a
+    // different mock (editor, split, viewer), confirming the full nextEditorMode
+    // cycle runs through setTabMode.
     await act(async () => {
       listeners["menu-toggle-edit"]?.({ payload: undefined });
     });
     expect(await findByTestId("lazy-editor")).toBeInTheDocument();
+
+    await act(async () => {
+      listeners["menu-toggle-edit"]?.({ payload: undefined });
+    });
+    expect(await findByTestId("lazy-split")).toBeInTheDocument();
+
+    await act(async () => {
+      listeners["menu-toggle-edit"]?.({ payload: undefined });
+    });
+    expect(await findByTestId("markdown-viewer")).toBeInTheDocument();
 
     // menu-close-tab: closes the open file (covers closeActiveTab path).
     await act(async () => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -15,6 +15,7 @@ import { usePrint } from "@/hooks/usePrint";
 import { useReadAloudController } from "@/hooks/useReadAloudController";
 import { useSettings } from "@/hooks/useSettings";
 import { useWindowReveal } from "@/hooks/useWindowReveal";
+import { EDITOR_MODE } from "@/lib/settings";
 import { EmptyState } from "./layout/EmptyState";
 import { Sidebar } from "./layout/Sidebar";
 import { StatusBar } from "./layout/StatusBar";
@@ -97,8 +98,13 @@ export function AppShell() {
 
   const handleToggleEdit = useCallback(() => {
     if (!activeTabId) return;
-    const current = activeFile?.mode ?? "view";
-    const next = current === "view" ? "edit" : current === "edit" ? "split" : "view";
+    const current = activeFile?.mode ?? EDITOR_MODE.view;
+    const next =
+      current === EDITOR_MODE.view
+        ? EDITOR_MODE.edit
+        : current === EDITOR_MODE.edit
+          ? EDITOR_MODE.split
+          : EDITOR_MODE.view;
     setTabMode(activeTabId, next);
   }, [activeTabId, activeFile?.mode, setTabMode]);
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -15,7 +15,7 @@ import { usePrint } from "@/hooks/usePrint";
 import { useReadAloudController } from "@/hooks/useReadAloudController";
 import { useSettings } from "@/hooks/useSettings";
 import { useWindowReveal } from "@/hooks/useWindowReveal";
-import { EDITOR_MODE } from "@/lib/settings";
+import { nextEditorMode } from "@/lib/settings";
 import { EmptyState } from "./layout/EmptyState";
 import { Sidebar } from "./layout/Sidebar";
 import { StatusBar } from "./layout/StatusBar";
@@ -98,14 +98,9 @@ export function AppShell() {
 
   const handleToggleEdit = useCallback(() => {
     if (!activeTabId) return;
-    const current = activeFile?.mode ?? EDITOR_MODE.view;
-    const next =
-      current === EDITOR_MODE.view
-        ? EDITOR_MODE.edit
-        : current === EDITOR_MODE.edit
-          ? EDITOR_MODE.split
-          : EDITOR_MODE.view;
-    setTabMode(activeTabId, next);
+    // nextEditorMode treats an undefined mode as view, so no fallback branch
+    // is needed at the call site.
+    setTabMode(activeTabId, nextEditorMode(activeFile?.mode));
   }, [activeTabId, activeFile?.mode, setTabMode]);
 
   const handleAIActionFromMenu = useCallback(

--- a/src/components/TabContent.test.tsx
+++ b/src/components/TabContent.test.tsx
@@ -40,6 +40,34 @@ vi.mock("./markdown/MarkdownViewer", () => ({
   ),
 }));
 
+vi.mock("./notebook/lazyNotebook", () => ({
+  NotebookViewer: ({ filePath }: { filePath?: string }) => (
+    <div data-testid="notebook-viewer">{filePath}</div>
+  ),
+  NotebookSource: ({ filePath }: { filePath?: string }) => (
+    <div data-testid="notebook-source">{filePath}</div>
+  ),
+  NotebookSplit: ({ filePath }: { filePath?: string }) => (
+    <div data-testid="notebook-split">{filePath}</div>
+  ),
+}));
+
+function makeNotebookTab(mode: EditorMode = "view"): FileTab {
+  return {
+    id: "tab-nb",
+    kind: "file",
+    file: {
+      path: "/p/analysis.ipynb",
+      content: '{"cells": []}',
+      metadata: { name: "analysis.ipynb", path: "/p/analysis.ipynb", size: 0, modified: 0 },
+      scrollTop: 0,
+      mode,
+      editContent: null,
+      dirty: false,
+    },
+  };
+}
+
 function makeFileTab(mode: EditorMode = "view"): FileTab {
   return {
     id: "tab-1",
@@ -189,5 +217,27 @@ describe("TabContent", () => {
     });
     getByTestId("split-wikilink").click();
     expect(openFileInFolderTab).not.toHaveBeenCalled();
+  });
+
+  it("renders the notebook viewer for an .ipynb tab in view mode", () => {
+    const tab = makeNotebookTab("view");
+    renderTabContent({ activeTab: tab, activeTabId: tab.id, activeFile: tab.file });
+    expect(screen.getByTestId("notebook-viewer")).toHaveTextContent("/p/analysis.ipynb");
+    expect(screen.queryByTestId("markdown-viewer")).toBeNull();
+  });
+
+  it("renders the notebook source view for an .ipynb tab in edit mode", () => {
+    const tab = makeNotebookTab("edit");
+    renderTabContent({ activeTab: tab, activeTabId: tab.id, activeFile: tab.file });
+    expect(screen.getByTestId("notebook-source")).toBeInTheDocument();
+    // Never the markdown editor — that would expose a write path.
+    expect(screen.queryByTestId("lazy-editor")).toBeNull();
+  });
+
+  it("renders the notebook split view for an .ipynb tab in split mode", () => {
+    const tab = makeNotebookTab("split");
+    renderTabContent({ activeTab: tab, activeTabId: tab.id, activeFile: tab.file });
+    expect(screen.getByTestId("notebook-split")).toBeInTheDocument();
+    expect(screen.queryByTestId("lazy-split")).toBeNull();
   });
 });

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -3,6 +3,7 @@ import { useTabsContext } from "@/contexts/TabsContext";
 import { activeFileOf } from "@/hooks/useTabs";
 import { useTaskList } from "@/hooks/useTaskList";
 import { isNotebookFile } from "@/lib/notebookExtensions";
+import { EDITOR_MODE } from "@/lib/settings";
 import { MarkdownEditor, SplitView } from "./editor/lazyEditor";
 import { MarkdownViewer } from "./markdown/MarkdownViewer";
 import { NotebookSource, NotebookSplit, NotebookViewer } from "./notebook/lazyNotebook";
@@ -61,9 +62,9 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
   // would let autosave write malformed content back and corrupt the file.
   if (isNotebookFile(file.path)) {
     const NotebookComponent =
-      file.mode === "view"
+      file.mode === EDITOR_MODE.view
         ? NotebookViewer
-        : file.mode === "split"
+        : file.mode === EDITOR_MODE.split
           ? NotebookSplit
           : NotebookSource;
     return (
@@ -79,7 +80,7 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
     );
   }
 
-  if (file.mode === "edit") {
+  if (file.mode === EDITOR_MODE.edit) {
     return (
       <div className="flex-1 overflow-hidden">
         <MarkdownEditor
@@ -92,7 +93,7 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
     );
   }
 
-  if (file.mode === "split") {
+  if (file.mode === EDITOR_MODE.split) {
     return (
       <div className="flex-1 overflow-hidden">
         <SplitView

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -2,8 +2,10 @@ import { useCallback } from "react";
 import { useTabsContext } from "@/contexts/TabsContext";
 import { activeFileOf } from "@/hooks/useTabs";
 import { useTaskList } from "@/hooks/useTaskList";
+import { isNotebookFile } from "@/lib/notebookExtensions";
 import { MarkdownEditor, SplitView } from "./editor/lazyEditor";
 import { MarkdownViewer } from "./markdown/MarkdownViewer";
+import { NotebookSource, NotebookSplit, NotebookViewer } from "./notebook/lazyNotebook";
 
 interface TabContentProps {
   searchOpen: boolean;
@@ -52,6 +54,30 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
 
   const editorContent = file.editContent ?? file.content;
   const workspaceRoot = activeTab.kind === "folder" ? activeTab.root : undefined;
+
+  // Notebooks are read-only, so the three modes map to read-only views rather
+  // than editors: view = rendered cells, split = cells + raw JSON side by side,
+  // edit = raw JSON source. None drop the JSON into the markdown editor, which
+  // would let autosave write malformed content back and corrupt the file.
+  if (isNotebookFile(file.path)) {
+    const NotebookComponent =
+      file.mode === "view"
+        ? NotebookViewer
+        : file.mode === "split"
+          ? NotebookSplit
+          : NotebookSource;
+    return (
+      <NotebookComponent
+        key={`${activeTab.id}:${file.path}`}
+        content={file.content}
+        filePath={file.path}
+        initialScrollTop={file.scrollTop}
+        onScrollChange={saveScrollPosition}
+        searchOpen={searchOpen}
+        onSearchClose={onSearchClose}
+      />
+    );
+  }
 
   if (file.mode === "edit") {
     return (

--- a/src/components/layout/StatusBar.test.tsx
+++ b/src/components/layout/StatusBar.test.tsx
@@ -1,9 +1,21 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import type { FileTab } from "@/hooks/useTabs";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
 import { StatusBar } from "./StatusBar";
+
+// useSettings is read for the zoom indicator. Mock it so a test can drive a
+// non-default font size; default to DEFAULT_SETTINGS otherwise.
+const settingsRef = { current: DEFAULT_SETTINGS };
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => ({ settings: settingsRef.current, updateSettings: vi.fn() }),
+}));
+
+afterEach(() => {
+  settingsRef.current = DEFAULT_SETTINGS;
+});
 
 interface Opts {
   filePath?: string;
@@ -99,5 +111,24 @@ describe("StatusBar", () => {
   it("does not show zoom percentage at default zoom (100%)", () => {
     renderStatusBar({ displayContent: "some content" });
     expect(screen.queryByText("100%")).toBeNull();
+  });
+
+  it("shows the zoom percentage when font size differs from default", () => {
+    settingsRef.current = {
+      ...DEFAULT_SETTINGS,
+      appearance: { ...DEFAULT_SETTINGS.appearance, fontSize: 20 },
+    };
+    renderStatusBar({ displayContent: "some content" });
+    // 20 / 16 = 125%
+    expect(screen.getByText("125%")).toBeInTheDocument();
+  });
+
+  it("shows a Jupyter Notebook label (not word count) for an .ipynb file", () => {
+    // Notebooks suppress displayContent, so the bar still renders via the
+    // isNotebook path and shows the document-type label instead of word count.
+    renderStatusBar({ filePath: "/path/to/analysis.ipynb", displayContent: null });
+    expect(screen.getByText("Jupyter Notebook")).toBeInTheDocument();
+    expect(screen.queryByText(/words$/)).toBeNull();
+    expect(screen.getByText("/path/to/analysis.ipynb")).toBeInTheDocument();
   });
 });

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { useTabsContext } from "@/contexts/TabsContext";
 import { useSettings } from "@/hooks/useSettings";
 import { countWords, readingTime } from "@/lib/markdown";
+import { isNotebookFile } from "@/lib/notebookExtensions";
 import { ZOOM_DEFAULT } from "@/lib/settings";
 
 export function StatusBar() {
@@ -8,10 +9,15 @@ export function StatusBar() {
   const { activeFile, displayContent } = useTabsContext();
   const zoomPercent = Math.round((settings.appearance.fontSize / ZOOM_DEFAULT) * 100);
 
-  if (!displayContent) return null;
-
   const filePath = activeFile?.path;
-  const words = countWords(displayContent);
+  // Notebooks suppress `displayContent` (it would be raw JSON) in every mode,
+  // so the word count / reading time don't apply — show a document-type label
+  // instead.
+  const isNotebook = !!filePath && isNotebookFile(filePath);
+
+  if (!displayContent && !isNotebook) return null;
+
+  const words = displayContent ? countWords(displayContent) : 0;
 
   return (
     <div
@@ -23,8 +29,14 @@ export function StatusBar() {
           {filePath}
         </span>
       )}
-      <span className="ml-auto">{words.toLocaleString()} words</span>
-      <span>{readingTime(words)}</span>
+      {isNotebook ? (
+        <span className="ml-auto">Jupyter Notebook</span>
+      ) : (
+        <>
+          <span className="ml-auto">{words.toLocaleString()} words</span>
+          <span>{readingTime(words)}</span>
+        </>
+      )}
       {zoomPercent !== 100 && <span>{zoomPercent}%</span>}
     </div>
   );

--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -137,6 +137,20 @@ describe("TabBar", () => {
     expect(tabEl?.getAttribute("data-tab-kind")).toBe("folder");
   });
 
+  it("calls setTabMode with the chosen mode from each toggle button", () => {
+    const setTabMode = vi.fn();
+    renderTabBar({ tabs: makeTabs(1), activeTabId: "tab-0", setTabMode });
+
+    fireEvent.click(screen.getByRole("button", { name: "View mode" }));
+    expect(setTabMode).toHaveBeenCalledWith("tab-0", "view");
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit mode" }));
+    expect(setTabMode).toHaveBeenCalledWith("tab-0", "edit");
+
+    fireEvent.click(screen.getByRole("button", { name: "Split mode" }));
+    expect(setTabMode).toHaveBeenCalledWith("tab-0", "split");
+  });
+
   it("hides mode toggle when active tab is a folder with no current file", () => {
     renderTabBar({
       tabs: [makeFolderTab(0, "/Users/me/notes")],

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -1,5 +1,6 @@
 import { useTabsContext } from "@/contexts/TabsContext";
 import { activeFileOf, type Tab, tabPathOf } from "@/hooks/useTabs";
+import { EDITOR_MODE } from "@/lib/settings";
 import { FolderIcon } from "../icons/FolderIcon";
 
 function tabLabel(tab: Tab): string {
@@ -83,8 +84,8 @@ export function TabBar() {
           <button
             type="button"
             className="mode-toggle-btn"
-            data-active={activeFile.mode === "view" || undefined}
-            onClick={() => onModeChange(activeTab.id, "view")}
+            data-active={activeFile.mode === EDITOR_MODE.view || undefined}
+            onClick={() => onModeChange(activeTab.id, EDITOR_MODE.view)}
             aria-label="View mode"
             title="View"
           >
@@ -100,8 +101,8 @@ export function TabBar() {
           <button
             type="button"
             className="mode-toggle-btn"
-            data-active={activeFile.mode === "edit" || undefined}
-            onClick={() => onModeChange(activeTab.id, "edit")}
+            data-active={activeFile.mode === EDITOR_MODE.edit || undefined}
+            onClick={() => onModeChange(activeTab.id, EDITOR_MODE.edit)}
             aria-label="Edit mode"
             title="Edit"
           >
@@ -117,8 +118,8 @@ export function TabBar() {
           <button
             type="button"
             className="mode-toggle-btn"
-            data-active={activeFile.mode === "split" || undefined}
-            onClick={() => onModeChange(activeTab.id, "split")}
+            data-active={activeFile.mode === EDITOR_MODE.split || undefined}
+            onClick={() => onModeChange(activeTab.id, EDITOR_MODE.split)}
             aria-label="Split mode"
             title="Split"
           >

--- a/src/components/markdown/MarkdownContent.test.tsx
+++ b/src/components/markdown/MarkdownContent.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MarkdownContent } from "./MarkdownContent";
+
+// MarkdownContent is the shared rendering core (frontmatter + ReactMarkdown with
+// the full plugin set). MarkdownViewer.test covers the sanitiser/alert paths via
+// the viewer; these tests target the branches unique to this component: the
+// frontmatter toggle and the lazily-pushed highlight / katex plugins.
+describe("MarkdownContent", () => {
+  it("renders a frontmatter block when showFrontmatter is on", () => {
+    render(<MarkdownContent content={"---\ntitle: Hello\n---\n\nbody"} />);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText("body")).toBeInTheDocument();
+  });
+
+  it("skips the frontmatter block when showFrontmatter is off", () => {
+    const { container } = render(
+      <MarkdownContent content={"---\ntitle: Hidden\n---\n\nbody"} showFrontmatter={false} />,
+    );
+    // The raw frontmatter is not rendered as a metadata heading.
+    expect(container.textContent).not.toContain("Hidden");
+    expect(screen.getByText("body")).toBeInTheDocument();
+  });
+
+  it("lazily applies syntax highlighting to fenced code", async () => {
+    const { container } = render(
+      <MarkdownContent content={"```python\nx = 1\n```"} showFrontmatter={false} />,
+    );
+    await waitFor(() => expect(container.querySelector("code.hljs")).toBeTruthy());
+  });
+
+  it("lazily renders math via KaTeX", async () => {
+    const { container } = render(
+      <MarkdownContent content={"inline $x^2$ math"} showFrontmatter={false} />,
+    );
+    await waitFor(() => expect(container.querySelector(".katex")).toBeTruthy());
+  });
+});

--- a/src/components/markdown/MarkdownContent.tsx
+++ b/src/components/markdown/MarkdownContent.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useMemo } from "react";
+import ReactMarkdown, { type Options } from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
+import rehypeSlug from "rehype-slug";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkGemoji from "remark-gemoji";
+import remarkGfm from "remark-gfm";
+import { remarkAlert } from "remark-github-blockquote-alert";
+import remarkMath from "remark-math";
+import { useHighlightPlugin } from "@/hooks/useHighlightPlugin";
+import { useKatexPlugin } from "@/hooks/useKatexPlugin";
+import { parseFrontmatter } from "@/lib/frontmatter";
+import { remarkWikilink } from "@/lib/wikilink";
+import { CodeBlockComponent } from "./CodeBlockComponent";
+import { FrontmatterBlock } from "./FrontmatterBlock";
+import { useImageComponent } from "./ImageComponent";
+import { LinkComponent, type LinkComponentProps } from "./LinkComponent";
+import { markdownSanitizeSchema } from "./sanitizeSchema";
+import { TaskListItem } from "./TaskListItem";
+
+interface MarkdownContentProps {
+  content: string;
+  filePath?: string;
+  workspaceFiles?: string[];
+  onOpenWikilink?: (path: string, heading?: string) => void;
+  onTaskToggle?: (line: number) => void;
+  /** Render a YAML frontmatter block when present. Defaults to true. */
+  showFrontmatter?: boolean;
+}
+
+// The markdown rendering core: frontmatter block + ReactMarkdown wired up with
+// the full plugin/component set (GFM, math, alerts, wikilinks, syntax
+// highlighting, sanitized raw HTML). Extracted from MarkdownViewer so both the
+// document viewer and notebook markdown/HTML cells render identically. Owns no
+// scroll container or search — callers provide those.
+export function MarkdownContent({
+  content,
+  filePath,
+  workspaceFiles,
+  onOpenWikilink,
+  onTaskToggle,
+  showFrontmatter = true,
+}: MarkdownContentProps) {
+  const katexPlugin = useKatexPlugin(content);
+  const highlightPlugin = useHighlightPlugin(content);
+  const frontmatter = useMemo(
+    () => (showFrontmatter ? parseFrontmatter(content) : null),
+    [content, showFrontmatter],
+  );
+
+  const ImageComponent = useImageComponent(filePath);
+
+  const rehypePlugins: NonNullable<Options["rehypePlugins"]> = useMemo(() => {
+    const plugins: NonNullable<Options["rehypePlugins"]> = [
+      rehypeRaw,
+      [rehypeSanitize, markdownSanitizeSchema],
+      rehypeSlug,
+    ];
+    if (highlightPlugin) plugins.push(highlightPlugin);
+    if (katexPlugin) plugins.push(katexPlugin);
+    return plugins;
+  }, [katexPlugin, highlightPlugin]);
+
+  const remarkPlugins: NonNullable<Options["remarkPlugins"]> = useMemo(
+    () => [
+      remarkFrontmatter,
+      remarkGfm,
+      remarkMath,
+      remarkGemoji,
+      remarkAlert,
+      [remarkWikilink, { workspaceFiles, currentFilePath: filePath }],
+    ],
+    [workspaceFiles, filePath],
+  );
+
+  const LinkWithWikilink = useCallback(
+    (props: LinkComponentProps) => <LinkComponent {...props} onOpenWikilink={onOpenWikilink} />,
+    [onOpenWikilink],
+  );
+
+  const TaskListLi = useCallback(
+    (props: React.ComponentProps<typeof TaskListItem>) => (
+      <TaskListItem {...props} onTaskToggle={onTaskToggle} />
+    ),
+    [onTaskToggle],
+  );
+
+  return (
+    <>
+      {frontmatter && <FrontmatterBlock data={frontmatter} />}
+      <ReactMarkdown
+        remarkPlugins={remarkPlugins}
+        rehypePlugins={rehypePlugins}
+        components={{
+          a: LinkWithWikilink,
+          img: ImageComponent,
+          pre: CodeBlockComponent,
+          li: TaskListLi,
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </>
+  );
+}

--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -1,25 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import ReactMarkdown, { type Options } from "react-markdown";
-import rehypeRaw from "rehype-raw";
-import rehypeSanitize from "rehype-sanitize";
-import rehypeSlug from "rehype-slug";
-import remarkFrontmatter from "remark-frontmatter";
-import remarkGemoji from "remark-gemoji";
-import remarkGfm from "remark-gfm";
-import { remarkAlert } from "remark-github-blockquote-alert";
-import remarkMath from "remark-math";
-import { useHighlightPlugin } from "@/hooks/useHighlightPlugin";
-import { useKatexPlugin } from "@/hooks/useKatexPlugin";
+import { useEffect, useRef } from "react";
 import { useSearch } from "@/hooks/useSearch";
-import { parseFrontmatter } from "@/lib/frontmatter";
-import { remarkWikilink } from "@/lib/wikilink";
 import { SearchBar } from "../layout/SearchBar";
-import { CodeBlockComponent } from "./CodeBlockComponent";
-import { FrontmatterBlock } from "./FrontmatterBlock";
-import { useImageComponent } from "./ImageComponent";
-import { LinkComponent, type LinkComponentProps } from "./LinkComponent";
-import { markdownSanitizeSchema } from "./sanitizeSchema";
-import { TaskListItem } from "./TaskListItem";
+import { MarkdownContent } from "./MarkdownContent";
 
 interface MarkdownViewerProps {
   content: string;
@@ -48,9 +30,6 @@ export function MarkdownViewer({
   const contentRef = useRef<HTMLDivElement>(null);
 
   const search = useSearch({ containerRef: contentRef });
-  const katexPlugin = useKatexPlugin(content);
-  const highlightPlugin = useHighlightPlugin(content);
-  const frontmatter = useMemo(() => parseFrontmatter(content), [content]);
 
   // Restore scroll position on mount
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only — restore once when tab activates
@@ -75,47 +54,10 @@ export function MarkdownViewer({
     return () => el.removeEventListener("scroll", handler);
   }, [onScrollChange]);
 
-  const ImageComponent = useImageComponent(filePath);
-
   const handleSearchClose = () => {
     search.clear();
     onSearchClose();
   };
-
-  const rehypePlugins: NonNullable<Options["rehypePlugins"]> = useMemo(() => {
-    const plugins: NonNullable<Options["rehypePlugins"]> = [
-      rehypeRaw,
-      [rehypeSanitize, markdownSanitizeSchema],
-      rehypeSlug,
-    ];
-    if (highlightPlugin) plugins.push(highlightPlugin);
-    if (katexPlugin) plugins.push(katexPlugin);
-    return plugins;
-  }, [katexPlugin, highlightPlugin]);
-
-  const remarkPlugins: NonNullable<Options["remarkPlugins"]> = useMemo(
-    () => [
-      remarkFrontmatter,
-      remarkGfm,
-      remarkMath,
-      remarkGemoji,
-      remarkAlert,
-      [remarkWikilink, { workspaceFiles, currentFilePath: filePath }],
-    ],
-    [workspaceFiles, filePath],
-  );
-
-  const LinkWithWikilink = useCallback(
-    (props: LinkComponentProps) => <LinkComponent {...props} onOpenWikilink={onOpenWikilink} />,
-    [onOpenWikilink],
-  );
-
-  const TaskListLi = useCallback(
-    (props: React.ComponentProps<typeof TaskListItem>) => (
-      <TaskListItem {...props} onTaskToggle={onTaskToggle} />
-    ),
-    [onTaskToggle],
-  );
 
   return (
     <div className="flex-1 relative min-h-0 min-w-0">
@@ -140,19 +82,13 @@ export function MarkdownViewer({
         style={{ scrollPaddingTop: "16px" }}
       >
         <div ref={contentRef} className="markdown-body px-8 py-6">
-          {frontmatter && <FrontmatterBlock data={frontmatter} />}
-          <ReactMarkdown
-            remarkPlugins={remarkPlugins}
-            rehypePlugins={rehypePlugins}
-            components={{
-              a: LinkWithWikilink,
-              img: ImageComponent,
-              pre: CodeBlockComponent,
-              li: TaskListLi,
-            }}
-          >
-            {content}
-          </ReactMarkdown>
+          <MarkdownContent
+            content={content}
+            filePath={filePath}
+            workspaceFiles={workspaceFiles}
+            onOpenWikilink={onOpenWikilink}
+            onTaskToggle={onTaskToggle}
+          />
         </div>
       </div>
     </div>

--- a/src/components/notebook/AnsiText.test.tsx
+++ b/src/components/notebook/AnsiText.test.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AnsiText } from "./AnsiText";
+
+const ESC = "\x1b";
+
+describe("AnsiText", () => {
+  it("renders plain text inside a pre", () => {
+    const { container } = render(<AnsiText text="hello" />);
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent).toBe("hello");
+  });
+
+  it("applies ANSI colour classes to spans", () => {
+    const { container } = render(<AnsiText text={`${ESC}[31mred${ESC}[0m`} />);
+    const span = container.querySelector("span.ansi-fg-red");
+    expect(span?.textContent).toBe("red");
+  });
+
+  it("passes through the className to the pre element", () => {
+    const { container } = render(<AnsiText text="x" className="nb-output-text" />);
+    expect(container.querySelector("pre")?.className).toBe("nb-output-text");
+  });
+
+  it("applies inline colour styles for 256/truecolour segments", () => {
+    const { container } = render(<AnsiText text={`${ESC}[38;2;10;20;30mrgb`} />);
+    const span = container.querySelector("span") as HTMLElement;
+    expect(span.style.color).toBe("rgb(10, 20, 30)");
+  });
+});

--- a/src/components/notebook/AnsiText.tsx
+++ b/src/components/notebook/AnsiText.tsx
@@ -1,0 +1,35 @@
+import { parseAnsi } from "@/lib/notebook/ansi";
+
+interface AnsiTextProps {
+  text: string;
+  className?: string;
+}
+
+// Render text that may contain ANSI escape codes (stream output, tracebacks)
+// as a <pre> with per-segment styling. Keys are byte offsets, which are stable
+// and unique because segments never reorder.
+export function AnsiText({ text, className }: AnsiTextProps) {
+  const segments = parseAnsi(text);
+  let offset = 0;
+  return (
+    <pre className={className}>
+      {segments.map((seg) => {
+        const key = `${offset}:${seg.text.length}`;
+        offset += seg.text.length;
+        return (
+          <span
+            key={key}
+            className={seg.classes.length > 0 ? seg.classes.join(" ") : undefined}
+            style={
+              seg.style.color || seg.style.backgroundColor
+                ? { color: seg.style.color, backgroundColor: seg.style.backgroundColor }
+                : undefined
+            }
+          >
+            {seg.text}
+          </span>
+        );
+      })}
+    </pre>
+  );
+}

--- a/src/components/notebook/CellOutput.test.tsx
+++ b/src/components/notebook/CellOutput.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { NotebookOutput } from "@/lib/notebook/types";
+import { CellOutput } from "./CellOutput";
+
+describe("CellOutput", () => {
+  it("renders stream text", () => {
+    const out: NotebookOutput = { kind: "stream", name: "stdout", text: "hello\n" };
+    const { container } = render(<CellOutput output={out} />);
+    expect(container.querySelector("pre")?.textContent).toBe("hello\n");
+  });
+
+  it("marks stderr streams with the stderr class", () => {
+    const out: NotebookOutput = { kind: "stream", name: "stderr", text: "oops" };
+    const { container } = render(<CellOutput output={out} />);
+    expect(container.querySelector(".nb-output-stderr")).toBeTruthy();
+  });
+
+  it("renders a base64 PNG image output", () => {
+    const out: NotebookOutput = {
+      kind: "data",
+      executionCount: 1,
+      data: { "image/png": "AAAA" },
+    };
+    const { container } = render(<CellOutput output={out} />);
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("data:image/png;base64,AAAA");
+  });
+
+  it("prefers an image over text when both are present", () => {
+    const out: NotebookOutput = {
+      kind: "data",
+      executionCount: 1,
+      data: { "image/png": "AAAA", "text/plain": "<Figure>" },
+    };
+    const { container } = render(<CellOutput output={out} />);
+    expect(container.querySelector("img")).toBeTruthy();
+    expect(container.textContent).not.toContain("<Figure>");
+  });
+
+  it("renders an error traceback as preformatted text", () => {
+    const out: NotebookOutput = {
+      kind: "error",
+      ename: "ValueError",
+      evalue: "bad",
+      traceback: ["line 1", "ValueError: bad"],
+    };
+    const { container } = render(<CellOutput output={out} />);
+    expect(container.querySelector(".nb-output-error")?.textContent).toContain("ValueError: bad");
+  });
+
+  it("shows a placeholder for unsupported interactive output", () => {
+    const out: NotebookOutput = {
+      kind: "data",
+      executionCount: null,
+      data: { "application/vnd.plotly.v1+json": "{}" },
+    };
+    render(<CellOutput output={out} />);
+    expect(screen.getByText(/not supported yet/i)).toBeInTheDocument();
+  });
+
+  it("renders plain text output", () => {
+    const out: NotebookOutput = {
+      kind: "data",
+      executionCount: 2,
+      data: { "text/plain": "42" },
+    };
+    const { container } = render(<CellOutput output={out} />);
+    expect(container.textContent).toContain("42");
+  });
+
+  it("renders an SVG image output via a data URL", () => {
+    const out: NotebookOutput = {
+      kind: "data",
+      executionCount: null,
+      data: { "image/svg+xml": "<svg></svg>" },
+    };
+    const { container } = render(<CellOutput output={out} />);
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toContain("data:image/svg+xml;utf8,");
+    expect(img?.getAttribute("src")).toContain(encodeURIComponent("<svg></svg>"));
+  });
+
+  it("renders sanitized HTML output", () => {
+    const out: NotebookOutput = {
+      kind: "data",
+      executionCount: 1,
+      data: { "text/html": "<strong>bold</strong>" },
+    };
+    const { container } = render(<CellOutput output={out} />);
+    expect(container.querySelector(".nb-output-html")).toBeTruthy();
+    expect(container.querySelector("strong")?.textContent).toBe("bold");
+  });
+
+  it("renders markdown output through the markdown pipeline", () => {
+    const out: NotebookOutput = {
+      kind: "data",
+      executionCount: 1,
+      data: { "text/markdown": "# heading" },
+    };
+    const { container } = render(<CellOutput output={out} />);
+    expect(container.querySelector(".nb-output-markdown")).toBeTruthy();
+    expect(container.querySelector("h1")?.textContent).toBe("heading");
+  });
+
+  it("shows a generic placeholder for an unsupported non-interactive type", () => {
+    const out: NotebookOutput = {
+      kind: "data",
+      executionCount: null,
+      data: { "application/json": "{}" },
+    };
+    render(<CellOutput output={out} />);
+    expect(screen.getByText(/unsupported output/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/notebook/CellOutput.test.tsx
+++ b/src/components/notebook/CellOutput.test.tsx
@@ -49,6 +49,17 @@ describe("CellOutput", () => {
     expect(container.querySelector(".nb-output-error")?.textContent).toContain("ValueError: bad");
   });
 
+  it("falls back to ename: evalue when the traceback is empty", () => {
+    const out: NotebookOutput = {
+      kind: "error",
+      ename: "KeyError",
+      evalue: "'missing'",
+      traceback: [],
+    };
+    const { container } = render(<CellOutput output={out} />);
+    expect(container.querySelector(".nb-output-error")?.textContent).toBe("KeyError: 'missing'");
+  });
+
   it("shows a placeholder for unsupported interactive output", () => {
     const out: NotebookOutput = {
       kind: "data",

--- a/src/components/notebook/CellOutput.tsx
+++ b/src/components/notebook/CellOutput.tsx
@@ -1,0 +1,85 @@
+import type { DataOutput, NotebookOutput } from "@/lib/notebook/types";
+import { MarkdownContent } from "../markdown/MarkdownContent";
+import { AnsiText } from "./AnsiText";
+
+// MIME types we render, in order of preference. The richest representation an
+// output carries wins; anything past `text/plain` we don't yet handle (Plotly,
+// Vega, Jupyter widgets) falls through to a placeholder.
+const IMAGE_MIMES = ["image/png", "image/jpeg"] as const;
+
+function pickRichest(data: Record<string, string>): string | null {
+  for (const mime of IMAGE_MIMES) if (mime in data) return mime;
+  if ("image/svg+xml" in data) return "image/svg+xml";
+  if ("text/html" in data) return "text/html";
+  if ("text/markdown" in data) return "text/markdown";
+  if ("text/plain" in data) return "text/plain";
+  return null;
+}
+
+function DataOutputView({ output, filePath }: { output: DataOutput; filePath?: string }) {
+  const mime = pickRichest(output.data);
+  if (!mime) {
+    const interactive = Object.keys(output.data).find(
+      (m) => m.startsWith("application/") && m !== "application/json",
+    );
+    return (
+      <div className="nb-output-unsupported">
+        {interactive
+          ? `Interactive output (${interactive}) is not supported yet`
+          : "Unsupported output"}
+      </div>
+    );
+  }
+
+  const payload = output.data[mime];
+
+  if (mime === "image/png" || mime === "image/jpeg") {
+    return <img className="nb-output-image" src={`data:${mime};base64,${payload}`} alt="output" />;
+  }
+  if (mime === "image/svg+xml") {
+    // Render via a data URL so the SVG can't execute embedded scripts.
+    const src = `data:image/svg+xml;utf8,${encodeURIComponent(payload)}`;
+    return <img className="nb-output-image" src={src} alt="output" />;
+  }
+  if (mime === "text/html") {
+    // MarkdownContent runs rehype-raw + the shared sanitizer, so embedded HTML
+    // is cleaned the same way it is everywhere else in the app.
+    return (
+      <div className="markdown-body nb-output-html">
+        <MarkdownContent content={payload} filePath={filePath} showFrontmatter={false} />
+      </div>
+    );
+  }
+  if (mime === "text/markdown") {
+    return (
+      <div className="markdown-body nb-output-markdown">
+        <MarkdownContent content={payload} filePath={filePath} showFrontmatter={false} />
+      </div>
+    );
+  }
+  return <AnsiText className="nb-output-text" text={payload} />;
+}
+
+interface CellOutputProps {
+  output: NotebookOutput;
+  filePath?: string;
+}
+
+export function CellOutput({ output, filePath }: CellOutputProps) {
+  if (output.kind === "stream") {
+    return (
+      <AnsiText
+        className={`nb-output-text${output.name === "stderr" ? " nb-output-stderr" : ""}`}
+        text={output.text}
+      />
+    );
+  }
+  if (output.kind === "error") {
+    const text =
+      output.traceback.length > 0
+        ? output.traceback.join("\n")
+        : `${output.ename}: ${output.evalue}`;
+    return <AnsiText className="nb-output-text nb-output-error" text={text} />;
+  }
+  return <DataOutputView output={output} filePath={filePath} />;
+}

--- a/src/components/notebook/NotebookCell.tsx
+++ b/src/components/notebook/NotebookCell.tsx
@@ -1,0 +1,78 @@
+import { fenceCode } from "@/lib/notebook/fence";
+import type { NotebookCell as Cell, NotebookOutput } from "@/lib/notebook/types";
+import { MarkdownContent } from "../markdown/MarkdownContent";
+import { CellOutput } from "./CellOutput";
+
+/**
+ * Build a stable, unique React key for an output from its content plus an
+ * occurrence counter, so repeated identical outputs (e.g. two stdout streams)
+ * still get distinct keys without using the array index.
+ */
+function makeOutputKeyer() {
+  const seen = new Map<string, number>();
+  return (output: NotebookOutput): string => {
+    const base =
+      output.kind === "stream"
+        ? `stream:${output.name}`
+        : output.kind === "error"
+          ? `error:${output.ename}`
+          : `data:${Object.keys(output.data).sort().join(",")}`;
+    const ordinal = seen.get(base) ?? 0;
+    seen.set(base, ordinal + 1);
+    return `${base}#${ordinal}`;
+  };
+}
+
+function promptLabel(prefix: string, count: number | null): string {
+  return `${prefix} [${count ?? " "}]:`;
+}
+
+interface NotebookCellProps {
+  cell: Cell;
+  language: string;
+  filePath?: string;
+}
+
+export function NotebookCell({ cell, language, filePath }: NotebookCellProps) {
+  if (cell.type === "markdown") {
+    return (
+      <div className="nb-cell nb-cell-markdown markdown-body">
+        <MarkdownContent content={cell.source} filePath={filePath} showFrontmatter={false} />
+      </div>
+    );
+  }
+
+  if (cell.type === "raw") {
+    return (
+      <div className="nb-cell nb-cell-raw">
+        <pre className="nb-raw">{cell.source}</pre>
+      </div>
+    );
+  }
+
+  // Code cell: input row with `In [n]:` prompt, then one row per output.
+  const outputKey = makeOutputKeyer();
+  return (
+    <div className="nb-cell nb-cell-code">
+      <div className="nb-row">
+        <div className="nb-prompt nb-prompt-in">{promptLabel("In", cell.executionCount)}</div>
+        <div className="nb-row-body markdown-body nb-code-source">
+          <MarkdownContent content={fenceCode(cell.source, language)} showFrontmatter={false} />
+        </div>
+      </div>
+      {cell.outputs.map((output) => {
+        const outCount = output.kind === "data" ? output.executionCount : null;
+        return (
+          <div className="nb-row nb-output-row" key={outputKey(output)}>
+            <div className="nb-prompt nb-prompt-out">
+              {outCount != null ? promptLabel("Out", outCount) : ""}
+            </div>
+            <div className="nb-row-body">
+              <CellOutput output={output} filePath={filePath} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/notebook/NotebookSource.test.tsx
+++ b/src/components/notebook/NotebookSource.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NotebookSource } from "./NotebookSource";
+
+const props = { searchOpen: false, onSearchClose: () => {} };
+
+describe("NotebookSource", () => {
+  it("renders the raw JSON inside a code block", () => {
+    const json = '{"cells": [], "nbformat": 4}';
+    const { container } = render(<NotebookSource content={json} {...props} />);
+    // The JSON is fenced and rendered as a <code> block by the markdown viewer.
+    const code = container.querySelector("code");
+    expect(code?.textContent).toContain('"nbformat": 4');
+  });
+
+  it("shows the read-only banner", () => {
+    render(<NotebookSource content="{}" {...props} />);
+    expect(screen.getByText(/read-only source view/i)).toBeInTheDocument();
+  });
+
+  it("does not render an editable textarea", () => {
+    const { container } = render(<NotebookSource content="{}" {...props} />);
+    expect(container.querySelector("textarea")).toBeNull();
+    expect(container.querySelector('[contenteditable="true"]')).toBeNull();
+  });
+});

--- a/src/components/notebook/NotebookSource.tsx
+++ b/src/components/notebook/NotebookSource.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from "react";
+import { fenceCode } from "@/lib/notebook/fence";
+import { MarkdownViewer } from "../markdown/MarkdownViewer";
+
+interface NotebookSourceProps {
+  /** Raw `.ipynb` JSON text. */
+  content: string;
+  filePath?: string;
+  initialScrollTop?: number;
+  onScrollChange?: (scrollTop: number) => void;
+  searchOpen: boolean;
+  onSearchClose: () => void;
+  /**
+   * Banner text shown above the source. Defaults to the standalone "read-only"
+   * note; the split view passes a shorter pane label since the rendered pane
+   * beside it already makes the read-only intent obvious. Pass `null` to hide.
+   */
+  banner?: string | null;
+}
+
+const DEFAULT_BANNER = "Read-only source view — notebooks can't be edited in Glyph.";
+
+// Read-only view of a notebook's raw `.ipynb` JSON, shown when a notebook tab
+// is switched into edit/split mode. Notebooks are not editable in Glyph (see
+// the issue's read-only scope), so rather than dropping the JSON into the
+// markdown editor — which would let autosave write malformed content back and
+// corrupt the file — we render it as a syntax-highlighted JSON code block
+// through the standard viewer. That reuses highlighting, the copy button, and
+// in-document search for free, with no write path.
+export function NotebookSource({
+  content,
+  filePath,
+  initialScrollTop,
+  onScrollChange,
+  searchOpen,
+  onSearchClose,
+  banner = DEFAULT_BANNER,
+}: NotebookSourceProps) {
+  const fenced = useMemo(() => fenceCode(content, "json"), [content]);
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 min-w-0">
+      {banner !== null && (
+        <div className="nb-source-banner" data-print-hide="true">
+          {banner}
+        </div>
+      )}
+      <MarkdownViewer
+        content={fenced}
+        filePath={filePath}
+        initialScrollTop={initialScrollTop}
+        onScrollChange={onScrollChange}
+        searchOpen={searchOpen}
+        onSearchClose={onSearchClose}
+      />
+    </div>
+  );
+}

--- a/src/components/notebook/NotebookSplit.test.tsx
+++ b/src/components/notebook/NotebookSplit.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NotebookSplit } from "./NotebookSplit";
+
+function notebook(cells: unknown[]): string {
+  return JSON.stringify({ nbformat: 4, nbformat_minor: 5, cells });
+}
+
+const props = { searchOpen: false, onSearchClose: () => {} };
+
+describe("NotebookSplit", () => {
+  it("renders both the JSON source pane and the rendered cell pane", () => {
+    const content = notebook([{ cell_type: "markdown", source: "# Heading" }]);
+    const { container } = render(<NotebookSplit content={content} {...props} />);
+
+    // Source pane: raw JSON in a code block.
+    const code = container.querySelector(".split-view-editor code");
+    expect(code?.textContent).toContain('"cell_type"');
+
+    // Rendered pane: the markdown heading.
+    const heading = container.querySelector(".split-view-preview h1");
+    expect(heading?.textContent).toBe("Heading");
+  });
+
+  it("labels the source pane and does not show an editable field", () => {
+    const { container } = render(<NotebookSplit content={notebook([])} {...props} />);
+    expect(screen.getByText("Source (read-only)")).toBeInTheDocument();
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+});

--- a/src/components/notebook/NotebookSplit.tsx
+++ b/src/components/notebook/NotebookSplit.tsx
@@ -1,0 +1,50 @@
+import { NotebookSource } from "./NotebookSource";
+import { NotebookViewer } from "./NotebookViewer";
+
+interface NotebookSplitProps {
+  /** Raw `.ipynb` JSON text. */
+  content: string;
+  filePath?: string;
+  initialScrollTop?: number;
+  onScrollChange?: (scrollTop: number) => void;
+  searchOpen: boolean;
+  onSearchClose: () => void;
+}
+
+// Split view for a notebook: raw `.ipynb` JSON on the left, rendered cells on
+// the right — both read-only (notebooks can't be edited in Glyph). Mirrors the
+// markdown SplitView's source-left / rendered-right layout so the toggle feels
+// consistent. Search and scroll tracking attach to the rendered pane, which is
+// the primary content; the JSON pane scrolls independently.
+export function NotebookSplit({
+  content,
+  filePath,
+  initialScrollTop,
+  onScrollChange,
+  searchOpen,
+  onSearchClose,
+}: NotebookSplitProps) {
+  return (
+    <div className="split-view flex h-full w-full">
+      <div className="split-view-editor flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-r border-[var(--color-border)]">
+        <NotebookSource
+          content={content}
+          filePath={filePath}
+          searchOpen={false}
+          onSearchClose={onSearchClose}
+          banner="Source (read-only)"
+        />
+      </div>
+      <div className="split-view-preview flex flex-1 min-w-0 min-h-0 overflow-hidden">
+        <NotebookViewer
+          content={content}
+          filePath={filePath}
+          initialScrollTop={initialScrollTop}
+          onScrollChange={onScrollChange}
+          searchOpen={searchOpen}
+          onSearchClose={onSearchClose}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/notebook/NotebookViewer.test.tsx
+++ b/src/components/notebook/NotebookViewer.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { NotebookViewer } from "./NotebookViewer";
 
 function notebook(cells: unknown[], metadata?: unknown): string {
@@ -62,5 +62,75 @@ describe("NotebookViewer", () => {
     ]);
     const { container } = render(<NotebookViewer content={content} {...viewerProps} />);
     expect(container.querySelector(".ansi-fg-green")?.textContent).toBe("green");
+  });
+
+  it("renders a code cell with mixed outputs and a cleared execution count", () => {
+    // Exercises the output-keyer's stream/error/data arms in one cell, plus the
+    // `In [ ]:` prompt when execution_count is null.
+    const content = notebook([
+      {
+        cell_type: "code",
+        execution_count: null,
+        source: "work()",
+        outputs: [
+          { output_type: "stream", name: "stdout", text: "log\n" },
+          { output_type: "error", ename: "E", evalue: "v", traceback: ["E: v"] },
+          { output_type: "execute_result", data: { "text/plain": "result" } },
+        ],
+      },
+    ]);
+    const { container } = render(<NotebookViewer content={content} {...viewerProps} />);
+    expect(container.querySelector(".nb-prompt-in")?.textContent).toBe("In [ ]:");
+    expect(container.querySelectorAll(".nb-output-row").length).toBe(3);
+  });
+
+  it("restores the initial scroll position on mount", () => {
+    const raf = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+    const { container } = render(
+      <NotebookViewer
+        content={notebook([{ cell_type: "markdown", source: "x" }])}
+        initialScrollTop={120}
+        {...viewerProps}
+      />,
+    );
+    const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
+    expect(scroller.scrollTop).toBe(120);
+    raf.mockRestore();
+  });
+
+  it("reports scroll position changes to onScrollChange", () => {
+    const onScrollChange = vi.fn();
+    const { container } = render(
+      <NotebookViewer
+        content={notebook([{ cell_type: "markdown", source: "x" }])}
+        onScrollChange={onScrollChange}
+        {...viewerProps}
+      />,
+    );
+    const scroller = container.querySelector(".overflow-y-auto") as HTMLElement;
+    Object.defineProperty(scroller, "scrollTop", { value: 42, configurable: true });
+    fireEvent.scroll(scroller);
+    expect(onScrollChange).toHaveBeenCalledWith(42);
+  });
+
+  it("renders the search bar when searchOpen and closes it", () => {
+    const onSearchClose = vi.fn();
+    render(
+      <NotebookViewer
+        content={notebook([{ cell_type: "markdown", source: "findme" }])}
+        searchOpen
+        onSearchClose={onSearchClose}
+      />,
+    );
+    const closeBtn = screen.getByRole("button", { name: /close/i });
+    act(() => {
+      closeBtn.click();
+    });
+    expect(onSearchClose).toHaveBeenCalled();
   });
 });

--- a/src/components/notebook/NotebookViewer.test.tsx
+++ b/src/components/notebook/NotebookViewer.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NotebookViewer } from "./NotebookViewer";
+
+function notebook(cells: unknown[], metadata?: unknown): string {
+  return JSON.stringify({ nbformat: 4, nbformat_minor: 5, metadata, cells });
+}
+
+const viewerProps = {
+  searchOpen: false,
+  onSearchClose: () => {},
+};
+
+describe("NotebookViewer", () => {
+  it("renders a markdown cell's content", () => {
+    const content = notebook([{ cell_type: "markdown", source: "# Hello\n\nbody text" }]);
+    render(<NotebookViewer content={content} {...viewerProps} />);
+    expect(screen.getByRole("heading", { name: "Hello" })).toBeInTheDocument();
+    expect(screen.getByText("body text")).toBeInTheDocument();
+  });
+
+  it("shows In/Out prompts for a code cell with output", () => {
+    const content = notebook([
+      {
+        cell_type: "code",
+        execution_count: 5,
+        source: "1 + 1",
+        outputs: [
+          { output_type: "execute_result", execution_count: 5, data: { "text/plain": "2" } },
+        ],
+      },
+    ]);
+    const { container } = render(<NotebookViewer content={content} {...viewerProps} />);
+    expect(container.querySelector(".nb-prompt-in")?.textContent).toBe("In [5]:");
+    expect(container.querySelector(".nb-prompt-out")?.textContent).toBe("Out [5]:");
+  });
+
+  it("renders a raw cell verbatim", () => {
+    const content = notebook([{ cell_type: "raw", source: "raw <not> parsed" }]);
+    const { container } = render(<NotebookViewer content={content} {...viewerProps} />);
+    const raw = container.querySelector(".nb-raw");
+    expect(raw?.textContent).toBe("raw <not> parsed");
+  });
+
+  it("renders an empty-state message when there are no cells", () => {
+    render(<NotebookViewer content={notebook([])} {...viewerProps} />);
+    expect(screen.getByText(/no cells/i)).toBeInTheDocument();
+  });
+
+  it("renders an error state for invalid notebook JSON", () => {
+    render(<NotebookViewer content="{not valid" {...viewerProps} />);
+    expect(screen.getByText(/couldn't render this notebook/i)).toBeInTheDocument();
+  });
+
+  it("colourises ANSI in stream output", () => {
+    const content = notebook([
+      {
+        cell_type: "code",
+        source: "print('x')",
+        outputs: [{ output_type: "stream", name: "stdout", text: "\x1b[32mgreen\x1b[0m" }],
+      },
+    ]);
+    const { container } = render(<NotebookViewer content={content} {...viewerProps} />);
+    expect(container.querySelector(".ansi-fg-green")?.textContent).toBe("green");
+  });
+});

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -43,6 +43,9 @@ export function NotebookViewer({
     } catch (err) {
       return {
         notebook: null,
+        // parseNotebook only throws NotebookParseError; the String(err) arm is a
+        // defensive fallback for any unexpected throw.
+        /* c8 ignore next */
         error: err instanceof NotebookParseError ? err.message : String(err),
       };
     }
@@ -74,6 +77,30 @@ export function NotebookViewer({
 
   const cellKey = makeCellKeyer();
 
+  const renderBody = () => {
+    if (parsed.error) {
+      return (
+        <div className="nb-error-state">
+          <p className="nb-error-title">Couldn't render this notebook</p>
+          <p className="nb-error-detail">{parsed.error}</p>
+        </div>
+      );
+    }
+    // On the non-error path the parser always returns a notebook.
+    const notebook = parsed.notebook as NonNullable<typeof parsed.notebook>;
+    if (notebook.cells.length === 0) {
+      return <div className="nb-empty-state">This notebook has no cells.</div>;
+    }
+    return notebook.cells.map((cell) => (
+      <NotebookCell
+        key={cellKey(cell.type)}
+        cell={cell}
+        language={notebook.languageHint}
+        filePath={filePath}
+      />
+    ));
+  };
+
   return (
     <div className="flex-1 relative min-h-0 min-w-0">
       {searchOpen && (
@@ -93,23 +120,7 @@ export function NotebookViewer({
         style={{ scrollPaddingTop: "16px" }}
       >
         <div ref={contentRef} className="notebook-body px-8 py-6">
-          {parsed.error ? (
-            <div className="nb-error-state">
-              <p className="nb-error-title">Couldn't render this notebook</p>
-              <p className="nb-error-detail">{parsed.error}</p>
-            </div>
-          ) : parsed.notebook && parsed.notebook.cells.length === 0 ? (
-            <div className="nb-empty-state">This notebook has no cells.</div>
-          ) : (
-            parsed.notebook?.cells.map((cell) => (
-              <NotebookCell
-                key={cellKey(cell.type)}
-                cell={cell}
-                language={parsed.notebook?.languageHint ?? "python"}
-                filePath={filePath}
-              />
-            ))
-          )}
+          {renderBody()}
         </div>
       </div>
     </div>

--- a/src/components/notebook/NotebookViewer.tsx
+++ b/src/components/notebook/NotebookViewer.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useSearch } from "@/hooks/useSearch";
+import { parseNotebook } from "@/lib/notebook/parseNotebook";
+import { NotebookParseError } from "@/lib/notebook/types";
+import { SearchBar } from "../layout/SearchBar";
+import { NotebookCell } from "./NotebookCell";
+
+interface NotebookViewerProps {
+  /** Raw `.ipynb` JSON text. */
+  content: string;
+  filePath?: string;
+  initialScrollTop?: number;
+  onScrollChange?: (scrollTop: number) => void;
+  searchOpen: boolean;
+  onSearchClose: () => void;
+}
+
+/** Stable, unique keys for cells without relying on the array index. */
+function makeCellKeyer() {
+  const seen = new Map<string, number>();
+  return (type: string): string => {
+    const ordinal = seen.get(type) ?? 0;
+    seen.set(type, ordinal + 1);
+    return `${type}#${ordinal}`;
+  };
+}
+
+export function NotebookViewer({
+  content,
+  filePath,
+  initialScrollTop = 0,
+  onScrollChange,
+  searchOpen,
+  onSearchClose,
+}: NotebookViewerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const search = useSearch({ containerRef: contentRef });
+
+  const parsed = useMemo(() => {
+    try {
+      return { notebook: parseNotebook(content), error: null as string | null };
+    } catch (err) {
+      return {
+        notebook: null,
+        error: err instanceof NotebookParseError ? err.message : String(err),
+      };
+    }
+  }, [content]);
+
+  // Restore scroll position on mount
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only — restore once when tab activates
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && initialScrollTop > 0) {
+      requestAnimationFrame(() => {
+        el.scrollTop = initialScrollTop;
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !onScrollChange) return;
+    const handler = () => onScrollChange(el.scrollTop);
+    el.addEventListener("scroll", handler, { passive: true });
+    return () => el.removeEventListener("scroll", handler);
+  }, [onScrollChange]);
+
+  const handleSearchClose = () => {
+    search.clear();
+    onSearchClose();
+  };
+
+  const cellKey = makeCellKeyer();
+
+  return (
+    <div className="flex-1 relative min-h-0 min-w-0">
+      {searchOpen && (
+        <SearchBar
+          query={search.query}
+          onQueryChange={search.setQuery}
+          matchCount={search.matchCount}
+          currentMatch={search.currentMatch}
+          onNext={search.nextMatch}
+          onPrev={search.prevMatch}
+          onClose={handleSearchClose}
+        />
+      )}
+      <div
+        ref={scrollRef}
+        className="absolute inset-0 overflow-y-auto"
+        style={{ scrollPaddingTop: "16px" }}
+      >
+        <div ref={contentRef} className="notebook-body px-8 py-6">
+          {parsed.error ? (
+            <div className="nb-error-state">
+              <p className="nb-error-title">Couldn't render this notebook</p>
+              <p className="nb-error-detail">{parsed.error}</p>
+            </div>
+          ) : parsed.notebook && parsed.notebook.cells.length === 0 ? (
+            <div className="nb-empty-state">This notebook has no cells.</div>
+          ) : (
+            parsed.notebook?.cells.map((cell) => (
+              <NotebookCell
+                key={cellKey(cell.type)}
+                cell={cell}
+                language={parsed.notebook?.languageHint ?? "python"}
+                filePath={filePath}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/notebook/lazyNotebook.test.tsx
+++ b/src/components/notebook/lazyNotebook.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { NotebookSource, NotebookSplit, NotebookViewer } from "./lazyNotebook";
+
+const notebook = JSON.stringify({
+  nbformat: 4,
+  cells: [{ cell_type: "markdown", source: "lazy heading" }],
+});
+
+const props = { searchOpen: false as const, onSearchClose: () => {} };
+
+// These thin Suspense wrappers code-split the notebook renderer into its own
+// chunk. The dynamic import resolves asynchronously, so each test waits for the
+// real component to appear, which exercises both the fallback and resolved paths.
+describe("lazyNotebook", () => {
+  it("lazily renders the NotebookViewer", async () => {
+    render(<NotebookViewer content={notebook} {...props} />);
+    await waitFor(() => expect(screen.getByText("lazy heading")).toBeInTheDocument(), {
+      timeout: 5000,
+    });
+  });
+
+  it("lazily renders the NotebookSource", async () => {
+    const { container } = render(<NotebookSource content={notebook} {...props} />);
+    await waitFor(() => expect(container.querySelector("code")).toBeTruthy(), { timeout: 5000 });
+  });
+
+  it("lazily renders the NotebookSplit", async () => {
+    const { container } = render(<NotebookSplit content={notebook} {...props} />);
+    await waitFor(() => expect(container.querySelector(".split-view")).toBeTruthy(), {
+      timeout: 5000,
+    });
+  });
+});

--- a/src/components/notebook/lazyNotebook.tsx
+++ b/src/components/notebook/lazyNotebook.tsx
@@ -1,0 +1,40 @@
+import { type ComponentProps, lazy, Suspense } from "react";
+
+// The notebook renderer is only needed when a `.ipynb` file is open, so it (and
+// its cell/output/ANSI helpers) is code-split into its own async chunk and
+// pulled in on demand — keeping it out of the main bundle.
+const NotebookViewerLazy = lazy(() =>
+  import("./NotebookViewer").then((m) => ({ default: m.NotebookViewer })),
+);
+
+const NotebookSourceLazy = lazy(() =>
+  import("./NotebookSource").then((m) => ({ default: m.NotebookSource })),
+);
+
+const NotebookSplitLazy = lazy(() =>
+  import("./NotebookSplit").then((m) => ({ default: m.NotebookSplit })),
+);
+
+export function NotebookViewer(props: ComponentProps<typeof NotebookViewerLazy>) {
+  return (
+    <Suspense fallback={null}>
+      <NotebookViewerLazy {...props} />
+    </Suspense>
+  );
+}
+
+export function NotebookSource(props: ComponentProps<typeof NotebookSourceLazy>) {
+  return (
+    <Suspense fallback={null}>
+      <NotebookSourceLazy {...props} />
+    </Suspense>
+  );
+}
+
+export function NotebookSplit(props: ComponentProps<typeof NotebookSplitLazy>) {
+  return (
+    <Suspense fallback={null}>
+      <NotebookSplitLazy {...props} />
+    </Suspense>
+  );
+}

--- a/src/contexts/TabsContext.test.tsx
+++ b/src/contexts/TabsContext.test.tsx
@@ -1,9 +1,35 @@
 import { invoke } from "@tauri-apps/api/core";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
 import { TabsProvider, useTabsContext } from "./TabsContext";
+
+// Mock invoke so opening a file resolves with content/metadata. `read_file`
+// echoes a marker derived from the path so we can assert which file is active.
+function mockInvokeOpening(content: string) {
+  vi.mocked(invoke).mockImplementation(((cmd: string, args?: Record<string, unknown>) => {
+    switch (cmd) {
+      case "get_initial_folder":
+      case "get_initial_file":
+        return Promise.resolve(null);
+      case "read_file":
+        return Promise.resolve(content);
+      case "get_file_metadata":
+        return Promise.resolve({
+          name:
+            String(args?.path ?? "")
+              .split("/")
+              .pop() ?? "",
+          path: String(args?.path ?? ""),
+          size: 0,
+          modified: 0,
+        });
+      default:
+        return Promise.resolve(undefined);
+    }
+  }) as unknown as typeof invoke);
+}
 
 beforeEach(() => {
   vi.mocked(invoke).mockReset();
@@ -32,6 +58,45 @@ describe("TabsProvider", () => {
 
   it("throws a clear error when the hook is used outside the provider", () => {
     expect(() => renderHook(() => useTabsContext())).toThrow(/TabsProvider/);
+  });
+
+  it("suppresses displayContent for a notebook (raw JSON is never the body)", async () => {
+    mockInvokeOpening('{"cells": []}');
+    const { result } = renderHook(() => useTabsContext(), { wrapper: wrap() });
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/work/analysis.ipynb");
+    });
+    expect(result.current.activeFile?.path).toBe("/work/analysis.ipynb");
+    // Even though the file has content, displayContent is null for notebooks.
+    expect(result.current.displayContent).toBeNull();
+  });
+
+  it("derives displayContent from editContent in edit mode for markdown", async () => {
+    mockInvokeOpening("# saved");
+    const { result } = renderHook(() => useTabsContext(), { wrapper: wrap() });
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/work/notes.md");
+    });
+    const id = result.current.activeTabId as string;
+    // View mode → displayContent is the saved content.
+    expect(result.current.displayContent).toBe("# saved");
+
+    await act(async () => {
+      result.current.setTabMode(id, "edit");
+    });
+    // Entering edit mode seeds editContent from content; before any typing the
+    // `editContent ?? content` fallback resolves to the saved content.
+    expect(result.current.displayContent).toBe("# saved");
+
+    await act(async () => {
+      result.current.updateEditContent(id, "# editing");
+    });
+    // After typing, displayContent reflects the in-memory editContent.
+    expect(result.current.displayContent).toBe("# editing");
   });
 
   it("opens the file returned by get_initial_file (CLI path) on mount", async () => {

--- a/src/contexts/TabsContext.tsx
+++ b/src/contexts/TabsContext.tsx
@@ -3,7 +3,7 @@ import { type TocEntry, useTableOfContents } from "@/hooks/useTableOfContents";
 import { useTabs } from "@/hooks/useTabs";
 import { type Backlink, filterBacklinks } from "@/lib/backlinks";
 import { isNotebookFile } from "@/lib/notebookExtensions";
-import type { Settings } from "@/lib/settings";
+import { EDITOR_MODE, type Settings } from "@/lib/settings";
 
 type TabsApi = ReturnType<typeof useTabs>;
 
@@ -34,7 +34,7 @@ export function TabsProvider({ settings, updateSettings, children }: TabsProvide
     onSettingsChange: updateSettings,
   });
 
-  const activeMode = tabs.activeFile?.mode ?? "view";
+  const activeMode = tabs.activeFile?.mode ?? EDITOR_MODE.view;
   const content = tabs.activeFile?.content ?? null;
   const activePath = tabs.activeFile?.path;
   // A notebook never has a markdown body — view mode shows the rich cell
@@ -45,7 +45,7 @@ export function TabsProvider({ settings, updateSettings, children }: TabsProvide
   const isNotebook = !!activePath && isNotebookFile(activePath);
   const displayContent = isNotebook
     ? null
-    : activeMode !== "view"
+    : activeMode !== EDITOR_MODE.view
       ? // editContent is seeded when entering edit mode, so the `?? content`
         // fallback is defensive only.
         /* c8 ignore next */

--- a/src/contexts/TabsContext.tsx
+++ b/src/contexts/TabsContext.tsx
@@ -2,6 +2,7 @@ import { createContext, type ReactNode, useContext, useMemo } from "react";
 import { type TocEntry, useTableOfContents } from "@/hooks/useTableOfContents";
 import { useTabs } from "@/hooks/useTabs";
 import { type Backlink, filterBacklinks } from "@/lib/backlinks";
+import { isNotebookFile } from "@/lib/notebookExtensions";
 import type { Settings } from "@/lib/settings";
 
 type TabsApi = ReturnType<typeof useTabs>;
@@ -35,8 +36,18 @@ export function TabsProvider({ settings, updateSettings, children }: TabsProvide
 
   const activeMode = tabs.activeFile?.mode ?? "view";
   const content = tabs.activeFile?.content ?? null;
-  const displayContent =
-    activeMode !== "view" ? (tabs.activeFile?.editContent ?? content) : content;
+  const activePath = tabs.activeFile?.path;
+  // A notebook never has a markdown body — view mode shows the rich cell
+  // viewer, edit/split shows the raw `.ipynb` JSON read-only. Either way the
+  // features that read `displayContent` (word count, TOC, AI, read-aloud) would
+  // be chewing on raw JSON, which is worse than nothing. Suppress it in every
+  // mode so a notebook is never mistaken for editable markdown text.
+  const isNotebook = !!activePath && isNotebookFile(activePath);
+  const displayContent = isNotebook
+    ? null
+    : activeMode !== "view"
+      ? (tabs.activeFile?.editContent ?? content)
+      : content;
 
   const tocEntries = useTableOfContents(displayContent);
   const backlinks = useMemo(

--- a/src/contexts/TabsContext.tsx
+++ b/src/contexts/TabsContext.tsx
@@ -46,7 +46,10 @@ export function TabsProvider({ settings, updateSettings, children }: TabsProvide
   const displayContent = isNotebook
     ? null
     : activeMode !== "view"
-      ? (tabs.activeFile?.editContent ?? content)
+      ? // editContent is seeded when entering edit mode, so the `?? content`
+        // fallback is defensive only.
+        /* c8 ignore next */
+        (tabs.activeFile?.editContent ?? content)
       : content;
 
   const tocEntries = useTableOfContents(displayContent);

--- a/src/hooks/useTabs.test.tsx
+++ b/src/hooks/useTabs.test.tsx
@@ -348,6 +348,34 @@ describe("useTabs file operations", () => {
     }
   });
 
+  it("setTabMode preserves editContent when switching between non-view modes", async () => {
+    // Covers the branch where mode !== view but editContent is already set, so
+    // the first-time seeding is skipped and the existing edit buffer survives.
+    const { result } = renderHook(() => useTabs(defaultOptions()));
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/p/a.md");
+    });
+    const tabId = result.current.tabs[0].id;
+
+    act(() => {
+      result.current.setTabMode(tabId, "edit");
+    });
+    act(() => {
+      result.current.updateEditContent(tabId, "TYPED");
+    });
+    act(() => {
+      result.current.setTabMode(tabId, "split");
+    });
+
+    if (result.current.tabs[0].kind === "file") {
+      expect(result.current.tabs[0].file.mode).toBe("split");
+      // editContent is not re-seeded from content; the typed buffer is kept.
+      expect(result.current.tabs[0].file.editContent).toBe("TYPED");
+    }
+  });
+
   it("updateEditContent marks the file dirty and markSaved clears it", async () => {
     const { result } = renderHook(() => useTabs(defaultOptions()));
     await waitFor(() => expect(result.current.initializing).toBe(false));
@@ -519,6 +547,44 @@ describe("useTabs file operations", () => {
       await result.current.undoEdit(tabId);
     });
     expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("skips an external reload while the file is dirty in edit mode", async () => {
+    // Covers the guard that protects unsaved edits: a file-changed event must
+    // not overwrite the in-memory editContent when the tab is dirty.
+    let body = "original";
+    const fileChanged = captureListener("file-changed");
+    vi.mocked(invoke).mockImplementation(
+      makeInvoker({ read_file: async () => body }) as typeof invoke,
+    );
+
+    const { result } = renderHook(() => useTabs(defaultOptions({ autoReload: true })));
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/p/a.md");
+    });
+    const tabId = result.current.tabs[0].id;
+
+    act(() => {
+      result.current.setTabMode(tabId, "edit");
+    });
+    act(() => {
+      result.current.updateEditContent(tabId, "unsaved work");
+    });
+
+    body = "EXTERNAL CHANGE";
+    await act(async () => {
+      fileChanged.handler?.({ payload: "/p/a.md" });
+      await new Promise((r) => setTimeout(r, 350));
+    });
+
+    // The dirty edit buffer is preserved; the external change is not pulled in
+    // (content stays the originally-loaded body, not the EXTERNAL CHANGE).
+    if (result.current.tabs[0].kind === "file") {
+      expect(result.current.tabs[0].file.editContent).toBe("unsaved work");
+      expect(result.current.tabs[0].file.content).toBe("original");
+    }
   });
 
   it("saveScrollPosition + setActiveTab persists scrollTop to the leaving tab", async () => {

--- a/src/hooks/useTabs.test.tsx
+++ b/src/hooks/useTabs.test.tsx
@@ -194,8 +194,8 @@ describe("useTabs file operations", () => {
     expect(result.current.activeTab?.id).toBe(result.current.tabs[0].id);
   });
 
-  it("refuses to open a file whose extension isn't a supported markdown type", async () => {
-    // openFile gates non-markdown extensions so a random `.txt` / `.html`
+  it("refuses to open a file whose extension isn't a supported type", async () => {
+    // openFile gates unsupported extensions so a random `.txt` / `.html`
     // can't reach the renderer with embedded HTML / JS.
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { result } = renderHook(() => useTabs(defaultOptions()));
@@ -206,8 +206,47 @@ describe("useTabs file operations", () => {
     });
 
     expect(result.current.tabs).toHaveLength(0);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("non-markdown"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unsupported"));
     warnSpy.mockRestore();
+  });
+
+  it("opens a Jupyter notebook in view mode", async () => {
+    // `.ipynb` is a supported type and is forced into view mode (read-only)
+    // regardless of the default editor mode.
+    const { result } = renderHook(() =>
+      useTabs({ ...defaultOptions(), defaultEditorMode: "edit" }),
+    );
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/p/analysis.ipynb");
+    });
+
+    expect(result.current.tabs).toHaveLength(1);
+    const tab = result.current.tabs[0];
+    expect(tab.kind === "file" ? tab.file.mode : null).toBe("view");
+  });
+
+  it("never marks a notebook tab dirty when toggled into edit mode", async () => {
+    // Notebooks are read-only: switching modes shows the JSON source view, not
+    // an editor. The tab must never become dirty, or autosave would write the
+    // raw JSON back and could corrupt the notebook.
+    const { result } = renderHook(() => useTabs(defaultOptions()));
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile("/p/analysis.ipynb");
+    });
+    const id = result.current.tabs[0].id;
+
+    await act(async () => {
+      result.current.setTabMode(id, "edit");
+    });
+
+    const tab = result.current.tabs[0];
+    const file = tab.kind === "file" ? tab.file : null;
+    expect(file?.mode).toBe("edit");
+    expect(file?.dirty).toBe(false);
   });
 
   it("activates the existing tab instead of duplicating", async () => {
@@ -580,7 +619,7 @@ describe("useTabs dialog and events", () => {
     expect(updated?.kind === "folder" ? updated.file?.path : null).toBe("/p/ws/note.md");
   });
 
-  it("openFileInFolderTab refuses to load a non-markdown extension", async () => {
+  it("openFileInFolderTab refuses to load an unsupported extension", async () => {
     // Matches openFile: a `.txt` / `.html` / etc. dropped onto a folder tab
     // must not become the active file. Defends the renderer from arbitrary
     // HTML/JS the same way the top-level openFile gate does.
@@ -600,7 +639,7 @@ describe("useTabs dialog and events", () => {
 
     const updated = result.current.tabs.find((t) => t.id === folderTab!.id);
     expect(updated?.kind === "folder" ? updated.file : null).toBeNull();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("non-markdown"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unsupported"));
     warnSpy.mockRestore();
   });
 

--- a/src/hooks/useTabs.test.tsx
+++ b/src/hooks/useTabs.test.tsx
@@ -619,6 +619,30 @@ describe("useTabs dialog and events", () => {
     expect(updated?.kind === "folder" ? updated.file?.path : null).toBe("/p/ws/note.md");
   });
 
+  it("opens a notebook inside a folder tab in view mode", async () => {
+    // Covers the notebook → view-mode branch in openFileInFolderTab, mirroring
+    // the top-level openFile case: a `.ipynb` is read-only regardless of the
+    // configured default editor mode.
+    const { result } = renderHook(() =>
+      useTabs({ ...defaultOptions(), defaultEditorMode: "edit" }),
+    );
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFolder("/p/ws");
+    });
+    const folderTab = result.current.tabs.find((t) => t.kind === "folder");
+
+    await act(async () => {
+      await result.current.openFileInFolderTab(folderTab!.id, "/p/ws/analysis.ipynb");
+    });
+
+    const updated = result.current.tabs.find((t) => t.id === folderTab!.id);
+    const file = updated?.kind === "folder" ? updated.file : null;
+    expect(file?.path).toBe("/p/ws/analysis.ipynb");
+    expect(file?.mode).toBe("view");
+  });
+
   it("openFileInFolderTab refuses to load an unsupported extension", async () => {
     // Matches openFile: a `.txt` / `.html` / etc. dropped onto a folder tab
     // must not become the active file. Defends the renderer from arbitrary

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -7,7 +7,7 @@ import { emptyHistory, popRedo, popUndo, pushEntry, type TabHistory } from "@/li
 import { MARKDOWN_EXTENSIONS } from "@/lib/markdownExtensions";
 import { adaptMmdContent } from "@/lib/mmd";
 import { isNotebookFile, isSupportedFile, NOTEBOOK_EXTENSIONS } from "@/lib/notebookExtensions";
-import type { EditorMode } from "@/lib/settings";
+import { EDITOR_MODE, type EditorMode } from "@/lib/settings";
 import { toggleTaskAtLine } from "@/lib/taskList";
 
 interface FileMetadata {
@@ -224,7 +224,7 @@ export function useTabs(options: UseTabsOptions) {
         await invoke("watch_file", { path });
         // Notebooks are read-only; open straight into the viewer regardless of
         // the user's default editor mode.
-        const mode = isNotebookFile(path) ? "view" : optionsRef.current.defaultEditorMode;
+        const mode = isNotebookFile(path) ? EDITOR_MODE.view : optionsRef.current.defaultEditorMode;
         const newTab: FileTab = {
           id,
           kind: "file",
@@ -265,7 +265,7 @@ export function useTabs(options: UseTabsOptions) {
           invoke("unwatch_file", { path: previousFilePath }).catch(() => {});
         }
         await invoke("watch_file", { path });
-        const mode = isNotebookFile(path) ? "view" : optionsRef.current.defaultEditorMode;
+        const mode = isNotebookFile(path) ? EDITOR_MODE.view : optionsRef.current.defaultEditorMode;
         const newFile: FileState = { ...makeFileState(path, mode), content, metadata };
         setState((prev) => ({
           ...prev,
@@ -457,7 +457,7 @@ export function useTabs(options: UseTabsOptions) {
     (id: string, mode: EditorMode) => {
       updateActiveFile(id, (f) => {
         // When entering edit mode, initialize editContent from content
-        if (mode !== "view" && f.editContent === null) {
+        if (mode !== EDITOR_MODE.view && f.editContent === null) {
           return { ...f, mode, editContent: f.content };
         }
         return { ...f, mode };
@@ -505,7 +505,7 @@ export function useTabs(options: UseTabsOptions) {
       const file = activeFileOf(tab);
       if (!file) return false;
 
-      if (file.mode !== "view") {
+      if (file.mode !== EDITOR_MODE.view) {
         updateActiveFile(id, (f) => ({ ...f, editContent: next, dirty: true }));
         return true;
       }
@@ -532,7 +532,7 @@ export function useTabs(options: UseTabsOptions) {
       const file = activeFileOf(tab);
       if (!file?.content) return;
 
-      const isEditing = file.mode !== "view";
+      const isEditing = file.mode !== EDITOR_MODE.view;
       const source = isEditing ? (file.editContent ?? file.content) : file.content;
       const next = toggleTaskAtLine(source, line);
       if (next === source) return;
@@ -679,7 +679,7 @@ export function useTabs(options: UseTabsOptions) {
         const file = activeFileOf(matchingTab);
         if (!file) return;
         // Skip reload if the file is in edit mode with unsaved changes
-        if (file.mode !== "view" && file.dirty) return;
+        if (file.mode !== EDITOR_MODE.view && file.dirty) return;
         // Skip if this file-changed was triggered by our own auto-save —
         // re-syncing identical content into the editor would dismiss any
         // active autocomplete popup mid-completion.

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -4,8 +4,9 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { WikilinkRef } from "@/lib/backlinks";
 import { emptyHistory, popRedo, popUndo, pushEntry, type TabHistory } from "@/lib/editHistory";
-import { isMarkdownFile, MARKDOWN_EXTENSIONS } from "@/lib/markdownExtensions";
+import { MARKDOWN_EXTENSIONS } from "@/lib/markdownExtensions";
 import { adaptMmdContent } from "@/lib/mmd";
+import { isNotebookFile, isSupportedFile, NOTEBOOK_EXTENSIONS } from "@/lib/notebookExtensions";
 import type { EditorMode } from "@/lib/settings";
 import { toggleTaskAtLine } from "@/lib/taskList";
 
@@ -202,12 +203,13 @@ export function useTabs(options: UseTabsOptions) {
   // Open a file as a new top-level tab; if already open as a top-level tab, activate it.
   const openFile = useCallback(
     async (path: string) => {
-      // Defensive gate: never load a non-markdown file. Glyph rendering treats
+      // Defensive gate: never load an unsupported file. Glyph rendering treats
       // content as markdown (HTML included via the sanitizer), so opening a
-      // random `.txt` / `.html` / etc. is a code-injection vector. See
-      // memory/reject-unsupported-file-types.md.
-      if (!isMarkdownFile(path)) {
-        console.warn(`Refusing to open non-markdown file: ${path}`);
+      // random `.txt` / `.html` / etc. is a code-injection vector. Notebooks
+      // (`.ipynb`) are allowed — they take the dedicated NotebookViewer path.
+      // See memory/reject-unsupported-file-types.md.
+      if (!isSupportedFile(path)) {
+        console.warn(`Refusing to open unsupported file: ${path}`);
         return;
       }
       const existing = stateRef.current.tabs.find((t) => t.kind === "file" && t.file.path === path);
@@ -220,7 +222,9 @@ export function useTabs(options: UseTabsOptions) {
       try {
         const { content, metadata } = await loadFileContent(path);
         await invoke("watch_file", { path });
-        const mode = optionsRef.current.defaultEditorMode;
+        // Notebooks are read-only; open straight into the viewer regardless of
+        // the user's default editor mode.
+        const mode = isNotebookFile(path) ? "view" : optionsRef.current.defaultEditorMode;
         const newTab: FileTab = {
           id,
           kind: "file",
@@ -245,8 +249,8 @@ export function useTabs(options: UseTabsOptions) {
   // Watches the new file, unwatches the old. Folder's directory watcher stays.
   const openFileInFolderTab = useCallback(
     async (tabId: string, path: string) => {
-      if (!isMarkdownFile(path)) {
-        console.warn(`Refusing to open non-markdown file in folder tab: ${path}`);
+      if (!isSupportedFile(path)) {
+        console.warn(`Refusing to open unsupported file in folder tab: ${path}`);
         return;
       }
       const tab = stateRef.current.tabs.find((t) => t.id === tabId);
@@ -261,7 +265,7 @@ export function useTabs(options: UseTabsOptions) {
           invoke("unwatch_file", { path: previousFilePath }).catch(() => {});
         }
         await invoke("watch_file", { path });
-        const mode = optionsRef.current.defaultEditorMode;
+        const mode = isNotebookFile(path) ? "view" : optionsRef.current.defaultEditorMode;
         const newFile: FileState = { ...makeFileState(path, mode), content, metadata };
         setState((prev) => ({
           ...prev,
@@ -580,8 +584,16 @@ export function useTabs(options: UseTabsOptions) {
       multiple: true,
       filters: [
         {
+          name: "Documents",
+          extensions: [...MARKDOWN_EXTENSIONS, ...NOTEBOOK_EXTENSIONS] as string[],
+        },
+        {
           name: "Markdown",
           extensions: MARKDOWN_EXTENSIONS as string[],
+        },
+        {
+          name: "Jupyter Notebook",
+          extensions: NOTEBOOK_EXTENSIONS as string[],
         },
       ],
     });

--- a/src/lib/notebook/ansi.test.ts
+++ b/src/lib/notebook/ansi.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { hasAnsi, parseAnsi } from "./ansi";
+
+const ESC = "\x1b";
+
+describe("parseAnsi", () => {
+  it("returns a single plain segment for text with no codes", () => {
+    const segs = parseAnsi("hello world");
+    expect(segs).toEqual([{ text: "hello world", classes: [], style: {} }]);
+  });
+
+  it("applies a named foreground colour class", () => {
+    const segs = parseAnsi(`${ESC}[31mred${ESC}[0m`);
+    expect(segs[0]).toEqual({ text: "red", classes: ["ansi-fg-red"], style: {} });
+  });
+
+  it("clears styling on reset", () => {
+    const segs = parseAnsi(`${ESC}[1;32mok${ESC}[0m done`);
+    expect(segs[0].classes).toEqual(["ansi-bold", "ansi-fg-green"]);
+    expect(segs[1]).toEqual({ text: " done", classes: [], style: {} });
+  });
+
+  it("handles bright foreground and background colours", () => {
+    const segs = parseAnsi(`${ESC}[91;100mx`);
+    expect(segs[0].classes).toContain("ansi-fg-bright-red");
+    expect(segs[0].classes).toContain("ansi-bg-bright-black");
+  });
+
+  it("maps 256-colour foreground to an inline hex colour", () => {
+    const segs = parseAnsi(`${ESC}[38;5;196mx`);
+    expect(segs[0].style.color).toBe("#ff0000");
+  });
+
+  it("maps truecolour to an inline rgb colour", () => {
+    const segs = parseAnsi(`${ESC}[38;2;10;20;30mx`);
+    expect(segs[0].style.color).toBe("rgb(10, 20, 30)");
+  });
+
+  it("maps a 256-colour background to an inline hex backgroundColor", () => {
+    const segs = parseAnsi(`${ESC}[48;5;21mx`);
+    expect(segs[0].style.backgroundColor).toBe("#0000ff");
+  });
+
+  it("maps a truecolour background to an inline rgb backgroundColor", () => {
+    const segs = parseAnsi(`${ESC}[48;2;1;2;3mx`);
+    expect(segs[0].style.backgroundColor).toBe("rgb(1, 2, 3)");
+  });
+
+  it("maps the 232+ greyscale ramp of the 256-colour palette", () => {
+    const segs = parseAnsi(`${ESC}[38;5;232mx`);
+    expect(segs[0].style.color).toBe("#080808");
+  });
+
+  it("applies italic and underline attributes", () => {
+    const segs = parseAnsi(`${ESC}[3;4mx`);
+    expect(segs[0].classes).toContain("ansi-italic");
+    expect(segs[0].classes).toContain("ansi-underline");
+  });
+
+  it("treats a bare ESC[m as a reset", () => {
+    const segs = parseAnsi(`${ESC}[31ma${ESC}[mb`);
+    expect(segs[0].classes).toEqual(["ansi-fg-red"]);
+    expect(segs[1].classes).toEqual([]);
+  });
+
+  it("strips non-SGR CSI sequences without emitting style", () => {
+    const segs = parseAnsi(`a${ESC}[2Kb`);
+    expect(segs.map((s) => s.text).join("")).toBe("ab");
+  });
+
+  it("detects presence of ANSI codes", () => {
+    expect(hasAnsi(`${ESC}[31mx`)).toBe(true);
+    expect(hasAnsi("plain")).toBe(false);
+  });
+});

--- a/src/lib/notebook/ansi.test.ts
+++ b/src/lib/notebook/ansi.test.ts
@@ -72,4 +72,66 @@ describe("parseAnsi", () => {
     expect(hasAnsi(`${ESC}[31mx`)).toBe(true);
     expect(hasAnsi("plain")).toBe(false);
   });
+
+  it("turns individual attributes off (22/23/24)", () => {
+    // bold on then off, italic on then off, underline on then off.
+    const segs = parseAnsi(`${ESC}[1mB${ESC}[22mb${ESC}[3mI${ESC}[23mi${ESC}[4mU${ESC}[24mu`);
+    expect(segs[0].classes).toEqual(["ansi-bold"]);
+    expect(segs[1].classes).toEqual([]);
+    expect(segs[2].classes).toEqual(["ansi-italic"]);
+    expect(segs[3].classes).toEqual([]);
+    expect(segs[4].classes).toEqual(["ansi-underline"]);
+    expect(segs[5].classes).toEqual([]);
+  });
+
+  it("resets foreground (39) and background (49) to default", () => {
+    const segs = parseAnsi(`${ESC}[31;41mx${ESC}[39my${ESC}[49mz`);
+    expect(segs[0].classes).toEqual(["ansi-fg-red", "ansi-bg-red"]);
+    expect(segs[1].classes).toEqual(["ansi-bg-red"]); // fg cleared, bg kept
+    expect(segs[2].classes).toEqual([]); // bg cleared too
+  });
+
+  it("maps a standard background colour class", () => {
+    const segs = parseAnsi(`${ESC}[42mx`);
+    expect(segs[0].classes).toContain("ansi-bg-green");
+  });
+
+  it("maps the low (n<16) range of the 256-colour palette", () => {
+    // 38;5;0 → black, 38;5;9 → bright red, from the fixed 16-entry base table.
+    expect(parseAnsi(`${ESC}[38;5;0mx`)[0].style.color).toBe("#000000");
+    expect(parseAnsi(`${ESC}[38;5;9mx`)[0].style.color).toBe("#ff0000");
+  });
+
+  it("maps a mid-range (16-231) 256-colour cube index", () => {
+    // 16 is the first cube entry → pure black corner of the 6x6x6 cube.
+    expect(parseAnsi(`${ESC}[38;5;16mx`)[0].style.color).toBe("#000000");
+    // 231 is the last cube entry → white corner.
+    expect(parseAnsi(`${ESC}[38;5;231mx`)[0].style.color).toBe("#ffffff");
+  });
+
+  it("clamps out-of-range 256-colour indices", () => {
+    // idx > 255 is clamped to 255 (greyscale white-ish), idx missing → 0.
+    expect(parseAnsi(`${ESC}[38;5;999mx`)[0].style.color).toBe("#eeeeee");
+    expect(parseAnsi(`${ESC}[38;5mx`)[0].style.color).toBe("#000000");
+  });
+
+  it("defaults missing truecolour components to 0", () => {
+    // 38;2 with no r/g/b → rgb(0, 0, 0) via the `?? 0` fallbacks.
+    expect(parseAnsi(`${ESC}[38;2mx`)[0].style.color).toBe("rgb(0, 0, 0)");
+    // 48;2 background truecolour with only red supplied → green/blue default 0.
+    expect(parseAnsi(`${ESC}[48;2;7mx`)[0].style.backgroundColor).toBe("rgb(7, 0, 0)");
+  });
+
+  it("ignores an extended-colour code with an unknown mode", () => {
+    // 38;9 — mode 9 is neither 5 nor 2, so no colour is applied.
+    const segs = parseAnsi(`${ESC}[38;9mx`);
+    expect(segs[0].style.color).toBeUndefined();
+  });
+
+  it("ignores unknown SGR codes without affecting styling", () => {
+    // 5 (blink) and 7 (reverse) are intentionally unhandled.
+    const segs = parseAnsi(`${ESC}[5;7mx`);
+    expect(segs[0].classes).toEqual([]);
+    expect(segs[0].style).toEqual({});
+  });
 });

--- a/src/lib/notebook/ansi.ts
+++ b/src/lib/notebook/ansi.ts
@@ -1,0 +1,208 @@
+// Minimal ANSI (SGR) escape-sequence parser for notebook stream output and
+// tracebacks. Jupyter colourises stderr, rich reprs, and exception tracebacks
+// with the standard CSI `ESC[…m` codes; rendering them raw shows garbage like
+// `[0;31m`. We translate the subset that actually appears in notebooks —
+// the 16 named colours, 256-colour and truecolour, bold/italic/underline — into
+// styled segments. Named colours map to CSS classes (theme-aware via
+// notebook.css); 256/truecolour map to inline `color` so any RGB is exact.
+// Non-SGR control sequences are stripped.
+
+const COLOR_NAMES = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"];
+
+export interface AnsiSegment {
+  text: string;
+  /** CSS class names (e.g. `ansi-fg-red`, `ansi-bold`). */
+  classes: string[];
+  /** Inline styles for 256/truecolour, which have no fixed class. */
+  style: { color?: string; backgroundColor?: string };
+}
+
+interface AnsiState {
+  fgClass?: string;
+  bgClass?: string;
+  fgColor?: string;
+  bgColor?: string;
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+}
+
+function emptyState(): AnsiState {
+  return {
+    fgClass: undefined,
+    bgClass: undefined,
+    fgColor: undefined,
+    bgColor: undefined,
+    bold: false,
+    italic: false,
+    underline: false,
+  };
+}
+
+/** Reset all attributes in place (SGR 0). Clears colour fields too. */
+function resetState(state: AnsiState): void {
+  state.fgClass = undefined;
+  state.bgClass = undefined;
+  state.fgColor = undefined;
+  state.bgColor = undefined;
+  state.bold = false;
+  state.italic = false;
+  state.underline = false;
+}
+
+/** Convert an xterm 256-colour index to a `#rrggbb` string. */
+function xterm256ToHex(n: number): string {
+  if (n < 16) {
+    // Standard + bright palette approximations.
+    const base = [
+      "#000000",
+      "#800000",
+      "#008000",
+      "#808000",
+      "#000080",
+      "#800080",
+      "#008080",
+      "#c0c0c0",
+      "#808080",
+      "#ff0000",
+      "#00ff00",
+      "#ffff00",
+      "#0000ff",
+      "#ff00ff",
+      "#00ffff",
+      "#ffffff",
+    ];
+    return base[n];
+  }
+  if (n >= 232) {
+    const v = 8 + (n - 232) * 10;
+    const h = v.toString(16).padStart(2, "0");
+    return `#${h}${h}${h}`;
+  }
+  const i = n - 16;
+  const r = Math.floor(i / 36);
+  const g = Math.floor((i % 36) / 6);
+  const b = i % 6;
+  const channel = (c: number) => (c === 0 ? 0 : 55 + c * 40).toString(16).padStart(2, "0");
+  return `#${channel(r)}${channel(g)}${channel(b)}`;
+}
+
+/** Apply one parsed SGR parameter list to the running state (mutates `state`). */
+function applyCodes(state: AnsiState, codes: number[]): void {
+  for (let i = 0; i < codes.length; i++) {
+    const code = codes[i];
+    if (code === 0) {
+      resetState(state);
+    } else if (code === 1) {
+      state.bold = true;
+    } else if (code === 3) {
+      state.italic = true;
+    } else if (code === 4) {
+      state.underline = true;
+    } else if (code === 22) {
+      state.bold = false;
+    } else if (code === 23) {
+      state.italic = false;
+    } else if (code === 24) {
+      state.underline = false;
+    } else if (code >= 30 && code <= 37) {
+      state.fgClass = `ansi-fg-${COLOR_NAMES[code - 30]}`;
+      state.fgColor = undefined;
+    } else if (code >= 90 && code <= 97) {
+      state.fgClass = `ansi-fg-bright-${COLOR_NAMES[code - 90]}`;
+      state.fgColor = undefined;
+    } else if (code === 39) {
+      state.fgClass = undefined;
+      state.fgColor = undefined;
+    } else if (code >= 40 && code <= 47) {
+      state.bgClass = `ansi-bg-${COLOR_NAMES[code - 40]}`;
+      state.bgColor = undefined;
+    } else if (code >= 100 && code <= 107) {
+      state.bgClass = `ansi-bg-bright-${COLOR_NAMES[code - 100]}`;
+      state.bgColor = undefined;
+    } else if (code === 49) {
+      state.bgClass = undefined;
+      state.bgColor = undefined;
+    } else if (code === 38 || code === 48) {
+      // Extended colour: 38;5;n / 38;2;r;g;b (and 48;* for background).
+      const isFg = code === 38;
+      const mode = codes[i + 1];
+      if (mode === 5) {
+        const idx = codes[i + 2];
+        const hex = xterm256ToHex(Math.max(0, Math.min(255, idx ?? 0)));
+        if (isFg) {
+          state.fgColor = hex;
+          state.fgClass = undefined;
+        } else {
+          state.bgColor = hex;
+          state.bgClass = undefined;
+        }
+        i += 2;
+      } else if (mode === 2) {
+        const [r, g, b] = [codes[i + 2] ?? 0, codes[i + 3] ?? 0, codes[i + 4] ?? 0];
+        const rgb = `rgb(${r}, ${g}, ${b})`;
+        if (isFg) {
+          state.fgColor = rgb;
+          state.fgClass = undefined;
+        } else {
+          state.bgColor = rgb;
+          state.bgClass = undefined;
+        }
+        i += 4;
+      }
+    }
+    // Other codes (blink, reverse, etc.) are ignored.
+  }
+}
+
+function segmentFor(state: AnsiState, text: string): AnsiSegment {
+  const classes: string[] = [];
+  if (state.bold) classes.push("ansi-bold");
+  if (state.italic) classes.push("ansi-italic");
+  if (state.underline) classes.push("ansi-underline");
+  if (state.fgClass) classes.push(state.fgClass);
+  if (state.bgClass) classes.push(state.bgClass);
+  const style: AnsiSegment["style"] = {};
+  if (state.fgColor) style.color = state.fgColor;
+  if (state.bgColor) style.backgroundColor = state.bgColor;
+  return { text, classes, style };
+}
+
+// Matches any CSI sequence: ESC [ <params> <final-byte>. We only act on the
+// `m` (SGR) final byte; every other CSI sequence is consumed and discarded.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ESC (0x1b) is the ANSI marker we must match
+const CSI = /\x1b\[([0-9;]*)([A-Za-z])/g;
+
+/**
+ * Parse a string containing ANSI escape codes into styled segments. Segments
+ * with no styling still carry empty `classes`/`style`, so callers can render
+ * each as a `<span>` uniformly.
+ */
+export function parseAnsi(input: string): AnsiSegment[] {
+  const segments: AnsiSegment[] = [];
+  const state = emptyState();
+  let lastIndex = 0;
+  CSI.lastIndex = 0;
+  let match: RegExpExecArray | null = CSI.exec(input);
+  while (match !== null) {
+    if (match.index > lastIndex) {
+      segments.push(segmentFor(state, input.slice(lastIndex, match.index)));
+    }
+    if (match[2] === "m") {
+      const params = match[1] === "" ? [0] : match[1].split(";").map((p) => Number(p) || 0);
+      applyCodes(state, params);
+    }
+    lastIndex = match.index + match[0].length;
+    match = CSI.exec(input);
+  }
+  if (lastIndex < input.length) {
+    segments.push(segmentFor(state, input.slice(lastIndex)));
+  }
+  return segments;
+}
+
+/** True when the text contains at least one ANSI escape sequence. */
+export function hasAnsi(input: string): boolean {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ESC is the ANSI marker
+  return /\x1b\[/.test(input);
+}

--- a/src/lib/notebook/fence.test.ts
+++ b/src/lib/notebook/fence.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { fenceCode } from "./fence";
+
+describe("fenceCode", () => {
+  it("wraps plain source in a triple-backtick fence with the language", () => {
+    expect(fenceCode("x = 1", "python")).toBe("```python\nx = 1\n```");
+  });
+
+  it("grows the fence longer than any backtick run in the source", () => {
+    // Source contains a ``` run, so the fence must be at least ````.
+    const out = fenceCode("a\n```\nb", "json");
+    expect(out.startsWith("````json\n")).toBe(true);
+    expect(out.endsWith("\n````")).toBe(true);
+  });
+
+  it("handles source with a longer backtick run", () => {
+    const out = fenceCode("````", "text");
+    expect(out.startsWith("`````text\n")).toBe(true);
+    expect(out.endsWith("\n`````")).toBe(true);
+  });
+
+  it("uses an empty language tag when none is meaningful", () => {
+    expect(fenceCode("plain", "")).toBe("```\nplain\n```");
+  });
+});

--- a/src/lib/notebook/fence.ts
+++ b/src/lib/notebook/fence.ts
@@ -1,0 +1,10 @@
+// Wrap source text in a fenced markdown code block so it can be handed to the
+// markdown renderer for syntax highlighting. The fence is always longer than
+// any backtick run inside the source, so code (or JSON) containing ``` can't
+// break out of the block. Shared by the notebook code-cell renderer and the
+// read-only notebook source view.
+export function fenceCode(source: string, lang: string): string {
+  const longestRun = (source.match(/`+/g) ?? []).reduce((max, run) => Math.max(max, run.length), 0);
+  const fence = "`".repeat(Math.max(3, longestRun + 1));
+  return `${fence}${lang}\n${source}\n${fence}`;
+}

--- a/src/lib/notebook/parseNotebook.test.ts
+++ b/src/lib/notebook/parseNotebook.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { parseNotebook } from "./parseNotebook";
+import { NotebookParseError } from "./types";
+
+function nb(cells: unknown[], metadata?: unknown): string {
+  return JSON.stringify({ nbformat: 4, nbformat_minor: 5, metadata, cells });
+}
+
+describe("parseNotebook", () => {
+  it("parses a markdown cell, joining array source", () => {
+    const result = parseNotebook(nb([{ cell_type: "markdown", source: ["# Title\n", "body"] }]));
+    expect(result.cells).toEqual([{ type: "markdown", source: "# Title\nbody" }]);
+  });
+
+  it("parses a code cell with execution count and stream output", () => {
+    const result = parseNotebook(
+      nb([
+        {
+          cell_type: "code",
+          execution_count: 3,
+          source: "print('hi')",
+          outputs: [{ output_type: "stream", name: "stdout", text: ["hi\n"] }],
+        },
+      ]),
+    );
+    expect(result.cells[0]).toEqual({
+      type: "code",
+      source: "print('hi')",
+      executionCount: 3,
+      outputs: [{ kind: "stream", name: "stdout", text: "hi\n" }],
+    });
+  });
+
+  it("normalizes execute_result data bundles", () => {
+    const result = parseNotebook(
+      nb([
+        {
+          cell_type: "code",
+          execution_count: 1,
+          source: "1+1",
+          outputs: [
+            {
+              output_type: "execute_result",
+              execution_count: 1,
+              data: { "text/plain": ["2"], "text/html": "<b>2</b>" },
+            },
+          ],
+        },
+      ]),
+    );
+    const out = result.cells[0];
+    expect(out.type).toBe("code");
+    if (out.type === "code") {
+      expect(out.outputs[0]).toEqual({
+        kind: "data",
+        data: { "text/plain": "2", "text/html": "<b>2</b>" },
+        executionCount: 1,
+      });
+    }
+  });
+
+  it("keeps base64 image payloads verbatim", () => {
+    const result = parseNotebook(
+      nb([
+        {
+          cell_type: "code",
+          source: "",
+          outputs: [{ output_type: "display_data", data: { "image/png": "AAAA" } }],
+        },
+      ]),
+    );
+    const out = result.cells[0];
+    if (out.type === "code" && out.outputs[0].kind === "data") {
+      expect(out.outputs[0].data["image/png"]).toBe("AAAA");
+    }
+  });
+
+  it("stringifies JSON object mimetype payloads", () => {
+    const result = parseNotebook(
+      nb([
+        {
+          cell_type: "code",
+          source: "",
+          outputs: [
+            {
+              output_type: "execute_result",
+              data: { "application/json": { a: 1 } },
+            },
+          ],
+        },
+      ]),
+    );
+    const out = result.cells[0];
+    if (out.type === "code" && out.outputs[0].kind === "data") {
+      expect(out.outputs[0].data["application/json"]).toContain('"a": 1');
+    }
+  });
+
+  it("parses error outputs with traceback", () => {
+    const result = parseNotebook(
+      nb([
+        {
+          cell_type: "code",
+          source: "1/0",
+          outputs: [
+            {
+              output_type: "error",
+              ename: "ZeroDivisionError",
+              evalue: "division by zero",
+              traceback: ["Traceback", "ZeroDivisionError: division by zero"],
+            },
+          ],
+        },
+      ]),
+    );
+    const out = result.cells[0];
+    if (out.type === "code" && out.outputs[0].kind === "error") {
+      expect(out.outputs[0].ename).toBe("ZeroDivisionError");
+      expect(out.outputs[0].traceback).toHaveLength(2);
+    }
+  });
+
+  it("derives language from language_info then kernelspec", () => {
+    expect(parseNotebook(nb([], { language_info: { name: "rust" } })).languageHint).toBe("rust");
+    expect(parseNotebook(nb([], { kernelspec: { language: "julia" } })).languageHint).toBe("julia");
+    expect(parseNotebook(nb([])).languageHint).toBe("python");
+  });
+
+  it("drops unknown cell and output types instead of throwing", () => {
+    const result = parseNotebook(
+      nb([
+        { cell_type: "mystery", source: "x" },
+        {
+          cell_type: "code",
+          source: "",
+          outputs: [{ output_type: "weird" }, { output_type: "stream", text: "ok" }],
+        },
+      ]),
+    );
+    expect(result.cells).toHaveLength(1);
+    const out = result.cells[0];
+    if (out.type === "code") {
+      expect(out.outputs).toHaveLength(1);
+    }
+  });
+
+  it("reads v3 worksheets, input field, and prompt_number", () => {
+    const v3 = JSON.stringify({
+      nbformat: 3,
+      worksheets: [
+        {
+          cells: [
+            { cell_type: "code", input: ["x = 1"], prompt_number: 7, outputs: [] },
+            { cell_type: "heading", level: 2, source: "Section" },
+          ],
+        },
+      ],
+    });
+    const result = parseNotebook(v3);
+    expect(result.nbformat).toBe(3);
+    expect(result.cells[0]).toMatchObject({ type: "code", source: "x = 1", executionCount: 7 });
+    expect(result.cells[1]).toEqual({ type: "markdown", source: "## Section" });
+  });
+
+  it("parses a v4 raw cell", () => {
+    const result = parseNotebook(nb([{ cell_type: "raw", source: ["raw text"] }]));
+    expect(result.cells[0]).toEqual({ type: "raw", source: "raw text" });
+  });
+
+  it("coerces a non-string/non-array source to an empty string", () => {
+    const result = parseNotebook(nb([{ cell_type: "markdown", source: 42 }]));
+    expect(result.cells[0]).toEqual({ type: "markdown", source: "" });
+  });
+
+  it("stringifies a numeric mimetype payload via String()", () => {
+    const result = parseNotebook(
+      nb([
+        {
+          cell_type: "code",
+          source: "",
+          outputs: [{ output_type: "execute_result", data: { "text/plain": 7 } }],
+        },
+      ]),
+    );
+    const out = result.cells[0];
+    if (out.type === "code" && out.outputs[0].kind === "data") {
+      expect(out.outputs[0].data["text/plain"]).toBe("7");
+    }
+  });
+
+  it("throws on invalid JSON", () => {
+    expect(() => parseNotebook("{not json")).toThrow(NotebookParseError);
+  });
+
+  it("throws on JSON that is not a notebook", () => {
+    expect(() => parseNotebook(JSON.stringify({ foo: "bar" }))).toThrow(NotebookParseError);
+  });
+
+  it("accepts an empty but well-formed notebook", () => {
+    expect(parseNotebook(nb([])).cells).toEqual([]);
+  });
+});

--- a/src/lib/notebook/parseNotebook.test.ts
+++ b/src/lib/notebook/parseNotebook.test.ts
@@ -199,4 +199,119 @@ describe("parseNotebook", () => {
   it("accepts an empty but well-formed notebook", () => {
     expect(parseNotebook(nb([])).cells).toEqual([]);
   });
+
+  it("throws when the root JSON is not an object", () => {
+    expect(() => parseNotebook("42")).toThrow(NotebookParseError);
+    expect(() => parseNotebook("null")).toThrow(NotebookParseError);
+  });
+
+  it("defaults nbformat to 4 when missing or non-numeric", () => {
+    const noVersion = JSON.stringify({ cells: [] });
+    expect(parseNotebook(noVersion).nbformat).toBe(4);
+  });
+
+  it("drops non-object cells and outputs", () => {
+    const json = JSON.stringify({
+      nbformat: 4,
+      cells: [
+        null,
+        "not a cell",
+        {
+          cell_type: "code",
+          source: "x",
+          outputs: [null, 5, { output_type: "stream", text: "ok" }],
+        },
+      ],
+    });
+    const result = parseNotebook(json);
+    expect(result.cells).toHaveLength(1);
+    const out = result.cells[0];
+    if (out.type === "code") expect(out.outputs).toHaveLength(1);
+  });
+
+  it("treats a non-array outputs field as empty", () => {
+    const result = parseNotebook(nb([{ cell_type: "code", source: "x", outputs: "oops" }]));
+    const out = result.cells[0];
+    if (out.type === "code") expect(out.outputs).toEqual([]);
+  });
+
+  it("classifies stderr stream output by name", () => {
+    const result = parseNotebook(
+      nb([
+        {
+          cell_type: "code",
+          source: "",
+          outputs: [{ output_type: "stream", name: "stderr", text: "boom" }],
+        },
+      ]),
+    );
+    const out = result.cells[0];
+    if (out.type === "code" && out.outputs[0].kind === "stream") {
+      expect(out.outputs[0].name).toBe("stderr");
+    }
+  });
+
+  it("defaults error fields when missing", () => {
+    const result = parseNotebook(
+      nb([{ cell_type: "code", source: "", outputs: [{ output_type: "error" }] }]),
+    );
+    const out = result.cells[0];
+    if (out.type === "code" && out.outputs[0].kind === "error") {
+      expect(out.outputs[0].ename).toBe("");
+      expect(out.outputs[0].evalue).toBe("");
+      expect(out.outputs[0].traceback).toEqual([]);
+    }
+  });
+
+  it("renders a v3 heading cell with a default level when level is missing", () => {
+    const result = parseNotebook(nb([{ cell_type: "heading", source: "Title" }]));
+    expect(result.cells[0]).toEqual({ type: "markdown", source: "# Title" });
+  });
+
+  it("ignores worksheets entries that lack a cells array", () => {
+    const json = JSON.stringify({
+      nbformat: 3,
+      worksheets: [null, { foo: 1 }, { cells: [{ cell_type: "markdown", source: "hi" }] }],
+    });
+    const result = parseNotebook(json);
+    expect(result.cells).toEqual([{ type: "markdown", source: "hi" }]);
+  });
+
+  it("coerces non-string array source elements to empty strings", () => {
+    // joinSource maps a non-string array element to "" before joining.
+    const result = parseNotebook(nb([{ cell_type: "markdown", source: ["a", 5, "b"] }]));
+    expect(result.cells[0]).toEqual({ type: "markdown", source: "ab" });
+  });
+
+  it("renders a null mimetype payload as an empty string", () => {
+    // mimeToString hits the `value == null ? "" : String(value)` null arm.
+    const result = parseNotebook(
+      nb([
+        {
+          cell_type: "code",
+          source: "",
+          outputs: [{ output_type: "execute_result", data: { "text/plain": null } }],
+        },
+      ]),
+    );
+    const out = result.cells[0];
+    if (out.type === "code" && out.outputs[0].kind === "data") {
+      expect(out.outputs[0].data["text/plain"]).toBe("");
+    }
+  });
+
+  it("ignores a non-array source/value in cells and outputs", () => {
+    // joinSource on a number → "", parseDataBundle on a non-object → {}.
+    const result = parseNotebook(
+      nb([
+        { cell_type: "markdown", source: 5 },
+        { cell_type: "code", source: "", outputs: [{ output_type: "execute_result", data: 7 }] },
+      ]),
+    );
+    expect(result.cells[0]).toEqual({ type: "markdown", source: "" });
+    const out = result.cells[1];
+    if (out.type === "code" && out.outputs[0].kind === "data") {
+      expect(out.outputs[0].data).toEqual({});
+    }
+  });
 });

--- a/src/lib/notebook/parseNotebook.ts
+++ b/src/lib/notebook/parseNotebook.ts
@@ -26,11 +26,15 @@ function mimeToString(value: unknown): string {
   if (typeof value === "string") return value;
   if (Array.isArray(value)) return joinSource(value);
   if (value && typeof value === "object") {
+    /* c8 ignore start -- defensive: input always comes from JSON.parse, which
+       cannot produce a value JSON.stringify would throw on (no circular refs,
+       no BigInt), so the catch is unreachable in practice. */
     try {
       return JSON.stringify(value, null, 2);
     } catch {
       return "";
     }
+    /* c8 ignore stop */
   }
   return value == null ? "" : String(value);
 }
@@ -139,7 +143,8 @@ export function parseNotebook(jsonText: string): Notebook {
   try {
     parsed = JSON.parse(jsonText);
   } catch (err) {
-    throw new NotebookParseError(`Not valid JSON: ${err instanceof Error ? err.message : err}`);
+    // JSON.parse only ever throws a SyntaxError, so `err` is always an Error.
+    throw new NotebookParseError(`Not valid JSON: ${(err as Error).message}`);
   }
   if (!parsed || typeof parsed !== "object") {
     throw new NotebookParseError("Notebook root is not an object");

--- a/src/lib/notebook/parseNotebook.ts
+++ b/src/lib/notebook/parseNotebook.ts
@@ -1,0 +1,158 @@
+// Parse a `.ipynb` JSON string into the normalized `Notebook` model in
+// `./types`. Tolerant by design: notebooks in the wild mix nbformat v3 and v4,
+// store `source`/text as string-or-array, and carry mimetype payloads as
+// strings, arrays, or JSON objects. Anything we can't classify is dropped
+// rather than throwing, so a single odd cell never blanks the whole document.
+// The only hard failure is non-notebook JSON (no cells anywhere), which the
+// viewer surfaces as an error state.
+
+import {
+  type CodeCell,
+  type Notebook,
+  type NotebookCell,
+  type NotebookOutput,
+  NotebookParseError,
+} from "./types";
+
+/** nbformat stores multi-line text as an array of lines; flatten to a string. */
+function joinSource(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map((v) => (typeof v === "string" ? v : "")).join("");
+  return "";
+}
+
+/** Coerce one mimetype payload to a string: arrays join, objects stringify. */
+function mimeToString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return joinSource(value);
+  if (value && typeof value === "object") {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return "";
+    }
+  }
+  return value == null ? "" : String(value);
+}
+
+function toExecutionCount(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function parseDataBundle(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [mime, payload] of Object.entries(raw as Record<string, unknown>)) {
+    out[mime] = mimeToString(payload);
+  }
+  return out;
+}
+
+function parseOutput(raw: unknown): NotebookOutput | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  switch (o.output_type) {
+    case "stream":
+      return {
+        kind: "stream",
+        name: o.name === "stderr" ? "stderr" : "stdout",
+        text: joinSource(o.text),
+      };
+    case "execute_result":
+    case "display_data":
+      return {
+        kind: "data",
+        data: parseDataBundle(o.data),
+        executionCount: toExecutionCount(o.execution_count),
+      };
+    case "error":
+      return {
+        kind: "error",
+        ename: typeof o.ename === "string" ? o.ename : "",
+        evalue: typeof o.evalue === "string" ? o.evalue : "",
+        traceback: Array.isArray(o.traceback)
+          ? o.traceback.filter((t): t is string => typeof t === "string")
+          : [],
+      };
+    default:
+      return null;
+  }
+}
+
+function parseCell(raw: unknown): NotebookCell | null {
+  if (!raw || typeof raw !== "object") return null;
+  const c = raw as Record<string, unknown>;
+  // v3 code cells store the body under `input` instead of `source`.
+  const source = joinSource(c.source ?? c.input);
+  switch (c.cell_type) {
+    case "markdown":
+      return { type: "markdown", source };
+    case "raw":
+      return { type: "raw", source };
+    case "code": {
+      const outputs = Array.isArray(c.outputs)
+        ? c.outputs.map(parseOutput).filter((o): o is NotebookOutput => o !== null)
+        : [];
+      const cell: CodeCell = {
+        type: "code",
+        source,
+        executionCount: toExecutionCount(c.execution_count ?? c.prompt_number),
+        outputs,
+      };
+      return cell;
+    }
+    // v3 "heading" cells render fine as markdown.
+    case "heading":
+      return { type: "markdown", source: `${"#".repeat(Number(c.level) || 1)} ${source}` };
+    default:
+      return null;
+  }
+}
+
+/** Pull the raw cell array from either v4 (top-level) or v3 (worksheets). */
+function extractRawCells(nb: Record<string, unknown>): unknown[] {
+  if (Array.isArray(nb.cells)) return nb.cells;
+  if (Array.isArray(nb.worksheets)) {
+    return nb.worksheets.flatMap((ws) =>
+      ws && typeof ws === "object" && Array.isArray((ws as Record<string, unknown>).cells)
+        ? ((ws as Record<string, unknown>).cells as unknown[])
+        : [],
+    );
+  }
+  return [];
+}
+
+function extractLanguage(nb: Record<string, unknown>): string {
+  const metadata = (nb.metadata ?? {}) as Record<string, unknown>;
+  const langInfo = (metadata.language_info ?? {}) as Record<string, unknown>;
+  const kernelspec = (metadata.kernelspec ?? {}) as Record<string, unknown>;
+  const lang = langInfo.name ?? kernelspec.language;
+  return typeof lang === "string" && lang.length > 0 ? lang : "python";
+}
+
+/**
+ * Parse `.ipynb` JSON text into a `Notebook`. Throws `NotebookParseError` if
+ * the input isn't valid JSON or has no recognizable cells.
+ */
+export function parseNotebook(jsonText: string): Notebook {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    throw new NotebookParseError(`Not valid JSON: ${err instanceof Error ? err.message : err}`);
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new NotebookParseError("Notebook root is not an object");
+  }
+  const nb = parsed as Record<string, unknown>;
+  const rawCells = extractRawCells(nb);
+  if (rawCells.length === 0 && !("cells" in nb) && !("worksheets" in nb)) {
+    throw new NotebookParseError("File does not look like a Jupyter notebook (no cells)");
+  }
+  const cells = rawCells.map(parseCell).filter((c): c is NotebookCell => c !== null);
+  return {
+    cells,
+    languageHint: extractLanguage(nb),
+    nbformat: typeof nb.nbformat === "number" ? nb.nbformat : 4,
+  };
+}

--- a/src/lib/notebook/types.ts
+++ b/src/lib/notebook/types.ts
@@ -1,0 +1,77 @@
+// Normalized Jupyter notebook model. The on-disk `.ipynb` JSON (nbformat v3/v4)
+// is messy — `source` and output text come as either a string or an array of
+// line-strings, mimetype payloads can be strings, arrays, or JSON objects, and
+// v3 nests cells under `worksheets`. `parseNotebook` flattens all of that into
+// the shapes below so the renderer never has to branch on wire-format quirks.
+
+/** A single output attached to a code cell, normalized by output kind. */
+export type NotebookOutput = StreamOutput | DataOutput | ErrorOutput;
+
+/** `stream` output — stdout/stderr text, possibly carrying ANSI escapes. */
+export interface StreamOutput {
+  kind: "stream";
+  /** `stdout` or `stderr`; anything unknown is treated as stdout. */
+  name: "stdout" | "stderr";
+  text: string;
+}
+
+/**
+ * `execute_result` / `display_data` output. `data` maps a MIME type to its
+ * payload as a string (arrays joined, JSON objects stringified). Binary image
+ * payloads (`image/png`, `image/jpeg`) keep their base64 string verbatim.
+ */
+export interface DataOutput {
+  kind: "data";
+  data: Record<string, string>;
+  /** Execution count for `execute_result`; null for `display_data`. */
+  executionCount: number | null;
+}
+
+/** `error` output — an exception with a (usually ANSI-coloured) traceback. */
+export interface ErrorOutput {
+  kind: "error";
+  ename: string;
+  evalue: string;
+  /** Traceback frames; join with "\n" to reconstruct the printed trace. */
+  traceback: string[];
+}
+
+export type NotebookCell = MarkdownCell | CodeCell | RawCell;
+
+export interface MarkdownCell {
+  type: "markdown";
+  source: string;
+}
+
+export interface CodeCell {
+  type: "code";
+  source: string;
+  /** `In [n]` counter; null for never-run / cleared cells. */
+  executionCount: number | null;
+  outputs: NotebookOutput[];
+}
+
+export interface RawCell {
+  type: "raw";
+  source: string;
+}
+
+export interface Notebook {
+  cells: NotebookCell[];
+  /**
+   * Language for syntax-highlighting code cells, derived from
+   * `metadata.language_info.name` / `metadata.kernelspec.language`. Defaults to
+   * `"python"` since that's the overwhelming majority of notebooks.
+   */
+  languageHint: string;
+  /** Major nbformat version (4 for modern notebooks, 3 for legacy). */
+  nbformat: number;
+}
+
+/** Thrown when a file is not valid notebook JSON. */
+export class NotebookParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotebookParseError";
+  }
+}

--- a/src/lib/notebookExtensions.test.ts
+++ b/src/lib/notebookExtensions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isNotebookFile, isSupportedFile } from "./notebookExtensions";
+
+describe("isNotebookFile", () => {
+  it("matches .ipynb case-insensitively", () => {
+    expect(isNotebookFile("analysis.ipynb")).toBe(true);
+    expect(isNotebookFile("ANALYSIS.IPYNB")).toBe(true);
+    expect(isNotebookFile("/path/to/Untitled.ipynb")).toBe(true);
+  });
+
+  it("rejects non-notebook files", () => {
+    expect(isNotebookFile("readme.md")).toBe(false);
+    expect(isNotebookFile("data.json")).toBe(false);
+    expect(isNotebookFile("noext")).toBe(false);
+  });
+});
+
+describe("isSupportedFile", () => {
+  it("accepts both markdown and notebooks", () => {
+    expect(isSupportedFile("readme.md")).toBe(true);
+    expect(isSupportedFile("notes.markdown")).toBe(true);
+    expect(isSupportedFile("analysis.ipynb")).toBe(true);
+  });
+
+  it("rejects everything else", () => {
+    expect(isSupportedFile("image.png")).toBe(false);
+    expect(isSupportedFile("script.py")).toBe(false);
+  });
+});

--- a/src/lib/notebookExtensions.test.ts
+++ b/src/lib/notebookExtensions.test.ts
@@ -13,6 +13,10 @@ describe("isNotebookFile", () => {
     expect(isNotebookFile("data.json")).toBe(false);
     expect(isNotebookFile("noext")).toBe(false);
   });
+
+  it("rejects an empty path (no extension segment)", () => {
+    expect(isNotebookFile("")).toBe(false);
+  });
 });
 
 describe("isSupportedFile", () => {

--- a/src/lib/notebookExtensions.ts
+++ b/src/lib/notebookExtensions.ts
@@ -1,0 +1,22 @@
+// Jupyter notebooks are a separate document type from markdown. Unlike the
+// markdown extension list (driven by tauri.conf.json fileAssociations), the
+// notebook extension is fixed — `.ipynb` is the only one Jupyter ever uses — so
+// it lives here as a plain constant.
+//
+// Notebooks are intentionally NOT registered as an OS file association (only
+// markdown is). They open via the CLI, the open dialog, drag-and-drop, and the
+// workspace file tree. The Rust side mirrors this in src-tauri/src/notebook.rs.
+
+import { isMarkdownFile } from "./markdownExtensions";
+
+export const NOTEBOOK_EXTENSIONS: readonly string[] = ["ipynb"];
+
+export function isNotebookFile(path: string): boolean {
+  const ext = path.split(".").pop()?.toLowerCase();
+  return ext ? NOTEBOOK_EXTENSIONS.includes(ext) : false;
+}
+
+/** Any document Glyph can open: markdown or a Jupyter notebook. */
+export function isSupportedFile(path: string): boolean {
+  return isMarkdownFile(path) || isNotebookFile(path);
+}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   CONTENT_WIDTH_MAP,
   DEFAULT_SETTINGS,
+  EDITOR_MODE,
   FONT_FAMILY_MAP,
   LINE_HEIGHT_MAP,
   MODEL_SUGGESTIONS,
+  nextEditorMode,
 } from "./settings";
 
 describe("DEFAULT_SETTINGS", () => {
@@ -107,5 +109,17 @@ describe("MODEL_SUGGESTIONS", () => {
   it("has ollama models", () => {
     expect(MODEL_SUGGESTIONS.ollama).toBeInstanceOf(Array);
     expect(MODEL_SUGGESTIONS.ollama.length).toBeGreaterThan(0);
+  });
+});
+
+describe("nextEditorMode", () => {
+  it("cycles view → edit → split → view", () => {
+    expect(nextEditorMode(EDITOR_MODE.view)).toBe(EDITOR_MODE.edit);
+    expect(nextEditorMode(EDITOR_MODE.edit)).toBe(EDITOR_MODE.split);
+    expect(nextEditorMode(EDITOR_MODE.split)).toBe(EDITOR_MODE.view);
+  });
+
+  it("treats an undefined current mode as view (cycles to edit)", () => {
+    expect(nextEditorMode(undefined)).toBe(EDITOR_MODE.edit);
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -28,7 +28,16 @@ export interface LayoutSettings {
   swapSidebarSides: boolean;
 }
 
-export type EditorMode = "view" | "edit" | "split";
+// Editor modes for a document tab. Defined as a constant object so call sites
+// reference `EDITOR_MODE.view` etc. instead of bare string literals; the
+// `EditorMode` union is derived from it so the two never drift.
+export const EDITOR_MODE = {
+  view: "view",
+  edit: "edit",
+  split: "split",
+} as const;
+
+export type EditorMode = (typeof EDITOR_MODE)[keyof typeof EDITOR_MODE];
 
 export interface PersistedTab {
   kind: "file" | "folder";
@@ -106,7 +115,7 @@ export const DEFAULT_SETTINGS: Settings = {
     recentFiles: [],
     openTabs: [],
     activeTabPath: "",
-    defaultEditorMode: "view",
+    defaultEditorMode: EDITOR_MODE.view,
   },
   ai: {
     provider: "none",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -39,6 +39,23 @@ export const EDITOR_MODE = {
 
 export type EditorMode = (typeof EDITOR_MODE)[keyof typeof EDITOR_MODE];
 
+// Order the per-tab mode toggle cycles through: view → edit → split → view.
+const EDITOR_MODE_CYCLE: readonly EditorMode[] = [
+  EDITOR_MODE.view,
+  EDITOR_MODE.edit,
+  EDITOR_MODE.split,
+];
+
+/**
+ * The next mode when cycling the editor toggle (wraps view → edit → split →
+ * view). An undefined/unknown current mode is treated as `view`, so the cycle
+ * starts at `edit`.
+ */
+export function nextEditorMode(current: EditorMode | undefined): EditorMode {
+  const idx = current ? EDITOR_MODE_CYCLE.indexOf(current) : 0;
+  return EDITOR_MODE_CYCLE[(idx + 1) % EDITOR_MODE_CYCLE.length];
+}
+
 export interface PersistedTab {
   kind: "file" | "folder";
   path: string;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "./platform.css";
 @import "./markdown.css";
+@import "./notebook.css";
 @import "./settings.css";
 @import "./tabs.css";
 @import "./search.css";

--- a/src/styles/notebook.css
+++ b/src/styles/notebook.css
@@ -62,17 +62,22 @@
   font-size: 0.8rem;
   line-height: 1.5;
   text-align: right;
-  padding-top: 0.65rem;
   color: var(--color-text-tertiary);
   user-select: none;
   white-space: nowrap;
 }
 
+/* The Out prompt sits next to plain output content (no inner padding), so it
+   aligns at the row top with no extra offset. */
+.nb-prompt-out {
+  padding-top: 0;
+}
+
 .nb-prompt-in {
   color: var(--color-accent);
   /* The source `pre` carries 1em of internal padding before its first line, so
-     the input prompt needs more top padding than the base (used by the plain
-     Out prompt) to line up with the first line of code. */
+     the input prompt needs that much top padding to line up with the first
+     line of code. */
   padding-top: 1rem;
 }
 

--- a/src/styles/notebook.css
+++ b/src/styles/notebook.css
@@ -1,0 +1,274 @@
+/* Jupyter notebook viewer. The notebook is a vertical stack of cells; code
+   cells use a two-column grid (prompt gutter + body) so `In [n]:` / `Out [n]:`
+   line up the way they do in Jupyter/nbviewer. All colours go through the
+   theme custom properties so light/dark track the rest of the app. */
+
+.notebook-body {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding-bottom: 40vh;
+  color: var(--color-text-primary);
+}
+
+.nb-cell {
+  margin-bottom: 0.5rem;
+}
+
+/* Each cell embeds a `.markdown-body` for rendering. That class carries
+   document-level chrome meant for a whole file — a 70vh `padding-bottom` for
+   end-of-document scroll room — which would otherwise inject a huge empty gap
+   below every cell. Neutralise it (the notebook's own scroll room lives once on
+   `.notebook-body`) and collapse the body's outer first/last margins so the
+   only vertical rhythm between cells comes from `.nb-cell`. */
+.nb-cell .markdown-body {
+  padding-bottom: 0;
+}
+
+.nb-cell .markdown-body > :first-child {
+  margin-top: 0;
+}
+
+.nb-cell .markdown-body > :last-child {
+  margin-bottom: 0;
+}
+
+/* Code cell layout: a fixed prompt gutter and a flexible body column. */
+.nb-row {
+  display: grid;
+  grid-template-columns: 4.5rem minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: start;
+}
+
+.nb-prompt {
+  font-family: var(--glyph-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-align: right;
+  padding-top: 0.65rem;
+  color: var(--color-text-tertiary);
+  user-select: none;
+  white-space: nowrap;
+}
+
+.nb-prompt-in {
+  color: var(--color-accent);
+}
+
+.nb-row-body {
+  min-width: 0;
+}
+
+/* Code source: the inner <pre> already carries the highlight theme. Give the
+   input cell a subtle surface so it reads as an editor block. */
+.nb-code-source pre {
+  margin: 0;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-secondary);
+}
+
+.nb-output-row {
+  margin-top: 0.25rem;
+}
+
+/* Text outputs (stream, plain text, tracebacks) keep their whitespace and
+   wrap long lines so wide stdout doesn't force horizontal scroll. */
+.nb-output-text,
+.nb-raw {
+  margin: 0;
+  font-family: var(--glyph-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-text-primary);
+}
+
+.nb-output-stderr {
+  background: color-mix(in srgb, var(--color-alert-caution) 8%, transparent);
+}
+
+.nb-output-error {
+  background: color-mix(in srgb, var(--color-alert-caution) 10%, transparent);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+}
+
+.nb-output-image {
+  max-width: 100%;
+  height: auto;
+  background: #fff; /* plots usually assume a white canvas */
+  border-radius: 4px;
+}
+
+.nb-output-unsupported {
+  font-size: 0.8rem;
+  font-style: italic;
+  color: var(--color-text-tertiary);
+  padding: 0.4rem 0;
+}
+
+/* Banner above the read-only JSON source view (edit/split mode on a notebook). */
+.nb-source-banner {
+  flex-shrink: 0;
+  padding: 0.4rem 2rem;
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+  background: var(--color-surface-secondary);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.nb-error-state,
+.nb-empty-state {
+  max-width: 40rem;
+  margin: 2rem auto;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.nb-error-title {
+  font-weight: 600;
+  color: var(--color-alert-caution);
+  margin-bottom: 0.25rem;
+}
+
+.nb-error-detail {
+  font-family: var(--glyph-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.82rem;
+}
+
+/* ANSI colours for stream output and tracebacks. Named colours map to the
+   conventional terminal palette, tuned for legibility on both themes. */
+.ansi-bold {
+  font-weight: 600;
+}
+.ansi-italic {
+  font-style: italic;
+}
+.ansi-underline {
+  text-decoration: underline;
+}
+
+.ansi-fg-black {
+  color: #1d1d1f;
+}
+.ansi-fg-red {
+  color: #cf222e;
+}
+.ansi-fg-green {
+  color: #1a7f37;
+}
+.ansi-fg-yellow {
+  color: #9a6700;
+}
+.ansi-fg-blue {
+  color: #0969da;
+}
+.ansi-fg-magenta {
+  color: #8250df;
+}
+.ansi-fg-cyan {
+  color: #1b7c83;
+}
+.ansi-fg-white {
+  color: #6e6e73;
+}
+.ansi-fg-bright-black {
+  color: #6e6e73;
+}
+.ansi-fg-bright-red {
+  color: #ff6b6b;
+}
+.ansi-fg-bright-green {
+  color: #3fb950;
+}
+.ansi-fg-bright-yellow {
+  color: #d4a72c;
+}
+.ansi-fg-bright-blue {
+  color: #58a6ff;
+}
+.ansi-fg-bright-magenta {
+  color: #bf8cff;
+}
+.ansi-fg-bright-cyan {
+  color: #56d4dd;
+}
+.ansi-fg-bright-white {
+  color: #f5f5f7;
+}
+
+.dark .ansi-fg-black {
+  color: #c9c9cd;
+}
+.dark .ansi-fg-red {
+  color: #ff7b72;
+}
+.dark .ansi-fg-green {
+  color: #3fb950;
+}
+.dark .ansi-fg-yellow {
+  color: #d29922;
+}
+.dark .ansi-fg-blue {
+  color: #58a6ff;
+}
+.dark .ansi-fg-magenta {
+  color: #bf8cff;
+}
+.dark .ansi-fg-cyan {
+  color: #56d4dd;
+}
+.dark .ansi-fg-white {
+  color: #f5f5f7;
+}
+
+.ansi-bg-black {
+  background-color: #1d1d1f;
+}
+.ansi-bg-red {
+  background-color: #cf222e;
+}
+.ansi-bg-green {
+  background-color: #1a7f37;
+}
+.ansi-bg-yellow {
+  background-color: #9a6700;
+}
+.ansi-bg-blue {
+  background-color: #0969da;
+}
+.ansi-bg-magenta {
+  background-color: #8250df;
+}
+.ansi-bg-cyan {
+  background-color: #1b7c83;
+}
+.ansi-bg-white {
+  background-color: #d2d2d7;
+}
+.ansi-bg-bright-black {
+  background-color: #6e6e73;
+}
+.ansi-bg-bright-red {
+  background-color: #ff6b6b;
+}
+.ansi-bg-bright-green {
+  background-color: #3fb950;
+}
+.ansi-bg-bright-yellow {
+  background-color: #d4a72c;
+}
+.ansi-bg-bright-blue {
+  background-color: #58a6ff;
+}
+.ansi-bg-bright-magenta {
+  background-color: #bf8cff;
+}
+.ansi-bg-bright-cyan {
+  background-color: #56d4dd;
+}
+.ansi-bg-bright-white {
+  background-color: #f5f5f7;
+}

--- a/src/styles/notebook.css
+++ b/src/styles/notebook.css
@@ -11,24 +11,41 @@
 }
 
 .nb-cell {
-  margin-bottom: 0.5rem;
+  margin-bottom: 1.25rem;
 }
 
-/* Each cell embeds a `.markdown-body` for rendering. That class carries
-   document-level chrome meant for a whole file — a 70vh `padding-bottom` for
-   end-of-document scroll room — which would otherwise inject a huge empty gap
-   below every cell. Neutralise it (the notebook's own scroll room lives once on
-   `.notebook-body`) and collapse the body's outer first/last margins so the
-   only vertical rhythm between cells comes from `.nb-cell`. */
-.nb-cell .markdown-body {
+/* Cells render through `.markdown-body`, which carries document-level chrome
+   meant for a whole file — a 70vh `padding-bottom` for end-of-document scroll
+   room — that would otherwise inject a huge empty gap below every cell.
+   Neutralise it (the notebook's own scroll room lives once on `.notebook-body`)
+   and collapse the body's outer first/last margins so the only vertical rhythm
+   between cells comes from `.nb-cell`.
+
+   The selector must use `.notebook-body .markdown-body`, not
+   `.nb-cell .markdown-body`: a markdown cell puts `markdown-body` directly on
+   the `.nb-cell` element, so a descendant selector would miss it and leave the
+   70vh padding on every markdown (and Mermaid) cell. Both the cell-level body
+   and the nested code-source/output bodies are descendants of `.notebook-body`.
+
+   We also reset `.markdown-body`'s document-level `max-width` + horizontal
+   `margin: auto`: inside a cell (and especially the code cell's grid column)
+   those would centre and cap the content, so a code block shrink-wraps
+   mid-column instead of filling the row. The notebook's own width cap lives
+   once on `.notebook-body`. Use `margin-inline` so we only neutralise the
+   horizontal centring — zeroing all margins here (specificity 0,2,0) would
+   also clobber `.nb-cell`'s bottom margin on markdown cells, where
+   `markdown-body` sits on the cell element, collapsing the inter-cell gap. */
+.notebook-body .markdown-body {
   padding-bottom: 0;
+  max-width: none;
+  margin-inline: 0;
 }
 
-.nb-cell .markdown-body > :first-child {
+.notebook-body .markdown-body > :first-child {
   margin-top: 0;
 }
 
-.nb-cell .markdown-body > :last-child {
+.notebook-body .markdown-body > :last-child {
   margin-bottom: 0;
 }
 
@@ -53,23 +70,37 @@
 
 .nb-prompt-in {
   color: var(--color-accent);
+  /* The source `pre` carries 1em of internal padding before its first line, so
+     the input prompt needs more top padding than the base (used by the plain
+     Out prompt) to line up with the first line of code. */
+  padding-top: 1rem;
 }
 
 .nb-row-body {
   min-width: 0;
 }
 
-/* Code source: the inner <pre> already carries the highlight theme. Give the
-   input cell a subtle surface so it reads as an editor block. */
+/* Group a code cell's input and its outputs in one bordered block so they read
+   as a single connected cell (Jupyter/VS Code style), rather than a boxed input
+   floating above detached output. */
+.nb-cell-code {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  padding: 0.5rem 0.75rem;
+}
+
+/* Inside the grouped cell the source needs no box of its own; a subtle surface
+   tint is enough to set the input apart from the (transparent) output below. */
 .nb-code-source pre {
   margin: 0;
+  border: 0;
   border-radius: 6px;
-  border: 1px solid var(--color-border);
   background: var(--color-surface-secondary);
 }
 
 .nb-output-row {
-  margin-top: 0.25rem;
+  margin-top: 0.5rem;
 }
 
 /* Text outputs (stream, plain text, tracebacks) keep their whitespace and


### PR DESCRIPTION
## Summary

Open and render Jupyter notebook files (`.ipynb`) directly in Glyph, closing #198. Notebooks become a first-class, **read-only** document type alongside markdown, reusing the existing markdown, syntax-highlighting, KaTeX, and Mermaid pipelines.

## Changes

- **Parser** (`src/lib/notebook/`) — normalises nbformat v4 (best-effort v3) JSON into a cell model. Tolerant of string-or-array `source`, mixed mimetype payloads, and v3 `worksheets`/`input`/`prompt_number`; unknown cells/outputs are dropped, not fatal.
- **Viewer** (`src/components/notebook/`) — markdown cells render through the shared markdown pipeline (math, code, Mermaid, alerts); code cells are syntax-highlighted by kernel language with `In [n]:` prompts; outputs render by richest type (`image/png`/`jpeg`/`svg+xml`, sanitised HTML, markdown, plain text) with `Out [n]:` prompts.
- **ANSI** (`src/lib/notebook/ansi.ts`) — stream output and tracebacks are colourised via a small SGR parser (16 colours + bright, 256-colour, truecolour), rendered as styled spans with theme-aware CSS classes (no `innerHTML`).
- **Read-only modes** — view = rendered cells, edit = raw JSON source view, split = source + rendered side by side. None expose a write path, so autosave can never corrupt a notebook (covered by an invariant test).
- **Opening** — CLI, open dialog, drag-and-drop, and the workspace file tree accept `.ipynb` via a shared `is_supported_file` gate (TS + Rust). Notebooks are intentionally **not** registered as an OS file association; only markdown is.
- **Refactor** — extracted `MarkdownContent` out of `MarkdownViewer` so notebook cells and the document viewer render identically (existing MarkdownViewer tests unchanged).
- **Docs** — README feature bullet + comparison-table row, `samples/Notebook.ipynb` demo, and a samples/README section.
- Lazy-loaded so the notebook code is code-split (`NotebookViewer` ~9 KB, `NotebookSplit`/`NotebookSource` <1 KB each); the main bundle is unaffected.

## Testing

- `pnpm typecheck`, `pnpm check` (Biome) clean
- `pnpm test` — 680 frontend tests pass (parser, ANSI, fence, extension gate, viewer/source/split/cell/output components, TabContent routing, notebook-never-dirty invariant)
- `cargo test` — 96 tests pass; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean
- Ran the app on Windows with `samples/Notebook.ipynb`: markdown/code cells, images, sanitised HTML, colourised traceback, prompts, and the view/edit/split modes all verified

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Notes

- Plotly/Vega/Bokeh and Jupyter widgets are out of scope (show a placeholder), per the issue.
- Follow-up issue #244 filed for opening plain-text files under the same "openable but not OS-associated" pattern.

## Screenshots

_Rendered notebook (cells, highlighted code, image output, colourised traceback) verified locally on Windows; happy to attach captures if useful._