### PR TITLE
feat: image lightbox with zoom and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - YAML frontmatter — title, author, date, and tags render as a metadata block above the document; tags get a per-tag colour
 - Emoji shortcodes — `:smile:` → 😊, `:+1:` → 👍
 - Local and remote image display
+- Image lightbox — click any image to view it full-size over a dark backdrop, with zoom controls (fit, actual size, zoom in/out), arrow-key navigation between the document's images, and Escape or click-outside to close
 - External links open in system browser with optional confirmation dialog
 
 ### Editor

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 - Math/LaTeX rendering — inline (`$...$`) and block (`$$...$$`) equations via KaTeX
 - Mermaid diagrams — flowcharts, sequence diagrams, Gantt charts, and more (theme-aware); `.mmd` source files open directly as diagrams
 - CSV/TSV tables — ` ```csv ` and ` ```tsv ` code blocks render as styled, scrollable tables
-- Inline HTML — `<kbd>`, `<sub>`, `<sup>`, `<details>`, alignment attributes (sanitised allowlist)
+- Inline HTML — `<kbd>`, `<sub>`, `<sup>`, `<details>`, inline `<svg>` drawings, alignment attributes (sanitised allowlist)
 - YAML frontmatter — title, author, date, and tags render as a metadata block above the document; tags get a per-tag colour
 - Emoji shortcodes — `:smile:` → 😊, `:+1:` → 👍
 - Local and remote image display

--- a/samples/README.md
+++ b/samples/README.md
@@ -248,6 +248,23 @@ Relative paths resolve against this file's folder, so SVGs and other images comm
 
 Click any image to open it in the lightbox: zoom in/out, fit or actual size, and use the arrow keys to move between them. Press `Esc` or click the backdrop to close.
 
+### Inline SVG
+
+You can also embed SVG straight into the markdown. It renders inline from a sanitised allowlist (shapes, gradients, and text — no scripts or external references), which is handy for small, theme-friendly diagrams:
+
+<svg viewBox="0 0 320 120" width="320" height="120" role="img" aria-label="Inline SVG gradient badge">
+  <defs>
+    <linearGradient id="demo" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6366f1" />
+      <stop offset="1" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="312" height="112" rx="16" fill="url(#demo)" />
+  <circle cx="64" cy="60" r="34" fill="#ffffff" fill-opacity="0.18" />
+  <path d="M50 60 l10 10 l20 -24" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" />
+  <text x="190" y="68" text-anchor="middle" font-family="sans-serif" font-size="24" font-weight="700" fill="#ffffff">Inline SVG</text>
+</svg>
+
 ## Links
 
 - [Glyph on GitHub](https://github.com/hamidfzm/glyph) — External links open in your system browser

--- a/samples/README.md
+++ b/samples/README.md
@@ -240,6 +240,8 @@ Hidden content lives inside `<details>` blocks. Useful for FAQs, troubleshooting
 
 ![Forest path](https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=800&h=400&fit=crop)
 
+Click either image to open it in the lightbox: zoom in/out, fit or actual size, and use the arrow keys to move between the two. Press `Esc` or click the backdrop to close.
+
 ## Links
 
 - [Glyph on GitHub](https://github.com/hamidfzm/glyph) — External links open in your system browser

--- a/samples/README.md
+++ b/samples/README.md
@@ -240,7 +240,13 @@ Hidden content lives inside `<details>` blocks. Useful for FAQs, troubleshooting
 
 ![Forest path](https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=800&h=400&fit=crop)
 
-Click either image to open it in the lightbox: zoom in/out, fit or actual size, and use the arrow keys to move between the two. Press `Esc` or click the backdrop to close.
+### Local Images
+
+Relative paths resolve against this file's folder, so SVGs and other images committed next to your notes render inline:
+
+![Glyph turns Markdown into styled documents](./diagram.svg)
+
+Click any image to open it in the lightbox: zoom in/out, fit or actual size, and use the arrow keys to move between them. Press `Esc` or click the backdrop to close.
 
 ## Links
 

--- a/samples/diagram.svg
+++ b/samples/diagram.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" width="640" height="360" role="img" aria-label="Glyph renders Markdown into a styled document">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6366f1"/>
+      <stop offset="1" stop-color="#0ea5e9"/>
+    </linearGradient>
+    <linearGradient id="paper" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#eef2ff"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="640" height="360" rx="20" fill="url(#bg)"/>
+
+  <!-- Source panel -->
+  <rect x="40" y="60" width="230" height="240" rx="12" fill="#0f172a" opacity="0.92"/>
+  <text x="60" y="96" font-family="monospace" font-size="15" fill="#94a3b8"># Glyph</text>
+  <text x="60" y="128" font-family="monospace" font-size="15" fill="#e2e8f0">**Markdown** in,</text>
+  <text x="60" y="156" font-family="monospace" font-size="15" fill="#e2e8f0">styled docs out.</text>
+  <text x="60" y="196" font-family="monospace" font-size="15" fill="#38bdf8">- math, code</text>
+  <text x="60" y="224" font-family="monospace" font-size="15" fill="#38bdf8">- diagrams</text>
+  <text x="60" y="252" font-family="monospace" font-size="15" fill="#38bdf8">- images</text>
+
+  <!-- Arrow -->
+  <path d="M286 180 H354" stroke="#ffffff" stroke-width="6" stroke-linecap="round"/>
+  <path d="M346 166 L368 180 L346 194 Z" fill="#ffffff"/>
+
+  <!-- Rendered panel -->
+  <rect x="384" y="60" width="216" height="240" rx="12" fill="url(#paper)"/>
+  <rect x="408" y="86" width="120" height="18" rx="6" fill="#1e293b"/>
+  <rect x="408" y="120" width="168" height="10" rx="5" fill="#64748b"/>
+  <rect x="408" y="138" width="150" height="10" rx="5" fill="#64748b"/>
+  <rect x="408" y="170" width="168" height="40" rx="8" fill="#e0e7ff"/>
+  <circle cx="430" cy="190" r="9" fill="#6366f1"/>
+  <rect x="448" y="185" width="120" height="10" rx="5" fill="#818cf8"/>
+  <rect x="408" y="228" width="100" height="10" rx="5" fill="#64748b"/>
+  <rect x="408" y="246" width="140" height="10" rx="5" fill="#64748b"/>
+
+  <text x="320" y="338" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#ffffff" opacity="0.9">A local SVG, rendered inline and zoomable in the lightbox</text>
+</svg>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1766,6 +1766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4455,6 +4461,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ tauri-build = { version = "2", features = [] }
 serde_json = "1"
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-os = "2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,14 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": {
+          "allow": ["**"],
+          "requireLiteralLeadingDot": false
+        }
+      }
     }
   },
   "bundle": {

--- a/src/components/icons/ActualSizeIcon.tsx
+++ b/src/components/icons/ActualSizeIcon.tsx
@@ -1,0 +1,22 @@
+// "1:1" glyph, for the lightbox "actual size" control.
+export function ActualSizeIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={`inline-block ${className}`}
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 5.5L4.5 4.5V11.5" />
+      <path d="M11.5 5.5L13 4.5V11.5" />
+      <circle cx="8" cy="5" r="0.25" />
+      <circle cx="8" cy="11" r="0.25" />
+    </svg>
+  );
+}

--- a/src/components/icons/ChevronLeftIcon.tsx
+++ b/src/components/icons/ChevronLeftIcon.tsx
@@ -1,0 +1,20 @@
+// Left-pointing chevron, mirror of ChevronRightIcon. Used for lightbox
+// "previous image" navigation.
+export function ChevronLeftIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={`inline-block ${className}`}
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M6.5 2.5L3.5 5l3 2.5" />
+    </svg>
+  );
+}

--- a/src/components/icons/FitIcon.tsx
+++ b/src/components/icons/FitIcon.tsx
@@ -1,0 +1,19 @@
+// Inward-pointing corners, for the lightbox "fit to screen" control.
+export function FitIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={`inline-block ${className}`}
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M6 2H2v4M14 6V2h-4M10 14h4v-4M2 10v4h4" />
+    </svg>
+  );
+}

--- a/src/components/icons/ZoomInIcon.tsx
+++ b/src/components/icons/ZoomInIcon.tsx
@@ -1,0 +1,21 @@
+// Magnifier with a plus, for the lightbox "zoom in" control.
+export function ZoomInIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={`inline-block ${className}`}
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="7" cy="7" r="4.5" />
+      <path d="M10.5 10.5L14 14" />
+      <path d="M7 5v4M5 7h4" />
+    </svg>
+  );
+}

--- a/src/components/icons/ZoomOutIcon.tsx
+++ b/src/components/icons/ZoomOutIcon.tsx
@@ -1,0 +1,21 @@
+// Magnifier with a minus, for the lightbox "zoom out" control.
+export function ZoomOutIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={`inline-block ${className}`}
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="7" cy="7" r="4.5" />
+      <path d="M10.5 10.5L14 14" />
+      <path d="M5 7h4" />
+    </svg>
+  );
+}

