### PR TITLE
feat(packaging): publish Glyph to Flathub (Flatpak)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,22 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
 
+  validate-flatpak:
+    name: Validate Flatpak metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install validators
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y appstream desktop-file-utils python3-yaml
+      - name: Validate AppStream metainfo
+        run: appstreamcli validate --no-net flatpak/com.hamidfzm.glyph.metainfo.xml
+      - name: Validate desktop entry
+        run: desktop-file-validate flatpak/com.hamidfzm.glyph.desktop
+      - name: Validate manifest parses
+        run: python3 -c "import yaml; yaml.safe_load(open('flatpak/com.hamidfzm.glyph.yml'))"
+
   build:
     name: Build (${{ matrix.platform }})
     needs: [lint, typecheck, test-frontend, test-rust, clippy]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,9 @@ jobs:
 
             ### Linux
             ```bash
+            # Flathub (Flatpak)
+            flatpak install flathub com.hamidfzm.glyph
+
             # Snap Store
             sudo snap install glyph
 
@@ -149,6 +152,9 @@ jobs:
 
           ### Linux
           ```bash
+          # Flathub (Flatpak)
+          flatpak install flathub com.hamidfzm.glyph
+
           # Snap Store
           sudo snap install glyph
 
@@ -671,3 +677,79 @@ jobs:
         with:
           snap: ${{ steps.build.outputs.snap }}
           release: stable
