### PR TITLE
feat: spec-driven workflow and worktree conventions for AI development

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,33 @@
+---
+description: Implement a spec issue task-by-task with tests, ticking off acceptance criteria and running the gates
+argument-hint: <issue-number> (defaults to the issue named in the current branch)
+allowed-tools: Bash(gh issue *), Bash(pnpm *), Bash(npx tauri *), Bash(cd src-tauri && cargo *), Bash(git *), Read, Edit, Write, Grep, Glob, Task
+---
+
+You are the **implement** stage of Glyph's spec-driven workflow. Build the feature defined in issue **#$ARGUMENTS** (if no number is given, infer it from the current branch name or ask). The issue body + its plan comment are the source of truth.
+
+## Steps
+
+1. **Load the spec and plan.** `gh issue view $ARGUMENTS --comments`. Re-read the Acceptance Criteria and Implementation Tasks. Confirm you are on the feature branch created by `/plan` (not `main`).
+
+2. **Implement task-by-task**, smallest verifiable increments first. Follow `.claude/rules/` strictly:
+   - One component per file, ~200-line soft cap, `@/` imports, named exports (`code-organization.md`).
+   - `invoke()`/`listen()`, CSS custom properties for theme + platform (`frontend.md`).
+   - `Result`/`Option`, `camelCase` serde, register commands in `lib.rs` (`rust.md`).
+   - Update `README.md` / `samples/README.md` and keyboard-shortcut tables when shipping user-facing features (`docs.md`).
+   - When removing or replacing anything, clean up fully, with no dead code or shims (`cleanup.md`).
+
+3. **Add tests beside the source**: `*.test.{ts,tsx}` (Vitest + Testing Library) and Rust `#[cfg(test)]` modules, covering each acceptance criterion.
+
+4. **Run the gates** before declaring any task done (delegate to the `tester` agent, or run directly):
+   ```bash
+   pnpm typecheck && pnpm check && pnpm test
+   cd src-tauri && cargo clippy --all-targets -- -D warnings
+   ```
+   Fix every Biome warning per `ci-hygiene.md`: apply the fix, do not suppress.
+
+5. **Keep the issue current.** As tasks and acceptance criteria are satisfied, tick their checkboxes in the issue body (`gh issue edit $ARGUMENTS --body-file ...`) so the issue reflects real progress.
+
+6. When all acceptance criteria are met and the gates are green, commit with a conventional-commit message (no co-authored-by line) and tell the user the next step is `/ship $ARGUMENTS`.
+
+No em dashes anywhere. Do not open the PR here; that is `/ship`.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,32 @@
+---
+description: Read a GitHub issue (the spec) and produce an implementation plan, post it back, and create the branch
+argument-hint: <issue-number>
+allowed-tools: Bash(gh issue *), Bash(gh project *), Bash(git *), Read, Grep, Glob, Task
+---
+
+You are the **plan** stage of Glyph's spec-driven workflow. Turn the spec in issue **#$ARGUMENTS** into a concrete implementation plan. Do not write feature code yet.
+
+## Steps
+
+1. **Read the spec.** `gh issue view $ARGUMENTS --comments`. Treat the issue body as the source of truth; its Acceptance Criteria define done.
+
+2. **Explore the affected code.** Launch an `Explore` agent (or read directly) over the areas the spec names. Read the relevant `.claude/rules/` before planning so the plan already respects them:
+   - `code-organization.md`: one component per file, ~200-line soft cap, `@/` imports, tests beside source.
+   - `frontend.md`: `invoke()`/`listen()`, theme + platform via CSS custom properties.
+   - `rust.md`: `Result`/`Option` returns, `camelCase` serde, command registration in `lib.rs`.
+   - `app-shell.md` if `App.tsx`/`AppShell.tsx` are involved.
+
+3. **Write the plan**, mapping each step to the spec's acceptance criteria:
+   - **Files to create / modify** (concrete paths), reusing existing utilities you found.
+   - **Task breakdown** as a `- [ ]` checklist, ordered for incremental, verifiable progress.
+   - **Test plan**: which `*.test.{ts,tsx}` and Rust `#[cfg(test)]` modules to add and what they assert.
+   - **Risks / open questions** if any.
+
+4. **Persist the plan and start the branch.** After the user approves the plan:
+   - Post it as an issue comment: `gh issue comment $ARGUMENTS --body "<plan markdown>"`.
+   - If the spec's Implementation Tasks were empty or coarse, update the issue body to the refined checklist (`gh issue edit $ARGUMENTS --body-file ...`).
+   - Create the branch from `main` per CONTRIBUTING.md naming (`feat/<slug>` or `fix/<slug>`): `git checkout main && git pull && git checkout -b feat/<slug>`.
+   - Move the issue to **In Progress** on the Glyph Roadmap board.
+   - Tell the user the next step is `/implement $ARGUMENTS`.
+
+No em dashes. Keep the plan scannable.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,30 @@
+---
+description: Review the diff with the code-reviewer agent, then open a PR that closes the spec issue
+argument-hint: <issue-number>
+allowed-tools: Bash(gh pr *), Bash(gh issue *), Bash(pnpm *), Bash(cd src-tauri && cargo *), Bash(git *), Read, Grep, Glob, Task
+---
+
+You are the **ship** stage of Glyph's spec-driven workflow. Get the work for issue **#$ARGUMENTS** reviewed and into a PR. Do not add new features here.
+
+## Steps
+
+1. **Verify done.** `gh issue view $ARGUMENTS` and confirm every Acceptance Criterion checkbox is checked. If any is unchecked, stop and route the user back to `/implement $ARGUMENTS`.
+
+2. **Confirm the gates are green** (re-run if unsure):
+   ```bash
+   pnpm typecheck && pnpm check && pnpm test
+   cd src-tauri && cargo clippy --all-targets -- -D warnings
+   ```
+
+3. **Review the diff.** Invoke the `code-reviewer` agent (via the Task tool) on `git diff main...HEAD`. Surface its findings by severity (critical / warning / suggestion) and fix anything critical or warranted before opening the PR. Re-run the gates after fixes.
+
+4. **Push and open the PR:**
+   - `git push -u origin <branch>`.
+   - Title: conventional-commit style matching the work (`feat: ...` / `fix: ...`).
+   - Body: fill in `.github/PULL_REQUEST_TEMPLATE.md` (Summary, Changes, Testing checklist, Screenshots). Include **`Closes #$ARGUMENTS`** in the body so the issue auto-closes on merge.
+     - Use only GitHub's recognized keywords (`Closes`, `Fixes`, `Resolves`). Never `closing`/`fixing`/`resolving`, which silently leave the issue open (see CLAUDE.md).
+   - Create it: `gh pr create --title "..." --body-file ...`.
+
+5. Print the PR URL and remind the user CI must pass on all 3 platforms before merge.
+
+No em dashes. Do not push to `main` or create releases.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -1,0 +1,36 @@
+---
+description: Turn a rough idea into a structured GitHub issue (the spec) with acceptance criteria and tasks
+argument-hint: <rough idea, e.g. "add a word-count item to the status bar">
+allowed-tools: Bash(gh issue *), Bash(gh project *), Bash(gh label *), Bash(git *), Read, Grep, Glob, Task
+---
+
+You are the **spec** stage of Glyph's spec-driven workflow. The GitHub issue body is the single source of truth for a feature. Your job: turn the user's idea into a well-formed, implementable issue, not to write any code.
+
+Idea: **$ARGUMENTS**
+
+## Steps
+
+1. **Ground the idea in the codebase.** Launch an `Explore` agent (or read directly for a small idea) to find the components, hooks, Rust commands, settings, and menu items the feature would touch. Reference `src/components/`, `src/hooks/`, `src/lib/`, `src-tauri/src/`, `src/lib/settings.ts`, and `src-tauri/src/menu.rs` as relevant. Note existing patterns to reuse, and do not propose new code where something already exists.
+
+2. **Draft the spec** matching the Feature Request issue template (`.github/ISSUE_TEMPLATE/feature_request.yml`). Sections:
+   - **Problem**: the user need / frustration, concrete.
+   - **Proposed Solution**: what we'll build, grounded in the files you found.
+   - **Acceptance Criteria**: a `- [ ]` checklist of observable, testable outcomes. These define "done".
+   - **Scope / Out of scope**: what this issue does and explicitly does not cover.
+   - **Implementation Tasks**: a `- [ ]` checklist (frontend, Rust, tests, docs). Keep coarse; `/plan` refines it.
+   - **Affected areas**: pick from markdown rendering, layout / app-shell, modals, Rust backend, settings, build / CI.
+   - **Platform**: All / macOS / Windows / Linux.
+
+3. **Resolve ambiguity first.** If scope or acceptance criteria are genuinely ambiguous, ask the user before creating anything. Never invent acceptance criteria silently.
+
+4. **Show the full draft** and get a confirmation. Only after the user approves:
+   - Create the issue with an **imperative-mood title** (per CONTRIBUTING.md, e.g. "Add word count to the status bar"):
+     ```
+     gh issue create --title "<imperative title>" --body "<spec markdown>" \
+       --label enhancement --label "priority: <low|medium|high>" --label <category>
+     ```
+     Category labels where they fit: `markdown`, `ui`, `navigation` (check `gh label list` first; omit if none fit).
+   - Add it to the **Glyph Roadmap** project board with status **Todo** (`gh project item-add`; resolve the project number via `gh project list --owner hamidfzm`).
+   - Print the new issue URL and tell the user the next step is `/plan <issue-number>`.
+
+Keep writing tight and free of em dashes. Do not start implementing; that is `/implement`.

