### PR TITLE
docs(readme): mark command palette as implemented in feature matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Glyph is built around speed, native feel, and offline-first usage. The tables be
 | Folder / vault sidebar | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ |
 | Wikilinks & backlinks | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | plugin |
 | Tag / metadata search | planned | ✅ | ❌ | ❌ | ✅ | ✅ | plugin |
-| Command palette | planned | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Command palette | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | In-document search | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Table of contents | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Live reload on disk change | ✅ | ⚠️ | n/a | n/a | ⚠️ | n/a | ✅ |


### PR DESCRIPTION
@
## Summary

The command palette (`Cmd/Ctrl+K`) is fully implemented, but the feature comparison matrix still listed it as `planned`. This corrects the matrix to `✅` so it matches reality.

The feature already appears as shipped elsewhere in the README (the feature list and the keyboard shortcuts table), so the matrix was the only stale spot. Implementation lives in `src/components/modals/CommandPalette.tsx`, `src/hooks/useCommandPalette.ts`, the native menu item in `src-tauri/src/menu_runtime.rs`, with test coverage in `src/components/modals/CommandPalette.test.tsx`.

Spell check and Tag / metadata search remain marked `planned` — those are genuinely not implemented yet.

## Changes

- Update the Navigation feature matrix in `README.md`: Command palette `planned` → `✅` for Glyph

## Testing

Docs-only change, no code affected.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A
@