### PR TITLE
fix(chocolatey): preserve changelog line breaks in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,10 +304,17 @@ jobs:
           # release notes) so the Chocolatey package page shows what changed in
           # this release instead of only linking to the releases list.
           $prevTag = gh release list --repo $repo --limit 2 --json tagName --jq '.[1].tagName'
-          $changelog = gh api "repos/$repo/releases/generate-notes" `
+          # gh emits the body as multiple lines, which PowerShell captures as a
+          # string[]. Join it back with newlines so the Markdown survives (string
+          # interpolation would otherwise flatten the array with spaces and turn
+          # the whole changelog into one run-on paragraph).
+          $changelog = (gh api "repos/$repo/releases/generate-notes" `
             -f tag_name="$tag" `
             -f previous_tag_name="$prevTag" `
-            --jq .body
+            --jq .body) -join "`n"
+          # Drop the leading "<!-- Release notes generated ... -->" comment GitHub
+          # prepends; Chocolatey renders raw HTML as literal text, not a comment.
+          $changelog = ($changelog -replace '(?s)^\s*<!--.*?-->\s*', '').Trim()
 
           # Append a "Links" section so users can jump to the release page,
           # docs, and issue tracker straight from the Chocolatey listing.


### PR DESCRIPTION
## Summary

Follow-up to #252. The Chocolatey package page for v0.9.0 rendered the changelog as one run-on paragraph (see [glyph/0.9.0#releasenotes](https://community.chocolatey.org/packages/glyph/0.9.0#releasenotes)). Root cause: `gh ... generate-notes` output was captured as a PowerShell `string[]` (one element per line), and string-interpolating it flattened the array with spaces, destroying every newline. The Links section rendered fine because it was built with an explicit `-join` newline.

## Changes

- Join the `gh generate-notes` output with newlines (`-join "`n"`) so the Markdown structure survives interpolation.
- Strip GitHub's leading `<!-- Release notes generated ... -->` comment, which Chocolatey renders as literal text rather than hiding.

## Testing

Simulated the exact PowerShell notes-building logic against the real v0.9.0 `generate-notes` output: the changelog now retains all line breaks (22 lines, proper `##`/`###` headings and `*` bullets) and the HTML comment is gone. The fix runs at release time, so it takes effect on the next tagged release.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A (CI workflow change)