### PR TITLE
ci: cache apt packages for Linux Tauri build deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,10 @@ jobs:
         with:
           workspaces: src-tauri
       - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          version: ci-rust
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install cargo-nextest
@@ -169,9 +170,10 @@ jobs:
         with:
           workspaces: src-tauri
       - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          version: ci-clippy
       - name: Add Clippy problem matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Run Clippy
@@ -208,9 +210,10 @@ jobs:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
       - name: Install Linux dependencies
         if: startsWith(matrix.platform, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+          version: ci-build
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri

--- a/.github/workflows/dependabot-tauri-npm-sync.yml
+++ b/.github/workflows/dependabot-tauri-npm-sync.yml
@@ -52,13 +52,10 @@ jobs:
           cache: pnpm
 
       - name: Install Linux Tauri build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          version: dependabot-sync
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,10 @@ jobs:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
       - name: Install Linux dependencies
         if: startsWith(matrix.platform, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+          version: release-build
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri


### PR DESCRIPTION
## Summary

The "Install Linux dependencies" step ran `apt-get update && apt-get install` on every Ubuntu runner, re-downloading and unpacking the `libwebkit2gtk-4.1-dev` dependency tree from scratch each run. It was never cached.

In the Clippy job, that step took **~4m of a 4m25s run**, while Clippy itself ran in **7s**. The same install is duplicated across `test-rust`, `clippy`, and both `build` matrix legs (`ubuntu-22.04` + `ubuntu-22.04-arm`), so it costs roughly **~16 minutes of wasted compute per CI run**.

This swaps the manual apt blocks for [`awalsh128/cache-apt-pkgs-action`](https://github.com/awalsh128/cache-apt-pkgs-action), which caches the resolved `.deb` set plus installed files and restores them in ~20-30s on a warm cache. On a cold cache it runs `apt-get update` internally, so behavior is identical; warm runs are ~8x faster on that step.

## Changes

- Replace `apt-get update && apt-get install` with `awalsh128/cache-apt-pkgs-action@v1` for the webkit/Tauri build deps in:
  - `ci.yml` — `test-rust`, `clippy`, and `build` (Ubuntu legs only, via the existing `if: startsWith(matrix.platform, 'ubuntu')` guard)
  - `release.yml` — `build` matrix (Ubuntu legs)
  - `dependabot-tauri-npm-sync.yml` — Tauri build deps
- Each job gets a distinct cache `version` key so caches stay isolated per job/arch.
- `apt-get update` is kept (handled internally by the action) since installs otherwise 404 against the runner's stale package index.

### Notes / out of scope

- The action is current (v1.6.1, not deprecated) and runs on Node 20; the workflow's `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env covers the runtime per CI hygiene.
- The small toolchain installs in `release.yml` publishing jobs (`devscripts`/`debhelper`/`dput`, `dpkg-dev`/`gpg`) are left as-is. They're tiny and run rarely, so caching them adds little.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Validated via CI itself: the workflow YAML changes are exercised by this PR's own CI run. First run populates the cache (cold, ~same as before); subsequent runs hit the warm cache.
