### PR TITLE
refactor: one component per file across settings, palette, notebook

### DIFF
--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -1,10 +1,6 @@
-import { type KeyboardEvent, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
-import {
-  type Command,
-  type CommandSection,
-  type RankedCommand,
-  rankCommands,
-} from "@/lib/commands";
+import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+import { type Command, type CommandSection, rankCommands } from "@/lib/commands";
+import { CommandPaletteItem } from "./CommandPaletteItem";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -132,66 +128,5 @@ export function CommandPalette({
         </div>
       </div>
     </div>
-  );
-}
-
-interface CommandPaletteItemProps {
-  row: RankedCommand;
-  selected: boolean;
-  onActivate: () => void;
-  onHover: () => void;
-}
-
-function CommandPaletteItem({ row, selected, onActivate, onHover }: CommandPaletteItemProps) {
-  return (
-    <button
-      type="button"
-      onClick={onActivate}
-      onMouseEnter={onHover}
-      onFocus={onHover}
-      className="command-palette-item"
-      data-selected={selected ? "true" : undefined}
-      // The visible input keeps focus while arrow keys drive selection — items
-      // are pointer-actionable but never the keyboard's focus target.
-      tabIndex={-1}
-    >
-      <span className="command-palette-title">
-        {renderHighlight(row.command.title, row.matches)}
-      </span>
-      {row.command.subtitle && (
-        <span className="command-palette-subtitle">{row.command.subtitle}</span>
-      )}
-      {row.command.shortcut && (
-        <span className="command-palette-shortcut">{row.command.shortcut}</span>
-      )}
-    </button>
-  );
-}
-
-function renderHighlight(text: string, indices: readonly number[]): ReactNode {
-  if (indices.length === 0) return text;
-  const set = new Set(indices);
-  // Group runs of matched / unmatched chars so each React key is anchored at
-  // the run's starting index — stable across re-renders of the same string.
-  const runs: Array<{ text: string; matched: boolean; start: number }> = [];
-  let i = 0;
-  for (const ch of text) {
-    const matched = set.has(i);
-    const last = runs[runs.length - 1];
-    if (last && last.matched === matched) {
-      last.text += ch;
-    } else {
-      runs.push({ text: ch, matched, start: i });
-    }
-    i++;
-  }
-  return runs.map((run) =>
-    run.matched ? (
-      <mark key={`m:${run.start}`} className="command-palette-mark">
-        {run.text}
-      </mark>
-    ) : (
-      <span key={`t:${run.start}`}>{run.text}</span>
-    ),
   );
 }

--- a/src/components/modals/CommandPaletteItem.tsx
+++ b/src/components/modals/CommandPaletteItem.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import type { RankedCommand } from "@/lib/commands";
+
+interface CommandPaletteItemProps {
+  row: RankedCommand;
+  selected: boolean;
+  onActivate: () => void;
+  onHover: () => void;
+}
+
+// A single result row in the command palette: title (with fuzzy-match
+// highlights), optional subtitle, and optional shortcut hint.
+export function CommandPaletteItem({
+  row,
+  selected,
+  onActivate,
+  onHover,
+}: CommandPaletteItemProps) {
+  return (
+    <button
+      type="button"
+      onClick={onActivate}
+      onMouseEnter={onHover}
+      onFocus={onHover}
+      className="command-palette-item"
+      data-selected={selected ? "true" : undefined}
+      // The visible input keeps focus while arrow keys drive selection — items
+      // are pointer-actionable but never the keyboard's focus target.
+      tabIndex={-1}
+    >
+      <span className="command-palette-title">
+        {renderHighlight(row.command.title, row.matches)}
+      </span>
+      {row.command.subtitle && (
+        <span className="command-palette-subtitle">{row.command.subtitle}</span>
+      )}
+      {row.command.shortcut && (
+        <span className="command-palette-shortcut">{row.command.shortcut}</span>
+      )}
+    </button>
+  );
+}
+
+function renderHighlight(text: string, indices: readonly number[]): ReactNode {
+  if (indices.length === 0) return text;
+  const set = new Set(indices);
+  // Group runs of matched / unmatched chars so each React key is anchored at
+  // the run's starting index — stable across re-renders of the same string.
+  const runs: Array<{ text: string; matched: boolean; start: number }> = [];
+  let i = 0;
+  for (const ch of text) {
+    const matched = set.has(i);
+    const last = runs[runs.length - 1];
+    if (last && last.matched === matched) {
+      last.text += ch;
+    } else {
+      runs.push({ text: ch, matched, start: i });
+    }
+    i++;
+  }
+  return runs.map((run) =>
+    run.matched ? (
+      <mark key={`m:${run.start}`} className="command-palette-mark">
+        {run.text}
+      </mark>
+    ) : (
+      <span key={`t:${run.start}`}>{run.text}</span>
+    ),
+  );
+}

--- a/src/components/modals/settings/AppearanceTab.tsx
+++ b/src/components/modals/settings/AppearanceTab.tsx
@@ -1,5 +1,5 @@
 import { useSettings } from "@/hooks/useSettings";
-import { Segmented } from "./controls";
+import { Segmented } from "./Segmented";
 
 export function AppearanceTab() {
   const { settings, updateSettings } = useSettings();

--- a/src/components/modals/settings/BehaviorTab.tsx
+++ b/src/components/modals/settings/BehaviorTab.tsx
@@ -1,5 +1,5 @@
 import { useSettings } from "@/hooks/useSettings";
-import { Toggle } from "./controls";
+import { Toggle } from "./Toggle";
 import { UpdatesSection } from "./UpdatesSection";
 
 export function BehaviorTab() {

--- a/src/components/modals/settings/LayoutTab.tsx
+++ b/src/components/modals/settings/LayoutTab.tsx
@@ -1,5 +1,6 @@
 import { useSettings } from "@/hooks/useSettings";
-import { Segmented, Toggle } from "./controls";
+import { Segmented } from "./Segmented";
+import { Toggle } from "./Toggle";
 
 export function LayoutTab() {
   const { settings, updateSettings } = useSettings();

--- a/src/components/modals/settings/PrintTab.tsx
+++ b/src/components/modals/settings/PrintTab.tsx
@@ -1,5 +1,6 @@
 import { useSettings } from "@/hooks/useSettings";
-import { Segmented, Toggle } from "./controls";
+import { Segmented } from "./Segmented";
+import { Toggle } from "./Toggle";
 
 export function PrintTab() {
   const { settings, updateSettings } = useSettings();

--- a/src/components/modals/settings/PrivacyTab.tsx
+++ b/src/components/modals/settings/PrivacyTab.tsx
@@ -1,5 +1,5 @@
 import { useSettings } from "@/hooks/useSettings";
-import { Toggle } from "./controls";
+import { Toggle } from "./Toggle";
 
 export function PrivacyTab() {
   const { settings, updateSettings } = useSettings();

--- a/src/components/modals/settings/Segmented.tsx
+++ b/src/components/modals/settings/Segmented.tsx
@@ -1,21 +1,4 @@
-// Shared form primitives used across the settings tabs.
-
-export function Toggle({
-  checked,
-  onChange,
-}: {
-  checked: boolean;
-  onChange: (v: boolean) => void;
-}) {
-  return (
-    <label className="settings-toggle">
-      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
-      <span className="settings-toggle-track" />
-      <span className="settings-toggle-thumb" />
-    </label>
-  );
-}
-
+// Settings form primitive: a segmented single-choice button group.
 export function Segmented<T extends string>({
   value,
   options,

--- a/src/components/modals/settings/Toggle.tsx
+++ b/src/components/modals/settings/Toggle.tsx
@@ -1,0 +1,16 @@
+// Settings form primitive: an on/off toggle switch.
+export function Toggle({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="settings-toggle">
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+      <span className="settings-toggle-track" />
+      <span className="settings-toggle-thumb" />
+    </label>
+  );
+}

--- a/src/components/modals/settings/UpdatesSection.tsx
+++ b/src/components/modals/settings/UpdatesSection.tsx
@@ -2,7 +2,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useState } from "react";
 import { useSettings } from "@/hooks/useSettings";
 import { checkForUpdate } from "@/lib/updateCheck";
-import { Toggle } from "./controls";
+import { Toggle } from "./Toggle";
 
 // Outcome of a manual "Check Now": idle before the first click, then the
 // resolved state of the most recent check.

--- a/src/components/notebook/CellOutput.tsx
+++ b/src/components/notebook/CellOutput.tsx
@@ -1,64 +1,6 @@
-import type { DataOutput, NotebookOutput } from "@/lib/notebook/types";
-import { MarkdownContent } from "../markdown/MarkdownContent";
+import type { NotebookOutput } from "@/lib/notebook/types";
 import { AnsiText } from "./AnsiText";
-
-// MIME types we render, in order of preference. The richest representation an
-// output carries wins; anything past `text/plain` we don't yet handle (Plotly,
-// Vega, Jupyter widgets) falls through to a placeholder.
-const IMAGE_MIMES = ["image/png", "image/jpeg"] as const;
-
-function pickRichest(data: Record<string, string>): string | null {
-  for (const mime of IMAGE_MIMES) if (mime in data) return mime;
-  if ("image/svg+xml" in data) return "image/svg+xml";
-  if ("text/html" in data) return "text/html";
-  if ("text/markdown" in data) return "text/markdown";
-  if ("text/plain" in data) return "text/plain";
-  return null;
-}
-
-function DataOutputView({ output, filePath }: { output: DataOutput; filePath?: string }) {
-  const mime = pickRichest(output.data);
-  if (!mime) {
-    const interactive = Object.keys(output.data).find(
-      (m) => m.startsWith("application/") && m !== "application/json",
-    );
-    return (
-      <div className="nb-output-unsupported">
-        {interactive
-          ? `Interactive output (${interactive}) is not supported yet`
-          : "Unsupported output"}
-      </div>
-    );
-  }
-
-  const payload = output.data[mime];
-
-  if (mime === "image/png" || mime === "image/jpeg") {
-    return <img className="nb-output-image" src={`data:${mime};base64,${payload}`} alt="output" />;
-  }
-  if (mime === "image/svg+xml") {
-    // Render via a data URL so the SVG can't execute embedded scripts.
-    const src = `data:image/svg+xml;utf8,${encodeURIComponent(payload)}`;
-    return <img className="nb-output-image" src={src} alt="output" />;
-  }
-  if (mime === "text/html") {
-    // MarkdownContent runs rehype-raw + the shared sanitizer, so embedded HTML
-    // is cleaned the same way it is everywhere else in the app.
-    return (
-      <div className="markdown-body nb-output-html">
-        <MarkdownContent content={payload} filePath={filePath} showFrontmatter={false} />
-      </div>
-    );
-  }
-  if (mime === "text/markdown") {
-    return (
-      <div className="markdown-body nb-output-markdown">
-        <MarkdownContent content={payload} filePath={filePath} showFrontmatter={false} />
-      </div>
-    );
-  }
-  return <AnsiText className="nb-output-text" text={payload} />;
-}
+import { DataOutputView } from "./DataOutputView";
 
 interface CellOutputProps {
   output: NotebookOutput;

--- a/src/components/notebook/DataOutputView.tsx
+++ b/src/components/notebook/DataOutputView.tsx
@@ -1,0 +1,63 @@
+import type { DataOutput } from "@/lib/notebook/types";
+import { MarkdownContent } from "../markdown/MarkdownContent";
+import { AnsiText } from "./AnsiText";
+
+// MIME types we render, in order of preference. The richest representation an
+// output carries wins; anything past `text/plain` we don't yet handle (Plotly,
+// Vega, Jupyter widgets) falls through to a placeholder.
+const IMAGE_MIMES = ["image/png", "image/jpeg"] as const;
+
+function pickRichest(data: Record<string, string>): string | null {
+  for (const mime of IMAGE_MIMES) if (mime in data) return mime;
+  if ("image/svg+xml" in data) return "image/svg+xml";
+  if ("text/html" in data) return "text/html";
+  if ("text/markdown" in data) return "text/markdown";
+  if ("text/plain" in data) return "text/plain";
+  return null;
+}
+
+// Renders a notebook "execute_result" / "display_data" output, choosing the
+// richest available MIME representation.
+export function DataOutputView({ output, filePath }: { output: DataOutput; filePath?: string }) {
+  const mime = pickRichest(output.data);
+  if (!mime) {
+    const interactive = Object.keys(output.data).find(
+      (m) => m.startsWith("application/") && m !== "application/json",
+    );
+    return (
+      <div className="nb-output-unsupported">
+        {interactive
+          ? `Interactive output (${interactive}) is not supported yet`
+          : "Unsupported output"}
+      </div>
+    );
+  }
+
+  const payload = output.data[mime];
+
+  if (mime === "image/png" || mime === "image/jpeg") {
+    return <img className="nb-output-image" src={`data:${mime};base64,${payload}`} alt="output" />;
+  }
+  if (mime === "image/svg+xml") {
+    // Render via a data URL so the SVG can't execute embedded scripts.
+    const src = `data:image/svg+xml;utf8,${encodeURIComponent(payload)}`;
+    return <img className="nb-output-image" src={src} alt="output" />;
+  }
+  if (mime === "text/html") {
+    // MarkdownContent runs rehype-raw + the shared sanitizer, so embedded HTML
+    // is cleaned the same way it is everywhere else in the app.
+    return (
+      <div className="markdown-body nb-output-html">
+        <MarkdownContent content={payload} filePath={filePath} showFrontmatter={false} />
+      </div>
+    );
+  }
+  if (mime === "text/markdown") {
+    return (
+      <div className="markdown-body nb-output-markdown">
+        <MarkdownContent content={payload} filePath={filePath} showFrontmatter={false} />
+      </div>
+    );
+  }
+  return <AnsiText className="nb-output-text" text={payload} />;
+}


### PR DESCRIPTION
## Summary

Applies the **one component per file** rule (`.claude/rules/code-organization.md`) to the remaining multi-component files on `main`, following the same cleanup done for the file-tree menu UI in #278.

Closes #281.

## Changes

- **Settings controls** — split `controls.tsx` into `Toggle.tsx` and `Segmented.tsx`; updated the six settings tabs (`Appearance`, `Behavior`, `Layout`, `Print`, `Privacy`, `UpdatesSection`) to import from the new modules.
- **Command palette** — extracted `CommandPaletteItem` (and its private `renderHighlight` helper) out of `CommandPalette.tsx` into `CommandPaletteItem.tsx`.
- **Notebook output** — extracted `DataOutputView` (and its `pickRichest` / `IMAGE_MIMES` helpers) out of `CellOutput.tsx` into `DataOutputView.tsx`.

### Intentionally left as-is

- `lazyNotebook.tsx`, `lazyEditor.tsx`, `lazySettings.tsx` — thin `lazy()` + `Suspense` wrapper entrypoints, the rule's explicit code-splitting exception.
- `MarkdownContent.tsx`'s `LinkWithWikilink` / `TaskListLi` — `useCallback` render adapters bound to props (passed to react-markdown's `components` map), not standalone module-level components.

## Testing

- `pnpm typecheck`, `pnpm lint`, and `pnpm test` (1167 tests) all pass.
- Pure file-organization refactor: no behavior change, no public API change.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)