+
+  publish-flathub:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # The canonical Flatpak manifest lives in this repo (flatpak/). Flathub
+      # builds from its own app repo (flathub/com.hamidfzm.glyph), so each
+      # release we rewrite the version + per-arch sha256 in the manifest and
+      # push it (with the desktop + metainfo files) to that repo, whose
+      # buildbot then builds and publishes. No-op until FLATHUB_TOKEN (a PAT
+      # with push access to the Flathub app repo) is set, so it never fails a
+      # release before the Flathub submission is accepted.
+      - name: Check for Flathub token
+        id: gate
+        env:
+          TOKEN: ${{ secrets.FLATHUB_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No FLATHUB_TOKEN secret; skipping Flathub publish."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Get version
+        if: steps.gate.outputs.enabled == 'true'
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Download debs and compute sha256
+        if: steps.gate.outputs.enabled == 'true'
+        id: sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release download "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "Glyph_${VERSION}_amd64.deb" \
+            --pattern "Glyph_${VERSION}_arm64.deb"
+          echo "amd64=$(sha256sum "Glyph_${VERSION}_amd64.deb" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          echo "arm64=$(sha256sum "Glyph_${VERSION}_arm64.deb" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Update manifest and push to the Flathub app repo
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.FLATHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA_AMD64="${{ steps.sha.outputs.amd64 }}"
+          SHA_ARM64="${{ steps.sha.outputs.arm64 }}"
+
+          # Rewrite the version in both download URLs and the per-arch sha256.
+          # Each `url:` line is immediately followed by its `sha256:` line, so
+          # tag the arch on the url and replace the next sha256 accordingly.
+          awk -v v="$VERSION" -v a="$SHA_AMD64" -v r="$SHA_ARM64" '
+            /releases\/download\/.*_amd64\.deb/ { sub(/v[0-9][0-9.]*\/Glyph_[0-9][0-9.]*_/, "v" v "/Glyph_" v "_"); arch="amd64" }
+            /releases\/download\/.*_arm64\.deb/ { sub(/v[0-9][0-9.]*\/Glyph_[0-9][0-9.]*_/, "v" v "/Glyph_" v "_"); arch="arm64" }
+            /^[[:space:]]*sha256:/ {
+              if (arch == "amd64") { sub(/sha256:.*/, "sha256: " a); arch="" }
+              else if (arch == "arm64") { sub(/sha256:.*/, "sha256: " r); arch="" }
+            }
+            { print }
+          ' flatpak/com.hamidfzm.glyph.yml > /tmp/manifest.yml
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/flathub/com.hamidfzm.glyph.git" /tmp/flathub
+          cp /tmp/manifest.yml /tmp/flathub/com.hamidfzm.glyph.yml
+          cp flatpak/com.hamidfzm.glyph.desktop /tmp/flathub/
+          cp flatpak/com.hamidfzm.glyph.metainfo.xml /tmp/flathub/
+
+          cd /tmp/flathub
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || {
+            git commit -m "Update to $VERSION"
+            git push
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -740,6 +740,13 @@ jobs:
             { print }
           ' flatpak/com.hamidfzm.glyph.yml > /tmp/manifest.yml
 
+          # Single-source the homepage URL from package.json (falls back to the
+          # committed value if the field is absent).
+          HOMEPAGE=$(jq -r '.homepage // empty' package.json)
+          if [ -n "$HOMEPAGE" ]; then
+            sed -i "s|<url type=\"homepage\">.*</url>|<url type=\"homepage\">$HOMEPAGE</url>|" flatpak/com.hamidfzm.glyph.metainfo.xml
+          fi
+
           git clone "https://x-access-token:${GH_TOKEN}@github.com/flathub/com.hamidfzm.glyph.git" /tmp/flathub
           cp /tmp/manifest.yml /tmp/flathub/com.hamidfzm.glyph.yml
           cp flatpak/com.hamidfzm.glyph.desktop /tmp/flathub/

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ scoop bucket add hamidfzm https://github.com/hamidfzm/scoop-bucket
 scoop install glyph
 ```
 
+### Linux (Flathub)
+
+```bash
+flatpak install flathub com.hamidfzm.glyph
+flatpak run com.hamidfzm.glyph
+```
+
 ### Linux (Snap)
 
 ```bash

--- a/flatpak/com.hamidfzm.glyph.desktop
+++ b/flatpak/com.hamidfzm.glyph.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name=Glyph
+GenericName=Markdown Viewer
+Comment=Cross-platform markdown viewer and editor
+Exec=glyph %F
+Icon=com.hamidfzm.glyph
+Terminal=false
+Categories=Office;Utility;TextEditor;
+MimeType=text/markdown;
+Keywords=markdown;md;viewer;editor;notes;
+StartupNotify=true
+StartupWMClass=Glyph

--- a/flatpak/com.hamidfzm.glyph.metainfo.xml
+++ b/flatpak/com.hamidfzm.glyph.metainfo.xml
@@ -32,7 +32,7 @@
 
   <launchable type="desktop-id">com.hamidfzm.glyph.desktop</launchable>
 
-  <url type="homepage">https://github.com/hamidfzm/glyph</url>
+  <url type="homepage">https://glyph-md.github.io</url>
   <url type="bugtracker">https://github.com/hamidfzm/glyph/issues</url>
   <url type="vcs-browser">https://github.com/hamidfzm/glyph</url>
 

--- a/flatpak/com.hamidfzm.glyph.metainfo.xml
+++ b/flatpak/com.hamidfzm.glyph.metainfo.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Maintainer: hamidfzm <hamidfzm@users.noreply.github.com> -->
+<component type="desktop-application">
+  <id>com.hamidfzm.glyph</id>
+
+  <name>Glyph</name>
+  <summary>Cross-platform markdown viewer and editor</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <developer id="com.hamidfzm">
+    <name>hamidfzm</name>
+  </developer>
+
+  <description>
+    <p>
+      Glyph is a modern, cross-platform markdown viewer and editor with
+      platform-native styling. Built with Tauri v2, React 19, and TypeScript.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>GitHub Flavored Markdown with syntax highlighting</li>
+      <li>KaTeX math and Mermaid diagrams</li>
+      <li>Multi-file tabs and a table-of-contents outline</li>
+      <li>Live file watching that reloads on disk changes</li>
+      <li>Wikilinks, backlinks, and workspace navigation</li>
+      <li>Optional AI summarization (Claude, OpenAI, Ollama) and text-to-speech</li>
+      <li>Light and dark themes that follow the system appearance</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">com.hamidfzm.glyph.desktop</launchable>
+
+  <url type="homepage">https://github.com/hamidfzm/glyph</url>
+  <url type="bugtracker">https://github.com/hamidfzm/glyph/issues</url>
+  <url type="vcs-browser">https://github.com/hamidfzm/glyph</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/hamidfzm/glyph/main/docs/assets/hero.png</image>
+      <caption>Glyph rendering a markdown document with the outline sidebar</caption>
+    </screenshot>
+  </screenshots>
+
+  <categories>
+    <category>Office</category>
+    <category>Utility</category>
+    <category>TextEditor</category>
+  </categories>
+
+  <keywords>
+    <keyword>markdown</keyword>
+    <keyword>md</keyword>
+    <keyword>viewer</keyword>
+    <keyword>editor</keyword>
+    <keyword>notes</keyword>
+  </keywords>
+
+  <provides>
+    <binary>glyph</binary>
+  </provides>
+
+  <content_rating type="oars-1.1" />
+
+  <branding>
+    <color type="primary" scheme_preference="light">#f5f5f5</color>
+    <color type="primary" scheme_preference="dark">#1e1e1e</color>
+  </branding>
+
+  <releases>
+    <release version="0.10.0" date="2026-06-11">
+      <url type="details">https://github.com/hamidfzm/glyph/releases/tag/v0.10.0</url>
+    </release>
+  </releases>
+</component>

--- a/flatpak/com.hamidfzm.glyph.yml
+++ b/flatpak/com.hamidfzm.glyph.yml
@@ -1,0 +1,64 @@
+# Flatpak manifest for Glyph.
+#
+# This installs the released Debian package into the GNOME runtime rather than
+# recompiling from source, matching the AUR/PPA pattern already used in
+# `.github/workflows/release.yml`. flatpak-builder understands `.deb` archives
+# and unpacks the embedded data tarball, so `usr/...` paths below come straight
+# from the Tauri-generated package.
+#
+# The `url` versions and `sha256` checksums below are placeholders. They are
+# filled in per release (the SHA256s are the same ones computed by the
+# `publish-aur` / `publish-debian` jobs). Validate this manifest in a Linux
+# environment with:
+#   flatpak-builder --user --install --force-clean build-dir flatpak/com.hamidfzm.glyph.yml
+#
+# See the Tauri Flatpak guide: https://v2.tauri.app/distribute/flatpak/
+id: com.hamidfzm.glyph
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+command: glyph
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=ipc
+  # Network access is needed for the optional AI features (Claude/OpenAI/Ollama).
+  - --share=network
+  # Read/write access to the user's documents so markdown files can be opened.
+  - --filesystem=home
+  # Desktop notifications.
+  - --talk-name=org.freedesktop.Notifications
+
+modules:
+  - name: glyph
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 usr/bin/glyph /app/bin/glyph
+      - install -Dm644 com.hamidfzm.glyph.desktop /app/share/applications/com.hamidfzm.glyph.desktop
+      - install -Dm644 com.hamidfzm.glyph.metainfo.xml /app/share/metainfo/com.hamidfzm.glyph.metainfo.xml
+      # Re-home every Tauri-generated PNG icon under the Flatpak app-id,
+      # preserving its hicolor size directory (the .deb ships 32x32, 128x128,
+      # and 256x256@2). Iterating over whatever exists avoids hardcoding the
+      # exact set of sizes the bundler emits.
+      - |
+        for src in $(find usr/share/icons -name glyph.png); do
+          dest="/app/${src#usr/}"
+          install -Dm644 "$src" "${dest%/glyph.png}/com.hamidfzm.glyph.png"
+        done
+    sources:
+      - type: archive
+        only-arches:
+          - x86_64
+        url: https://github.com/hamidfzm/glyph/releases/download/v0.10.0/Glyph_0.10.0_amd64.deb
+        sha256: 93e5d40ba44ee78563bc27e717ee954c714bbe6e63337d361a801c6c8cb53e4d
+      - type: archive
+        only-arches:
+          - aarch64
+        url: https://github.com/hamidfzm/glyph/releases/download/v0.10.0/Glyph_0.10.0_arm64.deb
+        sha256: 86dbc1e9b0f29e8c20464b7e2aaa33daead86f270d65a3b0f8ebed7f204c8dcb
+      - type: file
+        path: com.hamidfzm.glyph.desktop
+      - type: file
+        path: com.hamidfzm.glyph.metainfo.xml


### PR DESCRIPTION
## Summary

Adds Flatpak packaging so Glyph can publish to **Flathub**, the largest Linux desktop discovery + install channel. One of three independent packaging PRs (split so each store merges on its own):

- Snap Store — separate PR (#293)
- **Flathub (Flatpak) — this PR**
- Microsoft Store — separate PR

## Changes

- `flatpak/com.hamidfzm.glyph.metainfo.xml` — AppStream metadata (summary, description, screenshot, categories, OARS rating, branding, release entry).
- `flatpak/com.hamidfzm.glyph.desktop` — desktop entry with the markdown MIME association.
- `flatpak/com.hamidfzm.glyph.yml` — manifest installing the released `.deb` into the GNOME 50 runtime (per-arch `x86_64`/`aarch64` sources, pinned v0.10.0 sha256s).
- `publish-flathub` job in `release.yml` — each release, rewrites the version + per-arch sha256 in the manifest and pushes it (with desktop + metainfo) to the Flathub app repo `flathub/com.hamidfzm.glyph`, whose buildbot then publishes. Gated on a `FLATHUB_TOKEN` secret, so it is a no-op until the app repo exists.
- `validate-flatpak` CI job — `appstreamcli validate`, `desktop-file-validate`, and a manifest YAML parse.
- Flathub install instructions in `README.md` and both Linux blocks of the release notes.

## Status / caveats

- The deb checksums are pinned for v0.10.0 (the current latest release); the `publish-flathub` job refreshes them per release.
- A full local `flatpak-builder` validation could not be completed in the available environment (heavily throttled runtime download, no display for a GUI launch). The `validate-flatpak` CI job covers metadata/manifest validity.
- **Flathub itself is not yet set up.** Submitting to `flathub/flathub` and the resulting `flathub/com.hamidfzm.glyph` repo + `FLATHUB_TOKEN` secret are maintainer-only steps, and must be done by a human per Flathub's generative-AI policy. Until then, this PR just lands the in-repo packaging; the publish job stays inert.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Refs #117, #290
