### PR TITLE
fix(sync): cloud-sync polish (drop dead auto-sync setting, live status pill)

### DIFF
--- a/src-tauri/src/sync/commands.rs
+++ b/src-tauri/src/sync/commands.rs
@@ -159,7 +159,6 @@ mod tests {
                 remote_url: self.remote_path.clone(),
                 remote_branch: DEFAULT_REMOTE_BRANCH.into(),
                 conflict_policy: ConflictPolicy::Prompt,
-                auto_sync_seconds: None,
                 author: Some(CommitIdentity {
                     name: "Test User".into(),
                     email: "test@example.com".into(),

--- a/src-tauri/src/sync/config.rs
+++ b/src-tauri/src/sync/config.rs
@@ -29,9 +29,6 @@ pub struct WorkspaceSyncConfig {
     pub remote_branch: String,
     /// What to do when local and remote disagree on the same file.
     pub conflict_policy: ConflictPolicy,
-    /// Auto-sync interval in seconds, or `None` to disable background
-    /// sync. The scheduler lives in a follow-up PR.
-    pub auto_sync_seconds: Option<u32>,
     /// Author identity used for commits Glyph creates on the user's
     /// behalf. Optional — falls back to libgit2's global config when
     /// `None`.
@@ -69,7 +66,6 @@ impl WorkspaceSyncConfig {
             remote_url: String::new(),
             remote_branch: DEFAULT_REMOTE_BRANCH.to_string(),
             conflict_policy: ConflictPolicy::default(),
-            auto_sync_seconds: None,
             author: None,
         }
     }
@@ -87,7 +83,6 @@ mod tests {
         assert!(cfg.remote_url.is_empty());
         assert_eq!(cfg.remote_branch, DEFAULT_REMOTE_BRANCH);
         assert_eq!(cfg.conflict_policy, ConflictPolicy::Prompt);
-        assert!(cfg.auto_sync_seconds.is_none());
         assert!(cfg.author.is_none());
     }
 
@@ -99,7 +94,6 @@ mod tests {
             remote_url: "https://example.com/notes.git".to_string(),
             remote_branch: "trunk".to_string(),
             conflict_policy: ConflictPolicy::PreferRemote,
-            auto_sync_seconds: Some(300),
             author: Some(CommitIdentity {
                 name: "Hamid".into(),
                 email: "h@example.com".into(),
@@ -110,7 +104,6 @@ mod tests {
         assert_eq!(v["remoteUrl"], "https://example.com/notes.git");
         assert_eq!(v["remoteBranch"], "trunk");
         assert_eq!(v["conflictPolicy"], "prefer-remote");
-        assert_eq!(v["autoSyncSeconds"], 300);
         assert_eq!(v["author"]["name"], "Hamid");
 
         let round: WorkspaceSyncConfig = serde_json::from_value(v).unwrap();
@@ -125,11 +118,9 @@ mod tests {
             "remoteUrl": "https://example.com/n.git",
             "remoteBranch": "main",
             "conflictPolicy": "prompt",
-            "autoSyncSeconds": null,
             "author": null,
         });
         let cfg: WorkspaceSyncConfig = serde_json::from_value(json).unwrap();
-        assert!(cfg.auto_sync_seconds.is_none());
         assert!(cfg.author.is_none());
     }
 }

--- a/src-tauri/src/sync/ops.rs
+++ b/src-tauri/src/sync/ops.rs
@@ -223,7 +223,6 @@ mod tests {
                 remote_url: self.remote_path.clone(),
                 remote_branch: DEFAULT_REMOTE_BRANCH.to_string(),
                 conflict_policy: ConflictPolicy::Prompt,
-                auto_sync_seconds: None,
                 author: Some(CommitIdentity {
                     name: "Test User".into(),
                     email: "test@example.com".into(),
@@ -292,7 +291,6 @@ mod tests {
             remote_url: String::new(),
             remote_branch: DEFAULT_REMOTE_BRANCH.into(),
             conflict_policy: ConflictPolicy::Prompt,
-            auto_sync_seconds: None,
             author: None,
         };
         let path = config.workspace_path.clone();

--- a/src-tauri/src/sync/state.rs
+++ b/src-tauri/src/sync/state.rs
@@ -81,7 +81,6 @@ mod tests {
             remote_url: "https://example.com/n.git".to_string(),
             remote_branch: "main".to_string(),
             conflict_policy: ConflictPolicy::Prompt,
-            auto_sync_seconds: None,
             author: None,
         })
         .unwrap();

--- a/src-tauri/src/workspace/config.rs
+++ b/src-tauri/src/workspace/config.rs
@@ -61,8 +61,6 @@ pub struct SyncSettings {
     pub remote_branch: String,
     pub conflict_policy: ConflictPolicy,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub auto_sync_seconds: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub author: Option<CommitIdentity>,
 }
 
@@ -73,7 +71,6 @@ impl SyncSettings {
             remote_url: c.remote_url.clone(),
             remote_branch: c.remote_branch.clone(),
             conflict_policy: c.conflict_policy,
-            auto_sync_seconds: c.auto_sync_seconds,
             author: c.author.clone(),
         }
     }
@@ -85,7 +82,6 @@ impl SyncSettings {
             remote_url: self.remote_url,
             remote_branch: self.remote_branch,
             conflict_policy: self.conflict_policy,
-            auto_sync_seconds: self.auto_sync_seconds,
             author: self.author,
         }
     }
@@ -213,7 +209,6 @@ mod tests {
             remote_url: "https://example.com/n.git".to_string(),
             remote_branch: "main".to_string(),
             conflict_policy: ConflictPolicy::PreferLocal,
-            auto_sync_seconds: Some(120),
             author: Some(CommitIdentity {
                 name: "Hamid".into(),
                 email: "h@example.com".into(),
@@ -229,7 +224,6 @@ mod tests {
         let raw = std::fs::read_to_string(tmp.path().join(".glyph/config.json")).unwrap();
         assert!(raw.contains("\"remoteUrl\""));
         assert!(raw.contains("\"conflictPolicy\""));
-        assert!(raw.contains("\"autoSyncSeconds\""));
         // The implied root is never written to disk.
         assert!(!raw.contains("workspacePath"));
 
@@ -240,7 +234,6 @@ mod tests {
         assert_eq!(loaded.workspace_path, tmp.path().to_string_lossy());
         assert_eq!(loaded.remote_url, "https://example.com/n.git");
         assert_eq!(loaded.conflict_policy, ConflictPolicy::PreferLocal);
-        assert_eq!(loaded.auto_sync_seconds, Some(120));
     }
 
     #[test]

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,5 @@
 import { SidebarLayoutProvider } from "@/contexts/SidebarLayoutContext";
+import { SyncConfigProvider } from "@/contexts/SyncConfigContext";
 import { TabsProvider } from "@/contexts/TabsContext";
 import { useCodeThemeStyle } from "@/hooks/useCodeThemeStyle";
 import { useSettings } from "@/hooks/useSettings";
@@ -16,7 +17,9 @@ export function App() {
   return (
     <TabsProvider settings={settings} updateSettings={updateSettings}>
       <SidebarLayoutProvider settings={settings} updateSettings={updateSettings}>
-        <AppShell />
+        <SyncConfigProvider>
+          <AppShell />
+        </SyncConfigProvider>
       </SidebarLayoutProvider>
     </TabsProvider>
   );

--- a/src/components/layout/StatusBar.test.tsx
+++ b/src/components/layout/StatusBar.test.tsx
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SyncConfigProvider } from "@/contexts/SyncConfigContext";
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import type { FileTab, FolderTab } from "@/hooks/useTabs";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
@@ -72,7 +73,12 @@ function buildContext(opts: Opts): TabsContextValue {
 }
 
 function Wrapper({ value, children }: { value: TabsContextValue; children: ReactNode }) {
-  return <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
+  // StatusBar renders the sync pill, which reads from SyncConfigContext.
+  return (
+    <TabsContext.Provider value={value}>
+      <SyncConfigProvider>{children}</SyncConfigProvider>
+    </TabsContext.Provider>
+  );
 }
 
 function renderStatusBar(opts: Opts = {}) {

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -13,7 +13,7 @@ interface StatusBarProps {
 
 export function StatusBar({ onOpenSync }: StatusBarProps) {
   const { settings } = useSettings();
-  const { activeFile, activeTab, displayContent } = useTabsContext();
+  const { activeFile, displayContent } = useTabsContext();
   const zoomPercent = Math.round((settings.appearance.fontSize / ZOOM_DEFAULT) * 100);
 
   const filePath = activeFile?.path;
@@ -25,7 +25,6 @@ export function StatusBar({ onOpenSync }: StatusBarProps) {
   if (!displayContent && !isNotebook) return null;
 
   const words = displayContent ? countWords(displayContent) : 0;
-  const workspacePath = activeTab?.kind === "folder" ? activeTab.root : null;
 
   return (
     <div
@@ -46,7 +45,7 @@ export function StatusBar({ onOpenSync }: StatusBarProps) {
         </>
       )}
       {zoomPercent !== 100 && <span>{zoomPercent}%</span>}
-      {onOpenSync && <SyncStatusIndicator workspacePath={workspacePath} onOpenSync={onOpenSync} />}
+      {onOpenSync && <SyncStatusIndicator onOpenSync={onOpenSync} />}
     </div>
   );
 }

--- a/src/components/layout/SyncStatusIndicator.test.tsx
+++ b/src/components/layout/SyncStatusIndicator.test.tsx
@@ -1,20 +1,8 @@
-import { invoke } from "@tauri-apps/api/core";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SyncConfigContext, type SyncConfigContextValue } from "@/contexts/SyncConfigContext";
 import type { StatusReport, WorkspaceSyncConfig } from "@/lib/sync";
 import { relativeTime, summarise, SyncStatusIndicator } from "./SyncStatusIndicator";
-
-beforeEach(() => {
-  vi.mocked(invoke).mockReset();
-});
-
-function routeInvoke(handlers: Record<string, (args: unknown) => unknown>) {
-  vi.mocked(invoke).mockImplementation((cmd: string, args?: unknown) => {
-    const handler = handlers[cmd];
-    if (!handler) return Promise.reject(new Error(`no handler for ${cmd}`));
-    return Promise.resolve(handler(args) as never);
-  });
-}
 
 function cfg(overrides: Partial<WorkspaceSyncConfig> = {}): WorkspaceSyncConfig {
   return {
@@ -28,32 +16,60 @@ function cfg(overrides: Partial<WorkspaceSyncConfig> = {}): WorkspaceSyncConfig 
   };
 }
 
+/** Build a full context value; the indicator only reads config/status/path. */
+function ctxValue(over: Partial<SyncConfigContextValue> = {}): SyncConfigContextValue {
+  return {
+    workspacePath: "/w",
+    config: null,
+    status: null,
+    defaultAuthor: null,
+    repoPresent: null,
+    loading: false,
+    busy: false,
+    error: null,
+    save: vi.fn(),
+    remove: vi.fn(),
+    setToken: vi.fn(),
+    clearToken: vi.fn(),
+    initRepo: vi.fn(),
+    cloneRemote: vi.fn(),
+    setOrigin: vi.fn(),
+    commitConfig: vi.fn(),
+    runSync: vi.fn(),
+    refreshStatus: vi.fn(),
+    refreshRepoPresent: vi.fn(),
+    ...over,
+  };
+}
+
+function renderIndicator(over: Partial<SyncConfigContextValue>, onOpenSync = vi.fn()) {
+  return render(
+    <SyncConfigContext.Provider value={ctxValue(over)}>
+      <SyncStatusIndicator onOpenSync={onOpenSync} />
+    </SyncConfigContext.Provider>,
+  );
+}
+
 describe("SyncStatusIndicator", () => {
   it("renders nothing when there is no workspace path", () => {
-    const { container } = render(<SyncStatusIndicator workspacePath={null} onOpenSync={vi.fn()} />);
+    const { container } = renderIndicator({ workspacePath: null });
     expect(container.firstChild).toBeNull();
   });
 
-  it("shows 'Sync off' for an unconfigured workspace", async () => {
-    routeInvoke({ sync_get_config: () => null });
-    render(<SyncStatusIndicator workspacePath="/w" onOpenSync={vi.fn()} />);
-    const btn = await screen.findByText("Sync off");
-    expect(btn).toHaveAttribute("data-tone", "off");
+  it("shows 'Sync off' for an unconfigured workspace", () => {
+    renderIndicator({ workspacePath: "/w", config: null, status: null });
+    expect(screen.getByText("Sync off")).toHaveAttribute("data-tone", "off");
   });
 
-  it("shows 'Sync configured' when config is loaded but no status fetched yet", async () => {
-    routeInvoke({ sync_get_config: () => cfg() });
-    render(<SyncStatusIndicator workspacePath="/w" onOpenSync={vi.fn()} />);
-    const btn = await screen.findByText("Sync configured");
-    expect(btn).toHaveAttribute("data-tone", "ok");
+  it("shows 'Sync configured' when config is loaded but no status fetched yet", () => {
+    renderIndicator({ config: cfg(), status: null });
+    expect(screen.getByText("Sync configured")).toHaveAttribute("data-tone", "ok");
   });
 
-  it("clicking the indicator calls onOpenSync", async () => {
-    routeInvoke({ sync_get_config: () => null });
+  it("clicking the indicator calls onOpenSync", () => {
     const onOpenSync = vi.fn();
-    render(<SyncStatusIndicator workspacePath="/w" onOpenSync={onOpenSync} />);
-    const btn = await screen.findByRole("button");
-    fireEvent.click(btn);
+    renderIndicator({ config: cfg() }, onOpenSync);
+    fireEvent.click(screen.getByRole("button"));
     expect(onOpenSync).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/layout/SyncStatusIndicator.test.tsx
+++ b/src/components/layout/SyncStatusIndicator.test.tsx
@@ -23,7 +23,6 @@ function cfg(overrides: Partial<WorkspaceSyncConfig> = {}): WorkspaceSyncConfig 
     remoteUrl: "https://example.com/r.git",
     remoteBranch: "main",
     conflictPolicy: "prompt",
-    autoSyncSeconds: null,
     author: null,
     ...overrides,
   };

--- a/src/components/layout/SyncStatusIndicator.tsx
+++ b/src/components/layout/SyncStatusIndicator.tsx
@@ -6,14 +6,14 @@
 // "+1/-3", "dirty"). Clicking opens the Cloud Sync modal so the user can
 // inspect or trigger a sync.
 //
-// We deliberately don't poll for fresh status here — background fetch is
-// the scheduler PR's job. For now the indicator shows whatever the user
-// last refreshed (or just "Sync configured" until they hit refresh once).
+// Config/status come from the shared `SyncConfigContext`, the same instance
+// the Cloud Sync modal writes to, so enabling sync there updates this pill
+// immediately. We deliberately don't poll for fresh status here — the pill
+// shows whatever was last loaded or refreshed.
 
-import { useSyncConfig } from "@/hooks/useSyncConfig";
+import { useSyncConfigContext } from "@/contexts/SyncConfigContext";
 
 interface SyncStatusIndicatorProps {
-  workspacePath: string | null;
   onOpenSync: () => void;
 }
 
@@ -26,8 +26,8 @@ export function relativeTime(unix: number): string {
 }
 
 export function summarise(
-  config: ReturnType<typeof useSyncConfig>["config"],
-  status: ReturnType<typeof useSyncConfig>["status"],
+  config: ReturnType<typeof useSyncConfigContext>["config"],
+  status: ReturnType<typeof useSyncConfigContext>["status"],
 ): { label: string; tone: "off" | "ok" | "warn" | "error" } {
   if (!config) return { label: "Sync off", tone: "off" };
   if (!status) return { label: "Sync configured", tone: "ok" };
@@ -44,8 +44,8 @@ export function summarise(
   return { label: "Synced", tone: "ok" };
 }
 
-export function SyncStatusIndicator({ workspacePath, onOpenSync }: SyncStatusIndicatorProps) {
-  const { config, status } = useSyncConfig(workspacePath);
+export function SyncStatusIndicator({ onOpenSync }: SyncStatusIndicatorProps) {
+  const { config, status, workspacePath } = useSyncConfigContext();
   if (!workspacePath) return null;
 
   const { label, tone } = summarise(config, status);

--- a/src/components/modals/SyncSettingsModal.test.tsx
+++ b/src/components/modals/SyncSettingsModal.test.tsx
@@ -120,7 +120,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "develop",
       conflictPolicy: "prefer-remote",
-      autoSyncSeconds: 300,
       author: { name: "A", email: "a@example.com" },
     };
     routeInvoke({ sync_get_config: () => stored });
@@ -189,7 +188,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
     routeInvoke({
@@ -289,7 +287,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
     routeInvoke({
@@ -331,7 +328,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
     routeInvoke({
@@ -370,7 +366,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
     routeInvoke({
@@ -404,7 +399,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
     routeInvoke({
@@ -435,7 +429,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
     routeInvoke({
@@ -578,7 +571,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
     routeInvoke({
@@ -594,66 +586,6 @@ describe("SyncSettingsModal", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Sync now" }));
     expect(await screen.findByText(/Authentication failed: bad token/)).toBeInTheDocument();
-  });
-
-  it("autoSyncSeconds: positive integers are persisted as-is", async () => {
-    const calls: Array<Record<string, unknown>> = [];
-    routeInvoke({
-      sync_get_config: () => null,
-      sync_default_author: () => ({ name: null, email: null }),
-      sync_repo_present: () => true,
-      sync_set_config: (args) => {
-        calls.push(args as Record<string, unknown>);
-        return null;
-      },
-      sync_set_origin: () => null,
-      sync_commit_config: () => false,
-    });
-    const wrapper = withTabs(tabsValue(folderTab()));
-    render(<SyncSettingsModal open={true} onClose={vi.fn()} />, { wrapper });
-
-    const remote = await screen.findByPlaceholderText("https://github.com/you/notes.git");
-    fireEvent.change(remote, { target: { value: "https://example.com/r.git" } });
-    fireEvent.change(screen.getByPlaceholderText("off"), { target: { value: "30" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save config" }));
-
-    await waitFor(() => expect(calls).toHaveLength(1));
-    const cfg = calls[0].config as WorkspaceSyncConfig;
-    expect(cfg.autoSyncSeconds).toBe(30);
-  });
-
-  it("autoSyncSeconds: 0, negative, and blank all collapse to null", async () => {
-    // Cases are independent renders so the React effect that syncs form
-    // state from the persisted config never overwrites a fresh edit
-    // mid-test.
-    for (const raw of ["0", "-5", ""]) {
-      const calls: Array<Record<string, unknown>> = [];
-      routeInvoke({
-        sync_get_config: () => null,
-        sync_default_author: () => ({ name: null, email: null }),
-        sync_repo_present: () => true,
-        sync_set_config: (args) => {
-          calls.push(args as Record<string, unknown>);
-          return null;
-        },
-        sync_set_origin: () => null,
-        sync_commit_config: () => false,
-      });
-      const wrapper = withTabs(tabsValue(folderTab()));
-      const { unmount } = render(<SyncSettingsModal open={true} onClose={vi.fn()} />, {
-        wrapper,
-      });
-
-      const remote = await screen.findByPlaceholderText("https://github.com/you/notes.git");
-      fireEvent.change(remote, { target: { value: "https://example.com/r.git" } });
-      fireEvent.change(screen.getByPlaceholderText("off"), { target: { value: raw } });
-      fireEvent.click(screen.getByRole("button", { name: "Save config" }));
-
-      await waitFor(() => expect(calls).toHaveLength(1));
-      const cfg = calls[0].config as WorkspaceSyncConfig;
-      expect(cfg.autoSyncSeconds).toBeNull();
-      unmount();
-    }
   });
 
   it("Author identity: name+email -> author object", async () => {
@@ -724,7 +656,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
     const cases: Array<{ delta: number; expectMatch: RegExp }> = [
@@ -769,7 +700,6 @@ describe("SyncSettingsModal", () => {
       remoteUrl: "https://example.com/r.git",
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
     routeInvoke({
@@ -954,7 +884,6 @@ function makeForm(overrides: Partial<FormState> = {}): FormState {
     conflictPolicy: "prompt",
     authorName: "",
     authorEmail: "",
-    autoSyncSeconds: "",
     token: "",
     commitMessage: "",
     ...overrides,
@@ -1005,7 +934,6 @@ describe("commitSaveConfig", () => {
       remoteUrl,
       remoteBranch: "main",
       conflictPolicy: "prompt",
-      autoSyncSeconds: null,
       author: null,
     };
   }

--- a/src/components/modals/SyncSettingsModal.test.tsx
+++ b/src/components/modals/SyncSettingsModal.test.tsx
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SyncConfigProvider } from "@/contexts/SyncConfigContext";
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import type { FolderTab } from "@/hooks/useTabs";
 import type { WorkspaceSyncConfig } from "@/lib/sync";
@@ -70,8 +71,13 @@ function tabsValue(activeTab: FolderTab | null): TabsContextValue {
 }
 
 function withTabs(value: TabsContextValue) {
+  // The modal reads sync state from SyncConfigContext, which derives the
+  // workspace path from TabsContext and drives the (mocked) sync commands —
+  // so wrap children in the real provider.
   const wrapper = ({ children }: { children: ReactNode }) => (
-    <TabsContext.Provider value={value}>{children}</TabsContext.Provider>
+    <TabsContext.Provider value={value}>
+      <SyncConfigProvider>{children}</SyncConfigProvider>
+    </TabsContext.Provider>
   );
   return wrapper;
 }

--- a/src/components/modals/SyncSettingsModal.tsx
+++ b/src/components/modals/SyncSettingsModal.tsx
@@ -43,7 +43,6 @@ export interface FormState {
   conflictPolicy: ConflictPolicy;
   authorName: string;
   authorEmail: string;
-  autoSyncSeconds: string;
   /** Plain-text PAT. Never displayed back — re-entered each session. */
   token: string;
   /**
@@ -61,18 +60,12 @@ function formFromConfig(config: WorkspaceSyncConfig): FormState {
     conflictPolicy: config.conflictPolicy,
     authorName: config.author?.name ?? "",
     authorEmail: config.author?.email ?? "",
-    autoSyncSeconds:
-      config.autoSyncSeconds === null || config.autoSyncSeconds === undefined
-        ? ""
-        : String(config.autoSyncSeconds),
     token: "",
     commitMessage: "",
   };
 }
 
 function configFromForm(workspacePath: string, form: FormState): WorkspaceSyncConfig {
-  const auto = form.autoSyncSeconds.trim();
-  const parsed = auto === "" ? null : Number.parseInt(auto, 10);
   const author =
     form.authorName.trim() || form.authorEmail.trim()
       ? { name: form.authorName.trim(), email: form.authorEmail.trim() }
@@ -83,7 +76,6 @@ function configFromForm(workspacePath: string, form: FormState): WorkspaceSyncCo
     remoteUrl: form.remoteUrl.trim(),
     remoteBranch: form.remoteBranch.trim() || "main",
     conflictPolicy: form.conflictPolicy,
-    autoSyncSeconds: parsed !== null && Number.isFinite(parsed) && parsed > 0 ? parsed : null,
     author,
   };
 }
@@ -410,21 +402,6 @@ export function SyncSettingsModal({ open, onClose }: SyncSettingsModalProps) {
                       Stored in memory only for now. The next release routes it through your OS
                       keychain.
                     </span>
-                  </label>
-
-                  <label className="settings-field">
-                    <span className="settings-field-label">
-                      Auto-sync interval{" "}
-                      <span className="settings-field-hint">(seconds, blank = off)</span>
-                    </span>
-                    <input
-                      type="number"
-                      className="settings-input"
-                      min={30}
-                      placeholder="off"
-                      value={form.autoSyncSeconds}
-                      onChange={(e) => update("autoSyncSeconds", e.target.value)}
-                    />
                   </label>
 
                   <label className="settings-field">

--- a/src/components/modals/SyncSettingsModal.tsx
+++ b/src/components/modals/SyncSettingsModal.tsx
@@ -18,8 +18,7 @@
 // component stays a thin form view.
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useTabsContext } from "@/contexts/TabsContext";
-import { useSyncConfig } from "@/hooks/useSyncConfig";
+import { useSyncConfigContext } from "@/contexts/SyncConfigContext";
 import {
   type ConflictPolicy,
   defaultConfigFor,
@@ -167,9 +166,8 @@ interface SyncSettingsModalProps {
 }
 
 export function SyncSettingsModal({ open, onClose }: SyncSettingsModalProps) {
-  const { activeTab } = useTabsContext();
-  const workspacePath = activeTab?.kind === "folder" ? activeTab.root : null;
   const {
+    workspacePath,
     config,
     status,
     defaultAuthor,
@@ -185,7 +183,7 @@ export function SyncSettingsModal({ open, onClose }: SyncSettingsModalProps) {
     commitConfig,
     runSync,
     refreshStatus,
-  } = useSyncConfig(workspacePath);
+  } = useSyncConfigContext();
 
   const defaultForm = useMemo(
     () => formFromConfig(config ?? defaultConfigFor(workspacePath ?? "")),

--- a/src/contexts/SyncConfigContext.test.tsx
+++ b/src/contexts/SyncConfigContext.test.tsx
@@ -1,0 +1,135 @@
+import { invoke } from "@tauri-apps/api/core";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SyncStatusIndicator } from "@/components/layout/SyncStatusIndicator";
+import type { FolderTab } from "@/hooks/useTabs";
+import type { WorkspaceSyncConfig } from "@/lib/sync";
+import { TabsContext, type TabsContextValue } from "./TabsContext";
+import { SyncConfigProvider, useSyncConfigContext } from "./SyncConfigContext";
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+});
+
+function routeInvoke(handlers: Record<string, (args: unknown) => unknown>) {
+  vi.mocked(invoke).mockImplementation((cmd: string, args?: unknown) => {
+    const handler = handlers[cmd];
+    if (!handler) return Promise.reject(new Error(`no handler for ${cmd}`));
+    return Promise.resolve(handler(args) as never);
+  });
+}
+
+function folderTab(root = "/w"): FolderTab {
+  return { id: "t1", kind: "folder", root, expanded: new Set(), nodes: new Map(), file: null };
+}
+
+function tabsValue(activeTab: FolderTab | null): TabsContextValue {
+  return {
+    tabs: activeTab ? [activeTab] : [],
+    activeTab,
+    activeTabId: activeTab?.id ?? null,
+    activeFile: null,
+    initializing: false,
+    workspaceFiles: [],
+    wikilinkRefs: [],
+    openFile: vi.fn(),
+    openFolder: vi.fn(),
+    openFileInFolderTab: vi.fn(),
+    toggleExpand: vi.fn(),
+    closeTab: vi.fn(),
+    setActiveTab: vi.fn(),
+    setTabMode: vi.fn(),
+    updateEditContent: vi.fn(),
+    markSaved: vi.fn(),
+    toggleTask: vi.fn(),
+    saveScrollPosition: vi.fn(),
+    openFileDialog: vi.fn(),
+    undoEdit: vi.fn(),
+    redoEdit: vi.fn(),
+    displayContent: null,
+    tocEntries: [],
+    backlinks: [],
+    workspaceNotice: null,
+    dismissWorkspaceNotice: vi.fn(),
+  };
+}
+
+function wrap(activeTab: FolderTab | null) {
+  return ({ children }: { children: ReactNode }) => (
+    <TabsContext.Provider value={tabsValue(activeTab)}>
+      <SyncConfigProvider>{children}</SyncConfigProvider>
+    </TabsContext.Provider>
+  );
+}
+
+const localConfig: WorkspaceSyncConfig = {
+  workspacePath: "/w",
+  backend: "git",
+  remoteUrl: "",
+  remoteBranch: "main",
+  conflictPolicy: "prompt",
+  author: null,
+};
+
+// A tiny consumer that enables sync through the shared context, mimicking
+// what the Cloud Sync modal does on "Save config".
+function EnableButton() {
+  const { save } = useSyncConfigContext();
+  return (
+    <button type="button" onClick={() => save(localConfig)}>
+      enable
+    </button>
+  );
+}
+
+describe("SyncConfigContext", () => {
+  it("the status pill reflects a config saved through the shared context", async () => {
+    // Starts unconfigured: get_config returns null.
+    routeInvoke({
+      sync_get_config: () => null,
+      sync_default_author: () => ({ name: null, email: null }),
+      sync_repo_present: () => false,
+      sync_set_config: () => null,
+    });
+
+    render(
+      <>
+        <SyncStatusIndicator onOpenSync={vi.fn()} />
+        <EnableButton />
+      </>,
+      { wrapper: wrap(folderTab()) },
+    );
+
+    // The pill starts on "Sync off" (no config loaded).
+    expect(await screen.findByText("Sync off")).toBeInTheDocument();
+
+    // Enabling through the shared context updates the same instance the
+    // pill reads from, so it flips without a remount or manual refresh.
+    fireEvent.click(screen.getByRole("button", { name: "enable" }));
+    await waitFor(() => expect(screen.getByText("Sync configured")).toBeInTheDocument());
+    expect(screen.queryByText("Sync off")).toBeNull();
+  });
+
+  it("exposes a null workspace path when no folder tab is active", async () => {
+    let seen: string | null | undefined;
+    function Probe() {
+      seen = useSyncConfigContext().workspacePath;
+      return null;
+    }
+    render(<Probe />, { wrapper: wrap(null) });
+    await waitFor(() => expect(seen).toBeNull());
+    // No folder => no sync commands fire on mount.
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("throws when used outside the provider", () => {
+    function Bare() {
+      useSyncConfigContext();
+      return null;
+    }
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Bare />)).toThrow(/SyncConfigProvider/);
+    spy.mockRestore();
+  });
+});

--- a/src/contexts/SyncConfigContext.tsx
+++ b/src/contexts/SyncConfigContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, type ReactNode, useContext, useMemo } from "react";
+import { useSyncConfig } from "@/hooks/useSyncConfig";
+import { useTabsContext } from "./TabsContext";
+
+// Single source of truth for the active workspace's sync config. Both the
+// status-bar pill and the Cloud Sync modal read from here, so enabling /
+// disabling sync (or running one) in the modal is reflected on the pill
+// immediately — they share one `useSyncConfig` instance instead of each
+// holding a stale copy.
+
+type SyncConfigApi = ReturnType<typeof useSyncConfig>;
+
+export interface SyncConfigContextValue extends SyncConfigApi {
+  /** Active folder workspace root, or null when no folder tab is active. */
+  workspacePath: string | null;
+}
+
+export const SyncConfigContext = createContext<SyncConfigContextValue | null>(null);
+
+export function SyncConfigProvider({ children }: { children: ReactNode }) {
+  const { activeTab } = useTabsContext();
+  const workspacePath = activeTab?.kind === "folder" ? activeTab.root : null;
+  const sync = useSyncConfig(workspacePath);
+
+  const value = useMemo<SyncConfigContextValue>(
+    () => ({ ...sync, workspacePath }),
+    [sync, workspacePath],
+  );
+
+  return <SyncConfigContext.Provider value={value}>{children}</SyncConfigContext.Provider>;
+}
+
+export function useSyncConfigContext(): SyncConfigContextValue {
+  const ctx = useContext(SyncConfigContext);
+  if (!ctx) throw new Error("useSyncConfigContext must be used inside <SyncConfigProvider>");
+  return ctx;
+}

--- a/src/hooks/useSyncConfig.test.ts
+++ b/src/hooks/useSyncConfig.test.ts
@@ -15,7 +15,6 @@ function config(overrides: Partial<WorkspaceSyncConfig> = {}): WorkspaceSyncConf
     remoteUrl: "https://example.com/r.git",
     remoteBranch: "main",
     conflictPolicy: "prompt",
-    autoSyncSeconds: null,
     author: null,
     ...overrides,
   };

--- a/src/lib/sync.test.ts
+++ b/src/lib/sync.test.ts
@@ -29,7 +29,6 @@ function makeConfig(): WorkspaceSyncConfig {
     remoteUrl: "https://example.com/n.git",
     remoteBranch: "main",
     conflictPolicy: "prompt",
-    autoSyncSeconds: null,
     author: null,
   };
 }
@@ -42,7 +41,6 @@ describe("defaultConfigFor", () => {
     expect(cfg.remoteUrl).toBe("");
     expect(cfg.remoteBranch).toBe("main");
     expect(cfg.conflictPolicy).toBe("prompt");
-    expect(cfg.autoSyncSeconds).toBeNull();
     expect(cfg.author).toBeNull();
   });
 });

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -34,7 +34,6 @@ export interface WorkspaceSyncConfig {
   remoteUrl: string;
   remoteBranch: string;
   conflictPolicy: ConflictPolicy;
-  autoSyncSeconds: number | null;
   author: CommitIdentity | null;
 }
 
@@ -83,7 +82,6 @@ export function defaultConfigFor(workspacePath: string): WorkspaceSyncConfig {
     remoteUrl: "",
     remoteBranch: "main",
     conflictPolicy: "prompt",
-    autoSyncSeconds: null,
     author: null,
   };
 }


### PR DESCRIPTION
## Summary

Two small Cloud Sync fixes on the feature branch, stacked because they touch the same files.

### 1. Remove the unbuilt auto-sync interval setting
The form advertised an "Auto-sync interval (seconds)" field and persisted `autoSyncSeconds`, but no scheduler ever fired on it, so the setting did nothing. Removed it end to end (UI field + parsing, the `WorkspaceSyncConfig` IPC type, the Rust `WorkspaceSyncConfig` and on-disk `SyncSettings` structs, defaults, converters, tests). Sync stays a manual action ("Sync now"). No migration needed: the field was `skip_serializing_if` + defaulted, so existing `.glyph/config.json` files load unchanged.

### 2. Status pill now updates live when sync is enabled
The status-bar pill and the Cloud Sync modal each created their own `useSyncConfig`. The modal unmounts on close, so enabling sync never reached the pill's separate instance, which stayed on "Sync off" until the workspace was reopened. Introduced a `SyncConfigProvider` (per the app-shell "shared state via context" rule) that owns one `useSyncConfig` keyed to the active folder workspace; the modal and pill both consume it, so enabling/disabling sync updates the pill immediately.

## Changes

- Drop `autoSyncSeconds` / `auto_sync_seconds` from the form, IPC type, both Rust structs, defaults, and converters; delete the tests that exercised it.
- Add `src/contexts/SyncConfigContext.tsx` (provider + `useSyncConfigContext`); mount it in `App.tsx`.
- `SyncStatusIndicator` and `SyncSettingsModal` read from the shared context; `StatusBar` no longer threads `workspacePath` into the pill.
- Add a `SyncConfigContext` regression test: the pill flips "Sync off" → "Sync configured" when sync is enabled through the shared context.

## Testing

- `pnpm typecheck`, `pnpm lint`, Biome format check, `pnpm test --run` (1072 passing)
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (235 passing)
- Manual: opened a fresh folder workspace, enabled local-only sync, confirmed the pill updates without reopening; verified `.glyph/config.json` + the two-stage commit history on disk.
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)
