### PR TITLE
feat: vertical tab sidebar in the settings dialog

### DIFF
--- a/src/components/modals/settings/SettingsModal.tsx
+++ b/src/components/modals/settings/SettingsModal.tsx
@@ -72,28 +72,30 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           </button>
         </div>
 
-        <nav className="settings-nav">
-          {tabs.map((t) => (
-            <button
-              type="button"
-              key={t.id}
-              className="settings-tab"
-              data-active={tab === t.id}
-              onClick={() => setTab(t.id)}
-            >
-              {t.label}
-            </button>
-          ))}
-        </nav>
+        <div className="settings-main">
+          <nav className="settings-nav">
+            {tabs.map((t) => (
+              <button
+                type="button"
+                key={t.id}
+                className="settings-tab"
+                data-active={tab === t.id}
+                onClick={() => setTab(t.id)}
+              >
+                {t.label}
+              </button>
+            ))}
+          </nav>
 
-        <div className="settings-body">
-          {tab === "appearance" && <AppearanceTab />}
-          {tab === "layout" && <LayoutTab />}
-          {tab === "behavior" && <BehaviorTab />}
-          {tab === "hotkeys" && <HotkeysTab />}
-          {tab === "ai" && <AITab />}
-          {tab === "print" && <PrintTab />}
-          {tab === "privacy" && <PrivacyTab />}
+          <div className="settings-body">
+            {tab === "appearance" && <AppearanceTab />}
+            {tab === "layout" && <LayoutTab />}
+            {tab === "behavior" && <BehaviorTab />}
+            {tab === "hotkeys" && <HotkeysTab />}
+            {tab === "ai" && <AITab />}
+            {tab === "print" && <PrintTab />}
+            {tab === "privacy" && <PrivacyTab />}
+          </div>
         </div>
 
         <div className="settings-footer">

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -78,35 +78,47 @@
   color: var(--color-text-primary);
 }
 
-/* Tab Navigation */
+/* Main row: vertical tab sidebar + scrollable body */
+.settings-main {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Tab Navigation — vertical sidebar down the left edge */
 .settings-nav {
   display: flex;
-  gap: 0;
-  padding: 0 20px;
-  border-bottom: 1px solid var(--color-border);
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 8px;
+  width: 148px;
   flex-shrink: 0;
+  overflow-y: auto;
+  border-right: 1px solid var(--color-border);
 }
 
 .settings-tab {
   appearance: none;
   background: none;
   border: none;
-  border-bottom: 2px solid transparent;
   cursor: pointer;
-  padding: 8px 14px;
+  padding: 7px 12px;
   font-size: 12px;
+  text-align: left;
   color: var(--color-text-secondary);
   font-weight: 500;
-  transition: color 0.15s, border-color 0.15s;
+  border-radius: var(--glyph-radius-sm);
+  transition: color 0.15s, background-color 0.15s;
 }
 
 .settings-tab:hover {
   color: var(--color-text-primary);
+  background: var(--color-surface-tertiary);
 }
 
 .settings-tab[data-active="true"] {
   color: var(--color-accent);
-  border-bottom-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
 
 /* Settings Body — native macOS overlay scrollbar */


### PR DESCRIPTION
## Summary

The settings categories have grown (Appearance, Layout, Behavior, Hotkeys, AI, Print, Privacy — and more on the way), and a horizontal tab strip was getting crowded. This moves the tabs into a **vertical sidebar** down the left of the dialog.

## Changes

- `SettingsModal`: the nav and body now sit inside a `.settings-main` flex row.
- `settings.css`: `.settings-nav` is a fixed-width column with a right border; the active tab uses a filled highlight instead of an underline. Body scrolls independently beside it. Header and footer still span the full width.

No behavior change — same tabs, same content, same keyboard/escape/backdrop handling.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (1202 tests) pass.
- Layout is visual; worth a quick look in the running app.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux