### PR TITLE
feat: customizable hotkeys (Settings → Hotkeys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ cd src-tauri && cargo clippy    # Lint Rust
 | `Cmd+W` / `Ctrl+W` | Close tab |
 | `Cmd+Shift+W` / `Ctrl+Shift+W` | Close window |
 
+Most of these shortcuts are customizable in **Settings → Hotkeys**: record a new
+key combo for any command, reset it to the default, and spot conflicts inline.
+
 ## Comparison with Other Markdown Apps
 
 Glyph is built around speed, native feel, and offline-first usage. The tables below compare its current capabilities against widely used markdown apps. Items marked "planned" track to issues on the [roadmap](https://github.com/hamidfzm/glyph/issues).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 ### Platform
 - Cross-platform: macOS (universal), Windows (x64), Linux (amd64 + arm64)
 - Window state persistence across restarts
-- Native menu bar with keyboard shortcuts
+- Native menu bar with customizable keyboard shortcuts (remap any command in Settings → Hotkeys)
 - Update notifications — checks for a newer release on launch and shows a banner when one is available (toggle in Settings → Behavior)
 
 ### Privacy
@@ -210,9 +210,6 @@ cd src-tauri && cargo clippy    # Lint Rust
 | `Cmd+,` / `Ctrl+,` | Settings |
 | `Cmd+W` / `Ctrl+W` | Close tab |
 | `Cmd+Shift+W` / `Ctrl+Shift+W` | Close window |
-
-Most of these shortcuts are customizable in **Settings → Hotkeys**: record a new
-key combo for any command, reset it to the default, and spot conflicts inline.
 
 ## Comparison with Other Markdown Apps
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,6 +175,7 @@ pub fn run() {
             watcher::watch_directory,
             watcher::unwatch_directory,
             menu_runtime::set_menu_state,
+            menu_runtime::apply_keybindings,
             sync::commands::sync_set_config,
             sync::commands::sync_get_config,
             sync::commands::sync_remove_config,

--- a/src-tauri/src/menu_runtime.rs
+++ b/src-tauri/src/menu_runtime.rs
@@ -6,6 +6,8 @@
 // [`crate::menu`] and have direct tests there; this file is excluded from
 // codecov so it doesn't drag the patch coverage down.
 
+use std::collections::HashMap;
+
 use serde::Deserialize;
 use tauri::{
     menu::{AboutMetadataBuilder, MenuBuilder, MenuItem, MenuItemBuilder, SubmenuBuilder},
@@ -14,10 +16,13 @@ use tauri::{
 
 use crate::menu::{dispatch_menu_action, menu_action_for_id};
 
-/// Handles to the menu items whose enabled state changes at runtime.
-/// Held in managed state so the `set_menu_state` command can toggle them.
+/// Handles to the menu items whose enabled state or accelerator changes at
+/// runtime. Held in managed state so the `set_menu_state` and
+/// `apply_keybindings` commands can mutate them.
 #[derive(Clone)]
 pub struct MenuItemRefs {
+    open: MenuItem<Wry>,
+    open_folder: MenuItem<Wry>,
     close_tab: MenuItem<Wry>,
     print: MenuItem<Wry>,
     export_html: MenuItem<Wry>,
@@ -25,7 +30,14 @@ pub struct MenuItemRefs {
     export_epub: MenuItem<Wry>,
     export_pdf: MenuItem<Wry>,
     find: MenuItem<Wry>,
+    command_palette: MenuItem<Wry>,
+    toggle_files_sidebar: MenuItem<Wry>,
+    toggle_outline_sidebar: MenuItem<Wry>,
     toggle_edit: MenuItem<Wry>,
+    zoom_in: MenuItem<Wry>,
+    zoom_out: MenuItem<Wry>,
+    actual_size: MenuItem<Wry>,
+    settings: MenuItem<Wry>,
     ai_summarize: MenuItem<Wry>,
     ai_explain: MenuItem<Wry>,
     ai_simplify: MenuItem<Wry>,
@@ -252,6 +264,8 @@ pub fn build_menu(app: &App) -> tauri::Result<(tauri::menu::Menu<Wry>, MenuItemR
     };
 
     let refs = MenuItemRefs {
+        open,
+        open_folder,
         close_tab,
         print,
         export_html,
@@ -259,7 +273,14 @@ pub fn build_menu(app: &App) -> tauri::Result<(tauri::menu::Menu<Wry>, MenuItemR
         export_epub,
         export_pdf,
         find,
+        command_palette,
+        toggle_files_sidebar,
+        toggle_outline_sidebar,
         toggle_edit,
+        zoom_in,
+        zoom_out,
+        actual_size,
+        settings,
         ai_summarize,
         ai_explain,
         ai_simplify,
@@ -267,6 +288,52 @@ pub fn build_menu(app: &App) -> tauri::Result<(tauri::menu::Menu<Wry>, MenuItemR
     };
 
     Ok((menu, refs))
+}
+
+/// Maps a bindable command id to its menu item, for accelerator updates.
+fn accelerator_target<'a>(refs: &'a MenuItemRefs, id: &str) -> Option<&'a MenuItem<Wry>> {
+    let item = match id {
+        "open" => &refs.open,
+        "open-folder" => &refs.open_folder,
+        "print" => &refs.print,
+        "close-tab" => &refs.close_tab,
+        "find" => &refs.find,
+        "open-command-palette" => &refs.command_palette,
+        "toggle-files-sidebar" => &refs.toggle_files_sidebar,
+        "toggle-outline-sidebar" => &refs.toggle_outline_sidebar,
+        "toggle-edit" => &refs.toggle_edit,
+        "zoom-in" => &refs.zoom_in,
+        "zoom-out" => &refs.zoom_out,
+        "actual-size" => &refs.actual_size,
+        "open-settings" => &refs.settings,
+        _ => return None,
+    };
+    Some(item)
+}
+
+/// Apply user-resolved accelerators to the native menu items. `bindings` maps a
+/// command id to a Tauri accelerator string ("CmdOrCtrl+O"); unknown ids are
+/// ignored. The frontend resolves defaults + overrides before calling this, so
+/// the map is the full source of truth.
+pub fn apply_keybindings_impl(
+    refs: &MenuItemRefs,
+    bindings: &HashMap<String, String>,
+) -> Result<(), String> {
+    for (id, accelerator) in bindings {
+        if let Some(item) = accelerator_target(refs, id) {
+            item.set_accelerator(Some(accelerator.as_str()))
+                .map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn apply_keybindings(
+    refs: State<MenuItemRefs>,
+    bindings: HashMap<String, String>,
+) -> Result<(), String> {
+    apply_keybindings_impl(&refs, &bindings)
 }
 
 /// Apply enabled flags to every conditional menu item. Errors from individual

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -10,6 +10,7 @@ import { useErrorReporting } from "@/hooks/useErrorReporting";
 import { useExport } from "@/hooks/useExport";
 import { useFontZoom } from "@/hooks/useFontZoom";
 import { useMenuEvents } from "@/hooks/useMenuEvents";
+import { useNativeKeybindings } from "@/hooks/useNativeKeybindings";
 import { useNativeMenuState } from "@/hooks/useNativeMenuState";
 import { usePlatform } from "@/hooks/usePlatform";
 import { usePrint } from "@/hooks/usePrint";
@@ -173,6 +174,7 @@ export function AppShell() {
     ],
   );
   useMenuEvents(menuHandlers);
+  useNativeKeybindings();
 
   const palette = useCommandPaletteController({
     platform,

--- a/src/components/modals/settings/HotkeyRow.tsx
+++ b/src/components/modals/settings/HotkeyRow.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import type { Platform } from "@/hooks/usePlatform";
+import { acceleratorFromEvent, type BindableCommand, formatAccelerator } from "@/lib/keybindings";
+
+interface HotkeyRowProps {
+  command: BindableCommand;
+  accelerator: string;
+  platform: Platform;
+  isOverridden: boolean;
+  isConflict: boolean;
+  onRecord: (accelerator: string) => void;
+  onReset: () => void;
+}
+
+// One command row in the Hotkeys pane: shows the current binding, captures a new
+// one when recording, and offers a reset when the binding has been overridden.
+export function HotkeyRow({
+  command,
+  accelerator,
+  platform,
+  isOverridden,
+  isConflict,
+  onRecord,
+  onReset,
+}: HotkeyRowProps) {
+  const [recording, setRecording] = useState(false);
+
+  // While recording, swallow the next modifier+key combo and store it. Escape
+  // cancels; a bare key (no Cmd/Ctrl/Alt) is ignored so shortcuts stay distinct
+  // from typing.
+  useEffect(() => {
+    if (!recording) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.code === "Escape") {
+        setRecording(false);
+        return;
+      }
+      if (!event.metaKey && !event.ctrlKey && !event.altKey) return;
+      const next = acceleratorFromEvent(event);
+      if (next) {
+        onRecord(next);
+        setRecording(false);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [recording, onRecord]);
+
+  return (
+    <div className="settings-row">
+      <div>
+        <span className="settings-label">{command.label}</span>
+        {isConflict && (
+          <div className="settings-description" style={{ color: "#e5484d" }}>
+            Conflicts with another shortcut
+          </div>
+        )}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <button
+          type="button"
+          onClick={() => setRecording((r) => !r)}
+          aria-label={
+            recording
+              ? `Recording shortcut for ${command.label}`
+              : `Change shortcut for ${command.label}`
+          }
+          style={{
+            minWidth: 96,
+            padding: "4px 10px",
+            borderRadius: "var(--glyph-radius-sm)",
+            border: `1px solid ${isConflict ? "#e5484d" : "var(--color-border)"}`,
+            background: recording ? "var(--color-accent)" : "var(--color-surface-secondary)",
+            color: recording ? "#fff" : "var(--color-text-primary)",
+            fontFamily: "var(--glyph-code-font, ui-monospace, monospace)",
+            fontSize: 12,
+          }}
+        >
+          {recording ? "Press keys…" : formatAccelerator(accelerator, platform)}
+        </button>
+        {isOverridden && (
+          <button
+            type="button"
+            onClick={onReset}
+            title="Reset to default"
+            aria-label={`Reset shortcut for ${command.label}`}
+            className="settings-description"
+            style={{ background: "none", border: "none", cursor: "pointer", padding: 2 }}
+          >
+            Reset
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/settings/HotkeysTab.test.tsx
+++ b/src/components/modals/settings/HotkeysTab.test.tsx
@@ -47,6 +47,22 @@ describe("HotkeysTab", () => {
     expect(updateSettings).not.toHaveBeenCalled();
   });
 
+  it("cancels recording on Escape without writing an override", () => {
+    const { updateSettings } = setup();
+    fireEvent.click(screen.getByLabelText("Change shortcut for Open File"));
+    expect(screen.getByLabelText("Recording shortcut for Open File")).toBeInTheDocument();
+    fireEvent.keyDown(document, { code: "Escape" });
+    expect(updateSettings).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Change shortcut for Open File")).toBeInTheDocument();
+  });
+
+  it("ignores a modifier combined with an unmappable key while recording", () => {
+    const { updateSettings } = setup();
+    fireEvent.click(screen.getByLabelText("Change shortcut for Open File"));
+    fireEvent.keyDown(document, { code: "F13", ctrlKey: true });
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
   it("resets an overridden binding by removing its key", () => {
     const { updateSettings } = setup({ open: "CmdOrCtrl+G" });
     fireEvent.click(screen.getByLabelText("Reset shortcut for Open File"));

--- a/src/components/modals/settings/HotkeysTab.test.tsx
+++ b/src/components/modals/settings/HotkeysTab.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SettingsContext, type SettingsContextValue } from "@/contexts/SettingsContext";
+import { DEFAULT_SETTINGS, type Settings } from "@/lib/settings";
+import { HotkeysTab } from "./HotkeysTab";
+
+function setup(overrides: Record<string, string> = {}) {
+  const settings: Settings = {
+    ...DEFAULT_SETTINGS,
+    keybindings: { overrides },
+  };
+  const updateSettings = vi.fn();
+  const value: SettingsContextValue = {
+    settings,
+    updateSettings,
+    resetSettings: vi.fn(),
+    loaded: true,
+  };
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+  );
+  render(<HotkeysTab />, { wrapper });
+  return { updateSettings };
+}
+
+describe("HotkeysTab", () => {
+  it("lists bindable commands grouped by category", () => {
+    setup();
+    expect(screen.getByText("Open File")).toBeInTheDocument();
+    expect(screen.getByText("Command Palette")).toBeInTheDocument();
+    expect(screen.getByText("File")).toBeInTheDocument();
+    expect(screen.getByText("View")).toBeInTheDocument();
+  });
+
+  it("records a new shortcut and writes it to the overrides", () => {
+    const { updateSettings } = setup();
+    fireEvent.click(screen.getByLabelText("Change shortcut for Open File"));
+    fireEvent.keyDown(document, { code: "KeyG", ctrlKey: true });
+    expect(updateSettings).toHaveBeenCalledWith("keybindings.overrides", { open: "CmdOrCtrl+G" });
+  });
+
+  it("ignores a bare key with no modifier while recording", () => {
+    const { updateSettings } = setup();
+    fireEvent.click(screen.getByLabelText("Change shortcut for Open File"));
+    fireEvent.keyDown(document, { code: "KeyG" });
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("resets an overridden binding by removing its key", () => {
+    const { updateSettings } = setup({ open: "CmdOrCtrl+G" });
+    fireEvent.click(screen.getByLabelText("Reset shortcut for Open File"));
+    expect(updateSettings).toHaveBeenCalledWith("keybindings.overrides", {});
+  });
+
+  it("flags both sides of a conflict", () => {
+    setup({ "open-folder": "CmdOrCtrl+O" });
+    expect(screen.getAllByText("Conflicts with another shortcut")).toHaveLength(2);
+  });
+});

--- a/src/components/modals/settings/HotkeysTab.tsx
+++ b/src/components/modals/settings/HotkeysTab.tsx
@@ -36,27 +36,26 @@ export function HotkeysTab() {
 
   return (
     <>
-      {CATEGORY_ORDER.map((category) => {
-        const commands = BINDABLE_COMMANDS.filter((c) => c.category === category);
-        if (commands.length === 0) return null;
-        return (
-          <div className="settings-section" key={category}>
-            <div className="settings-section-title">{category}</div>
-            {commands.map((command) => (
+      {CATEGORY_ORDER.map((category) => (
+        <div className="settings-section" key={category}>
+          <div className="settings-section-title">{category}</div>
+          {BINDABLE_COMMANDS.filter((c) => c.category === category).map((command) => {
+            const accelerator = overrides[command.id] || command.defaultAccelerator;
+            return (
               <HotkeyRow
                 key={command.id}
                 command={command}
-                accelerator={resolved.get(command.id) ?? command.defaultAccelerator}
+                accelerator={accelerator}
                 platform={platform}
                 isOverridden={command.id in overrides}
                 isConflict={conflicts.has(command.id)}
-                onRecord={(accelerator) => setOverride(command.id, accelerator)}
+                onRecord={(value) => setOverride(command.id, value)}
                 onReset={() => resetOverride(command.id)}
               />
-            ))}
-          </div>
-        );
-      })}
+            );
+          })}
+        </div>
+      ))}
     </>
   );
 }

--- a/src/components/modals/settings/HotkeysTab.tsx
+++ b/src/components/modals/settings/HotkeysTab.tsx
@@ -1,0 +1,62 @@
+import { useCallback } from "react";
+import { usePlatform } from "@/hooks/usePlatform";
+import { useSettings } from "@/hooks/useSettings";
+import {
+  BINDABLE_COMMANDS,
+  type CommandCategory,
+  findConflicts,
+  resolveBindings,
+} from "@/lib/keybindings";
+import { HotkeyRow } from "./HotkeyRow";
+
+const CATEGORY_ORDER: CommandCategory[] = ["File", "Edit", "View", "Application"];
+
+export function HotkeysTab() {
+  const platform = usePlatform();
+  const { settings, updateSettings } = useSettings();
+  const overrides = settings.keybindings.overrides;
+  const resolved = resolveBindings(overrides);
+  const conflicts = findConflicts(resolved);
+
+  const setOverride = useCallback(
+    (id: string, accelerator: string) => {
+      updateSettings("keybindings.overrides", { ...overrides, [id]: accelerator });
+    },
+    [overrides, updateSettings],
+  );
+
+  const resetOverride = useCallback(
+    (id: string) => {
+      const next = { ...overrides };
+      delete next[id];
+      updateSettings("keybindings.overrides", next);
+    },
+    [overrides, updateSettings],
+  );
+
+  return (
+    <>
+      {CATEGORY_ORDER.map((category) => {
+        const commands = BINDABLE_COMMANDS.filter((c) => c.category === category);
+        if (commands.length === 0) return null;
+        return (
+          <div className="settings-section" key={category}>
+            <div className="settings-section-title">{category}</div>
+            {commands.map((command) => (
+              <HotkeyRow
+                key={command.id}
+                command={command}
+                accelerator={resolved.get(command.id) ?? command.defaultAccelerator}
+                platform={platform}
+                isOverridden={command.id in overrides}
+                isConflict={conflicts.has(command.id)}
+                onRecord={(accelerator) => setOverride(command.id, accelerator)}
+                onReset={() => resetOverride(command.id)}
+              />
+            ))}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/modals/settings/SettingsModal.test.tsx
+++ b/src/components/modals/settings/SettingsModal.test.tsx
@@ -35,6 +35,7 @@ describe("SettingsModal", () => {
     expect(screen.getByText("Appearance")).toBeInTheDocument();
     expect(screen.getByText("Layout")).toBeInTheDocument();
     expect(screen.getByText("Behavior")).toBeInTheDocument();
+    expect(screen.getByText("Hotkeys")).toBeInTheDocument();
     expect(screen.getByText("AI")).toBeInTheDocument();
     expect(screen.getByText("Print")).toBeInTheDocument();
     expect(screen.getByText("Privacy")).toBeInTheDocument();
@@ -49,6 +50,9 @@ describe("SettingsModal", () => {
 
     fireEvent.click(screen.getByText("Behavior"));
     expect(screen.getByText("Auto-reload")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Hotkeys"));
+    expect(screen.getByText("Open File")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("AI"));
     expect(screen.getByText("AI Provider")).toBeInTheDocument();

--- a/src/components/modals/settings/SettingsModal.tsx
+++ b/src/components/modals/settings/SettingsModal.tsx
@@ -3,11 +3,12 @@ import { useSettings } from "@/hooks/useSettings";
 import { AITab } from "./AITab";
 import { AppearanceTab } from "./AppearanceTab";
 import { BehaviorTab } from "./BehaviorTab";
+import { HotkeysTab } from "./HotkeysTab";
 import { LayoutTab } from "./LayoutTab";
 import { PrintTab } from "./PrintTab";
 import { PrivacyTab } from "./PrivacyTab";
 
-type Tab = "appearance" | "layout" | "behavior" | "ai" | "print" | "privacy";
+type Tab = "appearance" | "layout" | "behavior" | "hotkeys" | "ai" | "print" | "privacy";
 
 interface SettingsModalProps {
   open: boolean;
@@ -41,6 +42,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
     { id: "appearance", label: "Appearance" },
     { id: "layout", label: "Layout" },
     { id: "behavior", label: "Behavior" },
+    { id: "hotkeys", label: "Hotkeys" },
     { id: "ai", label: "AI" },
     { id: "print", label: "Print" },
     { id: "privacy", label: "Privacy" },
@@ -88,6 +90,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           {tab === "appearance" && <AppearanceTab />}
           {tab === "layout" && <LayoutTab />}
           {tab === "behavior" && <BehaviorTab />}
+          {tab === "hotkeys" && <HotkeysTab />}
           {tab === "ai" && <AITab />}
           {tab === "print" && <PrintTab />}
           {tab === "privacy" && <PrivacyTab />}

--- a/src/hooks/useCommandPalette.test.ts
+++ b/src/hooks/useCommandPalette.test.ts
@@ -25,22 +25,22 @@ describe("useCommandPalette", () => {
 
   it("opens on Cmd+K (macOS)", () => {
     const { result } = renderHook(() => useCommandPalette({ platform: "macos" }));
-    const event = dispatch({ key: "k", metaKey: true });
+    const event = dispatch({ code: "KeyK", key: "k", metaKey: true });
     expect(result.current.open).toBe(true);
     expect(event.defaultPrevented).toBe(true);
   });
 
   it("opens on Ctrl+K (windows / linux)", () => {
     const { result } = renderHook(() => useCommandPalette({ platform: "linux" }));
-    dispatch({ key: "k", ctrlKey: true });
+    dispatch({ code: "KeyK", key: "k", ctrlKey: true });
     expect(result.current.open).toBe(true);
   });
 
   it("toggles closed on repeat shortcut", () => {
     const { result } = renderHook(() => useCommandPalette({ platform: "macos" }));
-    dispatch({ key: "k", metaKey: true });
+    dispatch({ code: "KeyK", key: "k", metaKey: true });
     expect(result.current.open).toBe(true);
-    dispatch({ key: "k", metaKey: true });
+    dispatch({ code: "KeyK", key: "k", metaKey: true });
     expect(result.current.open).toBe(false);
   });
 
@@ -49,7 +49,7 @@ describe("useCommandPalette", () => {
     editor.className = "cm-editor";
     document.body.appendChild(editor);
     const { result } = renderHook(() => useCommandPalette({ platform: "macos" }));
-    const event = dispatch({ key: "k", metaKey: true }, editor);
+    const event = dispatch({ code: "KeyK", key: "k", metaKey: true }, editor);
     expect(result.current.open).toBe(false);
     expect(event.defaultPrevented).toBe(false);
   });
@@ -60,7 +60,7 @@ describe("useCommandPalette", () => {
     act(() => result.current.setQuery("foo"));
     expect(result.current.query).toBe("foo");
     act(() => result.current.closePalette());
-    dispatch({ key: "k", metaKey: true });
+    dispatch({ code: "KeyK", key: "k", metaKey: true });
     expect(result.current.open).toBe(true);
     expect(result.current.query).toBe("");
   });
@@ -76,11 +76,11 @@ describe("useCommandPalette", () => {
 
   it("ignores keys that don't match the palette shortcut", () => {
     const { result } = renderHook(() => useCommandPalette({ platform: "macos" }));
-    dispatch({ key: "k" });
+    dispatch({ code: "KeyK", key: "k" });
     expect(result.current.open).toBe(false);
-    dispatch({ key: "k", metaKey: true, shiftKey: true });
+    dispatch({ code: "KeyK", key: "k", metaKey: true, shiftKey: true });
     expect(result.current.open).toBe(false);
-    dispatch({ key: "j", metaKey: true });
+    dispatch({ code: "KeyJ", key: "j", metaKey: true });
     expect(result.current.open).toBe(false);
   });
 

--- a/src/hooks/useCommandPalette.ts
+++ b/src/hooks/useCommandPalette.ts
@@ -1,7 +1,9 @@
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 import type { Platform } from "@/hooks/usePlatform";
-import { KEYBOARD_EVENT, matchesCommandPaletteShortcut } from "@/lib/keyboard";
+import { useSettings } from "@/hooks/useSettings";
+import { matchesAccelerator, resolveBindings } from "@/lib/keybindings";
+import { KEYBOARD_EVENT } from "@/lib/keyboard";
 
 interface UseCommandPaletteOptions {
   platform: Platform;
@@ -12,6 +14,8 @@ interface UseCommandPaletteOptions {
 // inside the editor pane so users can still type "k" with the modifier without
 // hijacking the editor's chord-style shortcuts.
 export function useCommandPalette({ platform }: UseCommandPaletteOptions) {
+  const { settings } = useSettings();
+  const overrides = settings.keybindings.overrides;
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
 
@@ -33,8 +37,9 @@ export function useCommandPalette({ platform }: UseCommandPaletteOptions) {
   }, []);
 
   useEffect(() => {
+    const binding = resolveBindings(overrides).get("open-command-palette");
     const onKeyDown = (event: KeyboardEvent) => {
-      if (!matchesCommandPaletteShortcut(event, platform)) return;
+      if (!binding || !matchesAccelerator(event, binding, platform)) return;
       const target = event.target as Element | null;
       if (target?.closest(".cm-editor")) return;
       event.preventDefault();
@@ -42,7 +47,7 @@ export function useCommandPalette({ platform }: UseCommandPaletteOptions) {
     };
     document.addEventListener(KEYBOARD_EVENT.KeyDown, onKeyDown);
     return () => document.removeEventListener(KEYBOARD_EVENT.KeyDown, onKeyDown);
-  }, [platform, toggle]);
+  }, [platform, toggle, overrides]);
 
   // The native View menu's "Command Palette…" item emits this event so users
   // who don't know the Cmd/Ctrl+K accelerator can still discover the feature.

--- a/src/hooks/useNativeKeybindings.test.tsx
+++ b/src/hooks/useNativeKeybindings.test.tsx
@@ -1,0 +1,56 @@
+import { invoke } from "@tauri-apps/api/core";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsContext, type SettingsContextValue } from "@/contexts/SettingsContext";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
+import { useNativeKeybindings } from "./useNativeKeybindings";
+
+function ctx(over: Partial<SettingsContextValue> = {}): SettingsContextValue {
+  return {
+    settings: DEFAULT_SETTINGS,
+    updateSettings: vi.fn(),
+    resetSettings: vi.fn(),
+    loaded: true,
+    ...over,
+  };
+}
+
+function wrapperFor(value: SettingsContextValue) {
+  return ({ children }: { children: ReactNode }) => (
+    <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+  vi.mocked(invoke).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useNativeKeybindings", () => {
+  it("does nothing until settings have loaded", () => {
+    renderHook(() => useNativeKeybindings(), { wrapper: wrapperFor(ctx({ loaded: false })) });
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("sends the resolved bindings to the native menu once loaded", async () => {
+    renderHook(() => useNativeKeybindings(), { wrapper: wrapperFor(ctx()) });
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith(
+        "apply_keybindings",
+        expect.objectContaining({ bindings: expect.objectContaining({ open: "CmdOrCtrl+O" }) }),
+      ),
+    );
+  });
+
+  it("logs when the native call rejects", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(invoke).mockRejectedValue(new Error("nope"));
+    renderHook(() => useNativeKeybindings(), { wrapper: wrapperFor(ctx()) });
+    await waitFor(() => expect(error).toHaveBeenCalled());
+  });
+});

--- a/src/hooks/useNativeKeybindings.ts
+++ b/src/hooks/useNativeKeybindings.ts
@@ -1,0 +1,20 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect } from "react";
+import { useSettings } from "@/hooks/useSettings";
+import { resolveBindings } from "@/lib/keybindings";
+
+// Pushes the resolved keybindings (defaults merged with user overrides) to the
+// native menu so its accelerators reflect the user's choices. Runs once settings
+// have loaded and again whenever the overrides change.
+export function useNativeKeybindings() {
+  const { settings, loaded } = useSettings();
+  const overrides = settings.keybindings.overrides;
+
+  useEffect(() => {
+    if (!loaded) return;
+    const bindings = Object.fromEntries(resolveBindings(overrides));
+    invoke("apply_keybindings", { bindings }).catch((err) => {
+      console.error("Failed to apply keybindings to the native menu:", err);
+    });
+  }, [loaded, overrides]);
+}

--- a/src/lib/keybindings.test.ts
+++ b/src/lib/keybindings.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  acceleratorFromEvent,
+  BINDABLE_COMMANDS,
+  findConflicts,
+  formatAccelerator,
+  getBindableCommand,
+  matchesAccelerator,
+  parseAccelerator,
+  resolveBindings,
+} from "./keybindings";
+
+function kd(
+  code: string,
+  mods: { meta?: boolean; ctrl?: boolean; alt?: boolean; shift?: boolean } = {},
+): KeyboardEvent {
+  return new KeyboardEvent("keydown", {
+    code,
+    metaKey: !!mods.meta,
+    ctrlKey: !!mods.ctrl,
+    altKey: !!mods.alt,
+    shiftKey: !!mods.shift,
+  });
+}
+
+describe("parseAccelerator", () => {
+  it("parses a single-modifier accelerator", () => {
+    expect(parseAccelerator("CmdOrCtrl+O")).toEqual({
+      cmdOrCtrl: true,
+      alt: false,
+      shift: false,
+      key: "O",
+    });
+  });
+
+  it("normalizes a lowercase key and modifier aliases", () => {
+    expect(parseAccelerator("Cmd+o")).toEqual({
+      cmdOrCtrl: true,
+      alt: false,
+      shift: false,
+      key: "O",
+    });
+  });
+
+  it("parses multiple modifiers and a symbol key", () => {
+    expect(parseAccelerator("Alt+Shift+,")).toEqual({
+      cmdOrCtrl: false,
+      alt: true,
+      shift: true,
+      key: ",",
+    });
+  });
+
+  it("returns null for a modifier-only string", () => {
+    expect(parseAccelerator("CmdOrCtrl")).toBeNull();
+  });
+
+  it("returns null when two non-modifier keys are present", () => {
+    expect(parseAccelerator("CmdOrCtrl+O+P")).toBeNull();
+  });
+});
+
+describe("acceleratorFromEvent", () => {
+  it("builds a canonical string from a letter key", () => {
+    expect(acceleratorFromEvent(kd("KeyO", { meta: true }))).toBe("CmdOrCtrl+O");
+  });
+
+  it("includes Alt and Shift and maps digits", () => {
+    expect(acceleratorFromEvent(kd("Digit5", { ctrl: true, shift: true }))).toBe(
+      "CmdOrCtrl+Shift+5",
+    );
+  });
+
+  it("maps punctuation codes to their tokens", () => {
+    expect(acceleratorFromEvent(kd("Backslash", { meta: true }))).toBe("CmdOrCtrl+\\");
+    expect(acceleratorFromEvent(kd("Equal", { ctrl: true }))).toBe("CmdOrCtrl+=");
+    expect(acceleratorFromEvent(kd("Comma", { alt: true }))).toBe("Alt+,");
+  });
+
+  it("returns null when only modifier keys are held", () => {
+    expect(acceleratorFromEvent(kd("ShiftLeft", { shift: true }))).toBeNull();
+    expect(acceleratorFromEvent(kd("MetaLeft", { meta: true }))).toBeNull();
+  });
+});
+
+describe("matchesAccelerator", () => {
+  it("matches CmdOrCtrl against Cmd on macOS and Ctrl elsewhere", () => {
+    expect(matchesAccelerator(kd("KeyO", { meta: true }), "CmdOrCtrl+O", "macos")).toBe(true);
+    expect(matchesAccelerator(kd("KeyO", { ctrl: true }), "CmdOrCtrl+O", "windows")).toBe(true);
+  });
+
+  it("rejects the wrong primary modifier for the platform", () => {
+    expect(matchesAccelerator(kd("KeyO", { ctrl: true }), "CmdOrCtrl+O", "macos")).toBe(false);
+    expect(matchesAccelerator(kd("KeyO", { meta: true }), "CmdOrCtrl+O", "windows")).toBe(false);
+  });
+
+  it("requires Shift state to match", () => {
+    expect(
+      matchesAccelerator(kd("KeyO", { meta: true, shift: true }), "CmdOrCtrl+Shift+O", "macos"),
+    ).toBe(true);
+    expect(
+      matchesAccelerator(kd("KeyO", { meta: true, shift: true }), "CmdOrCtrl+O", "macos"),
+    ).toBe(false);
+  });
+
+  it("matches symbol bindings", () => {
+    expect(matchesAccelerator(kd("Backslash", { ctrl: true }), "CmdOrCtrl+\\", "windows")).toBe(
+      true,
+    );
+    expect(matchesAccelerator(kd("Comma", { meta: true }), "CmdOrCtrl+,", "macos")).toBe(true);
+  });
+
+  it("returns false for an unmappable key", () => {
+    expect(matchesAccelerator(kd("ShiftLeft", { meta: true }), "CmdOrCtrl+O", "macos")).toBe(false);
+  });
+});
+
+describe("formatAccelerator", () => {
+  it("renders macOS glyphs", () => {
+    expect(formatAccelerator("CmdOrCtrl+Shift+O", "macos")).toBe("⌘⇧O");
+    expect(formatAccelerator("CmdOrCtrl+,", "macos")).toBe("⌘,");
+    expect(formatAccelerator("CmdOrCtrl+Up", "macos")).toBe("⌘↑");
+  });
+
+  it("renders a +-joined label elsewhere", () => {
+    expect(formatAccelerator("CmdOrCtrl+Shift+O", "windows")).toBe("Ctrl+Shift+O");
+    expect(formatAccelerator("CmdOrCtrl+\\", "linux")).toBe("Ctrl+\\");
+  });
+});
+
+describe("resolveBindings", () => {
+  it("returns defaults when there are no overrides", () => {
+    const resolved = resolveBindings();
+    expect(resolved.get("open")).toBe("CmdOrCtrl+O");
+    expect(resolved.get("open-command-palette")).toBe("CmdOrCtrl+K");
+  });
+
+  it("applies an override and ignores an empty one", () => {
+    const resolved = resolveBindings({ open: "CmdOrCtrl+Shift+P", find: "" });
+    expect(resolved.get("open")).toBe("CmdOrCtrl+Shift+P");
+    expect(resolved.get("find")).toBe("CmdOrCtrl+F");
+  });
+});
+
+describe("findConflicts", () => {
+  it("reports no conflicts for the default bindings", () => {
+    expect(findConflicts(resolveBindings()).size).toBe(0);
+  });
+
+  it("flags both commands that share an accelerator", () => {
+    const conflicts = findConflicts(resolveBindings({ open: "CmdOrCtrl+F" }));
+    expect(conflicts.has("open")).toBe(true);
+    expect(conflicts.has("find")).toBe(true);
+  });
+});
+
+describe("BINDABLE_COMMANDS", () => {
+  it("has unique ids", () => {
+    const ids = BINDABLE_COMMANDS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("is looked up by id", () => {
+    expect(getBindableCommand("open")?.label).toBe("Open File");
+    expect(getBindableCommand("nope")).toBeUndefined();
+  });
+});

--- a/src/lib/keybindings.test.ts
+++ b/src/lib/keybindings.test.ts
@@ -81,6 +81,10 @@ describe("acceleratorFromEvent", () => {
     expect(acceleratorFromEvent(kd("ShiftLeft", { shift: true }))).toBeNull();
     expect(acceleratorFromEvent(kd("MetaLeft", { meta: true }))).toBeNull();
   });
+
+  it("maps function keys", () => {
+    expect(acceleratorFromEvent(kd("F5", { ctrl: true }))).toBe("CmdOrCtrl+F5");
+  });
 });
 
 describe("matchesAccelerator", () => {
@@ -113,6 +117,10 @@ describe("matchesAccelerator", () => {
   it("returns false for an unmappable key", () => {
     expect(matchesAccelerator(kd("ShiftLeft", { meta: true }), "CmdOrCtrl+O", "macos")).toBe(false);
   });
+
+  it("returns false for an invalid accelerator string", () => {
+    expect(matchesAccelerator(kd("KeyO", { meta: true }), "CmdOrCtrl", "macos")).toBe(false);
+  });
 });
 
 describe("formatAccelerator", () => {
@@ -125,6 +133,19 @@ describe("formatAccelerator", () => {
   it("renders a +-joined label elsewhere", () => {
     expect(formatAccelerator("CmdOrCtrl+Shift+O", "windows")).toBe("Ctrl+Shift+O");
     expect(formatAccelerator("CmdOrCtrl+\\", "linux")).toBe("Ctrl+\\");
+  });
+
+  it("renders the macOS Option glyph and modifier-less combos", () => {
+    expect(formatAccelerator("CmdOrCtrl+Alt+O", "macos")).toBe("⌘⌥O");
+    expect(formatAccelerator("Alt+Shift+O", "macos")).toBe("⌥⇧O");
+  });
+
+  it("renders Alt and modifier-less combos elsewhere", () => {
+    expect(formatAccelerator("Alt+Shift+5", "windows")).toBe("Alt+Shift+5");
+  });
+
+  it("returns the raw string for an invalid accelerator", () => {
+    expect(formatAccelerator("CmdOrCtrl", "macos")).toBe("CmdOrCtrl");
   });
 });
 
@@ -151,6 +172,28 @@ describe("findConflicts", () => {
     const conflicts = findConflicts(resolveBindings({ open: "CmdOrCtrl+F" }));
     expect(conflicts.has("open")).toBe(true);
     expect(conflicts.has("find")).toBe(true);
+  });
+
+  it("skips entries whose accelerator is invalid", () => {
+    const conflicts = findConflicts(
+      new Map([
+        ["a", "CmdOrCtrl+O"],
+        ["bad", "CmdOrCtrl"],
+        ["b", "CmdOrCtrl+O"],
+      ]),
+    );
+    expect(conflicts).toEqual(new Set(["a", "b"]));
+  });
+
+  it("detects conflicts among Alt / modifier-less bindings", () => {
+    const conflicts = findConflicts(
+      new Map([
+        ["x", "Alt+P"],
+        ["y", "Alt+P"],
+      ]),
+    );
+    expect(conflicts.has("x")).toBe(true);
+    expect(conflicts.has("y")).toBe(true);
   });
 });
 

--- a/src/lib/keybindings.ts
+++ b/src/lib/keybindings.ts
@@ -1,0 +1,338 @@
+import type { Platform } from "@/hooks/usePlatform";
+import { isMac } from "@/lib/platform";
+
+// The single source of truth for every user-customizable keyboard shortcut.
+//
+// A binding is stored as a Tauri-style accelerator string ("CmdOrCtrl+Shift+O")
+// so the same value drives both the in-app keydown matcher and the native menu
+// accelerators (which the Rust side rebuilds when a binding changes). `CmdOrCtrl`
+// resolves to Cmd on macOS and Ctrl elsewhere.
+
+export type CommandCategory = "File" | "Edit" | "View" | "Application";
+
+export interface BindableCommand {
+  /** Stable id; for native-menu commands this equals the Rust menu item id. */
+  id: string;
+  label: string;
+  category: CommandCategory;
+  /** Default accelerator in Tauri format, e.g. "CmdOrCtrl+O". */
+  defaultAccelerator: string;
+  /** The `menu-*` event this command dispatches (the existing action bus). */
+  event: string;
+  /** True when the command also appears in the native menu, so a remap must
+   *  rebuild the native accelerator. */
+  nativeMenu: boolean;
+}
+
+// Order here is the display order in the Hotkeys settings pane.
+export const BINDABLE_COMMANDS: readonly BindableCommand[] = [
+  {
+    id: "open",
+    label: "Open File",
+    category: "File",
+    defaultAccelerator: "CmdOrCtrl+O",
+    event: "menu-open-file",
+    nativeMenu: true,
+  },
+  {
+    id: "open-folder",
+    label: "Open Folder",
+    category: "File",
+    defaultAccelerator: "CmdOrCtrl+Shift+O",
+    event: "menu-open-folder",
+    nativeMenu: true,
+  },
+  {
+    id: "print",
+    label: "Print",
+    category: "File",
+    defaultAccelerator: "CmdOrCtrl+P",
+    event: "menu-print",
+    nativeMenu: true,
+  },
+  {
+    id: "close-tab",
+    label: "Close Tab",
+    category: "File",
+    defaultAccelerator: "CmdOrCtrl+W",
+    event: "menu-close-tab",
+    nativeMenu: true,
+  },
+  {
+    id: "find",
+    label: "Find in Document",
+    category: "Edit",
+    defaultAccelerator: "CmdOrCtrl+F",
+    event: "menu-find",
+    nativeMenu: true,
+  },
+  {
+    id: "open-command-palette",
+    label: "Command Palette",
+    category: "View",
+    defaultAccelerator: "CmdOrCtrl+K",
+    event: "menu-open-command-palette",
+    nativeMenu: true,
+  },
+  {
+    id: "toggle-files-sidebar",
+    label: "Toggle Files Sidebar",
+    category: "View",
+    defaultAccelerator: "CmdOrCtrl+B",
+    event: "menu-toggle-files-sidebar",
+    nativeMenu: true,
+  },
+  {
+    id: "toggle-outline-sidebar",
+    label: "Toggle Outline Sidebar",
+    category: "View",
+    defaultAccelerator: "CmdOrCtrl+\\",
+    event: "menu-toggle-outline-sidebar",
+    nativeMenu: true,
+  },
+  {
+    id: "toggle-edit",
+    label: "Toggle Edit Mode",
+    category: "View",
+    defaultAccelerator: "CmdOrCtrl+E",
+    event: "menu-toggle-edit",
+    nativeMenu: true,
+  },
+  {
+    id: "zoom-in",
+    label: "Zoom In",
+    category: "View",
+    defaultAccelerator: "CmdOrCtrl+=",
+    event: "menu-zoom-in",
+    nativeMenu: true,
+  },
+  {
+    id: "zoom-out",
+    label: "Zoom Out",
+    category: "View",
+    defaultAccelerator: "CmdOrCtrl+-",
+    event: "menu-zoom-out",
+    nativeMenu: true,
+  },
+  {
+    id: "actual-size",
+    label: "Actual Size",
+    category: "View",
+    defaultAccelerator: "CmdOrCtrl+0",
+    event: "menu-zoom-reset",
+    nativeMenu: true,
+  },
+  {
+    id: "open-settings",
+    label: "Settings",
+    category: "Application",
+    defaultAccelerator: "CmdOrCtrl+,",
+    event: "menu-open-settings",
+    nativeMenu: true,
+  },
+] as const;
+
+const COMMAND_BY_ID = new Map(BINDABLE_COMMANDS.map((c) => [c.id, c]));
+
+export function getBindableCommand(id: string): BindableCommand | undefined {
+  return COMMAND_BY_ID.get(id);
+}
+
+// --- Accelerator parsing / matching -----------------------------------------
+
+export interface ParsedAccelerator {
+  cmdOrCtrl: boolean;
+  alt: boolean;
+  shift: boolean;
+  /** Canonical key token, e.g. "O", "5", ",", "\\", "Up". */
+  key: string;
+}
+
+// Maps a KeyboardEvent.code to its canonical accelerator key token. Physical-key
+// based (like VS Code) so bindings survive keyboard-layout differences.
+const CODE_TO_TOKEN: Record<string, string> = {
+  Comma: ",",
+  Period: ".",
+  Slash: "/",
+  Backslash: "\\",
+  Minus: "-",
+  Equal: "=",
+  Semicolon: ";",
+  Quote: "'",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Backquote: "`",
+  Space: "Space",
+  Enter: "Enter",
+  Tab: "Tab",
+  ArrowUp: "Up",
+  ArrowDown: "Down",
+  ArrowLeft: "Left",
+  ArrowRight: "Right",
+  Home: "Home",
+  End: "End",
+  PageUp: "PageUp",
+  PageDown: "PageDown",
+  Delete: "Delete",
+  Backspace: "Backspace",
+};
+
+function tokenFromCode(code: string): string | null {
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3);
+  if (/^Digit[0-9]$/.test(code)) return code.slice(5);
+  if (/^F([1-9]|1[0-2])$/.test(code)) return code;
+  return CODE_TO_TOKEN[code] ?? null;
+}
+
+const MODIFIER_TOKENS = new Set(["CmdOrCtrl", "Cmd", "Ctrl", "Control", "Command", "Alt", "Shift"]);
+
+/** Parse a Tauri-style accelerator string into its parts, or null if invalid. */
+export function parseAccelerator(accelerator: string): ParsedAccelerator | null {
+  const parts = accelerator.split("+").map((p) => p.trim());
+  if (parts.length === 0) return null;
+  let cmdOrCtrl = false;
+  let alt = false;
+  let shift = false;
+  let key: string | null = null;
+  for (const part of parts) {
+    if (
+      part === "CmdOrCtrl" ||
+      part === "Cmd" ||
+      part === "Ctrl" ||
+      part === "Control" ||
+      part === "Command"
+    ) {
+      cmdOrCtrl = true;
+    } else if (part === "Alt" || part === "Option") {
+      alt = true;
+    } else if (part === "Shift") {
+      shift = true;
+    } else {
+      // The key token. A second non-modifier means a malformed accelerator.
+      if (key !== null) return null;
+      key = normalizeKeyToken(part);
+    }
+  }
+  if (key === null) return null;
+  return { cmdOrCtrl, alt, shift, key };
+}
+
+function normalizeKeyToken(token: string): string {
+  if (token.length === 1) return token.toUpperCase();
+  return token;
+}
+
+/** Build a canonical accelerator string from a keydown event, or null if only
+ *  modifier keys (or an unmappable key) are held. */
+export function acceleratorFromEvent(event: KeyboardEvent): string | null {
+  const token = tokenFromCode(event.code);
+  if (token === null || MODIFIER_TOKENS.has(token)) return null;
+  const mods: string[] = [];
+  if (event.metaKey || event.ctrlKey) mods.push("CmdOrCtrl");
+  if (event.altKey) mods.push("Alt");
+  if (event.shiftKey) mods.push("Shift");
+  return [...mods, token].join("+");
+}
+
+/** True when the event matches the given accelerator on this platform. */
+export function matchesAccelerator(
+  event: KeyboardEvent,
+  accelerator: string,
+  platform: Platform,
+): boolean {
+  const parsed = parseAccelerator(accelerator);
+  if (!parsed) return false;
+  const token = tokenFromCode(event.code);
+  if (token === null) return false;
+  const cmdOrCtrl = isMac(platform) ? event.metaKey : event.ctrlKey;
+  // The "other" primary modifier must not be held, so Ctrl+O on macOS doesn't
+  // trigger a Cmd+O binding.
+  const otherPrimary = isMac(platform) ? event.ctrlKey : event.metaKey;
+  return (
+    cmdOrCtrl === parsed.cmdOrCtrl &&
+    !otherPrimary &&
+    event.altKey === parsed.alt &&
+    event.shiftKey === parsed.shift &&
+    token === parsed.key
+  );
+}
+
+// --- Display formatting ------------------------------------------------------
+
+const TOKEN_SYMBOLS_MAC: Record<string, string> = {
+  Up: "↑",
+  Down: "↓",
+  Left: "←",
+  Right: "→",
+  Enter: "↵",
+  Space: "Space",
+  Backspace: "⌫",
+  Delete: "⌦",
+  Tab: "⇥",
+};
+
+/** Human-readable rendering of an accelerator, e.g. "⌘⇧O" on macOS or
+ *  "Ctrl+Shift+O" elsewhere. */
+export function formatAccelerator(accelerator: string, platform: Platform): string {
+  const parsed = parseAccelerator(accelerator);
+  if (!parsed) return accelerator;
+  const mac = isMac(platform);
+  const keyLabel = (mac ? TOKEN_SYMBOLS_MAC[parsed.key] : undefined) ?? parsed.key;
+  if (mac) {
+    return (
+      (parsed.cmdOrCtrl ? "⌘" : "") + (parsed.alt ? "⌥" : "") + (parsed.shift ? "⇧" : "") + keyLabel
+    );
+  }
+  const parts: string[] = [];
+  if (parsed.cmdOrCtrl) parts.push("Ctrl");
+  if (parsed.alt) parts.push("Alt");
+  if (parsed.shift) parts.push("Shift");
+  parts.push(keyLabel);
+  return parts.join("+");
+}
+
+// --- Resolution + conflicts --------------------------------------------------
+
+export type BindingOverrides = Record<string, string>;
+
+/** Merge default bindings with user overrides into a id -> accelerator map. */
+export function resolveBindings(overrides: BindingOverrides = {}): Map<string, string> {
+  const resolved = new Map<string, string>();
+  for (const command of BINDABLE_COMMANDS) {
+    const override = overrides[command.id];
+    resolved.set(
+      command.id,
+      override && override.length > 0 ? override : command.defaultAccelerator,
+    );
+  }
+  return resolved;
+}
+
+/** Returns a set of command ids that share an accelerator with another command.
+ *  Accelerators are compared in canonical (parsed) form so "Cmd+O" and
+ *  "CmdOrCtrl+o" collide. */
+export function findConflicts(resolved: Map<string, string>): Set<string> {
+  const byCanonical = new Map<string, string[]>();
+  for (const [id, accel] of resolved) {
+    const parsed = parseAccelerator(accel);
+    if (!parsed) continue;
+    const canonical = canonicalKey(parsed);
+    const ids = byCanonical.get(canonical) ?? [];
+    ids.push(id);
+    byCanonical.set(canonical, ids);
+  }
+  const conflicts = new Set<string>();
+  for (const ids of byCanonical.values()) {
+    if (ids.length > 1) for (const id of ids) conflicts.add(id);
+  }
+  return conflicts;
+}
+
+function canonicalKey(parsed: ParsedAccelerator): string {
+  return [
+    parsed.cmdOrCtrl ? "M" : "",
+    parsed.alt ? "A" : "",
+    parsed.shift ? "S" : "",
+    parsed.key,
+  ].join("|");
+}

--- a/src/lib/keybindings.ts
+++ b/src/lib/keybindings.ts
@@ -189,7 +189,6 @@ const MODIFIER_TOKENS = new Set(["CmdOrCtrl", "Cmd", "Ctrl", "Control", "Command
 /** Parse a Tauri-style accelerator string into its parts, or null if invalid. */
 export function parseAccelerator(accelerator: string): ParsedAccelerator | null {
   const parts = accelerator.split("+").map((p) => p.trim());
-  if (parts.length === 0) return null;
   let cmdOrCtrl = false;
   let alt = false;
   let shift = false;

--- a/src/lib/keyboard.test.ts
+++ b/src/lib/keyboard.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  KEYBOARD_EVENT,
-  matchesCommandPaletteShortcut,
-  matchesRedoShortcut,
-  matchesUndoShortcut,
-} from "./keyboard";
+import { KEYBOARD_EVENT, matchesRedoShortcut, matchesUndoShortcut } from "./keyboard";
 
 function makeEvent(init: KeyboardEventInit): KeyboardEvent {
   return new KeyboardEvent(KEYBOARD_EVENT.KeyDown, init);
@@ -60,40 +55,5 @@ describe("matchesRedoShortcut", () => {
 
   it("rejects plain Cmd+Z without shift", () => {
     expect(matchesRedoShortcut(makeEvent({ key: "z", metaKey: true }), "macos")).toBe(false);
-  });
-});
-
-describe("matchesCommandPaletteShortcut", () => {
-  it("matches Cmd+K on macOS", () => {
-    expect(matchesCommandPaletteShortcut(makeEvent({ key: "k", metaKey: true }), "macos")).toBe(
-      true,
-    );
-  });
-
-  it("matches Ctrl+K on windows and linux", () => {
-    expect(matchesCommandPaletteShortcut(makeEvent({ key: "k", ctrlKey: true }), "windows")).toBe(
-      true,
-    );
-    expect(matchesCommandPaletteShortcut(makeEvent({ key: "k", ctrlKey: true }), "linux")).toBe(
-      true,
-    );
-  });
-
-  it("rejects when shift or alt is held", () => {
-    expect(
-      matchesCommandPaletteShortcut(
-        makeEvent({ key: "k", metaKey: true, shiftKey: true }),
-        "macos",
-      ),
-    ).toBe(false);
-    expect(
-      matchesCommandPaletteShortcut(makeEvent({ key: "k", metaKey: true, altKey: true }), "macos"),
-    ).toBe(false);
-  });
-
-  it("rejects the wrong platform modifier", () => {
-    expect(matchesCommandPaletteShortcut(makeEvent({ key: "k", ctrlKey: true }), "macos")).toBe(
-      false,
-    );
   });
 });

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -8,7 +8,6 @@ export const KEYBOARD_EVENT = {
 const Key = {
   Z: "z",
   Y: "y",
-  K: "k",
 } as const;
 
 function hasPlatformModifier(event: KeyboardEvent, platform: Platform): boolean {
@@ -26,9 +25,4 @@ export function matchesRedoShortcut(event: KeyboardEvent, platform: Platform): b
   if (key === Key.Z && event.shiftKey) return true;
   // Ctrl+Y is the Windows/Linux convention for redo; macOS uses Shift+Cmd+Z.
   return !isMac(platform) && key === Key.Y && !event.shiftKey;
-}
-
-export function matchesCommandPaletteShortcut(event: KeyboardEvent, platform: Platform): boolean {
-  if (!hasPlatformModifier(event, platform) || event.altKey || event.shiftKey) return false;
-  return event.key.toLowerCase() === Key.K;
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -102,6 +102,14 @@ export interface PrivacySettings {
   errorReporting: boolean;
 }
 
+export interface KeybindingSettings {
+  // Map of bindable command id -> accelerator override (Tauri "CmdOrCtrl+..."
+  // format). Command ids absent from the map fall back to their default
+  // binding. Stored and updated as a whole object, not per-key, because the
+  // settings validator allowlists path segments against the defaults shape.
+  overrides: Record<string, string>;
+}
+
 export interface Settings {
   appearance: AppearanceSettings;
   layout: LayoutSettings;
@@ -109,6 +117,7 @@ export interface Settings {
   ai: AISettings;
   print: PrintSettings;
   privacy: PrivacySettings;
+  keybindings: KeybindingSettings;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -154,6 +163,9 @@ export const DEFAULT_SETTINGS: Settings = {
   },
   privacy: {
     errorReporting: false,
+  },
+  keybindings: {
+    overrides: {},
   },
 };
 


### PR DESCRIPTION
## Summary

First slice of #269: every menu-bound keyboard shortcut is now a named command with a user-overridable binding, editable in **Settings → Hotkeys**. A single registry is the source of truth; overrides persist to settings, drive the native menu accelerators (updated live), and the in-app command-palette shortcut.

## Changes

- **Registry + utilities** (`src/lib/keybindings.ts`): `BINDABLE_COMMANDS` (id == Rust menu id, default accelerator, `menu-*` event, category) plus accelerator helpers in Tauri `CmdOrCtrl+...` format — parse, physical-key (`code`) based event matching, build-from-event for record-a-shortcut, macOS-glyph formatting, `resolveBindings`, and `findConflicts`.
- **Settings**: `keybindings.overrides` (command id → accelerator), stored/updated as a whole object like `ai.apiKeys`.
- **Native menu** (Rust): `MenuItemRefs` extended to every accelerator-bearing item; new `apply_keybindings` command calls `MenuItem::set_accelerator` at runtime — a remap updates the live menu, no rebuild. The frontend resolves defaults+overrides and sends the full map (`useNativeKeybindings`, called from `AppShell`).
- **Command palette**: matches the resolved `open-command-palette` binding instead of a hardcoded Cmd/Ctrl+K, so remaps apply in the webview too.
- **Settings → Hotkeys pane** (`HotkeysTab` + `HotkeyRow`): searchable-by-category list, record-a-shortcut capture, reset-to-default, inline conflict warnings.

## Scope / follow-ups

- Editor-internal keys (Vim mode #221, CodeMirror keymap presets) are intentionally out of scope here — that's the editor-keymap track.
- Undo/redo stay editor/document-context handlers and aren't in the remappable registry yet.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (1190 tests, incl. new keybindings + Hotkeys-pane suites) pass; `cargo build` + `cargo clippy` clean.
- Note: the native-menu accelerator update (`set_accelerator`) and global-key behavior should be smoke-tested in the running app per-OS, which can't be exercised in unit tests.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
