### PR TITLE
docs(claude): require recognized issue-closing keywords

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,12 @@ Cross-platform markdown viewer built with Tauri v2 + React 19 + TypeScript.
 
 When creating PRs, always follow the PR template. When creating issues, use the appropriate issue template.
 
+### Closing issues from PRs and commits
+
+To auto-close an issue, GitHub only recognizes these keywords in a PR description or commit message, each followed directly by `#<number>`: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
+
+Do **not** use `closing` (or `closed out`, `fixing`, `resolving`, or any other variant). GitHub does not treat those as keywords, so the issue silently stays open. Write `Closes #110`, never `closing #110`.
+
 ## Architecture
 
 - **Backend** (`src-tauri/src/`): Rust — Tauri commands, file watcher via `notify` crate, plugin setup, native menus


### PR DESCRIPTION
## Summary

Documents the GitHub issue-closing keyword rule in `CLAUDE.md` so PRs and commits actually auto-close the issues they reference.

GitHub only recognizes `close`/`closes`/`closed` (and the `fix`/`resolve` families) as closing keywords. Non-keyword phrasing like `closing #110` is treated as plain text, so the issue silently stays open. This is exactly what stranded #110 after its export PR (#249) merged in v0.9.0. Its body said "closing #110", so the issue was never closed.

## Changes

- Add a "Closing issues from PRs and commits" subsection to `CLAUDE.md` listing the recognized keywords and forbidding non-keyword variants (`closing`, `fixing`, `resolving`, `closed out`).

## Testing

Docs-only change to `CLAUDE.md`; no code paths affected.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A
