### PR TITLE
feat(packaging): publish Glyph to the Snap Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,9 @@ jobs:
 
             ### Linux
             ```bash
+            # Snap Store
+            sudo snap install glyph
+
             # Arch (AUR)
             yay -S glyph-md-bin
 
@@ -134,6 +137,9 @@ jobs:
 
           ### Linux
           ```bash
+          # Snap Store
+          sudo snap install glyph
+
           # Arch (AUR)
           yay -S glyph-md-bin
 
@@ -601,3 +607,49 @@ jobs:
             git commit -m "chore: update packages to $VERSION"
             git push
           }
+
+  publish-snap:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      # The snap is built from the released .deb (see snap/snapcraft.yaml), so
+      # this job needs no toolchain. It is a no-op until the maintainer adds the
+      # SNAPCRAFT_STORE_CREDENTIALS secret (snapcraft export-login), so it never
+      # fails releases before the Snap Store account is set up.
+      - name: Check for store credentials
+        id: gate
+        env:
+          CREDS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          if [ -n "$CREDS" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No SNAPCRAFT_STORE_CREDENTIALS secret; skipping snap publish."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      # snapcraft.yaml discovers the latest release and pulls the .deb for the
+      # build architecture. This job runs after the release is published, so
+      # "latest" is the tag that triggered this run. (Host env vars are not
+      # forwarded into the snapcraft build instance, so the version can't be
+      # passed that way.)
+      - name: Build snap
+        if: steps.gate.outputs.enabled == 'true'
+        id: build
+        uses: snapcore/action-build@v1
+      - name: Publish snap to stable
+        if: steps.gate.outputs.enabled == 'true'
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ scoop bucket add hamidfzm https://github.com/hamidfzm/scoop-bucket
 scoop install glyph
 ```
 
+### Linux (Snap)
+
+```bash
+sudo snap install glyph
+```
+
 ### Arch Linux (AUR)
 
 ```bash

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,84 @@
+# Snapcraft recipe for Glyph.
+#
+# Like the AUR/PPA/Flatpak packaging, this reuses the released Debian package
+# instead of recompiling. By default it discovers the latest GitHub release and
+# pulls the .deb matching the build architecture, so it needs no inputs and
+# works under any snapcraft provider (LXD, multipass, destructive mode) and in
+# `snapcore/action-build` — none of which forward arbitrary host env vars into
+# the build instance. To pin a specific version (e.g. for a local test build of
+# an older release), export GLYPH_VERSION *and* build in --destructive-mode so
+# the variable reaches the build environment.
+#
+# The `publish-snap` job in `.github/workflows/release.yml` runs after the
+# release is published, so "latest" there is the tag that triggered the run.
+#
+# Validate locally with:
+#   snapcraft --build-for amd64        # builds the latest release for amd64
+#
+# See the Tauri Snapcraft guide: https://v2.tauri.app/distribute/snapcraft/
+name: glyph
+base: core22
+adopt-info: glyph
+summary: Cross-platform markdown viewer and editor
+description: |
+  Glyph is a modern, cross-platform markdown viewer and editor with
+  platform-native styling. Built with Tauri v2, React 19, and TypeScript.
+
+  Features GitHub Flavored Markdown with syntax highlighting, KaTeX math,
+  Mermaid diagrams, multi-file tabs, a table-of-contents outline, live file
+  watching, wikilinks and backlinks, optional AI summarization
+  (Claude/OpenAI/Ollama), text-to-speech, and light/dark themes that follow
+  the system appearance.
+
+grade: stable
+confinement: strict
+license: MIT
+website: https://github.com/hamidfzm/glyph
+issues: https://github.com/hamidfzm/glyph/issues
+source-code: https://github.com/hamidfzm/glyph
+compression: lzo
+
+apps:
+  glyph:
+    command: usr/bin/glyph
+    desktop: usr/share/applications/Glyph.desktop
+    extensions:
+      - gnome
+    plugs:
+      - home
+      - removable-media
+      - network
+      - desktop
+      - desktop-legacy
+      - wayland
+      - x11
+
+parts:
+  glyph:
+    plugin: dump
+    source: .
+    build-packages:
+      - curl
+      - dpkg
+    override-pull: |
+      craftctl default
+      case "$CRAFT_ARCH_BUILD_FOR" in
+        amd64) DEB_ARCH=amd64 ;;
+        arm64) DEB_ARCH=arm64 ;;
+        *) echo "unsupported arch: $CRAFT_ARCH_BUILD_FOR" >&2; exit 1 ;;
+      esac
+      REPO="hamidfzm/glyph"
+      if [ -n "${GLYPH_VERSION:-}" ]; then
+        VERSION="$GLYPH_VERSION"
+        URL="https://github.com/${REPO}/releases/download/v${VERSION}/Glyph_${VERSION}_${DEB_ARCH}.deb"
+      else
+        # Discover the .deb for this arch from the latest published release.
+        URL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+          | grep -oE "https://github.com/${REPO}/releases/download/[^\"]+_${DEB_ARCH}\.deb")
+        VERSION=$(printf '%s' "$URL" | sed -E "s#.*/Glyph_([^_]+)_${DEB_ARCH}\.deb#\1#")
+      fi
+      test -n "$URL" || { echo "could not resolve a .deb URL for $DEB_ARCH" >&2; exit 1; }
+      curl -fSL -o glyph.deb "$URL"
+      dpkg-deb -x glyph.deb .
+      rm glyph.deb
+      craftctl set version="$VERSION"


### PR DESCRIPTION
## Summary

Publishes Glyph to the **Snap Store** (Ubuntu's default app channel, also the `snap` command across many distros). This is one of three independent packaging PRs split out so each store can be reviewed and merged on its own:

- **Snap Store — this PR**
- Flathub (Flatpak) — separate PR
- Microsoft Store — separate PR

## Changes

- `snap/snapcraft.yaml` — `core22`, strict confinement, built from the released `.deb`. The recipe auto-discovers the latest GitHub release and pulls the `.deb` for the build architecture (snapcraft does not forward host env into the build instance, so the version can't be passed that way; `publish-snap` runs after publish, so "latest" is the triggering tag).
- `publish-snap` job in `release.yml` (amd64 + arm64). Gated on a `SNAPCRAFT_STORE_CREDENTIALS` secret, so it is a no-op (green, skipped steps) until the Snap Store account is set up, and never fails a release before then.
- Snap install instructions in `README.md` and both Linux blocks of the release notes.

## Validation

- Recipe structure validated with `snapcraft expand-extensions` (GNOME extension wiring, plugs, `desktop-launch` command-chain, `build-for` resolution).
- The pull/extract logic and the `.deb` file paths were validated against the real release `.deb` (this caught and fixed the `Glyph.desktop` capital-G path).
- A full local `snapcraft pack` could not be run in the available WSL environment (its kernel has AppArmor disabled, so snapd can't install the GNOME runtime). The `publish-snap` job builds on real `ubuntu-22.04` runners where this works.

## Maintainer setup

- [x] Register the snap name `glyph` and add the `SNAPCRAFT_STORE_CREDENTIALS` secret (`snapcraft export-login`). Done.
- After merge, the snap builds + publishes to the **stable** channel on the next tagged release.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Refs #117, #291
