### PR TITLE
fix: correct Homebrew install instructions and Linux formula template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
             ### macOS
             ```bash
-            brew tap hamidfzm/tap && brew install --cask glyph
+            brew tap hamidfzm/tap && brew trust hamidfzm/tap && brew install --cask glyph
             ```
             Or download `Glyph_*_universal.dmg` below.
 
@@ -117,7 +117,7 @@ jobs:
 
           ### macOS
           ```bash
-          brew tap hamidfzm/tap && brew install --cask glyph
+          brew tap hamidfzm/tap && brew trust hamidfzm/tap && brew install --cask glyph
           ```
           Or download `Glyph_*_universal.dmg` below.
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,11 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 
 ```bash
 brew tap hamidfzm/tap
+brew trust hamidfzm/tap
 brew install --cask glyph
 ```
+
+`brew trust` is required once because Glyph ships from a third-party tap; recent Homebrew refuses to load casks from untrusted taps.
 
 ### Windows (Chocolatey)
 

--- a/homebrew/glyph-formula.rb.template
+++ b/homebrew/glyph-formula.rb.template
@@ -4,15 +4,15 @@ class Glyph < Formula
   license "MIT"
   version "{{VERSION}}"
 
-  on_linux do
-    if Hardware::CPU.intel?
-      url "https://github.com/hamidfzm/glyph/releases/download/v{{VERSION}}/Glyph_{{VERSION}}_amd64.deb"
-      sha256 "{{SHA256_AMD64}}"
-    end
-    if Hardware::CPU.arm?
-      url "https://github.com/hamidfzm/glyph/releases/download/v{{VERSION}}/Glyph_{{VERSION}}_arm64.deb"
-      sha256 "{{SHA256_ARM64}}"
-    end
+  # url/sha256 must be defined at the top level so the formula parses on every
+  # platform (otherwise macOS taps fail with "formula requires at least a URL").
+  # `depends_on :linux` is what keeps this Linux-only at install time.
+  if Hardware::CPU.arm?
+    url "https://github.com/hamidfzm/glyph/releases/download/v{{VERSION}}/Glyph_{{VERSION}}_arm64.deb"
+    sha256 "{{SHA256_ARM64}}"
+  else
+    url "https://github.com/hamidfzm/glyph/releases/download/v{{VERSION}}/Glyph_{{VERSION}}_amd64.deb"
+    sha256 "{{SHA256_AMD64}}"
   end
 
   depends_on :linux


### PR DESCRIPTION
## Summary

Closes #303.

Resolves the broken `brew tap hamidfzm/tap` flow on macOS. Two independent problems were surfacing in the same install attempt:

1. **`formula requires at least a URL` import error** — the Linux formula template declared `url`/`sha256` only inside an `on_linux do` block. On macOS that block is skipped, so the formula parsed with no URL and failed to import, which broke the whole tap read.
2. **`Refusing to load cask … from untrusted tap`** — current Homebrew behavior for third-party cask taps (not a code bug), fixed by documenting the one-time `brew trust` step.

## Changes

- `homebrew/glyph-formula.rb.template`: move `url`/`sha256` to the top level (branching on `Hardware::CPU.arm?`) so the formula parses on every platform. `depends_on :linux` still keeps it Linux-only at install time, so Linux resolution is unchanged.
- `README.md`: add the required `brew trust hamidfzm/tap` step to the macOS instructions, with a short note on why.
- `.github/workflows/release.yml`: add `brew trust hamidfzm/tap` to both copies of the macOS install snippet in the generated release notes.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Note: the live tap's `Formula/glyph.rb` keeps the broken form until the next release regenerates it from this corrected template.

## Screenshots

N/A