--- a/.claude/rules/worktrees.md
+++ b/.claude/rules/worktrees.md
@@ -1,0 +1,54 @@
+---
+paths:
+  - ".claude/worktrees/**"
+---
+
+# Worktree Workflow (GitHub Flow)
+
+Glyph follows GitHub Flow with one git worktree per branch. There is no `develop`, `release/*`, or `hotfix/*` branch (that is Git Flow, which this project does not use).
+
+## Model
+
+- `main` is the only long-lived branch. It is always green and releasable.
+- Every change lands on a short-lived branch cut from the latest `main`: `feat/<slug>`, `fix/<slug>`, or `chore/<slug>` / `docs/<slug>` / `refactor/<slug>` as the change warrants.
+- Each branch lives in its own worktree under `.claude/worktrees/<slug>/`, so several branches can be checked out at once without stashing. `.claude/worktrees/` is gitignored, so nothing inside a worktree directory is itself committed to the parent repo.
+- Branches merge into `main` only through a PR, with linear history (squash or rebase, no merge commits), per [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Create a worktree for new work
+
+```bash
+git fetch origin
+git worktree add -b feat/<slug> ".claude/worktrees/<slug>" origin/main
+cd ".claude/worktrees/<slug>"
+```
+
+- Name the worktree directory after the slug so it matches the branch.
+- For an existing branch, omit `-b`: `git worktree add ".claude/worktrees/<slug>" <branch>`.
+- Always cut from `origin/main`, never off another in-progress branch.
+
+## Clean up merged worktrees
+
+After a branch's PR is merged into `main`, remove its worktree and branch. Always list first, confirm with the user, then remove. Never delete without confirmation.
+
+1. Refresh state and find merged branches:
+   ```bash
+   git fetch --prune origin
+   git worktree list
+   git branch --merged origin/main
+   ```
+2. For each worktree whose branch appears in `git branch --merged origin/main` (excluding `main` and the current worktree), confirm with the user, then:
+   ```bash
+   git worktree remove ".claude/worktrees/<slug>"   # refuses if there are uncommitted changes
+   git branch -d <branch>                            # -d refuses if the branch is not merged
+   ```
+3. Prune administrative entries for worktrees whose directory was deleted by hand:
+   ```bash
+   git worktree prune
+   ```
+
+### Safety rules
+
+- Never pass `--force` to `git worktree remove` to discard uncommitted tracked changes. If it refuses, stop and investigate.
+- Never use `git branch -D` for cleanup. `-d` only deletes branches already merged into `main`, which is the guard you want.
+- Never remove the `main` worktree or delete the `main` branch.
+- Confirm the exact list of worktrees to remove with the user before deleting anything.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,10 @@
       "Bash(git log*)",
       "Bash(git add *)",
       "Bash(git commit *)",
+      "Bash(gh issue *)",
+      "Bash(gh pr *)",
+      "Bash(gh project *)",
+      "Bash(gh label *)",
       "Bash(lsof *)",
       "Bash(kill *)"
     ]

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,11 +1,11 @@
 name: Feature Request
-description: Suggest a new feature or improvement
+description: Suggest a new feature or improvement (doubles as the implementable spec)
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting a feature! Please describe what you'd like to see.
+        Thanks for suggesting a feature! Describe what you'd like to see. The more of this you fill in, the closer it is to a ready-to-build spec, but only Problem, Proposed Solution, and Acceptance Criteria are required. Maintainers (and the `/plan` command) flesh out the rest.
 
   - type: textarea
     id: problem
@@ -22,6 +22,48 @@ body:
       description: Describe the solution you'd like.
     validations:
       required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Observable, testable outcomes that define "done". One per line as a checklist.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / Out of scope
+      description: What this issue does and does not cover, to keep it focused.
+      placeholder: |
+        In scope: ...
+        Out of scope: ...
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Implementation Tasks
+      description: Coarse task breakdown as a checklist. Leave blank if unsure; `/plan` will fill it in.
+      value: |
+        - [ ]
+
+  - type: dropdown
+    id: areas
+    attributes:
+      label: Affected areas
+      description: Which parts of Glyph does this touch?
+      multiple: true
+      options:
+        - Markdown rendering
+        - Layout / app-shell
+        - Modals (settings, AI panel)
+        - Rust backend
+        - Settings
+        - Build / CI
 
   - type: textarea
     id: alternatives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,14 +23,14 @@ The spec stays current throughout: acceptance-criteria and task checkboxes on th
 
 - **Plan before non-trivial work.** Anything beyond a one-line change starts from a spec (`/spec`) or an existing issue, not freeform edits.
 - **Ask, don't guess.** When acceptance criteria or scope are ambiguous, ask the user before writing code.
