### PR TITLE
test(watcher): cover watch/unwatch commands and event emission

### DIFF
--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -2,7 +2,7 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 
 pub struct FileWatcherState(pub Arc<Mutex<HashMap<String, RecommendedWatcher>>>);
 
@@ -22,7 +22,7 @@ pub fn is_relevant_directory_change(event: &Event) -> bool {
 }
 
 #[tauri::command]
-pub fn watch_file(path: String, app: AppHandle) -> Result<(), String> {
+pub fn watch_file<R: Runtime>(path: String, app: AppHandle<R>) -> Result<(), String> {
     let state = app.state::<FileWatcherState>();
     let mut watchers = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
 
@@ -54,7 +54,7 @@ pub fn watch_file(path: String, app: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn unwatch_file(path: String, app: AppHandle) -> Result<(), String> {
+pub fn unwatch_file<R: Runtime>(path: String, app: AppHandle<R>) -> Result<(), String> {
     let state = app.state::<FileWatcherState>();
     let mut watchers = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
     watchers.remove(&path);
@@ -62,7 +62,7 @@ pub fn unwatch_file(path: String, app: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn watch_directory(path: String, app: AppHandle) -> Result<(), String> {
+pub fn watch_directory<R: Runtime>(path: String, app: AppHandle<R>) -> Result<(), String> {
     let state = app.state::<FileWatcherState>();
     let mut watchers = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
 
@@ -90,7 +90,7 @@ pub fn watch_directory(path: String, app: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn unwatch_directory(path: String, app: AppHandle) -> Result<(), String> {
+pub fn unwatch_directory<R: Runtime>(path: String, app: AppHandle<R>) -> Result<(), String> {
     let state = app.state::<FileWatcherState>();
     let mut watchers = state.0.lock().map_err(|e| format!("Lock error: {e}"))?;
     watchers.remove(&path);
@@ -102,12 +102,77 @@ mod tests {
     use super::*;
     use notify::event::{CreateKind, ModifyKind, RemoveKind};
     use std::path::PathBuf;
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+    use tauri::test::{mock_app, MockRuntime};
+    use tauri::{App, Listener};
 
     fn event(kind: EventKind, paths: Vec<PathBuf>) -> Event {
         Event {
             kind,
             paths,
             attrs: Default::default(),
+        }
+    }
+
+    /// A mock Tauri app with an empty [`FileWatcherState`] managed, so the
+    /// `watch_*` / `unwatch_*` commands resolve `app.state::<FileWatcherState>()`
+    /// without booting a real window manager.
+    fn mock_app_with_state() -> App<MockRuntime> {
+        let app = mock_app();
+        app.manage(FileWatcherState(Arc::new(Mutex::new(HashMap::new()))));
+        app
+    }
+
+    /// Number of paths currently registered in the watcher state map.
+    fn watched_count(app: &App<MockRuntime>) -> usize {
+        app.state::<FileWatcherState>().0.lock().unwrap().len()
+    }
+
+    fn is_watched(app: &App<MockRuntime>, path: &str) -> bool {
+        app.state::<FileWatcherState>()
+            .0
+            .lock()
+            .unwrap()
+            .contains_key(path)
+    }
+
+    /// Create a unique temp directory for a test, returning its path.
+    fn unique_tmp(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "glyph_watcher_test_{}_{}_{}",
+            name,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Subscribe to `event` on the app handle, returning a shared counter that
+    /// the listener bumps every time the event fires.
+    fn count_event(app: &App<MockRuntime>, event: &'static str) -> Arc<Mutex<usize>> {
+        let counter: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+        let sink = Arc::clone(&counter);
+        app.handle().listen(event, move |_| {
+            *sink.lock().unwrap() += 1;
+        });
+        counter
+    }
+
+    /// Poll `counter` until it is non-zero or `timeout` elapses. Returns the
+    /// final count. Filesystem-notification latency varies by platform, so the
+    /// emission tests poll rather than sleeping a fixed amount.
+    fn wait_for_event(counter: &Arc<Mutex<usize>>, timeout: Duration) -> usize {
+        let start = Instant::now();
+        loop {
+            let n = *counter.lock().unwrap();
+            if n > 0 || start.elapsed() >= timeout {
+                return n;
+            }
+            std::thread::sleep(Duration::from_millis(20));
         }
     }
 
@@ -184,5 +249,174 @@ mod tests {
     fn not_relevant_when_paths_are_empty() {
         let e = event(EventKind::Create(CreateKind::File), vec![]);
         assert!(!is_relevant_directory_change(&e));
+    }
+
+    #[test]
+    fn watch_file_registers_the_path_in_state() {
+        let dir = unique_tmp("watch_file");
+        let file = dir.join("note.md");
+        std::fs::write(&file, "hello").unwrap();
+        let path = file.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        assert!(watch_file(path.clone(), app.handle().clone()).is_ok());
+
+        assert!(is_watched(&app, &path));
+        assert_eq!(watched_count(&app), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn watch_file_is_idempotent_for_the_same_path() {
+        let dir = unique_tmp("watch_file_idem");
+        let file = dir.join("note.md");
+        std::fs::write(&file, "hello").unwrap();
+        let path = file.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        assert!(watch_file(path.clone(), app.handle().clone()).is_ok());
+        // Second call hits the early `contains_key` return and must not add a
+        // duplicate entry.
+        assert!(watch_file(path.clone(), app.handle().clone()).is_ok());
+
+        assert_eq!(watched_count(&app), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn watch_file_errors_for_a_nonexistent_path() {
+        let dir = unique_tmp("watch_file_missing");
+        let missing = dir.join("does-not-exist.md");
+        let path = missing.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        let result = watch_file(path.clone(), app.handle().clone());
+
+        assert!(result.is_err(), "watching a missing path should fail");
+        // A failed watch must not leave a dangling entry behind.
+        assert!(!is_watched(&app, &path));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unwatch_file_removes_the_registered_path() {
+        let dir = unique_tmp("unwatch_file");
+        let file = dir.join("note.md");
+        std::fs::write(&file, "hello").unwrap();
+        let path = file.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        watch_file(path.clone(), app.handle().clone()).unwrap();
+        assert_eq!(watched_count(&app), 1);
+
+        assert!(unwatch_file(path.clone(), app.handle().clone()).is_ok());
+        assert!(!is_watched(&app, &path));
+        assert_eq!(watched_count(&app), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unwatch_file_for_an_unknown_path_is_a_noop() {
+        let app = mock_app_with_state();
+        assert!(unwatch_file("/never/watched.md".to_string(), app.handle().clone()).is_ok());
+        assert_eq!(watched_count(&app), 0);
+    }
+
+    #[test]
+    fn watch_directory_registers_the_path_in_state() {
+        let dir = unique_tmp("watch_dir");
+        let path = dir.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        assert!(watch_directory(path.clone(), app.handle().clone()).is_ok());
+
+        assert!(is_watched(&app, &path));
+        assert_eq!(watched_count(&app), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn watch_directory_is_idempotent_for_the_same_path() {
+        let dir = unique_tmp("watch_dir_idem");
+        let path = dir.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        assert!(watch_directory(path.clone(), app.handle().clone()).is_ok());
+        assert!(watch_directory(path.clone(), app.handle().clone()).is_ok());
+
+        assert_eq!(watched_count(&app), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn watch_directory_errors_for_a_nonexistent_path() {
+        let dir = unique_tmp("watch_dir_missing");
+        let missing = dir.join("no-such-dir");
+        let path = missing.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        let result = watch_directory(path.clone(), app.handle().clone());
+
+        assert!(result.is_err(), "watching a missing directory should fail");
+        assert!(!is_watched(&app, &path));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unwatch_directory_removes_the_registered_path() {
+        let dir = unique_tmp("unwatch_dir");
+        let path = dir.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        watch_directory(path.clone(), app.handle().clone()).unwrap();
+        assert_eq!(watched_count(&app), 1);
+
+        assert!(unwatch_directory(path.clone(), app.handle().clone()).is_ok());
+        assert!(!is_watched(&app, &path));
+        assert_eq!(watched_count(&app), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unwatch_directory_for_an_unknown_path_is_a_noop() {
+        let app = mock_app_with_state();
+        assert!(unwatch_directory("/never/watched".to_string(), app.handle().clone()).is_ok());
+        assert_eq!(watched_count(&app), 0);
+    }
+
+    #[test]
+    fn watch_file_emits_file_changed_when_the_file_is_modified() {
+        let dir = unique_tmp("watch_file_emit");
+        let file = dir.join("note.md");
+        std::fs::write(&file, "initial").unwrap();
+        let path = file.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        let fired = count_event(&app, "file-changed");
+        watch_file(path.clone(), app.handle().clone()).unwrap();
+
+        // Modify the watched file; the watcher closure should emit on Modify.
+        std::fs::write(&file, "changed").unwrap();
+
+        let count = wait_for_event(&fired, Duration::from_secs(10));
+        assert!(count > 0, "expected at least one file-changed emit");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn watch_directory_emits_directory_changed_when_a_markdown_file_appears() {
+        let dir = unique_tmp("watch_dir_emit");
+        let path = dir.to_string_lossy().to_string();
+
+        let app = mock_app_with_state();
+        let fired = count_event(&app, "directory-changed");
+        watch_directory(path.clone(), app.handle().clone()).unwrap();
+
+        // Creating a markdown file inside the watched dir is a relevant change.
+        std::fs::write(dir.join("new.md"), "# hi").unwrap();
+
+        let count = wait_for_event(&fired, Duration::from_secs(10));
+        assert!(count > 0, "expected at least one directory-changed emit");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
@
## Summary

Adds Rust test coverage for `src-tauri/src/watcher.rs`. Previously only the pure `is_relevant_directory_change` helper was tested; the four `#[tauri::command]` functions (`watch_file`, `unwatch_file`, `watch_directory`, `unwatch_directory`) and the watcher closures had no coverage.

To make the commands testable, they are now generic over the Tauri runtime (`AppHandle<R>` instead of the concrete `Wry` handle), mirroring the existing `handle_second_instance` pattern in `lib.rs`. This lets the tests drive them with `tauri::test::MockRuntime` without booting a real window manager. It is a no-op for the running app.

Part of #171.

## Changes

- Make `watch_file` / `unwatch_file` / `watch_directory` / `unwatch_directory` generic over `R: Runtime` so they can be driven by `MockRuntime`.
- Add 12 tests covering:
  - state registration and idempotency (the early `contains_key` return) for both file and directory variants
  - the error path when watching a nonexistent path (and that no dangling entry is left behind)
  - `unwatch_*` removing a registered path, and being a no-op for unknown paths
  - the watcher closures themselves: modify a watched file and assert a `file-changed` emit; create a markdown file in a watched directory and assert a `directory-changed` emit. These poll for the event (latency varies by platform) rather than sleeping a fixed amount.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

`cargo test --lib` (121 passed) and `cargo clippy --all-targets -- -D warnings` both clean.

## Screenshots

N/A (test-only change).
@