### PR TITLE
docs: mark Graph view as supported in the comparison tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Glyph is built around speed, native feel, and offline-first usage. The tables be
 | Text-to-speech | ✅ | plugin | ❌ | ❌ | ❌ | ❌ | plugin |
 | Plugin / extension API | planned | ✅ | ❌ | ❌ | ⚠️ | ✅ | ✅ |
 | Cloud sync | ⚠️ Git-backed | paid | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Graph view | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | plugin |
+| Graph view | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | plugin |
 
 ### Platform
 


### PR DESCRIPTION
## Summary

The README's **Power features** comparison table still listed **Graph view** as ❌ for Glyph, even though graph view shipped (it's documented in the Features list, the `Cmd/Ctrl+G` shortcut table, and the **Navigation** comparison table, all showing ✅). This corrects the stale cell.

## Changes

- `README.md` — Power features table: Graph view for Glyph `❌` → `✅`.

## Note

"Graph view" appears in **two** comparison tables (Navigation and Power features). This PR only corrects the stale value; if you'd rather not list the same feature twice, the Power-features row could be dropped (it's already covered, accurately, under Navigation). Happy to do that in a follow-up if you prefer.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
