### PR TITLE
fix: expose glyph CLI command on PATH for macOS and Windows installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,39 +185,8 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           SHA="${{ steps.sha.outputs.sha256 }}"
 
-          cat > /tmp/glyph.rb << 'CASK'
-          cask "glyph" do
-          CASK
-
-          cat >> /tmp/glyph.rb << CASK
-            version "$VERSION"
-            sha256 "$SHA"
-
-            url "https://github.com/hamidfzm/glyph/releases/download/v#{version}/Glyph_#{version}_universal.dmg"
-            name "Glyph"
-            desc "Cross-platform markdown viewer"
-            homepage "https://github.com/hamidfzm/glyph"
-
-            livecheck do
-              url :url
-              strategy :github_latest
-            end
-
-            app "Glyph.app"
-
-            postflight do
-              system_command "/usr/bin/xattr",
-                             args: ["-cr", "#{appdir}/Glyph.app"],
-                             sudo: false
-            end
-
-            zap trash: [
-              "~/Library/Application Support/com.hamidfzm.glyph",
-              "~/Library/Caches/com.hamidfzm.glyph",
-              "~/Library/Preferences/com.hamidfzm.glyph.plist",
-            ]
-          end
-          CASK
+          sed -e "s/{{VERSION}}/$VERSION/g" -e "s/{{SHA256}}/$SHA/g" \
+            homebrew/glyph.rb.template > /tmp/glyph.rb
 
           # Get current file SHA for update
           FILE_SHA=$(gh api repos/hamidfzm/homebrew-tap/contents/Casks/glyph.rb --jq .sha)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,14 +188,21 @@ jobs:
           sed -e "s/{{VERSION}}/$VERSION/g" -e "s/{{SHA256}}/$SHA/g" \
             homebrew/glyph.rb.template > /tmp/glyph.rb
 
-          # Get current file SHA for update
-          FILE_SHA=$(gh api repos/hamidfzm/homebrew-tap/contents/Casks/glyph.rb --jq .sha)
+          # Get current file SHA for update (or empty for first push)
+          FILE_SHA=$(gh api repos/hamidfzm/homebrew-tap/contents/Casks/glyph.rb --jq .sha 2>/dev/null || echo "")
 
-          gh api repos/hamidfzm/homebrew-tap/contents/Casks/glyph.rb \
-            --method PUT \
-            --field message="chore: update glyph to $VERSION" \
-            --field content="$(base64 -w0 /tmp/glyph.rb)" \
-            --field sha="$FILE_SHA"
+          if [ -n "$FILE_SHA" ]; then
+            gh api repos/hamidfzm/homebrew-tap/contents/Casks/glyph.rb \
+              --method PUT \
+              --field message="chore: update glyph to $VERSION" \
+              --field content="$(base64 -w0 /tmp/glyph.rb)" \
+              --field sha="$FILE_SHA"
+          else
+            gh api repos/hamidfzm/homebrew-tap/contents/Casks/glyph.rb \
+              --method PUT \
+              --field message="chore: add glyph cask $VERSION" \
+              --field content="$(base64 -w0 /tmp/glyph.rb)"
+          fi
       - name: Download Linux debs and compute sha256
         id: linux_sha
         env:

--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ chmod +x Glyph_*.AppImage
 ./Glyph_*.AppImage
 ```
 
+### Command-line usage
+
+Installing from a package manager puts a `glyph` command on your `PATH`:
+
+```bash
+glyph README.md      # open a file
+glyph ~/notes/       # open a folder as a workspace
+```
+
+The command is provided by the Homebrew cask (macOS), Chocolatey or Scoop (Windows), and the deb package or Homebrew formula (Linux). The macOS `.dmg` and Windows MSI install the app only; use a package manager for the terminal command.
+
 ## Development
 
 ```bash

--- a/chocolatey/tools/chocolateyinstall.ps1
+++ b/chocolatey/tools/chocolateyinstall.ps1
@@ -53,6 +53,13 @@ if ($exePath) {
     -WorkingDirectory $workingDir `
     -Description 'Cross-platform markdown viewer' `
     -IconLocation $exePath
+
+  # Expose a `glyph` command on PATH so `glyph file.md` works from a terminal,
+  # matching macOS (Homebrew cask binary) and Linux (deb /usr/bin/glyph). The
+  # MSI itself does not add the exe to PATH. Install-BinFile creates a shim in
+  # the Chocolatey bin directory (already on PATH); shimgen detects the GUI
+  # subsystem so the shim launches Glyph and returns instead of blocking.
+  Install-BinFile -Name 'glyph' -Path $exePath
 } else {
-  Write-Warning "Glyph.exe was not found after MSI install. Skipping shortcut creation."
+  Write-Warning "Glyph.exe was not found after MSI install. Skipping shortcut and shim creation."
 }

--- a/chocolatey/tools/chocolateyuninstall.ps1
+++ b/chocolatey/tools/chocolateyuninstall.ps1
@@ -26,3 +26,6 @@ foreach ($lnk in $shortcuts) {
     Remove-Item -LiteralPath $lnk -Force -ErrorAction SilentlyContinue
   }
 }
+
+# Remove the `glyph` PATH shim created by chocolateyinstall.ps1.
+Uninstall-BinFile -Name 'glyph'

--- a/homebrew/glyph.rb.template
+++ b/homebrew/glyph.rb.template
@@ -13,6 +13,13 @@ cask "glyph" do
   end
 
   app "Glyph.app"
+  binary "#{appdir}/Glyph.app/Contents/MacOS/Glyph", target: "glyph"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-cr", "#{appdir}/Glyph.app"],
+                   sudo: false
+  end
 
   zap trash: [
     "~/Library/Application Support/com.hamidfzm.glyph",


### PR DESCRIPTION
## Summary

After install, the `glyph` terminal command was only available on Linux (the `.deb` ships `/usr/bin/glyph`) and via Scoop. The macOS Homebrew cask installed only the GUI app bundle with no `binary` stanza, and the Chocolatey package created only Start Menu / Desktop shortcuts, so neither put `glyph` on `PATH`. This change makes the existing CLI binary reachable as `glyph` from a terminal on macOS and Windows too. No app code changes; packaging and docs only.

## Changes

- **macOS**: added `binary "#{appdir}/Glyph.app/Contents/MacOS/Glyph", target: "glyph"` to the Homebrew cask, and wired `homebrew/glyph.rb.template` into the `publish-homebrew` job (sed substitution, matching the Linux formula and Scoop jobs) instead of the inline heredoc. Ported the `postflight` xattr-clear block into the template so nothing is lost.
- **macOS (robustness)**: guarded the cask `FILE_SHA` fetch for the first-push case, matching the Linux formula and Scoop jobs (avoids a publish failure if the cask file does not yet exist in the tap).
- **Windows**: `chocolateyinstall.ps1` now creates a `glyph` shim with `Install-BinFile` (reusing the existing `$exePath` discovery); `chocolateyuninstall.ps1` removes it with `Uninstall-BinFile`.
- **Docs**: added a "Command-line usage" section to `README.md` covering the `glyph` command and per-platform availability.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Static and gate verification on this branch:
- Rendered the cask from the template (`sed` substitution) and confirmed it is valid cask Ruby containing the `binary` stanza, with `#{version}` / `#{appdir}` interpolation preserved.
- Validated `release.yml` as YAML and parse-checked both Chocolatey PowerShell scripts.
- `pnpm typecheck`, `pnpm check` (Biome), `pnpm test`, and `cargo clippy --all-targets -- -D warnings` all pass (pre-commit hook green).

The two install-time acceptance criteria (`brew install --cask glyph` then `glyph --version`; `choco install glyph` then `glyph file.md`) can only be confirmed against a published release, so the platform checkboxes are left for post-merge verification on the first release after this lands.

Note: the macOS `binary` path assumes the bundle executable is named `Glyph` (the current `productName`). If `productName` in `tauri.conf.json` is ever renamed, this path must be updated in sync; there is no automated check.

Closes #311