--- a/src/components/layout/WorkspaceNoticeBanner.tsx
+++ b/src/components/layout/WorkspaceNoticeBanner.tsx
@@ -6,10 +6,11 @@ interface WorkspaceNoticeBannerProps {
 }
 
 /**
- * Transient bar shown when a folder can't be opened as a workspace (it's nested
- * inside a parent git repo, or overlaps an already-open workspace — see #262).
- * Mirrors {@link UpdateBanner}'s layout; the close button hides it, and it
- * also auto-dismisses (see `useWorkspaceNotice`).
+ * Bar shown for a workspace notice (see #262): a refusal (the folder overlaps an
+ * open workspace, or sits inside another workspace's `.glyph/`) or a warning
+ * (the folder opened despite sitting inside a parent git repo). Mirrors
+ * {@link UpdateBanner}'s layout; the close button always hides it. Refusals also
+ * auto-dismiss, while warnings stay up until dismissed (see `useWorkspaceNotice`).
  */
 export function WorkspaceNoticeBanner({ notice, onDismiss }: WorkspaceNoticeBannerProps) {
   if (!notice) return null;

--- a/src/components/markdown/ImageComponent.test.tsx
+++ b/src/components/markdown/ImageComponent.test.tsx
@@ -35,6 +35,16 @@ describe("useImageComponent", () => {
     expect(src).toContain("/notes/img/cover.png");
   });
 
+  it("strips a Windows verbatim prefix and normalizes separators", () => {
+    const { result } = renderHook(() => useImageComponent("\\\\?\\C:\\Users\\me\\notes\\doc.md"));
+    const Img = result.current;
+    const { container } = render(<Img src="./diagram.svg" alt="d" />);
+    const decoded = decodeURIComponent(container.querySelector("img")?.getAttribute("src") ?? "");
+    // The unreadable "\\?\" prefix and the stray forward slash from the join are gone.
+    expect(decoded).not.toContain("\\\\?\\");
+    expect(decoded).toContain("C:\\Users\\me\\notes\\diagram.svg");
+  });
+
   it("leaves the src alone when no file path is known", () => {
     const { result } = renderHook(() => useImageComponent(undefined));
     const Img = result.current;

--- a/src/components/markdown/ImageComponent.tsx
+++ b/src/components/markdown/ImageComponent.tsx
@@ -1,26 +1,11 @@
-import { convertFileSrc } from "@tauri-apps/api/core";
 import { type ComponentPropsWithoutRef, useCallback } from "react";
+import { MarkdownImage } from "./MarkdownImage";
 
-function resolveImageSrc(
-  src: string | undefined,
-  filePath: string | undefined,
-): string | undefined {
-  if (!src) return src;
-  if (/^(https?:|data:)/i.test(src)) return src;
-  if (filePath) {
-    const dir = filePath.replace(/[/\\][^/\\]*$/, "");
-    const resolved = `${dir}/${src}`.replace(/\/\.\//g, "/");
-    return convertFileSrc(resolved);
-  }
-  return src;
-}
-
+// Binds the document's file path into the `img` component ReactMarkdown
+// renders, so relative image paths resolve against the right directory.
 export function useImageComponent(filePath: string | undefined) {
   return useCallback(
-    (props: ComponentPropsWithoutRef<"img">) => {
-      const { src, alt, ...rest } = props;
-      return <img src={resolveImageSrc(src, filePath)} alt={alt} {...rest} />;
-    },
+    (props: ComponentPropsWithoutRef<"img">) => <MarkdownImage {...props} filePath={filePath} />,
     [filePath],
   );
 }

--- a/src/components/markdown/Lightbox.test.tsx
+++ b/src/components/markdown/Lightbox.test.tsx
@@ -73,6 +73,21 @@ describe("Lightbox", () => {
     expect(screen.getByText("80%")).toBeInTheDocument();
   });
 
+  it("contains an image with no intrinsic size (SVG) instead of collapsing to zero width", () => {
+    render(<Harness />);
+    const img = screen.getByAltText("first") as HTMLImageElement;
+    // jsdom reports naturalWidth/Height === 0, like an SVG with only a viewBox.
+    fireEvent.load(img);
+
+    // Visible and contained (not width: 0), and zoom grows the contain box.
+    expect(img.style.opacity).toBe("1");
+    expect(img.style.width).toBe("");
+    expect(img.style.maxWidth).toBe("100%");
+
+    fireEvent.keyDown(window, { key: "+" });
+    expect(img.style.maxWidth).toBe("125%");
+  });
+
   it("zooms with the keyboard", () => {
     render(<Harness />);
     fireEvent.keyDown(window, { key: "+" });

--- a/src/components/markdown/Lightbox.test.tsx
+++ b/src/components/markdown/Lightbox.test.tsx
@@ -154,6 +154,29 @@ describe("Lightbox", () => {
     expect(screen.getByText("100%")).toBeInTheDocument();
   });
 
+  it("ignores arrow keys and hides nav when there is a single image", () => {
+    render(
+      <Lightbox
+        images={[{ src: "only.png", alt: "only" }]}
+        index={0}
+        onIndexChange={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.queryByLabelText("Next image (→)")).not.toBeInTheDocument();
+    // Arrow keys are no-ops with one image (the counter isn't shown either).
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(screen.getByAltText("only")).toBeInTheDocument();
+  });
+
+  it("ignores non-Escape keys dispatched on the dialog", () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "a" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("renders nothing when the index is out of range", () => {
     const { container } = render(
       <Lightbox images={IMAGES} index={99} onIndexChange={() => {}} onClose={() => {}} />,

--- a/src/components/markdown/Lightbox.test.tsx
+++ b/src/components/markdown/Lightbox.test.tsx
@@ -73,19 +73,19 @@ describe("Lightbox", () => {
     expect(screen.getByText("80%")).toBeInTheDocument();
   });
 
-  it("contains an image with no intrinsic size (SVG) instead of collapsing to zero width", () => {
+  it("shows an image with no intrinsic size (SVG) and zooms it via transform", () => {
     render(<Harness />);
     const img = screen.getByAltText("first") as HTMLImageElement;
     // jsdom reports naturalWidth/Height === 0, like an SVG with only a viewBox.
     fireEvent.load(img);
 
-    // Visible and contained (not width: 0), and zoom grows the contain box.
+    // Visible and contained (not collapsed), and zoom scales it.
     expect(img.style.opacity).toBe("1");
-    expect(img.style.width).toBe("");
-    expect(img.style.maxWidth).toBe("100%");
+    expect(img.style.objectFit).toBe("contain");
+    expect(img.style.transform).toBe("scale(1)");
 
     fireEvent.keyDown(window, { key: "+" });
-    expect(img.style.maxWidth).toBe("125%");
+    expect(img.style.transform).toBe("scale(1.25)");
   });
 
   it("zooms with the keyboard", () => {

--- a/src/components/markdown/Lightbox.test.tsx
+++ b/src/components/markdown/Lightbox.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { Lightbox } from "./Lightbox";
+
+const IMAGES = [
+  { src: "a.png", alt: "first" },
+  { src: "b.png", alt: "second" },
+  { src: "c.png", alt: "third" },
+];
+
+// Drives the controlled `index` so navigation can be asserted end to end.
+function Harness({ onClose = () => {}, start = 0 }: { onClose?: () => void; start?: number }) {
+  const [index, setIndex] = useState(start);
+  return <Lightbox images={IMAGES} index={index} onIndexChange={setIndex} onClose={onClose} />;
+}
+
+describe("Lightbox", () => {
+  it("renders the current image and a counter for multiple images", () => {
+    render(<Harness />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByAltText("first")).toBeInTheDocument();
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes when the backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("navigates with the arrow keys, clamping at the ends", () => {
+    render(<Harness />);
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+    expect(screen.getByAltText("second")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+
+    // Already at the first image — left does nothing.
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+
+  it("navigates with the prev/next buttons and disables them at the ends", () => {
+    render(<Harness />);
+    expect(screen.getByLabelText("Previous image (←)")).toBeDisabled();
+    fireEvent.click(screen.getByLabelText("Next image (→)"));
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+    expect(screen.getByLabelText("Previous image (←)")).toBeEnabled();
+  });
+
+  it("adjusts the zoom level via the toolbar and resets with actual size", () => {
+    render(<Harness />);
+    expect(screen.getByText("100%")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Zoom in (+)"));
+    expect(screen.getByText("125%")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Actual size (1)"));
+    expect(screen.getByText("100%")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Zoom out (-)"));
+    expect(screen.getByText("80%")).toBeInTheDocument();
+  });
+
+  it("zooms with the keyboard", () => {
+    render(<Harness />);
+    fireEvent.keyDown(window, { key: "+" });
+    expect(screen.getByText("125%")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "1" });
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+});

--- a/src/components/markdown/Lightbox.test.tsx
+++ b/src/components/markdown/Lightbox.test.tsx
@@ -95,4 +95,81 @@ describe("Lightbox", () => {
     fireEvent.keyDown(window, { key: "1" });
     expect(screen.getByText("100%")).toBeInTheDocument();
   });
+
+  it("zooms in with the = key (no shift needed)", () => {
+    render(<Harness />);
+    fireEvent.keyDown(window, { key: "=" });
+    expect(screen.getByText("125%")).toBeInTheDocument();
+  });
+
+  it("zooms out and refits with the keyboard", () => {
+    render(<Harness />);
+    fireEvent.keyDown(window, { key: "+" });
+    expect(screen.getByText("125%")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "-" });
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "+" });
+    fireEvent.keyDown(window, { key: "0" });
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("closes on Escape dispatched from the dialog itself", () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("navigates back with the prev button when past the first image", () => {
+    render(<Harness start={1} />);
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Previous image (←)"));
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+
+  it("lays out an image with intrinsic pixel size and scales its width on zoom", () => {
+    render(<Harness />);
+    const img = screen.getByAltText("first") as HTMLImageElement;
+    // Mock a real intrinsic size (jsdom reports 0 otherwise) to hit the pixel path.
+    Object.defineProperty(img, "naturalWidth", { value: 800, configurable: true });
+    Object.defineProperty(img, "naturalHeight", { value: 600, configurable: true });
+    fireEvent.load(img);
+
+    // Intrinsic branch: explicit pixel width, no object-fit contain.
+    const fitWidth = parseFloat(img.style.width);
+    expect(fitWidth).toBeGreaterThan(0);
+    expect(img.style.objectFit).toBe("");
+
+    fireEvent.keyDown(window, { key: "+" });
+    expect(parseFloat(img.style.width)).toBeCloseTo(fitWidth * 1.25);
+  });
+
+  it("recomputes the fit on window resize while fitted", () => {
+    render(<Harness />);
+    const img = screen.getByAltText("first") as HTMLImageElement;
+    Object.defineProperty(img, "naturalWidth", { value: 800, configurable: true });
+    Object.defineProperty(img, "naturalHeight", { value: 600, configurable: true });
+    fireEvent.load(img);
+    fireEvent(window, new Event("resize"));
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("renders nothing when the index is out of range", () => {
+    const { container } = render(
+      <Lightbox images={IMAGES} index={99} onIndexChange={() => {}} onClose={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("uses a generic label when the image has no alt text", () => {
+    render(
+      <Lightbox
+        images={[{ src: "a.png", alt: "" }]}
+        index={0}
+        onIndexChange={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByRole("dialog", { name: "Image viewer" })).toBeInTheDocument();
+  });
 });

--- a/src/components/markdown/Lightbox.tsx
+++ b/src/components/markdown/Lightbox.tsx
@@ -137,13 +137,16 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
   if (!image) return null;
 
   // With an intrinsic size we lay the image out at `natural × scale` so zooming
-  // past the viewport pans. Without one (SVG), contain it in `scale × 100%` of
-  // the stage so it stays visible and still grows on zoom.
+  // past the viewport pans. Without one (an SVG with only a viewBox) there are
+  // no pixels to multiply, so fill the stage with object-fit contain and zoom
+  // via transform — max-width alone caps the size but can't enlarge it.
   const imageStyle: CSSProperties = natural
     ? { width: natural.w * scale, opacity: loaded ? 1 : 0 }
     : {
-        maxWidth: `${scale * 100}%`,
-        maxHeight: `${scale * 100}%`,
+        width: "100%",
+        height: "100%",
+        objectFit: "contain",
+        transform: `scale(${scale})`,
         opacity: loaded ? 1 : 0,
       };
 

--- a/src/components/markdown/Lightbox.tsx
+++ b/src/components/markdown/Lightbox.tsx
@@ -141,7 +141,9 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
   // no pixels to multiply, so fill the stage with object-fit contain and zoom
   // via transform — max-width alone caps the size but can't enlarge it.
   const imageStyle: CSSProperties = natural
-    ? { width: natural.w * scale, opacity: loaded ? 1 : 0 }
+    ? // `natural` is only set together with `loaded` in handleLoad, so it's
+      // always loaded by the time this branch renders.
+      { width: natural.w * scale, opacity: 1 }
     : {
         width: "100%",
         height: "100%",

--- a/src/components/markdown/Lightbox.tsx
+++ b/src/components/markdown/Lightbox.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ActualSizeIcon } from "@/components/icons/ActualSizeIcon";
+import { ChevronLeftIcon } from "@/components/icons/ChevronLeftIcon";
+import { ChevronRightIcon } from "@/components/icons/ChevronRightIcon";
+import { FitIcon } from "@/components/icons/FitIcon";
+import { ModalCloseIcon } from "@/components/icons/ModalCloseIcon";
+import { ZoomInIcon } from "@/components/icons/ZoomInIcon";
+import { ZoomOutIcon } from "@/components/icons/ZoomOutIcon";
+import { clampScale, fitScale, type LightboxImage, ZOOM_STEP } from "@/lib/lightbox";
+
+interface LightboxProps {
+  images: LightboxImage[];
+  index: number;
+  onIndexChange: (index: number) => void;
+  onClose: () => void;
+}
+
+// Full-screen image viewer: dark backdrop, zoom controls (fit, actual size,
+// zoom in/out), and arrow-key navigation between the document's images. The
+// image is laid out at `natural × scale` inside a scrollable stage so zooming
+// past the viewport pans rather than clips.
+export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProps) {
+  const image = images[index];
+  const imgRef = useRef<HTMLImageElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const [isFit, setIsFit] = useState(true);
+  const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
+
+  const hasMultiple = images.length > 1;
+
+  const computeFit = useCallback(() => {
+    const stage = stageRef.current;
+    const img = imgRef.current;
+    if (!stage || !img?.naturalWidth) return 1;
+    // Subtract the overlay padding so a fitted image clears the toolbar/edges.
+    const styles = getComputedStyle(stage);
+    const availWidth =
+      stage.clientWidth - parseFloat(styles.paddingLeft) - parseFloat(styles.paddingRight);
+    const availHeight =
+      stage.clientHeight - parseFloat(styles.paddingTop) - parseFloat(styles.paddingBottom);
+    return fitScale(img.naturalWidth, img.naturalHeight, availWidth, availHeight);
+  }, []);
+
+  const applyFit = useCallback(() => {
+    setScale(computeFit());
+    setIsFit(true);
+  }, [computeFit]);
+
+  const zoomBy = useCallback((factor: number) => {
+    setScale((s) => clampScale(s * factor));
+    setIsFit(false);
+  }, []);
+
+  const actualSize = useCallback(() => {
+    setScale(1);
+    setIsFit(false);
+  }, []);
+
+  const goTo = useCallback(
+    (next: number) => {
+      if (next < 0 || next >= images.length) return;
+      setNatural(null);
+      onIndexChange(next);
+    },
+    [images.length, onIndexChange],
+  );
+
+  const handleLoad = useCallback(() => {
+    const img = imgRef.current;
+    if (img) setNatural({ w: img.naturalWidth, h: img.naturalHeight });
+    applyFit();
+  }, [applyFit]);
+
+  // Keyboard controls: close, navigate, and zoom.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case "Escape":
+          e.preventDefault();
+          onClose();
+          break;
+        case "ArrowLeft":
+          if (hasMultiple) {
+            e.preventDefault();
+            goTo(index - 1);
+          }
+          break;
+        case "ArrowRight":
+          if (hasMultiple) {
+            e.preventDefault();
+            goTo(index + 1);
+          }
+          break;
+        case "+":
+        case "=":
+          e.preventDefault();
+          zoomBy(ZOOM_STEP);
+          break;
+        case "-":
+          e.preventDefault();
+          zoomBy(1 / ZOOM_STEP);
+          break;
+        case "0":
+          e.preventDefault();
+          applyFit();
+          break;
+        case "1":
+          e.preventDefault();
+          actualSize();
+          break;
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [hasMultiple, index, goTo, zoomBy, applyFit, actualSize, onClose]);
+
+  // Keep the image fitted when the window resizes, unless the user has zoomed.
+  useEffect(() => {
+    if (!isFit) return;
+    const onResize = () => setScale(computeFit());
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [isFit, computeFit]);
+
+  if (!image) return null;
+
+  const displayWidth = natural ? natural.w * scale : undefined;
+
+  // The dialog is the scroll container and the backdrop: clicking it directly
+  // (i.e. the empty area around the image) closes. The controls below are
+  // `position: fixed`, so they stay pinned while a zoomed image scrolls.
+  return (
+    <div
+      ref={stageRef}
+      className="lightbox-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label={image.alt ? `Image: ${image.alt}` : "Image viewer"}
+      data-print-hide="true"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          onClose();
+        }
+      }}
+    >
+      <button
+        type="button"
+        className="lightbox-button lightbox-close"
+        onClick={onClose}
+        aria-label="Close (Esc)"
+        title="Close (Esc)"
+      >
+        <ModalCloseIcon />
+      </button>
+
+      {hasMultiple && (
+        <button
+          type="button"
+          className="lightbox-button lightbox-nav lightbox-prev"
+          onClick={() => goTo(index - 1)}
+          disabled={index === 0}
+          aria-label="Previous image (←)"
+          title="Previous image (←)"
+        >
+          <ChevronLeftIcon className="w-5 h-5" />
+        </button>
+      )}
+
+      <img
+        ref={imgRef}
+        src={image.src}
+        alt={image.alt}
+        className="lightbox-image"
+        style={{ width: displayWidth, opacity: natural ? 1 : 0 }}
+        onLoad={handleLoad}
+        draggable={false}
+      />
+
+      {hasMultiple && (
+        <button
+          type="button"
+          className="lightbox-button lightbox-nav lightbox-next"
+          onClick={() => goTo(index + 1)}
+          disabled={index === images.length - 1}
+          aria-label="Next image (→)"
+          title="Next image (→)"
+        >
+          <ChevronRightIcon className="w-5 h-5" />
+        </button>
+      )}
+
+      <div className="lightbox-toolbar">
+        <button
+          type="button"
+          className="lightbox-button"
+          onClick={() => zoomBy(1 / ZOOM_STEP)}
+          aria-label="Zoom out (-)"
+          title="Zoom out (-)"
+        >
+          <ZoomOutIcon />
+        </button>
+        <span className="lightbox-zoom-level" aria-live="polite">
+          {Math.round(scale * 100)}%
+        </span>
+        <button
+          type="button"
+          className="lightbox-button"
+          onClick={() => zoomBy(ZOOM_STEP)}
+          aria-label="Zoom in (+)"
+          title="Zoom in (+)"
+        >
+          <ZoomInIcon />
+        </button>
+        <span className="lightbox-toolbar-divider" aria-hidden="true" />
+        <button
+          type="button"
+          className="lightbox-button"
+          onClick={applyFit}
+          aria-label="Fit to screen (0)"
+          title="Fit to screen (0)"
+        >
+          <FitIcon />
+        </button>
+        <button
+          type="button"
+          className="lightbox-button"
+          onClick={actualSize}
+          aria-label="Actual size (1)"
+          title="Actual size (1)"
+        >
+          <ActualSizeIcon />
+        </button>
+        {hasMultiple && (
+          <>
+            <span className="lightbox-toolbar-divider" aria-hidden="true" />
+            <span className="lightbox-counter">
+              {index + 1} / {images.length}
+            </span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/markdown/Lightbox.tsx
+++ b/src/components/markdown/Lightbox.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { ActualSizeIcon } from "@/components/icons/ActualSizeIcon";
 import { ChevronLeftIcon } from "@/components/icons/ChevronLeftIcon";
 import { ChevronRightIcon } from "@/components/icons/ChevronRightIcon";
@@ -25,6 +25,9 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
   const stageRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
   const [isFit, setIsFit] = useState(true);
+  const [loaded, setLoaded] = useState(false);
+  // Intrinsic pixel size, or null when the image has none (SVGs with only a
+  // `viewBox` report naturalWidth/Height === 0). Drives the sizing model below.
   const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
 
   const hasMultiple = images.length > 1;
@@ -60,6 +63,7 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
   const goTo = useCallback(
     (next: number) => {
       if (next < 0 || next >= images.length) return;
+      setLoaded(false);
       setNatural(null);
       onIndexChange(next);
     },
@@ -68,7 +72,14 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
 
   const handleLoad = useCallback(() => {
     const img = imgRef.current;
-    if (img) setNatural({ w: img.naturalWidth, h: img.naturalHeight });
+    setLoaded(true);
+    // SVGs with only a viewBox report no intrinsic pixel size; fall back to a
+    // contained layout (see `imageStyle`) so they still display and zoom.
+    setNatural(
+      img && img.naturalWidth > 0 && img.naturalHeight > 0
+        ? { w: img.naturalWidth, h: img.naturalHeight }
+        : null,
+    );
     applyFit();
   }, [applyFit]);
 
@@ -125,7 +136,16 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
 
   if (!image) return null;
 
-  const displayWidth = natural ? natural.w * scale : undefined;
+  // With an intrinsic size we lay the image out at `natural × scale` so zooming
+  // past the viewport pans. Without one (SVG), contain it in `scale × 100%` of
+  // the stage so it stays visible and still grows on zoom.
+  const imageStyle: CSSProperties = natural
+    ? { width: natural.w * scale, opacity: loaded ? 1 : 0 }
+    : {
+        maxWidth: `${scale * 100}%`,
+        maxHeight: `${scale * 100}%`,
+        opacity: loaded ? 1 : 0,
+      };
 
   // The dialog is the scroll container and the backdrop: clicking it directly
   // (i.e. the empty area around the image) closes. The controls below are
@@ -176,7 +196,7 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
         src={image.src}
         alt={image.alt}
         className="lightbox-image"
-        style={{ width: displayWidth, opacity: natural ? 1 : 0 }}
+        style={imageStyle}
         onLoad={handleLoad}
         draggable={false}
       />

--- a/src/components/markdown/MarkdownContent.tsx
+++ b/src/components/markdown/MarkdownContent.tsx
@@ -8,6 +8,7 @@ import remarkGemoji from "remark-gemoji";
 import remarkGfm from "remark-gfm";
 import { remarkAlert } from "remark-github-blockquote-alert";
 import remarkMath from "remark-math";
+import { LightboxProvider } from "@/contexts/LightboxContext";
 import { useHighlightPlugin } from "@/hooks/useHighlightPlugin";
 import { useKatexPlugin } from "@/hooks/useKatexPlugin";
 import { parseFrontmatter } from "@/lib/frontmatter";
@@ -87,7 +88,7 @@ export function MarkdownContent({
   );
 
   return (
-    <>
+    <LightboxProvider>
       {frontmatter && <FrontmatterBlock data={frontmatter} />}
       <ReactMarkdown
         remarkPlugins={remarkPlugins}
@@ -101,6 +102,6 @@ export function MarkdownContent({
       >
         {content}
       </ReactMarkdown>
-    </>
+    </LightboxProvider>
   );
 }

--- a/src/components/markdown/MarkdownImage.tsx
+++ b/src/components/markdown/MarkdownImage.tsx
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithoutRef, useRef } from "react";
+import type { ComponentPropsWithoutRef, MouseEvent } from "react";
 import { useLightbox } from "@/contexts/LightboxContext";
 import { resolveImageSrc } from "./resolveImageSrc";
 
@@ -7,28 +7,27 @@ interface MarkdownImageProps extends ComponentPropsWithoutRef<"img"> {
 }
 
 // A markdown <img> with its src resolved for the webview. When a lightbox
-// provider is in scope the image is wrapped in a button that opens the lightbox
-// on click or Enter/Space; without one it renders as a plain image (e.g.
-// printing, notebook export).
+// provider is in scope, clicking the image opens it. The handler lives on the
+// image itself (no wrapper element) so it renders identically to a plain image
+// and stays valid inside a linked image (<a>). Without a provider it renders as
+// a plain image (e.g. printing, export).
 export function MarkdownImage({ filePath, src, alt, ...rest }: MarkdownImageProps) {
   const lightbox = useLightbox();
-  const imgRef = useRef<HTMLImageElement>(null);
   const resolved = resolveImageSrc(src, filePath);
 
   if (!lightbox || !resolved) {
     return <img src={resolved} alt={alt} {...rest} />;
   }
 
+  const handleClick = (event: MouseEvent<HTMLImageElement>) => {
+    // Win over an enclosing link so a linked image zooms instead of navigating.
+    event.preventDefault();
+    event.stopPropagation();
+    lightbox.open(event.currentTarget);
+  };
+
   return (
-    <button
-      type="button"
-      className="markdown-image-button"
-      aria-label={alt ? `View image: ${alt}` : "View image"}
-      onClick={() => {
-        if (imgRef.current) lightbox.open(imgRef.current);
-      }}
-    >
-      <img ref={imgRef} src={resolved} alt={alt} {...rest} data-zoomable="true" />
-    </button>
+    // biome-ignore lint/a11y/useKeyWithClickEvents: a markdown image is a click-to-zoom trigger and stays a plain <img> so it renders identically and remains valid inside a linked image (<a>); the lightbox itself is fully keyboard-operable once open (Esc, arrows, +/-)
+    <img src={resolved} alt={alt} {...rest} data-zoomable="true" onClick={handleClick} />
   );
 }

--- a/src/components/markdown/MarkdownImage.tsx
+++ b/src/components/markdown/MarkdownImage.tsx
@@ -1,0 +1,34 @@
+import { type ComponentPropsWithoutRef, useRef } from "react";
+import { useLightbox } from "@/contexts/LightboxContext";
+import { resolveImageSrc } from "./resolveImageSrc";
+
+interface MarkdownImageProps extends ComponentPropsWithoutRef<"img"> {
+  filePath: string | undefined;
+}
+
+// A markdown <img> with its src resolved for the webview. When a lightbox
+// provider is in scope the image is wrapped in a button that opens the lightbox
+// on click or Enter/Space; without one it renders as a plain image (e.g.
+// printing, notebook export).
+export function MarkdownImage({ filePath, src, alt, ...rest }: MarkdownImageProps) {
+  const lightbox = useLightbox();
+  const imgRef = useRef<HTMLImageElement>(null);
+  const resolved = resolveImageSrc(src, filePath);
+
+  if (!lightbox || !resolved) {
+    return <img src={resolved} alt={alt} {...rest} />;
+  }
+
+  return (
+    <button
+      type="button"
+      className="markdown-image-button"
+      aria-label={alt ? `View image: ${alt}` : "View image"}
+      onClick={() => {
+        if (imgRef.current) lightbox.open(imgRef.current);
+      }}
+    >
+      <img ref={imgRef} src={resolved} alt={alt} {...rest} data-zoomable="true" />
+    </button>
+  );
+}

--- a/src/components/markdown/resolveImageSrc.ts
+++ b/src/components/markdown/resolveImageSrc.ts
@@ -1,5 +1,13 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
 
+// Strip a Windows verbatim ("\\?\", or UNC "\\?\UNC\") path prefix. The backend
+// hands us canonicalized paths, which on Windows carry this prefix; it tells the
+// OS to read the path literally, so the forward slashes we join with stop being
+// valid separators and the asset server fails the read (HTTP 500).
+function stripVerbatimPrefix(path: string): string {
+  return path.replace(/^\\\\\?\\UNC\\/, "\\\\").replace(/^\\\\\?\\/, "");
+}
+
 // Resolve a markdown image `src` to something the webview can load: remote and
 // data URLs pass through untouched, while relative paths are joined to the
 // document's directory and run through Tauri's asset protocol.
@@ -11,7 +19,10 @@ export function resolveImageSrc(
   if (/^(https?:|data:)/i.test(src)) return src;
   if (filePath) {
     const dir = filePath.replace(/[/\\][^/\\]*$/, "");
-    const resolved = `${dir}/${src}`.replace(/\/\.\//g, "/");
+    let resolved = stripVerbatimPrefix(`${dir}/${src}`.replace(/\/\.\//g, "/"));
+    // On a Windows path (backslashes / drive letter), use a single backslash
+    // separator so the join doesn't leave a stray forward slash the OS rejects.
+    if (resolved.includes("\\")) resolved = resolved.replace(/\//g, "\\");
     return convertFileSrc(resolved);
   }
   return src;

--- a/src/components/markdown/resolveImageSrc.ts
+++ b/src/components/markdown/resolveImageSrc.ts
@@ -1,0 +1,18 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+
+// Resolve a markdown image `src` to something the webview can load: remote and
+// data URLs pass through untouched, while relative paths are joined to the
+// document's directory and run through Tauri's asset protocol.
+export function resolveImageSrc(
+  src: string | undefined,
+  filePath: string | undefined,
+): string | undefined {
+  if (!src) return src;
+  if (/^(https?:|data:)/i.test(src)) return src;
+  if (filePath) {
+    const dir = filePath.replace(/[/\\][^/\\]*$/, "");
+    const resolved = `${dir}/${src}`.replace(/\/\.\//g, "/");
+    return convertFileSrc(resolved);
+  }
+  return src;
+}

--- a/src/components/markdown/sanitizeSchema.test.tsx
+++ b/src/components/markdown/sanitizeSchema.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MarkdownContent } from "./MarkdownContent";
+
+// MarkdownContent runs rehype-raw + the shared sanitizer, so rendering an inline
+// <svg> exercises markdownSanitizeSchema end to end.
+function renderHtml(content: string): string {
+  const { container } = render(<MarkdownContent content={content} showFrontmatter={false} />);
+  return container.innerHTML.toLowerCase();
+}
+
+describe("markdownSanitizeSchema inline SVG", () => {
+  it("keeps static drawing primitives and gradients", () => {
+    const svg = [
+      '<svg viewBox="0 0 20 20" width="20" height="20">',
+      '<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">',
+      '<stop offset="0" stop-color="#6366f1" /></linearGradient></defs>',
+      '<rect x="0" y="0" width="20" height="20" rx="3" fill="url(#g)" />',
+      '<circle cx="10" cy="10" r="4" fill-opacity="0.5" />',
+      '<path d="M2 2 L8 8" stroke="#fff" stroke-width="2" />',
+      '<text x="4" y="6" text-anchor="middle" font-size="6">hi</text>',
+      "</svg>",
+    ].join("");
+
+    const html = renderHtml(svg);
+    for (const tag of ["<rect", "<circle", "<path", "<text", "lineargradient", "<stop"]) {
+      expect(html).toContain(tag);
+    }
+    // Geometry/paint attributes survive too.
+    expect(html).toContain("viewbox");
+    expect(html).toContain("stroke-width");
+    expect(html).toContain("fill-opacity");
+  });
+
+  it("strips unsafe SVG content (foreignObject, script)", () => {
+    const evil =
+      '<svg viewBox="0 0 10 10"><foreignObject>html</foreignObject>' +
+      "<script>alert(1)</script><rect /></svg>";
+
+    const html = renderHtml(evil);
+    expect(html).toContain("<rect");
+    expect(html).not.toContain("foreignobject");
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("alert(1)");
+  });
+});

--- a/src/components/markdown/sanitizeSchema.ts
+++ b/src/components/markdown/sanitizeSchema.ts
@@ -1,9 +1,132 @@
 import { defaultSchema } from "rehype-sanitize";
 
+// Inline SVG drawing primitives that are safe to render from markdown. We keep
+// out anything that can smuggle behaviour or external content: <foreignObject>
+// (arbitrary HTML), <script>, <style> (CSS injection), <a>/<use href>/<image
+// href> (external refs), and <animate>/<set> (attribute injection). What's left
+// is static, self-contained geometry.
+const svgTagNames = [
+  "svg",
+  "g",
+  "defs",
+  "title",
+  "desc",
+  "path",
+  "rect",
+  "circle",
+  "ellipse",
+  "line",
+  "polyline",
+  "polygon",
+  "text",
+  "tspan",
+  "linearGradient",
+  "radialGradient",
+  "stop",
+  "marker",
+  "symbol",
+  "clipPath",
+];
+
+// Geometry + paint attributes shared by the SVG elements above. hast-util-sanitize
+// matches property-information's camelCased SVG property names, so these follow
+// that casing (e.g. `stroke-width` -> `strokeWidth`, `viewBox` stays `viewBox`),
+// not the raw attribute spelling.
+const svgCommonAttributes = [
+  "id",
+  "transform",
+  "opacity",
+  "color",
+  // paint
+  "fill",
+  "fillOpacity",
+  "fillRule",
+  "clipRule",
+  "clipPath",
+  "stroke",
+  "strokeWidth",
+  "strokeLinecap",
+  "strokeLinejoin",
+  "strokeDasharray",
+  "strokeDashoffset",
+  "strokeOpacity",
+  "strokeMiterlimit",
+  // geometry
+  "x",
+  "y",
+  "x1",
+  "y1",
+  "x2",
+  "y2",
+  "dx",
+  "dy",
+  "cx",
+  "cy",
+  "r",
+  "rx",
+  "ry",
+  "fx",
+  "fy",
+  "width",
+  "height",
+  "points",
+  "d",
+  "offset",
+  // text
+  "textAnchor",
+  "dominantBaseline",
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "fontStyle",
+  "letterSpacing",
+];
+
+const svgAttributes: Record<string, string[]> = {
+  svg: [
+    "className",
+    "viewBox",
+    "preserveAspectRatio",
+    "xmlns",
+    "ariaHidden",
+    "role",
+    ...svgCommonAttributes,
+  ],
+  g: svgCommonAttributes,
+  defs: svgCommonAttributes,
+  title: [],
+  desc: [],
+  path: svgCommonAttributes,
+  rect: svgCommonAttributes,
+  circle: svgCommonAttributes,
+  ellipse: svgCommonAttributes,
+  line: svgCommonAttributes,
+  polyline: svgCommonAttributes,
+  polygon: svgCommonAttributes,
+  text: svgCommonAttributes,
+  tspan: svgCommonAttributes,
+  linearGradient: ["gradientUnits", "gradientTransform", "spreadMethod", ...svgCommonAttributes],
+  radialGradient: ["gradientUnits", "gradientTransform", "spreadMethod", ...svgCommonAttributes],
+  stop: ["stopColor", "stopOpacity", ...svgCommonAttributes],
+  marker: [
+    "markerWidth",
+    "markerHeight",
+    "markerUnits",
+    "refX",
+    "refY",
+    "orient",
+    "viewBox",
+    ...svgCommonAttributes,
+  ],
+  symbol: ["viewBox", "preserveAspectRatio", ...svgCommonAttributes],
+  clipPath: ["clipPathUnits", ...svgCommonAttributes],
+};
+
 // Allowlist for raw HTML in markdown. Glyph is a local-file viewer so the
 // XSS surface is small, but we still strip <script>, on* handlers, and
 // javascript: URLs (defaultSchema's behaviour) and only widen the allowlist
-// to the GitHub-style elements/attributes README authors actually use.
+// to the GitHub-style elements/attributes README authors actually use, plus
+// static inline SVG (see `svgTagNames`).
 //
 // `style` is intentionally allowed: badges and centered headers in GitHub
 // READMEs frequently rely on inline style. If Glyph ever loads remote
@@ -27,8 +150,7 @@ export const markdownSanitizeSchema = {
     "summary",
     "video",
     "source",
-    "svg",
-    "path",
+    ...svgTagNames,
   ],
   attributes: {
     ...defaultSchema.attributes,
@@ -48,7 +170,6 @@ export const markdownSanitizeSchema = {
     details: [...(defaultSchema.attributes?.details ?? []), "open"],
     video: ["src", "controls", "width", "height", "poster", "loop", "muted", "autoplay"],
     source: ["src", "type"],
-    svg: ["className", "viewBox", "width", "height", "ariaHidden", "fill"],
-    path: ["d", "fillRule", "clipRule"],
+    ...svgAttributes,
   },
 };

--- a/src/contexts/LightboxContext.test.tsx
+++ b/src/contexts/LightboxContext.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MarkdownImage } from "@/components/markdown/MarkdownImage";
-import { LightboxProvider } from "./LightboxContext";
+import { LightboxProvider, useLightbox } from "./LightboxContext";
 
 function renderDoc() {
   return render(
@@ -53,11 +53,26 @@ describe("LightboxProvider", () => {
         <MarkdownImage filePath={undefined} src="https://example.com/loose.png" alt="loose" />
       </LightboxProvider>,
     );
-    const img = screen.getByAltText("loose");
-    // currentSrc wins over src when the browser has resolved it; jsdom leaves it
-    // empty, so set it to exercise that path.
-    Object.defineProperty(img, "currentSrc", { value: "https://cdn.example/loose.png" });
-    fireEvent.click(img);
+    fireEvent.click(screen.getByAltText("loose"));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("does nothing when opening an image that isn't in the document", () => {
+    function Probe() {
+      const lightbox = useLightbox();
+      return (
+        <button type="button" onClick={() => lightbox?.open(document.createElement("img"))}>
+          probe
+        </button>
+      );
+    }
+    render(
+      <LightboxProvider>
+        <Probe />
+      </LightboxProvider>,
+    );
+    fireEvent.click(screen.getByText("probe"));
+    // A detached image isn't found in the scope, so no lightbox opens.
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });

--- a/src/contexts/LightboxContext.test.tsx
+++ b/src/contexts/LightboxContext.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MarkdownImage } from "@/components/markdown/MarkdownImage";
+import { LightboxProvider } from "./LightboxContext";
+
+function renderDoc() {
+  return render(
+    <LightboxProvider>
+      <div className="markdown-body">
+        <MarkdownImage filePath={undefined} src="https://example.com/a.png" alt="first" />
+        <MarkdownImage filePath={undefined} src="https://example.com/b.png" alt="second" />
+      </div>
+    </LightboxProvider>,
+  );
+}
+
+describe("LightboxProvider", () => {
+  it("marks images as zoomable and opens the lightbox on click", () => {
+    renderDoc();
+    const img = screen.getByAltText("first");
+    expect(img).toHaveAttribute("data-zoomable", "true");
+
+    fireEvent.click(img);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // Opened at the clicked image, with the document's images for navigation.
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+  });
+
+  it("opens at the index of the clicked image", () => {
+    renderDoc();
+    fireEvent.click(screen.getByAltText("second"));
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+  });
+
+  it("closes the lightbox so the overlay leaves the DOM", () => {
+    renderDoc();
+    fireEvent.click(screen.getByAltText("first"));
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/src/contexts/LightboxContext.test.tsx
+++ b/src/contexts/LightboxContext.test.tsx
@@ -38,4 +38,26 @@ describe("LightboxProvider", () => {
     fireEvent.keyDown(window, { key: "Escape" });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
+
+  it("navigates between the document's images, updating the index", () => {
+    renderDoc();
+    fireEvent.click(screen.getByAltText("first"));
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+  });
+
+  it("falls back to the whole document when no image sits in a markdown-body", () => {
+    render(
+      <LightboxProvider>
+        <MarkdownImage filePath={undefined} src="https://example.com/loose.png" alt="loose" />
+      </LightboxProvider>,
+    );
+    const img = screen.getByAltText("loose");
+    // currentSrc wins over src when the browser has resolved it; jsdom leaves it
+    // empty, so set it to exercise that path.
+    Object.defineProperty(img, "currentSrc", { value: "https://cdn.example/loose.png" });
+    fireEvent.click(img);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
 });

--- a/src/contexts/LightboxContext.tsx
+++ b/src/contexts/LightboxContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
+import { Lightbox } from "@/components/markdown/Lightbox";
+import type { LightboxImage } from "@/lib/lightbox";
+
+interface LightboxContextValue {
+  /** Open the lightbox, starting at the clicked image. */
+  open: (img: HTMLImageElement) => void;
+}
+
+const LightboxContext = createContext<LightboxContextValue | null>(null);
+
+interface LightboxState {
+  images: LightboxImage[];
+  index: number;
+}
+
+// Provides click-to-zoom for the images inside its subtree and renders the
+// lightbox overlay when one is open. Navigation is scoped to the images within
+// the same rendered document (`.markdown-body`), so the arrow keys cycle
+// through the document's images in source order.
+export function LightboxProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<LightboxState | null>(null);
+
+  const open = useCallback((img: HTMLImageElement) => {
+    const scope = img.closest(".markdown-body") ?? document;
+    const imgs = Array.from(scope.querySelectorAll("img"));
+    const index = imgs.indexOf(img);
+    if (index < 0) return;
+    const images = imgs.map((el) => ({ src: el.currentSrc || el.src, alt: el.alt }));
+    setState({ images, index });
+  }, []);
+
+  const close = useCallback(() => setState(null), []);
+  const setIndex = useCallback(
+    (next: number) => setState((s) => (s ? { ...s, index: next } : s)),
+    [],
+  );
+
+  const value = useMemo<LightboxContextValue>(() => ({ open }), [open]);
+
+  return (
+    <LightboxContext.Provider value={value}>
+      {children}
+      {state && (
+        <Lightbox
+          images={state.images}
+          index={state.index}
+          onIndexChange={setIndex}
+          onClose={close}
+        />
+      )}
+    </LightboxContext.Provider>
+  );
+}
+
+/** Returns the lightbox API, or null when rendered outside a provider. */
+export function useLightbox(): LightboxContextValue | null {
+  return useContext(LightboxContext);
+}

--- a/src/contexts/LightboxContext.tsx
+++ b/src/contexts/LightboxContext.tsx
@@ -26,13 +26,15 @@ export function LightboxProvider({ children }: { children: ReactNode }) {
     const imgs = Array.from(scope.querySelectorAll("img"));
     const index = imgs.indexOf(img);
     if (index < 0) return;
-    const images = imgs.map((el) => ({ src: el.currentSrc || el.src, alt: el.alt }));
+    // `el.src` is the webview-resolved URL (markdown images have no srcset).
+    const images = imgs.map((el) => ({ src: el.src, alt: el.alt }));
     setState({ images, index });
   }, []);
 
   const close = useCallback(() => setState(null), []);
   const setIndex = useCallback(
-    (next: number) => setState((s) => (s ? { ...s, index: next } : s)),
+    // setIndex is only wired to the open lightbox, so the state is non-null here.
+    (next: number) => setState((s) => ({ ...s!, index: next })),
     [],
   );
 

--- a/src/contexts/TabsContext.tsx
+++ b/src/contexts/TabsContext.tsx
@@ -14,7 +14,8 @@ export interface TabsContextValue extends TabsApi {
   displayContent: string | null;
   tocEntries: TocEntry[];
   backlinks: Backlink[];
-  // Transient message shown when a folder is refused as a workspace (#262).
+  // Message shown for a workspace event (#262): a refusal, or a persistent
+  // warning when a folder is opened inside a parent git repo.
   workspaceNotice: string | null;
   dismissWorkspaceNotice: () => void;
 }
@@ -37,7 +38,7 @@ export function TabsProvider({ settings, updateSettings, children }: TabsProvide
     autoReload: settings.behavior.autoReload,
     defaultEditorMode: settings.behavior.defaultEditorMode,
     onSettingsChange: updateSettings,
-    onWorkspaceRefusal: workspaceNotice.show,
+    onWorkspaceNotice: workspaceNotice.show,
   });
 
   const activeMode = tabs.activeFile?.mode ?? EDITOR_MODE.view;

--- a/src/hooks/useTabs.test.tsx
+++ b/src/hooks/useTabs.test.tsx
@@ -68,7 +68,7 @@ function defaultOptions(over: Partial<Parameters<typeof useTabs>[0]> = {}) {
     autoReload: false,
     defaultEditorMode: "view" as const,
     onSettingsChange: vi.fn(),
-    onWorkspaceRefusal: vi.fn(),
+    onWorkspaceNotice: vi.fn(),
     ...over,
   };
 }
@@ -1699,8 +1699,8 @@ describe("useTabs dialog and events", () => {
     });
   });
 
-  it("refuses a folder nested inside a parent git repo (#262)", async () => {
-    const onWorkspaceRefusal = vi.fn();
+  it("opens a folder nested inside a parent git repo with a persistent warning (#262)", async () => {
+    const onWorkspaceNotice = vi.fn();
     vi.mocked(invoke).mockImplementation(
       makeInvoker({
         workspace_resolve: async (_cmd, args) => ({
@@ -1712,19 +1712,24 @@ describe("useTabs dialog and events", () => {
         }),
       }) as typeof invoke,
     );
-    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceRefusal })));
+    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceNotice })));
     await waitFor(() => expect(result.current.initializing).toBe(false));
 
     await act(async () => {
       await result.current.openFolder("/p/repo/sub");
     });
 
-    expect(result.current.tabs.some((t) => t.kind === "folder")).toBe(false);
-    expect(onWorkspaceRefusal).toHaveBeenCalledWith(expect.stringContaining("/p/repo"));
+    // The folder opens (no longer refused) but a persistent warning is shown.
+    expect(result.current.tabs.some((t) => t.kind === "folder" && t.root === "/p/repo/sub")).toBe(
+      true,
+    );
+    expect(onWorkspaceNotice).toHaveBeenCalledWith(expect.stringContaining("/p/repo"), {
+      persistent: true,
+    });
   });
 
   it("refuses a folder nested inside another workspace's .glyph (#262)", async () => {
-    const onWorkspaceRefusal = vi.fn();
+    const onWorkspaceNotice = vi.fn();
     vi.mocked(invoke).mockImplementation(
       makeInvoker({
         workspace_resolve: async (_cmd, args) => ({
@@ -1736,7 +1741,7 @@ describe("useTabs dialog and events", () => {
         }),
       }) as typeof invoke,
     );
-    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceRefusal })));
+    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceNotice })));
     await waitFor(() => expect(result.current.initializing).toBe(false));
 
     await act(async () => {
@@ -1744,19 +1749,19 @@ describe("useTabs dialog and events", () => {
     });
 
     expect(result.current.tabs.some((t) => t.kind === "folder")).toBe(false);
-    expect(onWorkspaceRefusal).toHaveBeenCalledWith(expect.stringContaining("/p/outer"));
+    expect(onWorkspaceNotice).toHaveBeenCalledWith(expect.stringContaining("/p/outer"));
   });
 
   it("refuses a folder overlapping an already-open workspace (#262)", async () => {
-    const onWorkspaceRefusal = vi.fn();
-    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceRefusal })));
+    const onWorkspaceNotice = vi.fn();
+    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceNotice })));
     await waitFor(() => expect(result.current.initializing).toBe(false));
 
     await act(async () => {
       await result.current.openFolder("/p/ws");
     });
     expect(result.current.tabs.some((t) => t.kind === "folder" && t.root === "/p/ws")).toBe(true);
-    onWorkspaceRefusal.mockClear();
+    onWorkspaceNotice.mockClear();
 
     // A child of the open workspace overlaps it.
     await act(async () => {
@@ -1770,12 +1775,12 @@ describe("useTabs dialog and events", () => {
       await result.current.openFolder("/p");
     });
     expect(result.current.tabs.some((t) => t.kind === "folder" && t.root === "/p")).toBe(false);
-    expect(onWorkspaceRefusal).toHaveBeenCalledTimes(2);
+    expect(onWorkspaceNotice).toHaveBeenCalledTimes(2);
   });
 
   it("re-opening the same workspace activates it instead of refusing", async () => {
-    const onWorkspaceRefusal = vi.fn();
-    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceRefusal })));
+    const onWorkspaceNotice = vi.fn();
+    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceNotice })));
     await waitFor(() => expect(result.current.initializing).toBe(false));
 
     await act(async () => {
@@ -1788,11 +1793,11 @@ describe("useTabs dialog and events", () => {
     expect(
       result.current.tabs.filter((t) => t.kind === "folder" && t.root === "/p/ws"),
     ).toHaveLength(1);
-    expect(onWorkspaceRefusal).not.toHaveBeenCalled();
+    expect(onWorkspaceNotice).not.toHaveBeenCalled();
   });
 
-  it("silently skips a nested folder on restore without bannering", async () => {
-    const onWorkspaceRefusal = vi.fn();
+  it("restores a nested folder silently without bannering", async () => {
+    const onWorkspaceNotice = vi.fn();
     vi.mocked(invoke).mockImplementation(
       makeInvoker({
         workspace_resolve: async (_cmd, args) => ({
@@ -1807,19 +1812,22 @@ describe("useTabs dialog and events", () => {
     const { result } = renderHook(() =>
       useTabs(
         defaultOptions({
-          onWorkspaceRefusal,
+          onWorkspaceNotice,
           openTabs: [{ kind: "folder", path: "/p/repo/sub" }],
         }),
       ),
     );
     await waitFor(() => expect(result.current.initializing).toBe(false));
 
-    expect(result.current.tabs.some((t) => t.kind === "folder")).toBe(false);
-    expect(onWorkspaceRefusal).not.toHaveBeenCalled();
+    // A nested folder reopens on restore, but the warning banner stays silent.
+    expect(result.current.tabs.some((t) => t.kind === "folder" && t.root === "/p/repo/sub")).toBe(
+      true,
+    );
+    expect(onWorkspaceNotice).not.toHaveBeenCalled();
   });
 
   it("refuses and reports when workspace resolution fails", async () => {
-    const onWorkspaceRefusal = vi.fn();
+    const onWorkspaceNotice = vi.fn();
     vi.mocked(invoke).mockImplementation(
       makeInvoker({
         workspace_resolve: async () => {
@@ -1827,7 +1835,7 @@ describe("useTabs dialog and events", () => {
         },
       }) as typeof invoke,
     );
-    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceRefusal })));
+    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceNotice })));
     await waitFor(() => expect(result.current.initializing).toBe(false));
 
     await act(async () => {
@@ -1835,7 +1843,7 @@ describe("useTabs dialog and events", () => {
     });
 
     expect(result.current.tabs.some((t) => t.kind === "folder")).toBe(false);
-    expect(onWorkspaceRefusal).toHaveBeenCalledWith(expect.stringContaining("Couldn't open"));
+    expect(onWorkspaceNotice).toHaveBeenCalledWith(expect.stringContaining("Couldn't open"));
   });
 
   it("openFolder with an explicit filePath skips the auto-load probe", async () => {

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -99,9 +99,10 @@ interface UseTabsOptions {
   autoReload: boolean;
   defaultEditorMode: EditorMode;
   onSettingsChange: (key: string, value: unknown) => void;
-  // Called when a folder is refused as a workspace (nested git repo / overlapping
-  // workspace, see #262). The provider surfaces it as a transient banner.
-  onWorkspaceRefusal: (message: string) => void;
+  // Called to surface a workspace notice (see #262): a refusal (overlapping or
+  // nested-workspace folder) or a `persistent` warning (a folder opened despite
+  // sitting inside a parent git repo). The provider surfaces it as a banner.
+  onWorkspaceNotice: (message: string, options?: { persistent?: boolean }) => void;
 }
 
 async function loadFileContent(path: string) {
@@ -338,27 +339,25 @@ export function useTabs(options: UseTabsOptions) {
       }
 
       // A workspace is one git repo's top level (#262). Refuse a folder nested
-      // inside a parent repo / another workspace, or one overlapping an open
-      // workspace, so every workspace-wide feature has an unambiguous owner. The
+      // inside another workspace's `.glyph/`, or one overlapping an open
+      // workspace, so every workspace-wide feature has an unambiguous owner. A
+      // folder merely sitting inside a parent git repo is still allowed (so
+      // `samples/` inside this repo opens) but earns a persistent warning. The
       // `silent` path (persisted-tab restore) skips the banner.
-      const refuse = (message: string) => {
-        if (!options?.silent) optionsRef.current.onWorkspaceRefusal(message);
+      const notify = (message: string, persistent = false) => {
+        if (options?.silent) return;
+        if (persistent) optionsRef.current.onWorkspaceNotice(message, { persistent: true });
+        else optionsRef.current.onWorkspaceNotice(message);
       };
       let resolution: WorkspaceResolution;
       try {
         resolution = await resolveWorkspace(resolvedRoot);
       } catch (err) {
-        refuse(`Couldn't open this folder: ${String(err)}`);
-        return;
-      }
-      if (resolution.nestedUnder) {
-        refuse(
-          `This folder is inside the git repository at "${resolution.nestedUnder}". Open that folder instead — Glyph treats one repository as one workspace.`,
-        );
+        notify(`Couldn't open this folder: ${String(err)}`);
         return;
       }
       if (resolution.glyphConflict) {
-        refuse(
+        notify(
           `This folder sits inside another Glyph workspace ("${resolution.glyphConflict}"). Nested workspaces aren't supported.`,
         );
         return;
@@ -371,10 +370,19 @@ export function useTabs(options: UseTabsOptions) {
             isInWorkspace(t.root, resolvedRoot as string)),
       );
       if (overlap) {
-        refuse(
+        notify(
           `This folder overlaps the open workspace "${overlap.root}". Close it first or pick a non-overlapping folder.`,
         );
         return;
+      }
+      // Allowed, but a folder inside a parent git repo means workspace-wide
+      // features (Sync, `.glyph/` config) resolve against that repo, so warn and
+      // keep the notice up until the user dismisses it.
+      if (resolution.nestedUnder) {
+        notify(
+          `This folder is inside the git repository at "${resolution.nestedUnder}". Glyph treats one repository as one workspace, so some workspace features may act on the whole repository.`,
+          true,
+        );
       }
 
       const id = generateId();

--- a/src/hooks/useWorkspaceNotice.test.ts
+++ b/src/hooks/useWorkspaceNotice.test.ts
@@ -21,6 +21,20 @@ describe("useWorkspaceNotice", () => {
     expect(result.current.notice).toBeNull();
   });
 
+  it("keeps a persistent notice up past the auto-dismiss timeout", () => {
+    const { result } = renderHook(() => useWorkspaceNotice());
+
+    act(() => result.current.show("heads up", { persistent: true }));
+    expect(result.current.notice).toBe("heads up");
+
+    // Well past the transient timeout: a persistent notice stays until dismissed.
+    act(() => vi.advanceTimersByTime(60000));
+    expect(result.current.notice).toBe("heads up");
+
+    act(() => result.current.dismiss());
+    expect(result.current.notice).toBeNull();
+  });
+
   it("dismiss clears the notice immediately", () => {
     const { result } = renderHook(() => useWorkspaceNotice());
     act(() => result.current.show("nope"));

--- a/src/hooks/useWorkspaceNotice.ts
+++ b/src/hooks/useWorkspaceNotice.ts
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-/** How long a refusal notice stays up before auto-dismissing. */
+/** How long a transient notice stays up before auto-dismissing. */
 const AUTO_DISMISS_MS = 6000;
 
 /**
- * Transient one-line notice shown when a folder is refused as a workspace
- * (nested git repo / overlapping workspace, see #262). There's no toast system
- * in the app, so this is the lightest surface: a single message that
- * auto-dismisses after a few seconds and can be closed manually.
+ * One-line notice surfacing a workspace event (see #262). There's no toast
+ * system in the app, so this is the lightest surface: a single message that can
+ * always be closed manually. A refusal (folder rejected) auto-dismisses after a
+ * few seconds; a `persistent` warning (e.g. a folder opened despite sitting
+ * inside a parent git repo) stays up until the user dismisses it.
  */
 export function useWorkspaceNotice() {
   const [notice, setNotice] = useState<string | null>(null);
@@ -26,10 +27,12 @@ export function useWorkspaceNotice() {
   }, [clearTimer]);
 
   const show = useCallback(
-    (message: string) => {
+    (message: string, options?: { persistent?: boolean }) => {
       clearTimer();
       setNotice(message);
-      timerRef.current = setTimeout(() => setNotice(null), AUTO_DISMISS_MS);
+      if (!options?.persistent) {
+        timerRef.current = setTimeout(() => setNotice(null), AUTO_DISMISS_MS);
+      }
     },
     [clearTimer],
   );

--- a/src/lib/lightbox.test.ts
+++ b/src/lib/lightbox.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { clampScale, fitScale, MAX_SCALE, MIN_SCALE } from "./lightbox";
+
+describe("clampScale", () => {
+  it("keeps values within [MIN_SCALE, MAX_SCALE]", () => {
+    expect(clampScale(1)).toBe(1);
+    expect(clampScale(0)).toBe(MIN_SCALE);
+    expect(clampScale(1000)).toBe(MAX_SCALE);
+  });
+});
+
+describe("fitScale", () => {
+  it("returns 1 when a dimension is unknown", () => {
+    expect(fitScale(0, 100, 100, 100)).toBe(1);
+    expect(fitScale(100, 100, 0, 100)).toBe(1);
+  });
+
+  it("scales down a large image to contain it", () => {
+    // 2000x1000 into 1000x1000 → limited by width → 0.5
+    expect(fitScale(2000, 1000, 1000, 1000)).toBe(0.5);
+  });
+
+  it("scales up a small image to fill the box", () => {
+    // 100x100 into 500x500 → 5, but capped at MAX_SCALE only if exceeded
+    expect(fitScale(100, 100, 500, 500)).toBe(5);
+  });
+
+  it("uses the limiting axis", () => {
+    // 1000x2000 into 1000x1000 → limited by height → 0.5
+    expect(fitScale(1000, 2000, 1000, 1000)).toBe(0.5);
+  });
+});

--- a/src/lib/lightbox.ts
+++ b/src/lib/lightbox.ts
@@ -1,0 +1,30 @@
+// Types and zoom math for the image lightbox overlay (see Lightbox.tsx).
+
+export interface LightboxImage {
+  src: string;
+  alt: string;
+}
+
+/** Multiplier applied per zoom-in / zoom-out step. */
+export const ZOOM_STEP = 1.25;
+export const MIN_SCALE = 0.1;
+export const MAX_SCALE = 8;
+
+export function clampScale(scale: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale));
+}
+
+/**
+ * Scale that fits a natural-size image within the available box while
+ * preserving aspect ratio (CSS `contain`). Returns 1 when any dimension is
+ * unknown so the image renders at actual size until measured.
+ */
+export function fitScale(
+  naturalWidth: number,
+  naturalHeight: number,
+  availWidth: number,
+  availHeight: number,
+): number {
+  if (!naturalWidth || !naturalHeight || !availWidth || !availHeight) return 1;
+  return clampScale(Math.min(availWidth / naturalWidth, availHeight / naturalHeight));
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8,6 +8,7 @@
 @import "./search.css";
 @import "./editor.css";
 @import "./command-palette.css";
+@import "./lightbox.css";
 @import "./print.css";
 
 :root {

--- a/src/styles/lightbox.css
+++ b/src/styles/lightbox.css
@@ -1,0 +1,137 @@
+.markdown-image-button {
+  display: inline-block;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: zoom-in;
+  line-height: 0;
+}
+
+.markdown-image-button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--glyph-radius);
+}
+
+.lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  overflow: auto;
+  padding: 64px 72px;
+  background: rgba(0, 0, 0, 0.85);
+  animation: lightbox-fade-in 0.12s ease-out;
+}
+
+@keyframes lightbox-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* `margin: auto` centers the single flex child on both axes while still
+   allowing scroll to reach the overflow when a zoomed image exceeds the
+   viewport (plain flex centering would clip the top/left edge). */
+.lightbox-image {
+  margin: auto;
+  display: block;
+  max-width: none;
+  border-radius: var(--glyph-radius-sm);
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.5);
+  user-select: none;
+  transition: opacity 0.1s ease-out;
+}
+
+.lightbox-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  border-radius: var(--glyph-radius-sm);
+  padding: 6px;
+  transition:
+    background 0.1s ease-out,
+    color 0.1s ease-out;
+}
+
+.lightbox-button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+.lightbox-button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+/* Controls are fixed to the viewport so they stay put while the image scrolls. */
+.lightbox-close {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+}
+
+.lightbox-nav {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.lightbox-prev {
+  left: 16px;
+}
+
+.lightbox-next {
+  right: 16px;
+}
+
+.lightbox-toolbar {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  background: rgba(20, 20, 20, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--glyph-radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.lightbox-zoom-level {
+  min-width: 48px;
+  text-align: center;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.85);
+  user-select: none;
+}
+
+.lightbox-counter {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.7);
+  padding: 0 6px;
+  user-select: none;
+}
+
+.lightbox-toolbar-divider {
+  width: 1px;
+  align-self: stretch;
+  margin: 2px 4px;
+  background: rgba(255, 255, 255, 0.15);
+}

--- a/src/styles/lightbox.css
+++ b/src/styles/lightbox.css
@@ -1,17 +1,10 @@
-.markdown-image-button {
-  display: inline-block;
-  max-width: 100%;
-  padding: 0;
-  border: 0;
-  background: none;
+.markdown-body img[data-zoomable] {
   cursor: zoom-in;
-  line-height: 0;
 }
 
-.markdown-image-button:focus-visible {
+.markdown-body img[data-zoomable]:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
-  border-radius: var(--glyph-radius);
 }
 
 .lightbox-overlay {


### PR DESCRIPTION
## Summary

Implements click-to-zoom image viewing (issue #13). Click any markdown image to open it full-size in a lightbox overlay with zoom controls and keyboard navigation. Also unblocks opening folders that live inside a parent git repo (so the bundled `samples/` workspace opens), with a persistent warning instead of a hard refusal.

## Changes

### Image lightbox (#13)
- New `LightboxProvider` / `useLightbox` context mounted in the shared `MarkdownContent` core, so the lightbox works in the document viewer, notebook markdown cells, and canvas cards. Navigation is scoped to the surrounding `.markdown-body`, so arrow keys cycle through that document's images in source order.
- New `Lightbox` overlay: dark backdrop, zoom controls (zoom out / live percentage / zoom in, **Fit to screen**, **Actual size**), prev/next buttons with a `n / total` counter, and a fitted image that scrolls (pans) when zoomed past the viewport while the controls stay pinned.
- Keyboard: `Esc` close, `←`/`→` navigate, `+`/`-` zoom, `0` fit, `1` actual size. Backdrop click and the close button also dismiss.
- The click-to-zoom handler is attached to the `<img>` itself (no wrapper element), so images render identically to before and stay valid inside a linked image (`[![badge](img)](url)`). During print/export there's no provider, so images stay plain and non-interactive.
- Split the image resolver into `resolveImageSrc.ts` and the rendered image into `MarkdownImage.tsx`; added toolbar/nav icons and `lightbox.css`.

### Open folders inside a parent git repo
- A folder nested inside a parent git repo (like this repo's `samples/`) was refused outright, so the bundled samples workspace couldn't be opened. It now opens, with a **dismissable warning that stays up until dismissed** (no auto-timeout) explaining that workspace-wide features resolve against the containing repository.
- Genuine conflicts are still refused (and still auto-dismiss): overlapping an already-open workspace, or nesting inside another workspace's `.glyph/`.
- `useWorkspaceNotice` gained a `persistent` option; the `onWorkspaceRefusal` callback was renamed to `onWorkspaceNotice` to match its broader role.

### Docs
- README feature bullet for the lightbox; `samples/README.md` now has a **Local Images** demo backed by a new committed `samples/diagram.svg` (also gives the lightbox a local image to open).

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- `pnpm typecheck`, Biome (no warnings), and `pnpm build` pass clean
- Full suite green: 1610 JS tests + the Rust suite (run by the pre-commit hook)

## Screenshots

_Not captured. The overlay renders a dark backdrop with the image centered, a zoom toolbar at the bottom, prev/next arrows, and a close button._

Closes #13
