### PR TITLE
test(coverage): close remaining gaps from the coverage umbrella issue

### DIFF
--- a/src-tauri/src/commands/directory.rs
+++ b/src-tauri/src/commands/directory.rs
@@ -286,6 +286,28 @@ mod tests {
     }
 
     #[test]
+    fn get_initial_folder_returns_managed_value() {
+        use tauri::test::mock_app;
+        use tauri::Manager;
+
+        let app = mock_app();
+        app.manage(InitialFolder(Mutex::new(Some("/ws/folder".to_string()))));
+        let result = get_initial_folder(app.state::<InitialFolder>());
+        assert_eq!(result.as_deref(), Some("/ws/folder"));
+    }
+
+    #[test]
+    fn get_initial_folder_returns_none_when_unset() {
+        use tauri::test::mock_app;
+        use tauri::Manager;
+
+        let app = mock_app();
+        app.manage(InitialFolder(Mutex::new(None)));
+        let result = get_initial_folder(app.state::<InitialFolder>());
+        assert!(result.is_none());
+    }
+
+    #[test]
     fn dir_entry_camel_case_keys() {
         let entry = DirEntry {
             name: "file.md".to_string(),

--- a/src-tauri/src/commands/directory.rs
+++ b/src-tauri/src/commands/directory.rs
@@ -69,7 +69,13 @@ pub fn read_directory(path: String) -> Result<Vec<DirEntry>, String> {
 
 #[tauri::command]
 pub fn list_markdown_files(path: String) -> Result<Vec<String>, String> {
-    let root = Path::new(&path);
+    list_markdown_files_capped(&path, WALK_MAX_FILES)
+}
+
+/// Body of [`list_markdown_files`] with the file cap as a parameter, so the
+/// truncation branch is testable without creating `WALK_MAX_FILES` real files.
+fn list_markdown_files_capped(path: &str, max_files: usize) -> Result<Vec<String>, String> {
+    let root = Path::new(path);
     if !root.is_dir() {
         return Err(format!("Not a directory: {path}"));
     }
@@ -100,7 +106,7 @@ pub fn list_markdown_files(path: String) -> Result<Vec<String>, String> {
         if !crate::is_supported_file(p) {
             continue;
         }
-        if results.len() >= WALK_MAX_FILES {
+        if results.len() >= max_files {
             truncated = true;
             break;
         }
@@ -109,8 +115,7 @@ pub fn list_markdown_files(path: String) -> Result<Vec<String>, String> {
 
     if truncated {
         eprintln!(
-            "list_markdown_files: workspace at {} exceeds {} files; results truncated",
-            path, WALK_MAX_FILES
+            "list_markdown_files: workspace at {path} exceeds {max_files} files; results truncated"
         );
     }
 
@@ -255,6 +260,19 @@ mod tests {
             })
             .collect();
         assert_eq!(names, vec!["keep.md".to_string()]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn list_markdown_files_truncates_at_the_cap() {
+        let dir = unique_tmp("list_md_cap");
+        for i in 0..3 {
+            fs::write(dir.join(format!("f{i}.md")), "x").unwrap();
+        }
+
+        let result = list_markdown_files_capped(&dir.to_string_lossy(), 2).unwrap();
+        assert_eq!(result.len(), 2);
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -27,7 +27,7 @@ pub fn read_file(path: String) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub fn print_document(window: tauri::WebviewWindow) -> Result<(), String> {
+pub fn print_document<R: tauri::Runtime>(window: tauri::WebviewWindow<R>) -> Result<(), String> {
     window.print().map_err(|e| format!("Failed to print: {e}"))
 }
 
@@ -202,6 +202,63 @@ mod tests {
         let json = serde_json::to_string(&metadata).unwrap();
         assert!(!json.contains("file_name"));
         assert!(json.contains("name"));
+    }
+
+    #[test]
+    fn get_initial_file_returns_managed_value() {
+        use tauri::test::mock_app;
+        use tauri::Manager;
+
+        let app = mock_app();
+        app.manage(InitialFile(Mutex::new(Some("/ws/file.md".to_string()))));
+        let result = get_initial_file(app.state::<InitialFile>());
+        assert_eq!(result.as_deref(), Some("/ws/file.md"));
+    }
+
+    #[test]
+    fn get_initial_file_returns_none_when_unset() {
+        use tauri::test::mock_app;
+        use tauri::Manager;
+
+        let app = mock_app();
+        app.manage(InitialFile(Mutex::new(None)));
+        let result = get_initial_file(app.state::<InitialFile>());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn write_file_round_trips_text() {
+        let dir = std::env::temp_dir().join("glyph_test_write_text");
+        let _ = fs::create_dir_all(&dir);
+        let file_path = dir.join("out.md");
+
+        let result = write_file(
+            file_path.to_string_lossy().to_string(),
+            "# Saved\n".to_string(),
+        );
+        assert!(result.is_ok());
+        assert_eq!(fs::read_to_string(&file_path).unwrap(), "# Saved\n");
+
+        let _ = fs::remove_file(&file_path);
+    }
+
+    #[test]
+    fn write_file_bad_path_errors() {
+        let result = write_file("/nonexistent/dir/out.md".to_string(), "x".to_string());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to write file"));
+    }
+
+    #[test]
+    fn print_document_succeeds_on_a_mock_window() {
+        use tauri::test::mock_app;
+        use tauri::WebviewWindowBuilder;
+
+        let app = mock_app();
+        let window = WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .expect("mock window should build");
+        assert!(print_document(window).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/commands/wikilinks.rs
+++ b/src-tauri/src/commands/wikilinks.rs
@@ -250,6 +250,89 @@ mod tests {
     }
 
     #[test]
+    fn scan_wikilinks_skips_hidden_and_noisy_dirs() {
+        let dir = unique_tmp("scan_skip_dirs");
+        fs::write(dir.join("keep.md"), "see [[Kept]]").unwrap();
+        for skip in WALK_SKIP_DIRS {
+            fs::create_dir_all(dir.join(skip)).unwrap();
+            fs::write(dir.join(skip).join("ignored.md"), "see [[Skipped]]").unwrap();
+        }
+        fs::create_dir_all(dir.join(".hidden")).unwrap();
+        fs::write(dir.join(".hidden/ignored.md"), "see [[Hidden]]").unwrap();
+
+        let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
+        let targets: Vec<&str> = refs.iter().map(|r| r.target.as_str()).collect();
+        assert_eq!(targets, vec!["Kept"]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_skips_non_markdown_files() {
+        let dir = unique_tmp("scan_non_md");
+        fs::write(dir.join("a.md"), "see [[FromMd]]").unwrap();
+        fs::write(dir.join("notes.txt"), "see [[FromTxt]]").unwrap();
+
+        let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
+        let targets: Vec<&str> = refs.iter().map(|r| r.target.as_str()).collect();
+        assert_eq!(targets, vec!["FromMd"]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_skips_oversized_files() {
+        let dir = unique_tmp("scan_oversize");
+        let mut big = String::from("see [[FromBig]]\n");
+        big.push_str(&"x".repeat(SCAN_MAX_FILE_BYTES as usize + 1));
+        fs::write(dir.join("big.md"), big).unwrap();
+        fs::write(dir.join("small.md"), "see [[FromSmall]]").unwrap();
+
+        let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
+        let targets: Vec<&str> = refs.iter().map(|r| r.target.as_str()).collect();
+        assert_eq!(targets, vec!["FromSmall"]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_skips_files_that_are_not_valid_utf8() {
+        let dir = unique_tmp("scan_bad_utf8");
+        fs::write(
+            dir.join("bad.md"),
+            [0xff, 0xfe, b'[', b'[', b'X', b']', b']'],
+        )
+        .unwrap();
+        fs::write(dir.join("good.md"), "see [[Good]]").unwrap();
+
+        let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
+        let targets: Vec<&str> = refs.iter().map(|r| r.target.as_str()).collect();
+        assert_eq!(targets, vec!["Good"]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_in_file_ignores_unclosed_brackets() {
+        let mut out = Vec::new();
+        scan_wikilinks_in_file("an [[Unclosed link\nthen [[Closed]]\n", "/x/a.md", &mut out);
+        let targets: Vec<&str> = out.iter().map(|r| r.target.as_str()).collect();
+        assert_eq!(targets, vec!["Closed"]);
+    }
+
+    #[test]
+    fn scan_wikilinks_in_file_ignores_empty_targets() {
+        let mut out = Vec::new();
+        scan_wikilinks_in_file(
+            "empty [[]] and blank [[   ]] but [[Real]]\n",
+            "/x/a.md",
+            &mut out,
+        );
+        let targets: Vec<&str> = out.iter().map(|r| r.target.as_str()).collect();
+        assert_eq!(targets, vec!["Real"]);
+    }
+
+    #[test]
     fn wikilink_ref_camel_case_keys() {
         let r = WikilinkRef {
             source: "/x/a.md".to_string(),

--- a/src-tauri/src/commands/wikilinks.rs
+++ b/src-tauri/src/commands/wikilinks.rs
@@ -23,7 +23,13 @@ pub struct WikilinkRef {
 
 #[tauri::command]
 pub fn scan_wikilinks(path: String) -> Result<Vec<WikilinkRef>, String> {
-    let root = Path::new(&path);
+    scan_wikilinks_capped(&path, WALK_MAX_FILES)
+}
+
+/// Body of [`scan_wikilinks`] with the file cap as a parameter, so the
+/// truncation branch is testable without creating `WALK_MAX_FILES` real files.
+fn scan_wikilinks_capped(path: &str, max_files: usize) -> Result<Vec<WikilinkRef>, String> {
+    let root = Path::new(path);
     if !root.is_dir() {
         return Err(format!("Not a directory: {path}"));
     }
@@ -53,7 +59,7 @@ pub fn scan_wikilinks(path: String) -> Result<Vec<WikilinkRef>, String> {
         if !crate::is_markdown_file(p) {
             continue;
         }
-        if files_scanned >= WALK_MAX_FILES {
+        if files_scanned >= max_files {
             break;
         }
         files_scanned += 1;
@@ -308,6 +314,18 @@ mod tests {
         let refs = scan_wikilinks(dir.to_string_lossy().to_string()).unwrap();
         let targets: Vec<&str> = refs.iter().map(|r| r.target.as_str()).collect();
         assert_eq!(targets, vec!["Good"]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_wikilinks_stops_scanning_at_the_file_cap() {
+        let dir = unique_tmp("scan_cap");
+        fs::write(dir.join("a.md"), "see [[FromA]]").unwrap();
+        fs::write(dir.join("b.md"), "see [[FromB]]").unwrap();
+
+        let refs = scan_wikilinks_capped(&dir.to_string_lossy(), 1).unwrap();
+        assert_eq!(refs.len(), 1);
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -321,5 +321,29 @@ mod tests {
 
             dispatch_menu_action(&handle, MenuAction::CloseWindow);
         }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        fn toggle_devtools_with_no_main_window_is_a_silent_noop() {
+            let app = mock_app();
+            let handle = app.handle().clone();
+            dispatch_menu_action(&handle, MenuAction::ToggleDevTools);
+        }
+
+        #[cfg(debug_assertions)]
+        #[test]
+        fn toggle_devtools_opens_devtools_when_a_main_window_exists() {
+            // MockRuntime reports is_devtools_open() as false and implements
+            // open_devtools() as a no-op, so this drives the open arm. The
+            // close arm needs a runtime that reports devtools as open, which
+            // the mock can't do.
+            let app = mock_app();
+            WebviewWindowBuilder::new(&app, "main", Default::default())
+                .build()
+                .expect("mock main window should build");
+            let handle = app.handle().clone();
+
+            dispatch_menu_action(&handle, MenuAction::ToggleDevTools);
+        }
     }
 }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -21,6 +21,29 @@ pub fn is_relevant_directory_change(event: &Event) -> bool {
         .any(|p| crate::is_markdown_file(p) || p.is_dir())
 }
 
+/// A file watch should fire when the watched file's content changes. Editors
+/// commonly save by replacing the file, so creations count as changes too.
+/// Extracted as a pure helper so the filter is testable without a live watcher.
+pub fn is_relevant_file_change(event: &Event) -> bool {
+    matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_))
+}
+
+/// Shared body of the `notify` callbacks: drop watcher errors, filter the
+/// event through `is_relevant`, and emit when it passes. Extracted so the
+/// error and filtered-out arms are testable — a live watcher only delivers
+/// them on hard-to-reproduce filesystem conditions.
+fn forward_watch_event(
+    res: Result<Event, notify::Error>,
+    is_relevant: fn(&Event) -> bool,
+    emit: impl FnOnce(),
+) {
+    if let Ok(event) = res {
+        if is_relevant(&event) {
+            emit();
+        }
+    }
+}
+
 #[tauri::command]
 pub fn watch_file<R: Runtime>(path: String, app: AppHandle<R>) -> Result<(), String> {
     let state = app.state::<FileWatcherState>();
@@ -34,14 +57,9 @@ pub fn watch_file<R: Runtime>(path: String, app: AppHandle<R>) -> Result<(), Str
     let app_handle = app.clone();
     let watched_path = path.clone();
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
-        if let Ok(event) = res {
-            match event.kind {
-                EventKind::Modify(_) | EventKind::Create(_) => {
-                    let _ = app_handle.emit("file-changed", &watched_path);
-                }
-                _ => {}
-            }
-        }
+        forward_watch_event(res, is_relevant_file_change, || {
+            let _ = app_handle.emit("file-changed", &watched_path);
+        });
     })
     .map_err(|e| format!("Failed to create watcher: {e}"))?;
 
@@ -73,11 +91,9 @@ pub fn watch_directory<R: Runtime>(path: String, app: AppHandle<R>) -> Result<()
     let app_handle = app.clone();
     let watched_path = path.clone();
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
-        if let Ok(event) = res {
-            if is_relevant_directory_change(&event) {
-                let _ = app_handle.emit("directory-changed", &watched_path);
-            }
-        }
+        forward_watch_event(res, is_relevant_directory_change, || {
+            let _ = app_handle.emit("directory-changed", &watched_path);
+        });
     })
     .map_err(|e| format!("Failed to create watcher: {e}"))?;
 
@@ -174,6 +190,62 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(20));
         }
+    }
+
+    #[test]
+    fn file_change_relevant_for_modify_and_create() {
+        let md = PathBuf::from("/watch/note.md");
+        assert!(is_relevant_file_change(&event(
+            EventKind::Modify(ModifyKind::Any),
+            vec![md.clone()]
+        )));
+        assert!(is_relevant_file_change(&event(
+            EventKind::Create(CreateKind::Any),
+            vec![md.clone()]
+        )));
+        assert!(!is_relevant_file_change(&event(
+            EventKind::Remove(RemoveKind::Any),
+            vec![md]
+        )));
+    }
+
+    #[test]
+    fn forward_watch_event_emits_for_relevant_events() {
+        let mut fired = false;
+        forward_watch_event(
+            Ok(event(
+                EventKind::Modify(ModifyKind::Any),
+                vec![PathBuf::from("/watch/note.md")],
+            )),
+            is_relevant_file_change,
+            || fired = true,
+        );
+        assert!(fired);
+    }
+
+    #[test]
+    fn forward_watch_event_skips_irrelevant_events() {
+        let mut fired = false;
+        forward_watch_event(
+            Ok(event(
+                EventKind::Remove(RemoveKind::Any),
+                vec![PathBuf::from("/watch/note.md")],
+            )),
+            is_relevant_file_change,
+            || fired = true,
+        );
+        assert!(!fired);
+    }
+
+    #[test]
+    fn forward_watch_event_drops_watcher_errors() {
+        let mut fired = false;
+        forward_watch_event(
+            Err(notify::Error::generic("backend failure")),
+            is_relevant_file_change,
+            || fired = true,
+        );
+        assert!(!fired);
     }
 
     #[test]

--- a/src/hooks/useActiveHeading.test.ts
+++ b/src/hooks/useActiveHeading.test.ts
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useActiveHeading } from "./useActiveHeading";
+import type { TocEntry } from "./useTableOfContents";
+
+function entry(id: string): TocEntry {
+  return { id, text: id, level: 2 };
+}
+
+function addHeading(id: string) {
+  const el = document.createElement("h2");
+  el.id = id;
+  document.body.appendChild(el);
+  return el;
+}
+
+type Intersection = { isIntersecting: boolean; target: { id: string } };
+
+describe("useActiveHeading", () => {
+  let observerCallback: ((intersections: Intersection[]) => void) | undefined;
+  let observe: ReturnType<typeof vi.fn>;
+  let disconnect: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    observe = vi.fn();
+    disconnect = vi.fn();
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe = observe;
+        disconnect = disconnect;
+        unobserve = vi.fn();
+        constructor(cb: (intersections: Intersection[]) => void) {
+          observerCallback = cb;
+        }
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+    observerCallback = undefined;
+  });
+
+  it("returns an empty id initially and observes each heading that exists", () => {
+    const a = addHeading("a");
+    const b = addHeading("b");
+
+    const { result } = renderHook(() => useActiveHeading([entry("a"), entry("b"), entry("gone")]));
+
+    expect(result.current).toBe("");
+    expect(observe).toHaveBeenCalledWith(a);
+    expect(observe).toHaveBeenCalledWith(b);
+    expect(observe).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not create an observer when there are no entries", () => {
+    renderHook(() => useActiveHeading([]));
+    expect(observerCallback).toBeUndefined();
+  });
+
+  it("activates the first intersecting heading reported by the observer", () => {
+    addHeading("a");
+    addHeading("b");
+    const { result } = renderHook(() => useActiveHeading([entry("a"), entry("b")]));
+
+    act(() => {
+      observerCallback?.([
+        { isIntersecting: false, target: { id: "a" } },
+        { isIntersecting: true, target: { id: "b" } },
+      ]);
+    });
+
+    expect(result.current).toBe("b");
+  });
+
+  it("follows programmatic scrolls immediately and locks out the observer", () => {
+    addHeading("a");
+    addHeading("b");
+    const { result } = renderHook(() => useActiveHeading([entry("a"), entry("b")]));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("glyph:active-heading", { detail: { id: "b" } }));
+    });
+    expect(result.current).toBe("b");
+
+    act(() => {
+      observerCallback?.([{ isIntersecting: true, target: { id: "a" } }]);
+    });
+    expect(result.current).toBe("b");
+  });
+
+  it("disconnects the observer on unmount", () => {
+    addHeading("a");
+    const { unmount } = renderHook(() => useActiveHeading([entry("a")]));
+    unmount();
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useFileLoader.test.ts
+++ b/src/hooks/useFileLoader.test.ts
@@ -125,6 +125,21 @@ describe("useFileLoader", () => {
     expect(onRecentFilesChange).toHaveBeenLastCalledWith(["/p/new.md", "/p/old.md"]);
   });
 
+  it("starts the recent list from scratch when recentFiles is not provided", async () => {
+    setupInvokes({ initialFile: null });
+    const onRecentFilesChange = vi.fn();
+    const { result } = renderHook(() => useFileLoader({ onRecentFilesChange }));
+    await waitFor(() => {
+      expect(result.current.initializing).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.loadFile("/p/new.md");
+    });
+
+    expect(onRecentFilesChange).toHaveBeenLastCalledWith(["/p/new.md"]);
+  });
+
   it("dedupes recent files and caps the list at 10 entries", async () => {
     setupInvokes({ initialFile: null });
     const recent = Array.from({ length: 10 }, (_, i) => `/p/${i}.md`);

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useTheme } from "./useTheme";
+import { systemTheme, useTheme } from "./useTheme";
 
 describe("useTheme", () => {
   let matchMediaMock: ReturnType<typeof vi.fn>;
@@ -83,6 +83,15 @@ describe("useTheme", () => {
     });
     expect(result.current).toBe("light");
     expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("systemTheme falls back to light when window is unavailable", () => {
+    vi.stubGlobal("window", undefined);
+    try {
+      expect(systemTheme()).toBe("light");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("cleans up event listener on unmount", () => {

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useTheme } from "./useTheme";
 
@@ -57,6 +57,32 @@ describe("useTheme", () => {
 
     renderHook(() => useTheme());
     expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("updates theme when the system preference changes", () => {
+    let changeHandler: ((e: { matches: boolean }) => void) | undefined;
+    matchMediaMock.mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn((_event: string, handler: (e: { matches: boolean }) => void) => {
+        changeHandler = handler;
+      }),
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current).toBe("light");
+
+    act(() => {
+      changeHandler?.({ matches: true });
+    });
+    expect(result.current).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    act(() => {
+      changeHandler?.({ matches: false });
+    });
+    expect(result.current).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 
   it("cleans up event listener on unmount", () => {

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -2,13 +2,18 @@ import { useEffect, useState } from "react";
 
 export type Theme = "light" | "dark";
 
+// Theme for the first render, from the OS preference. Falls back to light
+// when there's no window. Exported because the fallback can't be reached
+// through the hook: React itself needs a window to render.
+export function systemTheme(): Theme {
+  if (typeof window !== "undefined") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  return "light";
+}
+
 export function useTheme(override?: "system" | "light" | "dark") {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof window !== "undefined") {
-      return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-    }
-    return "light";
-  });
+  const [theme, setTheme] = useState<Theme>(systemTheme);
 
   useEffect(() => {
     // If settings are managing theme, skip standalone behavior

--- a/src/lib/scrollToHeading.test.ts
+++ b/src/lib/scrollToHeading.test.ts
@@ -28,6 +28,39 @@ describe("scrollToHeading", () => {
     expect(["start", "end"]).toContain(arg.block);
   });
 
+  it("scrolls to start when the target fits the scroll container's range", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    const heading = document.createElement("h2");
+    heading.id = "in-scroller";
+    scroller.appendChild(heading);
+    document.body.appendChild(scroller);
+    const spy = vi.spyOn(heading, "scrollIntoView").mockImplementation(() => {});
+
+    expect(scrollToHeading("in-scroller")).toBe(true);
+    const arg = spy.mock.calls[0][0] as ScrollIntoViewOptions;
+    expect(arg.block).toBe("start");
+  });
+
+  it("scrolls to end when the target sits past the container's max scroll", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "scroll";
+    const heading = document.createElement("h2");
+    heading.id = "past-end";
+    scroller.appendChild(heading);
+    document.body.appendChild(scroller);
+    const spy = vi.spyOn(heading, "scrollIntoView").mockImplementation(() => {});
+    // happy-dom reports zero layout boxes; push the target's top past the
+    // container's max scroll (0) so the end branch is taken.
+    vi.spyOn(heading, "getBoundingClientRect").mockReturnValue({
+      top: 100,
+    } as DOMRect);
+
+    expect(scrollToHeading("past-end")).toBe(true);
+    const arg = spy.mock.calls[0][0] as ScrollIntoViewOptions;
+    expect(arg.block).toBe("end");
+  });
+
   it("dispatches a glyph:active-heading event with the target id", () => {
     const heading = document.createElement("h2");
     heading.id = "section";


### PR DESCRIPTION
## Summary

Adds the remaining missing tests for the files named in the coverage umbrella issue, then a second pass that makes the previously unreachable branches reachable through small extractions (the same pattern the repo already uses for menu/watcher helpers). Coverage on main was already past the targets (94.2% frontend / 98.6% Rust against 80% / 85%); this PR pushes the remaining gaps down further.

Closes #171

## Changes

First pass (missing tests for ticket-named files):

- `commands/wikilinks.rs`: tests for hidden and noisy directory filtering, non-markdown file skip, oversized (>5 MB) file skip, invalid UTF-8 file skip, unclosed `[[` brackets, and empty `[[]]` targets
- `commands/directory.rs`: tests for the `get_initial_folder` command through `MockRuntime` managed state (Some and None)
- `useTheme.test.ts`: test that the `matchMedia` change handler flips the theme and the `dark` class both ways
- `useFileLoader.test.ts`: test that the recent-files list starts from scratch when `recentFiles` is not provided

Second pass (small extractions to make hard branches testable):

- `watcher.rs`: extracted `is_relevant_file_change` and `forward_watch_event` so the notify-callback error arm and filtered-out arm have direct unit tests instead of depending on hard-to-reproduce filesystem conditions
- `directory.rs` / `wikilinks.rs`: the walk bodies now take the `WALK_MAX_FILES` cap as a parameter, so the truncation branches are tested with a cap of 1-2 instead of 10,000 real files
- `file.rs`: covered `get_initial_file` (MockRuntime state), `write_file` (round-trip and error), and `print_document` on a mock window (made generic over the runtime, like the watcher commands)
- `menu.rs`: drove both `ToggleDevTools` arms (windowless no-op and open-devtools) on `MockRuntime`
- `useTheme.ts`: extracted `systemTheme()` so the no-window fallback is testable (React itself needs a window to render, so it cannot be reached through the hook)
- `useActiveHeading.ts`: new test file covering the IntersectionObserver callback, the programmatic-scroll lock, missing-element skip, and observer cleanup (was the least-covered hook at 63%)
- `scrollToHeading.ts`: covered both `autoBlock` branches inside a scroll container

Still uncovered, and genuinely not unit-testable:

- `menu.rs` close-devtools arm: `MockRuntime` always reports devtools as closed
- `directory.rs` metadata-error skip: needs a metadata failure mid-walk, which cannot be staged portably
- A handful of mock-resistant lines in `sync/git` and `telemetry`

## Testing

- `pnpm vitest run`: 1259 tests pass; local line coverage 95.7% (was 94.2%)
- `cargo test`: 283 tests pass (was 270)
- `pnpm typecheck`, `pnpm lint`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` all clean

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A (test-only change)