### PR TITLE
feat: selectable Vim / VSCode / Default editor keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - Split view — edit and preview side-by-side, or switch between modes per tab
 - Live preview updates as you type
 - Wikilink autocomplete — type `[[` in a folder workspace to pick from existing notes; Tab/Enter to insert
+- Editor keymaps — choose Default, Vim, or VSCode bindings in Settings → Editor
 
 ### Viewer
 - Jupyter notebooks — open `.ipynb` files directly; markdown cells render with full markdown (math, code, diagrams), code cells are syntax-highlighted, and image, HTML, plain-text, and colourised stream/traceback outputs show under each cell with `In [n]:` / `Out [n]:` prompts (read-only)

--- a/codecov.yml
+++ b/codecov.yml
@@ -76,5 +76,11 @@ ignore:
   # SyncStatusIndicator), so we don't track AppShell.tsx lines toward
   # project / patch coverage. See .claude/rules/app-shell.md.
   - "src/components/AppShell.tsx"
+  # MarkdownEditor.tsx instantiates a CodeMirror EditorView, which needs a real
+  # browser layout/measurement engine (getBoundingClientRect, focus, key
+  # dispatch) that happy-dom doesn't provide — every consumer (SplitView) mocks
+  # it for the same reason. The testable piece (keymap-preset resolution) is
+  # extracted to src/lib/editorKeymap.ts and covered there.
+  - "src/components/editor/MarkdownEditor.tsx"
   - "**/*.test.ts"
   - "**/*.test.tsx"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.0",
     "@lezer/highlight": "^1.2.3",
+    "@replit/codemirror-vim": "^6.3.0",
+    "@replit/codemirror-vscode-keymap": "^6.0.2",
     "@sentry/react": "^10.56.0",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-cli": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,12 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
+      '@replit/codemirror-vim':
+        specifier: ^6.3.0
+        version: 6.3.0(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
+      '@replit/codemirror-vscode-keymap':
+        specifier: ^6.0.2
+        version: 6.0.2(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       '@sentry/react':
         specifier: ^10.56.0
         version: 10.56.0(react@19.2.7)
@@ -877,6 +883,26 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@replit/codemirror-vim@6.3.0':
+    resolution: {integrity: sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==}
+    peerDependencies:
+      '@codemirror/commands': 6.x.x
+      '@codemirror/language': 6.x.x
+      '@codemirror/search': 6.x.x
+      '@codemirror/state': 6.x.x
+      '@codemirror/view': 6.x.x
+
+  '@replit/codemirror-vscode-keymap@6.0.2':
+    resolution: {integrity: sha512-j45qTwGxzpsv82lMD/NreGDORFKSctMDVkGRopaP+OrzSzv+pXDQuU3LnFvKpasyjVT0lf+PKG1v2DSCn/vxxg==}
+    peerDependencies:
+      '@codemirror/autocomplete': ^6.0.0
+      '@codemirror/commands': ^6.0.0
+      '@codemirror/language': ^6.0.0
+      '@codemirror/lint': ^6.0.0
+      '@codemirror/search': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -4098,6 +4124,24 @@ snapshots:
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
+
+  '@replit/codemirror-vim@6.3.0(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
+    dependencies:
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+
+  '@replit/codemirror-vscode-keymap@6.0.2(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -13,6 +13,8 @@ import { EditorState } from "@codemirror/state";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
 import { useEffect, useRef } from "react";
+import { useSettings } from "@/hooks/useSettings";
+import { editorKeymapExtensions } from "@/lib/editorKeymap";
 import { wikilinkCompletionSource } from "@/lib/wikilinkCompletion";
 
 interface MarkdownEditorProps {
@@ -43,9 +45,14 @@ export function MarkdownEditor({
   workspaceFilesRef.current = workspaceFiles ?? [];
   workspaceRootRef.current = workspaceRoot;
 
+  const { settings } = useSettings();
+  const keymapPreset = settings.editor.keymap;
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: content is synced via separate effect below to avoid destroying the editor on every keystroke
   useEffect(() => {
     if (!containerRef.current) return;
+
+    const { leading, extraKeys } = editorKeymapExtensions(keymapPreset);
 
     const glyphHighlight = HighlightStyle.define([
       { tag: tags.heading1, class: "cm-heading cm-heading-1" },
@@ -70,6 +77,8 @@ export function MarkdownEditor({
       state: EditorState.create({
         doc: content,
         extensions: [
+          // Vim (when selected) installs first so its modal handler wins.
+          ...leading,
           lineNumbers(),
           history(),
           // Completion keymap (Tab-accept, Esc-close, arrows-navigate) goes
@@ -80,6 +89,9 @@ export function MarkdownEditor({
             { key: "ArrowDown", run: (v) => moveCompletionSelection(true)(v) },
             { key: "ArrowUp", run: (v) => moveCompletionSelection(false)(v) },
             ...completionKeymap,
+            // VSCode preset bindings (empty for other presets) take precedence
+            // over the CodeMirror defaults below.
+            ...extraKeys,
             ...defaultKeymap,
             ...historyKeymap,
           ]),
@@ -154,7 +166,7 @@ export function MarkdownEditor({
       view.destroy();
       viewRef.current = null;
     };
-  }, []);
+  }, [keymapPreset]);
 
   // Sync content from outside (e.g., file reload) without losing cursor
   useEffect(() => {

--- a/src/components/modals/settings/EditorTab.test.tsx
+++ b/src/components/modals/settings/EditorTab.test.tsx
@@ -34,4 +34,14 @@ describe("EditorTab", () => {
     fireEvent.click(screen.getByText("Vim"));
     expect(updateSettings).toHaveBeenCalledWith("editor.keymap", "vim");
   });
+
+  it("hides the Vim quick reference for non-Vim keymaps", () => {
+    setup();
+    expect(screen.queryByText("Vim quick reference")).toBeNull();
+  });
+
+  it("shows the Vim quick reference when Vim is selected", () => {
+    setup({ ...DEFAULT_SETTINGS, editor: { keymap: "vim" } });
+    expect(screen.getByText("Vim quick reference")).toBeInTheDocument();
+  });
 });

--- a/src/components/modals/settings/EditorTab.test.tsx
+++ b/src/components/modals/settings/EditorTab.test.tsx
@@ -35,13 +35,19 @@ describe("EditorTab", () => {
     expect(updateSettings).toHaveBeenCalledWith("editor.keymap", "vim");
   });
 
-  it("hides the Vim quick reference for non-Vim keymaps", () => {
+  it("shows the Default quick reference for the default keymap", () => {
     setup();
+    expect(screen.getByText("Default (Glyph) shortcuts")).toBeInTheDocument();
     expect(screen.queryByText("Vim quick reference")).toBeNull();
   });
 
   it("shows the Vim quick reference when Vim is selected", () => {
     setup({ ...DEFAULT_SETTINGS, editor: { keymap: "vim" } });
     expect(screen.getByText("Vim quick reference")).toBeInTheDocument();
+  });
+
+  it("shows the VSCode quick reference when VSCode is selected", () => {
+    setup({ ...DEFAULT_SETTINGS, editor: { keymap: "vscode" } });
+    expect(screen.getByText("VSCode shortcuts")).toBeInTheDocument();
   });
 });

--- a/src/components/modals/settings/EditorTab.test.tsx
+++ b/src/components/modals/settings/EditorTab.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SettingsContext, type SettingsContextValue } from "@/contexts/SettingsContext";
+import { DEFAULT_SETTINGS, type Settings } from "@/lib/settings";
+import { EditorTab } from "./EditorTab";
+
+function setup(settings: Settings = DEFAULT_SETTINGS) {
+  const updateSettings = vi.fn();
+  const value: SettingsContextValue = {
+    settings,
+    updateSettings,
+    resetSettings: vi.fn(),
+    loaded: true,
+  };
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+  );
+  render(<EditorTab />, { wrapper });
+  return { updateSettings };
+}
+
+describe("EditorTab", () => {
+  it("offers the keymap presets", () => {
+    setup();
+    expect(screen.getByText("Keymap")).toBeInTheDocument();
+    expect(screen.getByText("Default")).toBeInTheDocument();
+    expect(screen.getByText("Vim")).toBeInTheDocument();
+    expect(screen.getByText("VSCode")).toBeInTheDocument();
+  });
+
+  it("updates the keymap when a preset is chosen", () => {
+    const { updateSettings } = setup();
+    fireEvent.click(screen.getByText("Vim"));
+    expect(updateSettings).toHaveBeenCalledWith("editor.keymap", "vim");
+  });
+});

--- a/src/components/modals/settings/EditorTab.tsx
+++ b/src/components/modals/settings/EditorTab.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import { useSettings } from "@/hooks/useSettings";
 import type { EditorKeymap } from "@/lib/settings";
 import { Segmented } from "./Segmented";
@@ -8,9 +9,53 @@ const KEYMAP_OPTIONS: { value: EditorKeymap; label: string }[] = [
   { value: "vscode", label: "VSCode" },
 ];
 
+interface KeymapTip {
+  keys?: string;
+  text: string;
+}
+
+// Short, per-preset cheat sheet shown under the selector. Modifier-bearing
+// shortcuts are written generically ("Cmd/Ctrl") since the bindings are the same
+// across platforms apart from the primary modifier.
+const KEYMAP_HELP: Record<EditorKeymap, { title: string; tips: KeymapTip[] }> = {
+  default: {
+    title: "Default (Glyph) shortcuts",
+    tips: [
+      { keys: "[[", text: "in a folder workspace opens wikilink autocomplete" },
+      { keys: "Tab / Enter", text: "accept the highlighted completion" },
+      { keys: "Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z", text: "undo / redo" },
+      { text: "Standard OS text-editing shortcuts otherwise" },
+    ],
+  },
+  vim: {
+    title: "Vim quick reference",
+    tips: [
+      { keys: "Esc / i / a / v", text: "normal, insert, insert-after, visual modes" },
+      { keys: "w b e 0 $ gg G", text: "motions; f + char to jump; / to search" },
+      { keys: "d c y p", text: 'operators with counts and text objects (diw, ci")' },
+      {
+        text: "File commands like :w, :q, and :wq don't apply here — Glyph autosaves, and you close a tab with the Close Tab shortcut.",
+      },
+    ],
+  },
+  vscode: {
+    title: "VSCode shortcuts",
+    tips: [
+      { keys: "Alt+Up / Alt+Down", text: "move the current line up / down" },
+      { keys: "Shift+Alt+Up / Down", text: "copy the line up / down" },
+      { keys: "Cmd/Ctrl+/", text: "toggle line comment" },
+      {
+        keys: "Cmd/Ctrl+D",
+        text: "select the next occurrence; Cmd/Ctrl+] or [ to indent / outdent",
+      },
+    ],
+  },
+};
+
 export function EditorTab() {
   const { settings, updateSettings } = useSettings();
   const { editor } = settings;
+  const help = KEYMAP_HELP[editor.keymap];
 
   return (
     <div className="settings-section">
@@ -30,29 +75,21 @@ export function EditorTab() {
         />
       </div>
 
-      {editor.keymap === "vim" && (
-        <div className="settings-description settings-vim-help">
-          <strong>Vim quick reference</strong>
-          <ul>
-            <li>
-              Modes: <code>Esc</code> normal, <code>i</code>/<code>a</code> insert, <code>v</code>{" "}
-              visual
+      <div className="settings-description settings-keymap-help">
+        <strong>{help.title}</strong>
+        <ul>
+          {help.tips.map((tip) => (
+            <li key={tip.text}>
+              {tip.keys && (
+                <Fragment>
+                  <code>{tip.keys}</code>{" "}
+                </Fragment>
+              )}
+              {tip.text}
             </li>
-            <li>
-              Motions: <code>w b e 0 $ gg G</code>, <code>f</code> + char to jump, <code>/</code> to
-              search
-            </li>
-            <li>
-              Operators: <code>d c y p</code> with counts and text objects (e.g. <code>diw</code>,{" "}
-              <code>ci"</code>)
-            </li>
-            <li>
-              File commands like <code>:w</code>, <code>:q</code>, and <code>:wq</code> don't apply
-              here — Glyph autosaves, and you close a tab with the Close Tab shortcut.
-            </li>
-          </ul>
-        </div>
-      )}
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/src/components/modals/settings/EditorTab.tsx
+++ b/src/components/modals/settings/EditorTab.tsx
@@ -29,6 +29,30 @@ export function EditorTab() {
           onChange={(v) => updateSettings("editor.keymap", v)}
         />
       </div>
+
+      {editor.keymap === "vim" && (
+        <div className="settings-description settings-vim-help">
+          <strong>Vim quick reference</strong>
+          <ul>
+            <li>
+              Modes: <code>Esc</code> normal, <code>i</code>/<code>a</code> insert, <code>v</code>{" "}
+              visual
+            </li>
+            <li>
+              Motions: <code>w b e 0 $ gg G</code>, <code>f</code> + char to jump, <code>/</code> to
+              search
+            </li>
+            <li>
+              Operators: <code>d c y p</code> with counts and text objects (e.g. <code>diw</code>,{" "}
+              <code>ci"</code>)
+            </li>
+            <li>
+              File commands like <code>:w</code>, <code>:q</code>, and <code>:wq</code> don't apply
+              here — Glyph autosaves, and you close a tab with the Close Tab shortcut.
+            </li>
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/modals/settings/EditorTab.tsx
+++ b/src/components/modals/settings/EditorTab.tsx
@@ -1,0 +1,34 @@
+import { useSettings } from "@/hooks/useSettings";
+import type { EditorKeymap } from "@/lib/settings";
+import { Segmented } from "./Segmented";
+
+const KEYMAP_OPTIONS: { value: EditorKeymap; label: string }[] = [
+  { value: "default", label: "Default" },
+  { value: "vim", label: "Vim" },
+  { value: "vscode", label: "VSCode" },
+];
+
+export function EditorTab() {
+  const { settings, updateSettings } = useSettings();
+  const { editor } = settings;
+
+  return (
+    <div className="settings-section">
+      <div className="settings-section-title">Editor</div>
+      <div className="settings-row">
+        <div>
+          <span className="settings-label">Keymap</span>
+          <div className="settings-description">
+            Keyboard bindings for the markdown editor. Vim adds modal editing; VSCode mirrors common
+            VSCode shortcuts. Takes effect the next time a document enters edit or split mode.
+          </div>
+        </div>
+        <Segmented
+          value={editor.keymap}
+          options={KEYMAP_OPTIONS}
+          onChange={(v) => updateSettings("editor.keymap", v)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/settings/SettingsModal.test.tsx
+++ b/src/components/modals/settings/SettingsModal.test.tsx
@@ -35,6 +35,7 @@ describe("SettingsModal", () => {
     expect(screen.getByText("Appearance")).toBeInTheDocument();
     expect(screen.getByText("Layout")).toBeInTheDocument();
     expect(screen.getByText("Behavior")).toBeInTheDocument();
+    expect(screen.getByText("Editor")).toBeInTheDocument();
     expect(screen.getByText("Hotkeys")).toBeInTheDocument();
     expect(screen.getByText("AI")).toBeInTheDocument();
     expect(screen.getByText("Print")).toBeInTheDocument();
@@ -50,6 +51,9 @@ describe("SettingsModal", () => {
 
     fireEvent.click(screen.getByText("Behavior"));
     expect(screen.getByText("Auto-reload")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Editor"));
+    expect(screen.getByText("Keymap")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Hotkeys"));
     expect(screen.getByText("Open File")).toBeInTheDocument();

--- a/src/components/modals/settings/SettingsModal.tsx
+++ b/src/components/modals/settings/SettingsModal.tsx
@@ -3,12 +3,13 @@ import { useSettings } from "@/hooks/useSettings";
 import { AITab } from "./AITab";
 import { AppearanceTab } from "./AppearanceTab";
 import { BehaviorTab } from "./BehaviorTab";
+import { EditorTab } from "./EditorTab";
 import { HotkeysTab } from "./HotkeysTab";
 import { LayoutTab } from "./LayoutTab";
 import { PrintTab } from "./PrintTab";
 import { PrivacyTab } from "./PrivacyTab";
 
-type Tab = "appearance" | "layout" | "behavior" | "hotkeys" | "ai" | "print" | "privacy";
+type Tab = "appearance" | "layout" | "behavior" | "editor" | "hotkeys" | "ai" | "print" | "privacy";
 
 interface SettingsModalProps {
   open: boolean;
@@ -42,6 +43,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
     { id: "appearance", label: "Appearance" },
     { id: "layout", label: "Layout" },
     { id: "behavior", label: "Behavior" },
+    { id: "editor", label: "Editor" },
     { id: "hotkeys", label: "Hotkeys" },
     { id: "ai", label: "AI" },
     { id: "print", label: "Print" },
@@ -90,6 +92,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           {tab === "appearance" && <AppearanceTab />}
           {tab === "layout" && <LayoutTab />}
           {tab === "behavior" && <BehaviorTab />}
+          {tab === "editor" && <EditorTab />}
           {tab === "hotkeys" && <HotkeysTab />}
           {tab === "ai" && <AITab />}
           {tab === "print" && <PrintTab />}

--- a/src/lib/editorKeymap.test.ts
+++ b/src/lib/editorKeymap.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { editorKeymapExtensions } from "./editorKeymap";
+
+describe("editorKeymapExtensions", () => {
+  it("adds nothing for the default preset", () => {
+    const { leading, extraKeys } = editorKeymapExtensions("default");
+    expect(leading).toHaveLength(0);
+    expect(extraKeys).toHaveLength(0);
+  });
+
+  it("installs Vim as a leading extension", () => {
+    const { leading, extraKeys } = editorKeymapExtensions("vim");
+    expect(leading.length).toBeGreaterThan(0);
+    expect(extraKeys).toHaveLength(0);
+  });
+
+  it("supplies VSCode bindings as extra keys", () => {
+    const { leading, extraKeys } = editorKeymapExtensions("vscode");
+    expect(leading).toHaveLength(0);
+    expect(extraKeys.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/editorKeymap.ts
+++ b/src/lib/editorKeymap.ts
@@ -1,0 +1,21 @@
+import type { Extension } from "@codemirror/state";
+import type { KeyBinding } from "@codemirror/view";
+import { vim } from "@replit/codemirror-vim";
+import { vscodeKeymap } from "@replit/codemirror-vscode-keymap";
+import type { EditorKeymap } from "./settings";
+
+export interface KeymapExtensions {
+  /** Extensions that must precede the editor's other keymaps. Vim installs its
+   *  modal handler here so it has the highest precedence. */
+  leading: Extension[];
+  /** Extra key bindings merged into the editor's main keymap (VSCode preset). */
+  extraKeys: readonly KeyBinding[];
+}
+
+// Resolve a keymap preset into the CodeMirror pieces the editor needs to add.
+// "default" adds nothing (Glyph's built-in bindings stay as-is).
+export function editorKeymapExtensions(preset: EditorKeymap): KeymapExtensions {
+  if (preset === "vim") return { leading: [vim()], extraKeys: [] };
+  if (preset === "vscode") return { leading: [], extraKeys: vscodeKeymap };
+  return { leading: [], extraKeys: [] };
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -102,6 +102,14 @@ export interface PrivacySettings {
   errorReporting: boolean;
 }
 
+// Editor keymap preset for the markdown editor pane. "default" is Glyph's own
+// (CodeMirror default) bindings; "vim" and "vscode" load the matching keymap.
+export type EditorKeymap = "default" | "vim" | "vscode";
+
+export interface EditorSettings {
+  keymap: EditorKeymap;
+}
+
 export interface KeybindingSettings {
   // Map of bindable command id -> accelerator override (Tauri "CmdOrCtrl+..."
   // format). Command ids absent from the map fall back to their default
@@ -118,6 +126,7 @@ export interface Settings {
   print: PrintSettings;
   privacy: PrivacySettings;
   keybindings: KeybindingSettings;
+  editor: EditorSettings;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -166,6 +175,9 @@ export const DEFAULT_SETTINGS: Settings = {
   },
   keybindings: {
     overrides: {},
+  },
+  editor: {
+    keymap: "default",
   },
 };
 

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -156,6 +156,25 @@
   margin-top: 2px;
 }
 
+/* Vim keymap quick-reference shown under the keymap selector. */
+.settings-vim-help {
+  margin-top: 10px;
+  line-height: 1.6;
+}
+
+.settings-vim-help ul {
+  margin: 4px 0 0;
+  padding-left: 18px;
+  list-style: disc;
+}
+
+.settings-vim-help code {
+  font-family: var(--glyph-code-font, ui-monospace, monospace);
+  background: var(--color-surface-tertiary);
+  border-radius: var(--glyph-radius-sm);
+  padding: 0 4px;
+}
+
 /* Controls — native macOS style select */
 .settings-select {
   appearance: auto;

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -156,19 +156,19 @@
   margin-top: 2px;
 }
 
-/* Vim keymap quick-reference shown under the keymap selector. */
-.settings-vim-help {
+/* Per-preset keymap quick-reference shown under the keymap selector. */
+.settings-keymap-help {
   margin-top: 10px;
   line-height: 1.6;
 }
 
-.settings-vim-help ul {
+.settings-keymap-help ul {
   margin: 4px 0 0;
   padding-left: 18px;
   list-style: disc;
 }
 
-.settings-vim-help code {
+.settings-keymap-help code {
   font-family: var(--glyph-code-font, ui-monospace, monospace);
   background: var(--color-surface-tertiary);
   border-radius: var(--glyph-radius-sm);


### PR DESCRIPTION
## Summary

The editor-keymap track from the hotkeys work: the markdown editor can now use **Vim**, **VSCode**, or the **Default** (Glyph) keymap, chosen in **Settings → Editor**.

Closes #221.

## Changes

- **Settings**: new `editor.keymap` (`"default" | "vim" | "vscode"`).
- **`src/lib/editorKeymap.ts`**: isolates the heavy `@replit/codemirror-vim` and `@replit/codemirror-vscode-keymap` imports (so they only land in the lazy editor chunk) behind a pure `editorKeymapExtensions` helper.
- **`MarkdownEditor`**: installs Vim as a leading extension (highest precedence) or merges the VSCode bindings into its keymap, recreating the view when the preset changes. Reads the setting via `useSettings`, so no prop drilling.
- **Settings → Editor** tab with a keymap selector.
- **codecov**: `MarkdownEditor.tsx` added to the ignore list (a CodeMirror `EditorView` needs a real browser layout/measurement engine that happy-dom lacks — which is why every consumer mocks it; the testable logic is extracted to `editorKeymap.ts` and covered).

## Scope / follow-ups

- The Vim mode indicator in the status bar (also part of #221) is deferred to a follow-up — it needs editor→status-bar mode plumbing. Vim's block cursor already signals normal mode in the meantime.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (1207 tests, incl. new `editorKeymap` + `EditorTab` suites) pass.
- Vim/VSCode key behavior in the live editor should be smoke-tested in the running app (CodeMirror can't run in the unit-test environment).

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux