### PR TITLE
docs: require Sentry public shareable link in PRs that fix a Sentry issue

### DIFF
--- a/.claude/rules/sentry.md
+++ b/.claude/rules/sentry.md
@@ -1,0 +1,15 @@
+# Sentry Issue Rules
+
+When a PR fixes a Sentry issue, the reviewer needs to see the crash context without a Sentry login.
+
+- **Always include the Sentry public shareable link in the PR description.** Use the share URL, which is viewable without authentication:
+
+  ```
+  https://glyph-md.sentry.io/share/issue/<hash>/
+  ```
+
+  Example: `https://glyph-md.sentry.io/share/issue/c5d3d5c9443b47cd8af873d19b06ce46/`
+
+- **Do not substitute the internal issue URL** (`https://glyph-md.sentry.io/issues/<id>/`). It requires a login, so external reviewers can't open it.
+- Create the share link from the Sentry issue page ("Share" → copy public link). If it can't be generated automatically, ask the author to paste it before opening the PR.
+- Put the share link alongside the issue-closing reference. Sentry's GitHub integration recognizes `Fixes GLYPH-N` in the PR description (or a commit message) and auto-resolves the Sentry issue once merged, the same way GitHub closes issues (see [the closing-issues conventions in CLAUDE.md](../../CLAUDE.md)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ The spec stays current throughout: acceptance-criteria and task checkboxes on th
 
 - **Plan before non-trivial work.** Anything beyond a one-line change starts from a spec (`/spec`) or an existing issue, not freeform edits.
 - **Ask, don't guess.** When acceptance criteria or scope are ambiguous, ask the user before writing code.
-- **Follow the rules in `.claude/rules/`**, which are authoritative for code organization, frontend, Rust, app-shell, docs, cleanup, CI hygiene, and the worktree workflow.
+- **Follow the rules in `.claude/rules/`**, which are authoritative for code organization, frontend, Rust, app-shell, docs, cleanup, CI hygiene, the worktree workflow, and Sentry issue fixes.
 - **Run the gates before every PR** (the same gate the Husky pre-commit hook and CI enforce):
   ```bash
   pnpm typecheck && pnpm check && pnpm test


### PR DESCRIPTION
## Summary

Codifies a convention as a checked-in rule: when a PR fixes a Sentry issue, its description must include the Sentry **public shareable** link so reviewers can see the crash context without a Sentry login.

## Changes

- Add `.claude/rules/sentry.md` — requires the public `https://glyph-md.sentry.io/share/issue/<hash>/` link in the PR description, forbids substituting the login-gated `/issues/<id>/` URL, and notes that `Fixes GLYPH-N` auto-resolves the Sentry issue via the GitHub integration.
- Reference the new rule from the rules list in `CLAUDE.md`.

## Testing

Docs-only change. The pre-commit gate (lint-staged, typecheck, frontend tests, `cargo test --lib`, clippy) ran clean on commit.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A — documentation only.