-- **Follow the rules in `.claude/rules/`**, which are authoritative for code organization, frontend, Rust, app-shell, docs, cleanup, and CI hygiene.
+- **Follow the rules in `.claude/rules/`**, which are authoritative for code organization, frontend, Rust, app-shell, docs, cleanup, CI hygiene, and the worktree workflow.
 - **Run the gates before every PR** (the same gate the Husky pre-commit hook and CI enforce):
   ```bash
   pnpm typecheck && pnpm check && pnpm test
   cd src-tauri && cargo clippy --all-targets -- -D warnings
   ```
   Fix Biome warnings by applying the suggested fix, never by suppressing.
-- **Branches** are cut from `main` as `feat/<slug>` or `fix/<slug>` (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+- **Branches** are cut from `main` as `feat/<slug>` or `fix/<slug>`, each in its own git worktree under `.claude/worktrees/`. See [.claude/rules/worktrees.md](.claude/rules/worktrees.md) for the GitHub Flow worktree workflow and how to clean up merged worktrees (see [CONTRIBUTING.md](CONTRIBUTING.md) for the wider conventions).
 - **No co-authored-by lines** in commits, and no em dashes anywhere in output.
 
 ### Agents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,53 @@
 
 Cross-platform markdown viewer built with Tauri v2 + React 19 + TypeScript.
 
+## Spec-Driven Workflow
+
+Glyph features are built through a four-stage loop where **the GitHub issue body is the single source of truth** (the spec). Each stage is a Claude slash command in `.claude/commands/`:
+
+```
+/spec  →  /plan  →  /implement  →  /ship
+ idea     issue→     spec→code      review +
+ →issue   plan       + tests        PR (Closes #N)
+```
+
+- **`/spec <idea>`**: Explore the codebase, then draft and create a structured issue (Problem, Proposed Solution, Acceptance Criteria, Scope, Implementation Tasks) using the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml). Labels it and adds it to the **Glyph Roadmap** board as **Todo**. Ambiguous scope is clarified with the user, never invented.
+- **`/plan <issue-number>`**: Read the issue, explore affected code under `.claude/rules/`, write an implementation plan, post it as an issue comment, and create the `feat/…` or `fix/…` branch.
+- **`/implement <issue-number>`**: Build the spec task-by-task with tests, ticking off acceptance criteria on the issue and running the gates (below).
+- **`/ship <issue-number>`**: Review the diff with the `code-reviewer` agent, then open a PR using the [PR template](.github/PULL_REQUEST_TEMPLATE.md) with `Closes #N`.
+
+The spec stays current throughout: acceptance-criteria and task checkboxes on the issue are ticked as work lands, so the issue always reflects real state.
+
+## Working with AI
+
+- **Plan before non-trivial work.** Anything beyond a one-line change starts from a spec (`/spec`) or an existing issue, not freeform edits.
+- **Ask, don't guess.** When acceptance criteria or scope are ambiguous, ask the user before writing code.
+- **Follow the rules in `.claude/rules/`**, which are authoritative for code organization, frontend, Rust, app-shell, docs, cleanup, and CI hygiene.
+- **Run the gates before every PR** (the same gate the Husky pre-commit hook and CI enforce):
+  ```bash
+  pnpm typecheck && pnpm check && pnpm test
+  cd src-tauri && cargo clippy --all-targets -- -D warnings
+  ```
+  Fix Biome warnings by applying the suggested fix, never by suppressing.
+- **Branches** are cut from `main` as `feat/<slug>` or `fix/<slug>` (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+- **No co-authored-by lines** in commits, and no em dashes anywhere in output.
+
+### Agents
+
+Delegate to the project agents in `.claude/agents/` rather than doing their job inline:
+
+- **`tester`**: runs `pnpm typecheck`, `pnpm test`, `cargo check`, `cargo clippy`; use it to gate `/implement` and `/ship`.
+- **`code-reviewer`**: reviews the diff for correctness, typing, Rust error handling, security, and consistency; used by `/ship` before opening a PR.
+- **`builder`**: runs the production `pnpm tauri build` and reports bundle/binary size and warnings.
+- **`ui-inspector`**: audits components for accessibility, platform-adaptive styling, and dark mode.
+
 ## Community & Project Files
 
 - [README.md](README.md) — Project overview, installation, and usage
 - [CONTRIBUTING.md](CONTRIBUTING.md) — Development setup, commands, conventions, workflow, and release process
 - [SECURITY.md](SECURITY.md) — Security vulnerability reporting policy
 - [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) — PR template (always use when creating PRs)
-- [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) — Bug report and feature request templates
+- [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) — Bug report and feature request (spec) templates
 
 When creating PRs, always follow the PR template. When creating issues, use the appropriate issue template.
 


### PR DESCRIPTION
## Summary

Adds a spec-driven development workflow for working with Claude, plus a documented worktree branching convention. Tooling and docs only; no application code changes.

## Changes

- **Spec-driven loop** as four slash commands in `.claude/commands/`, where the GitHub issue body is the single source of truth:
  - `/spec` turns an idea into a structured issue (problem, acceptance criteria, scope, tasks).
  - `/plan` reads the issue, plans against `.claude/rules/`, posts the plan, and cuts the branch.
  - `/implement` builds task-by-task with tests and runs the gates.
  - `/ship` runs the `code-reviewer` agent and opens a PR with `Closes #N`.
- **Feature request issue template** reshaped into an implementable spec: adds Acceptance Criteria (required), Scope / Out of scope, Implementation Tasks, and Affected areas.
- **CLAUDE.md** gains a Spec-Driven Workflow, Working with AI, and Agents section, turning it into a workflow guide rather than only a reference.
- **Worktree workflow rule** at `.claude/rules/worktrees.md`: documents GitHub Flow with one worktree per branch (cut from `main`, merge via PR) and a list-confirm-remove cleanup process for merged worktrees. Referenced from CLAUDE.md.
- **Permissions**: allow `gh issue/pr/project/label` in `.claude/settings.json` so the loop runs without re-prompting.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Not platform-specific: this PR only touches `.claude/`, `.github/`, and `CLAUDE.md`. Verified the feature request template parses as valid YAML and `settings.json` parses as valid JSON.

## Screenshots

N/A
