### PR TITLE
feat(plugins): plugin API foundation (base)

### DIFF
--- a/src/lib/plugins/apiVersion.test.ts
+++ b/src/lib/plugins/apiVersion.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { PLUGIN_API_VERSION, satisfiesApiVersion } from "./apiVersion";
+
+describe("satisfiesApiVersion", () => {
+  it("matches an exact version", () => {
+    expect(satisfiesApiVersion("1.0.0", "1.0.0")).toBe(true);
+    expect(satisfiesApiVersion("1.0.1", "1.0.0")).toBe(false);
+  });
+
+  it("accepts a caret range with a higher host patch or minor", () => {
+    expect(satisfiesApiVersion("^1.0.0", "1.0.5")).toBe(true);
+    expect(satisfiesApiVersion("^1.2.0", "1.4.0")).toBe(true);
+  });
+
+  it("rejects a caret range the host is below", () => {
+    expect(satisfiesApiVersion("^1.2.0", "1.1.9")).toBe(false);
+    expect(satisfiesApiVersion("^1.0.5", "1.0.4")).toBe(false);
+  });
+
+  it("rejects a different major version", () => {
+    expect(satisfiesApiVersion("^1.0.0", "2.0.0")).toBe(false);
+    expect(satisfiesApiVersion("^2.0.0", "1.9.9")).toBe(false);
+  });
+
+  it("treats unparseable input as incompatible", () => {
+    expect(satisfiesApiVersion("latest", "1.0.0")).toBe(false);
+    expect(satisfiesApiVersion("^1.0", "1.0.0")).toBe(false);
+    expect(satisfiesApiVersion("^1.0.0", "nope")).toBe(false);
+  });
+
+  it("defaults the host to the current API version", () => {
+    expect(satisfiesApiVersion(`^${PLUGIN_API_VERSION}`)).toBe(true);
+  });
+});

--- a/src/lib/plugins/apiVersion.ts
+++ b/src/lib/plugins/apiVersion.ts
@@ -1,0 +1,47 @@
+/**
+ * The version of the Glyph plugin API this build implements. Plugins declare a
+ * compatible range in their manifest (`apiVersion`) and {@link satisfiesApiVersion}
+ * gates loading on it. Bump the major only on a breaking change to the plugin
+ * contract; bump the minor when adding backwards-compatible surface.
+ */
+export const PLUGIN_API_VERSION = "1.0.0";
+
+interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function parse(version: string): SemVer | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version.trim());
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+/**
+ * Does the host API satisfy a plugin's required range? Supports an exact
+ * version (`"1.2.3"`) or a caret range (`"^1.2.3"`: same major, with host
+ * `minor.patch >= required`). Intentionally tiny — the plugin contract only
+ * needs caret/exact, not the full semver grammar. Unparseable input is treated
+ * as incompatible rather than throwing.
+ */
+export function satisfiesApiVersion(range: string, current: string = PLUGIN_API_VERSION): boolean {
+  const host = parse(current);
+  if (!host) return false;
+
+  const trimmed = range.trim();
+  const caret = trimmed.startsWith("^");
+  const required = parse(caret ? trimmed.slice(1) : trimmed);
+  if (!required) return false;
+
+  if (host.major !== required.major) return false;
+  if (!caret) {
+    return host.minor === required.minor && host.patch === required.patch;
+  }
+  if (host.minor !== required.minor) return host.minor > required.minor;
+  return host.patch >= required.patch;
+}

