### PR TITLE
fix: categorize release notes by auto-labeling PRs from title

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,91 @@
+name: PR Labeler
+
+# Applies a changelog category label based on the PR's conventional-commit
+# title prefix (feat:, fix:, docs:, ...). The release notes in
+# .github/release.yml bucket "What's Changed" by these labels, so without
+# them every human PR falls into "Other Changes". Dependabot already labels
+# its own PRs `dependencies`, so this fills the gap for everything else.
+#
+# pull_request_target runs with a write token from the base repo. It is safe
+# here because the job only reads the PR title and never checks out or runs
+# any code from the pull request.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label by conventional-commit title
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // type (and optional scope) -> changelog category label.
+            const TYPE_TO_LABEL = {
+              feat: "enhancement",
+              perf: "enhancement",
+              fix: "bug",
+              docs: "documentation",
+              ci: "ci",
+              build: "ci",
+              test: "testing",
+              security: "security",
+            };
+
+            // Colors used to create a category label if it does not exist yet.
+            const LABEL_COLORS = {
+              ci: "ededed",
+              testing: "c5def5",
+              security: "ee0701",
+            };
+
+            const title = context.payload.pull_request.title || "";
+            const match = title.match(/^(\w+)(\([^)]*\))?!?:/);
+            if (!match) {
+              core.info(`Title "${title}" has no conventional-commit prefix; skipping.`);
+              return;
+            }
+
+            const type = match[1].toLowerCase();
+            const scope = (match[2] || "").toLowerCase();
+
+            // A `deps` scope (e.g. chore(deps), build(deps)) is a dependency bump.
+            let label = scope.includes("deps") ? "dependencies" : TYPE_TO_LABEL[type];
+            if (!label) {
+              core.info(`No category mapped for type "${type}"; leaving to "Other Changes".`);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+
+            // Ensure the label exists so categorization never silently no-ops.
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              core.info(`Creating missing label "${label}".`);
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: label,
+                color: LABEL_COLORS[label] || "ededed",
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label],
+            });
+            core.info(`Applied "${label}" from title type "${type}${scope}".`);

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -39,7 +39,6 @@ jobs:
               ci: "ci",
               build: "ci",
               test: "testing",
-              security: "security",
             };
 
             // Colors used to create a category label if it does not exist yet.
@@ -59,8 +58,18 @@ jobs:
             const type = match[1].toLowerCase();
             const scope = (match[2] || "").toLowerCase();
 
-            // A `deps` scope (e.g. chore(deps), build(deps)) is a dependency bump.
-            let label = scope.includes("deps") ? "dependencies" : TYPE_TO_LABEL[type];
+            // Scope takes precedence over type: a `deps` scope (chore(deps),
+            // build(deps)) is a dependency bump, and a `security` scope
+            // (fix(security), feat(security)) belongs in the Security section
+            // regardless of whether it is framed as a fix or a feature.
+            let label;
+            if (scope.includes("deps")) {
+              label = "dependencies";
+            } else if (scope.includes("security")) {
+              label = "security";
+            } else {
+              label = TYPE_TO_LABEL[type];
+            }
             if (!label) {
               core.info(`No category mapped for type "${type}"; leaving to "Other Changes".`);
               return;


### PR DESCRIPTION
## Summary

The `What's Changed` section in release notes (e.g. [v0.12.0](https://github.com/hamidfzm/glyph/releases/tag/v0.12.0)) lumped every feature, fix, doc, and CI PR into `🔧 Other Changes`, while only dependency bumps split into their own `📦 Dependencies` section.

Root cause: notes are built by GitHub's `releases/generate-notes` API, which buckets PRs **only by label**. Dependabot self-labels its PRs `dependencies`, but human PRs were never labeled, so there was nothing to categorize on. The existing `.github/release.yml` categories were correct, just unfed.

## Changes

- **New `.github/workflows/pr-labeler.yml`** — applies a changelog category label from the PR's conventional-commit title prefix, matching the categories already defined in `release.yml`:
  - `feat:`/`perf:` → `enhancement` (🚀 Features)
  - `fix:` → `bug` (🐛 Bug Fixes)
  - `fix(security):`/`feat(security):` (any `security` scope) → `security` (🔒 Security)
  - `docs:` → `documentation` (📝 Documentation)
  - `ci:`/`build:`/`test:` → `ci`/`testing` (🧪 Testing & CI)
  - any `(deps)` scope → `dependencies` (📦 Dependencies)
  - `refactor:`/`style:`/`chore:`/`revert:` → unlabeled (🔧 Other Changes)
- Scope takes precedence over type, so a `security`/`deps` scope routes correctly regardless of whether the PR is a fix or a feat. The type set matches exactly what the existing `pr-title` CI check (`.github/workflows/ci.yml`) already enforces — no non-standard types.
- Runs on `pull_request_target` so it can label fork PRs; safe because it only reads the title and never checks out or runs PR code.
- Creates the `ci`/`testing`/`security` labels on demand (they don't exist in the repo yet) so categorization never silently no-ops.
- Pinned to `actions/github-script@v8` per the CI-hygiene rule.

`.github/release.yml` is unchanged.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Workflow change (no app build). Validated the YAML parses and the embedded `github-script` body parses as an async function. The first real validation is the next release's `What's Changed`; already-open PRs pick up labels on their next edit/sync.

> [!NOTE]
> Forward-looking: v0.12.0's published notes are unchanged. The next tagged release will group correctly. This PR won't auto-label itself, since `pull_request_target` runs the workflow from the base branch where it doesn't exist yet.