### PR TITLE
ci: fix apt-install hangs and cache the Linux deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
         with:
           workspaces: src-tauri
       - name: Install Linux dependencies
+        timeout-minutes: 8
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
@@ -169,6 +172,9 @@ jobs:
         with:
           workspaces: src-tauri
       - name: Install Linux dependencies
+        timeout-minutes: 8
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
@@ -208,6 +214,9 @@ jobs:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
       - name: Install Linux dependencies
         if: startsWith(matrix.platform, 'ubuntu')
+        timeout-minutes: 8
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,13 +121,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-cache/*.deb
+          key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
       - name: Install Linux dependencies
         timeout-minutes: 8
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          mkdir -p ~/apt-cache/partial
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
+            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
+            install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install cargo-nextest
@@ -171,13 +179,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-cache/*.deb
+          key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
       - name: Install Linux dependencies
         timeout-minutes: 8
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          mkdir -p ~/apt-cache/partial
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
+            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
+            install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - name: Add Clippy problem matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Run Clippy
@@ -212,14 +228,23 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+      - name: Cache apt packages
+        if: startsWith(matrix.platform, 'ubuntu')
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-cache/*.deb
+          key: apt-webkit-${{ matrix.platform }}-v1
       - name: Install Linux dependencies
         if: startsWith(matrix.platform, 'ubuntu')
         timeout-minutes: 8
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          mkdir -p ~/apt-cache/partial
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
+            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
+            install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri

--- a/.github/workflows/dependabot-tauri-npm-sync.yml
+++ b/.github/workflows/dependabot-tauri-npm-sync.yml
@@ -51,13 +51,21 @@ jobs:
           node-version-file: ".nvmrc"
           cache: pnpm
 
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-cache/*.deb
+          key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
       - name: Install Linux Tauri build deps
         timeout-minutes: 8
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          mkdir -p ~/apt-cache/partial
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
+            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
+            install -y \
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
             librsvg2-dev \

--- a/.github/workflows/dependabot-tauri-npm-sync.yml
+++ b/.github/workflows/dependabot-tauri-npm-sync.yml
@@ -52,6 +52,9 @@ jobs:
           cache: pnpm
 
       - name: Install Linux Tauri build deps
+        timeout-minutes: 8
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
       - name: Install Linux dependencies
         if: startsWith(matrix.platform, 'ubuntu')
+        timeout-minutes: 8
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
@@ -438,6 +441,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install packaging tools
+        timeout-minutes: 8
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get update && sudo apt-get install -y devscripts debhelper dput
       - name: Get version
         id: version
@@ -520,6 +526,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install packaging tools
+        timeout-minutes: 8
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get update && sudo apt-get install -y dpkg-dev gpg
       - name: Get version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,14 +37,23 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+      - name: Cache apt packages
+        if: startsWith(matrix.platform, 'ubuntu')
+        uses: actions/cache@v4
+        with:
+          path: ~/apt-cache/*.deb
+          key: apt-webkit-${{ matrix.platform }}-v1
       - name: Install Linux dependencies
         if: startsWith(matrix.platform, 'ubuntu')
         timeout-minutes: 8
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          mkdir -p ~/apt-cache/partial
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
+            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
+            install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri


### PR DESCRIPTION
## Summary

Two related fixes for the Linux `apt-get` step that installs the Tauri/webkit build deps.

### 1. Stop apt from hanging the runner (the bug that stuck PRs)

A Clippy run hung on **"Install Linux dependencies"** for **over 2 hours**. The step had no step-level timeout, so a blocked `apt-get` sat until GitHub's 6-hour job ceiling, holding a runner slot and stalling other open PRs queued behind it. The hang is intermittent (the step normally finishes in ~4m), consistent with `apt-get` blocking on an interactive debconf prompt.

Guards on every apt step:
- **`DEBIAN_FRONTEND: noninteractive`** so a package post-install never blocks on a prompt CI can't answer.
- **`timeout-minutes: 8`** so a stuck install fails fast and frees the runner instead of hanging for hours.

### 2. Cache the downloaded `.deb` files

Point apt at a writable archive dir (`~/apt-cache`) with `Keep-Downloaded-Packages`, and cache the `.deb` files with `actions/cache`. On a warm cache the webkit download is skipped (apt only unpacks), cutting the step from ~4m toward ~1.5-2m per Ubuntu job.

- Caches the `*.deb` glob only, not the whole dir, so apt's root-owned `lock`/`partial` entries don't break the cache tar step.
- `test-rust`, `clippy`, and the dependabot sync share one key (same package set); `build` (ci + release) keys per ubuntu image/arch.
- GitHub scopes caches so a PR run can read `main`'s cache but not another feature branch's. **Full speedup lands once this is on `main`** and a `main` push primes the caches. Bump the `-v1` key suffix to invalidate after a webkit version bump.

## Changes

- `ci.yml` - `test-rust`, `clippy`, `build`
- `release.yml` - `build` matrix plus both packaging-tool installs (hang guards only on those two)
- `dependabot-tauri-npm-sync.yml` - Tauri build deps

No change to package lists or to install behavior on a healthy cold runner.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Exercised by this PR's own CI. Cold cache on the first run (same speed as before, populates the cache); warm cache on reruns.