--- a/src/lib/plugins/disposer.test.ts
+++ b/src/lib/plugins/disposer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { DisposerBag } from "./disposer";
+
+describe("DisposerBag", () => {
+  it("runs disposers most-recent first", () => {
+    const order: number[] = [];
+    const bag = new DisposerBag();
+    bag.add(() => order.push(1));
+    bag.add(() => order.push(2));
+    bag.add(() => order.push(3));
+
+    bag.dispose();
+
+    expect(order).toEqual([3, 2, 1]);
+  });
+
+  it("is idempotent — disposing twice runs each disposer once", () => {
+    const fn = vi.fn();
+    const bag = new DisposerBag();
+    bag.add(fn);
+
+    bag.dispose();
+    bag.dispose();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(bag.isDisposed).toBe(true);
+  });
+
+  it("runs a disposer immediately when added after disposal", () => {
+    const bag = new DisposerBag();
+    bag.dispose();
+
+    const fn = vi.fn();
+    bag.add(fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(bag.size).toBe(0);
+  });
+
+  it("keeps tearing down when a disposer throws", () => {
+    const after = vi.fn();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const bag = new DisposerBag();
+    // `after` is added first, so it runs last (reverse order) — after the throw.
+    bag.add(after);
+    bag.add(() => {
+      throw new Error("boom");
+    });
+
+    bag.dispose();
+
+    expect(after).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("reports the number of pending disposers", () => {
+    const bag = new DisposerBag();
+    expect(bag.size).toBe(0);
+    bag.add(() => {});
+    bag.add(() => {});
+    expect(bag.size).toBe(2);
+    bag.dispose();
+    expect(bag.size).toBe(0);
+  });
+});

--- a/src/lib/plugins/disposer.ts
+++ b/src/lib/plugins/disposer.ts
@@ -1,0 +1,55 @@
+/** A function that tears down whatever a `register*` call set up. */
+export type Disposer = () => void;
+
+/**
+ * Collects disposers so a plugin (or the host) can tear everything down in one
+ * call. Every registration in the plugin API returns a {@link Disposer}; the
+ * loader drops each plugin's disposers into a bag and empties it on unload,
+ * which is what keeps disable/uninstall from leaking listeners, panels, menu
+ * items, or settings.
+ */
+export class DisposerBag {
+  private disposers: Disposer[] = [];
+  private disposed = false;
+
+  /**
+   * Register a teardown callback. If the bag is already disposed the callback
+   * runs immediately, so late registrations can't leak.
+   */
+  add(disposer: Disposer): void {
+    if (this.disposed) {
+      disposer();
+      return;
+    }
+    this.disposers.push(disposer);
+  }
+
+  /**
+   * Run every collected disposer (most-recent first, so later registrations
+   * that build on earlier ones unwind first) and clear the bag. Idempotent; a
+   * throwing disposer is logged and does not stop the rest.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    const pending = this.disposers.slice().reverse();
+    this.disposers = [];
+    for (const disposer of pending) {
+      try {
+        disposer();
+      } catch (err) {
+        console.error("Plugin disposer threw during teardown:", err);
+      }
+    }
+  }
+
+  /** Whether {@link dispose} has already run. */
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  /** Number of disposers still pending. */
+  get size(): number {
+    return this.disposers.length;
+  }
+}

--- a/src/lib/plugins/registry.test.ts
+++ b/src/lib/plugins/registry.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRegistry } from "./registry";
+
+describe("createRegistry", () => {
+  it("lists registered entries in insertion order", () => {
+    const reg = createRegistry<string>();
+    reg.register("a");
+    reg.register("b");
+    expect(reg.list()).toEqual(["a", "b"]);
+  });
+
+  it("removes an entry when its disposer runs", () => {
+    const reg = createRegistry<string>();
+    const dispose = reg.register("a");
+    reg.register("b");
+
+    dispose();
+
+    expect(reg.list()).toEqual(["b"]);
+  });
+
+  it("notifies subscribers on register and unregister", () => {
+    const reg = createRegistry<string>();
+    const listener = vi.fn();
+    reg.subscribe(listener);
+
+    const dispose = reg.register("a");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    dispose();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify after a redundant disposer call", () => {
+    const reg = createRegistry<string>();
+    const dispose = reg.register("a");
+    const listener = vi.fn();
+    reg.subscribe(listener);
+
+    dispose();
+    dispose();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops notifying once a subscriber unsubscribes", () => {
+    const reg = createRegistry<string>();
+    const listener = vi.fn();
+    const unsubscribe = reg.subscribe(listener);
+
+    unsubscribe();
+    reg.register("a");
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("returns an independent snapshot from list()", () => {
+    const reg = createRegistry<string>();
+    reg.register("a");
+    const snapshot = reg.list();
+    reg.register("b");
+    expect(snapshot).toEqual(["a"]);
+  });
+});

--- a/src/lib/plugins/registry.ts
+++ b/src/lib/plugins/registry.ts
@@ -1,0 +1,46 @@
+import type { Disposer } from "./disposer";
+
+/**
+ * A live, ordered collection that plugins contribute to and the app reads from.
+ * `register` adds an entry and returns a {@link Disposer} that removes it;
+ * UI that renders the entries calls `subscribe` to re-read when the set
+ * changes. This is the single primitive behind every contribution point
+ * (commands, sidebar panels, status bar items, exporters, markdown plugins),
+ * so registration/teardown semantics live in exactly one place.
+ */
+export interface Registry<T> {
+  /** Add an entry; the returned disposer removes it. */
+  register(entry: T): Disposer;
+  /** Snapshot of the current entries, in insertion order. */
+  list(): readonly T[];
+  /** Observe changes; the returned disposer unsubscribes. */
+  subscribe(listener: () => void): Disposer;
+}
+
+export function createRegistry<T>(): Registry<T> {
+  const entries = new Set<T>();
+  const listeners = new Set<() => void>();
+
+  const notify = () => {
+    for (const listener of listeners) listener();
+  };
+
+  return {
+    register(entry) {
+      entries.add(entry);
+      notify();
+      return () => {
+        if (entries.delete(entry)) notify();
+      };
+    },
+    list() {
+      return [...entries];
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/src/lib/plugins/types.test.ts
+++ b/src/lib/plugins/types.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { GlyphPlugin, SidebarPanelContribution } from "./types";
+
+// These are compile-time contract checks: they fail `tsc` (not just at runtime)
+// if the public types regress. The runtime assertions exist only so vitest has
+// something to run.
+describe("plugin types contract", () => {
+  it("allows a mount with no return (no cleanup needed)", () => {
+    const panel: SidebarPanelContribution = {
+      id: "p",
+      title: "Panel",
+      mount: (el) => {
+        el.textContent = "hi";
+      },
+    };
+    expect(panel.id).toBe("p");
+  });
+
+  it("allows a mount that registers cleanup", () => {
+    const panel: SidebarPanelContribution = {
+      id: "p",
+      title: "Panel",
+      mount: (_el, registerCleanup) => {
+        registerCleanup(() => {
+          /* cleanup */
+        });
+      },
+    };
+    expect(typeof panel.mount).toBe("function");
+  });
+
+  it("describes a plugin with manifest + activate", () => {
+    const plugin: GlyphPlugin = {
+      manifest: { id: "com.x.demo", name: "Demo", version: "1.0.0", apiVersion: "^1.0.0" },
+      activate(ctx) {
+        ctx.notify("hello");
+      },
+    };
+    expect(plugin.manifest.id).toBe("com.x.demo");
+  });
+});

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -1,0 +1,135 @@
+import type * as React from "react";
+import type { Options } from "react-markdown";
+import type { Disposer } from "./disposer";
+
+/**
+ * A remark or rehype plugin entry, in the same shape react-markdown accepts
+ * (`plugin` or `[plugin, options]`). Sourced from react-markdown's own types so
+ * the plugin contract stays in lockstep with the renderer.
+ */
+export type MarkdownPlugin = NonNullable<Options["remarkPlugins"]>[number];
+
+/** Capability a plugin requests; surfaced for user consent before enabling. */
+export type PluginPermission = "workspace:read" | "workspace:write" | `network:${string}`;
+
+/**
+ * Declarative metadata shipped alongside a plugin's built `main.js`. Mirrors the
+ * `manifest.json` an installed plugin folder contains.
+ */
+export interface PluginManifest {
+  /** Reverse-DNS unique id, e.g. `com.author.slides`. */
+  id: string;
+  name: string;
+  /** The plugin's own semver. */
+  version: string;
+  /** Semver range against {@link PLUGIN_API_VERSION}, e.g. `^1.0.0`. */
+  apiVersion: string;
+  /** Minimum compatible Glyph app version. */
+  minAppVersion?: string;
+  description?: string;
+  author?: string;
+  /** Entry file relative to the plugin folder. Defaults to `main.js`. */
+  main?: string;
+  /** Capabilities requested; shown on the consent screen before first enable. */
+  permissions?: PluginPermission[];
+}
+
+/** A command contributed to the palette (and optionally a shortcut). */
+export interface CommandContribution {
+  id: string;
+  title: string;
+  run: () => void | Promise<void>;
+  keybinding?: string;
+}
+
+/**
+ * Renders into a host-provided container. The mount boundary is deliberately
+ * framework-agnostic: React authors get a thin helper on top, but Svelte/Vue/
+ * vanilla plugins can mount into `el` directly. Register any teardown (event
+ * listeners, timers, framework unmount) via `registerCleanup`; the host runs it
+ * on unload. Passing cleanup through a callback keeps the return type plain
+ * `void`, so a mount that needs no teardown is just `(el) => { ... }`.
+ */
+export interface MountContribution {
+  id: string;
+  mount: (el: HTMLElement, registerCleanup: (cleanup: Disposer) => void) => void;
+}
+
+/** A sidebar panel contribution. */
+export interface SidebarPanelContribution extends MountContribution {
+  title: string;
+  icon?: React.ComponentType;
+}
+
+/** A status bar item contribution. */
+export type StatusBarItemContribution = MountContribution;
+
+/** An export format contribution, run against the active document. */
+export interface ExporterContribution {
+  format: string;
+  label: string;
+  run: () => Promise<void>;
+}
+
+/** Lifecycle/workspace events a plugin can observe. */
+export type PluginEvent = "file-opened" | "file-saved" | "active-tab-changed";
+
+export interface MarkdownRegistry {
+  registerRemarkPlugin(plugin: MarkdownPlugin): Disposer;
+  registerRehypePlugin(plugin: MarkdownPlugin): Disposer;
+  registerComponent(tag: string, component: React.ComponentType<Record<string, unknown>>): Disposer;
+  registerFencedRenderer(lang: string, component: React.ComponentType<{ code: string }>): Disposer;
+}
+
+export interface CommandRegistry {
+  register(command: CommandContribution): Disposer;
+}
+
+export interface UiRegistry {
+  addSidebarPanel(panel: SidebarPanelContribution): Disposer;
+  addStatusBarItem(item: StatusBarItemContribution): Disposer;
+}
+
+export interface ExporterRegistry {
+  register(exporter: ExporterContribution): Disposer;
+}
+
+/** Per-plugin scoped settings, persisted under `settings.plugins.<id>`. */
+export interface PluginSettingsApi {
+  get<T = unknown>(key: string): T | undefined;
+  set(key: string, value: unknown): void;
+}
+
+export interface EventBus {
+  on(event: PluginEvent, handler: (payload: unknown) => void): Disposer;
+}
+
+/**
+ * The capability object passed to {@link GlyphPlugin.activate}. It is the only
+ * door a plugin has to the host — there is no direct `invoke`. Every `register*`
+ * call returns a {@link Disposer}; the loader collects them and runs them on
+ * unload.
+ */
+export interface GlyphPluginContext {
+  readonly apiVersion: string;
+  readonly markdown: MarkdownRegistry;
+  readonly commands: CommandRegistry;
+  readonly ui: UiRegistry;
+  readonly exporters: ExporterRegistry;
+  readonly settings: PluginSettingsApi;
+  readonly events: EventBus;
+  notify(message: string, level?: "info" | "warn" | "error"): void;
+  /** The host's single React instance — plugins must not bundle their own. */
+  readonly React: typeof React;
+}
+
+/**
+ * The object a plugin's `main.js` default-exports. `activate` wires the plugin
+ * into the host through {@link GlyphPluginContext}; `deactivate` runs on
+ * disable/unload (in addition to the auto-collected disposers).
+ */
+export interface GlyphPlugin {
+  manifest: PluginManifest;
+  activate(ctx: GlyphPluginContext): void | Promise<void>;
+  deactivate?(): void;
+}


### PR DESCRIPTION
## Summary

First, **base** PR for the plugin system (design tracked in #109). It lands the foundational, **inert** primitives that every later plugin PR stacks on — no loading, no UI, no behaviour change yet. Everything here is internal `src/lib/plugins/` scaffolding behind no entry point, so it ships safely ahead of the rest.

This is intentionally small and reviewable. The full delivery sequence (pipeline extraction → host wiring → loader → manager → first shipped plugin) is enumerated in #109.

> Draft until the API shape here is agreed, since later PRs depend on these types.

## Changes

- `src/lib/plugins/disposer.ts` — `Disposer` type + `DisposerBag` (reverse-order, idempotent, error-isolating teardown). The backbone for clean plugin unload.
- `src/lib/plugins/registry.ts` — generic `createRegistry<T>()` (register-returns-disposer, `list()` snapshot, `subscribe()`), the single primitive behind every contribution point.
- `src/lib/plugins/apiVersion.ts` — `PLUGIN_API_VERSION` + a tiny `satisfiesApiVersion()` (exact/caret) to gate plugin compatibility.
- `src/lib/plugins/types.ts` — the public contract: `GlyphPlugin`, `GlyphPluginContext`, `PluginManifest`/`PluginPermission`, and the registry + contribution interfaces (commands, sidebar panels, status bar items, exporters, markdown). The UI mount boundary is framework-agnostic (`mount(el, registerCleanup)`), so plugins aren't forced to use React.
- Tests beside each module (20 cases), including compile-time contract checks in `types.test.ts`.

### Notes for reviewers

- **No wiring.** Nothing imports these yet; `App.tsx`/`AppShell.tsx` are untouched. The `PluginsProvider` and consumer wiring come in the next PR.
- **`mount` signature.** Cleanup is passed via a `registerCleanup` callback rather than a returned `Disposer | void`, because `void`-in-union trips `noConfusingVoidType` and the `undefined` autofix breaks the no-return ergonomics (verified via the contract test). This keeps the lint rule on project-wide.
- **No React duplication later.** `ctx.React` exposes the host's single React instance; plugin builds will externalize React (enforced in a later PR + starter template).

## Testing

- `pnpm typecheck`, `pnpm check` (Biome, zero warnings), `pnpm test` — green (full suite ran via pre-commit; `cargo test`/`clippy` also ran clean and are unaffected).
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Manual app testing is N/A — this PR adds no runtime behaviour.

## Screenshots

_N/A — internal scaffolding only._
