### PR TITLE
chore: migrate Homebrew tap and Scoop bucket to the glyph-md org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
             ### macOS
             ```bash
-            brew tap hamidfzm/tap && brew trust hamidfzm/tap && brew install --cask glyph
+            brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask glyph
             ```
             Or download `Glyph_*_universal.dmg` below.
 
@@ -80,7 +80,7 @@ jobs:
             choco install glyph
 
             # Scoop
-            scoop bucket add hamidfzm https://github.com/hamidfzm/scoop-bucket
+            scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
             scoop install glyph
             ```
             Or download `Glyph_*_x64_en-US.msi` below.
@@ -94,7 +94,7 @@ jobs:
             yay -S glyph-md-bin
 
             # Homebrew (Linuxbrew)
-            brew tap hamidfzm/tap && brew install glyph
+            brew tap glyph-md/tap && brew install glyph
 
             # Debian/Ubuntu (PPA)
             sudo add-apt-repository ppa:hamidfzm/glyph
@@ -129,7 +129,7 @@ jobs:
 
           ### macOS
           ```bash
-          brew tap hamidfzm/tap && brew trust hamidfzm/tap && brew install --cask glyph
+          brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask glyph
           ```
           Or download `Glyph_*_universal.dmg` below.
 
@@ -139,7 +139,7 @@ jobs:
           choco install glyph
 
           # Scoop
-          scoop bucket add hamidfzm https://github.com/hamidfzm/scoop-bucket
+          scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
           scoop install glyph
           ```
           Or download `Glyph_*_x64_en-US.msi` below.
@@ -153,7 +153,7 @@ jobs:
           yay -S glyph-md-bin
 
           # Homebrew (Linuxbrew)
-          brew tap hamidfzm/tap && brew install glyph
+          brew tap glyph-md/tap && brew install glyph
 
           # Debian/Ubuntu (PPA)
           sudo add-apt-repository ppa:hamidfzm/glyph
@@ -206,16 +206,16 @@ jobs:
             homebrew/glyph.rb.template > /tmp/glyph.rb
 
           # Get current file SHA for update (or empty for first push)
-          FILE_SHA=$(gh api repos/hamidfzm/homebrew-tap/contents/Casks/glyph.rb --jq .sha 2>/dev/null || echo "")
+          FILE_SHA=$(gh api repos/glyph-md/homebrew-tap/contents/Casks/glyph.rb --jq .sha 2>/dev/null || echo "")
 
           if [ -n "$FILE_SHA" ]; then
-            gh api repos/hamidfzm/homebrew-tap/contents/Casks/glyph.rb \
+            gh api repos/glyph-md/homebrew-tap/contents/Casks/glyph.rb \
               --method PUT \
               --field message="chore: update glyph to $VERSION" \
               --field content="$(base64 -w0 /tmp/glyph.rb)" \
               --field sha="$FILE_SHA"
           else
-            gh api repos/hamidfzm/homebrew-tap/contents/Casks/glyph.rb \
+            gh api repos/glyph-md/homebrew-tap/contents/Casks/glyph.rb \
               --method PUT \
               --field message="chore: add glyph cask $VERSION" \
               --field content="$(base64 -w0 /tmp/glyph.rb)"
@@ -248,16 +248,16 @@ jobs:
             homebrew/glyph-formula.rb.template > /tmp/glyph.rb
 
           # Get current file SHA for update (or empty for first push)
-          FILE_SHA=$(gh api repos/hamidfzm/homebrew-tap/contents/Formula/glyph.rb --jq .sha 2>/dev/null || echo "")
+          FILE_SHA=$(gh api repos/glyph-md/homebrew-tap/contents/Formula/glyph.rb --jq .sha 2>/dev/null || echo "")
 
           if [ -n "$FILE_SHA" ]; then
-            gh api repos/hamidfzm/homebrew-tap/contents/Formula/glyph.rb \
+            gh api repos/glyph-md/homebrew-tap/contents/Formula/glyph.rb \
               --method PUT \
               --field message="chore: update glyph linux formula to $VERSION" \
               --field content="$(base64 -w0 /tmp/glyph.rb)" \
               --field sha="$FILE_SHA"
           else
-            gh api repos/hamidfzm/homebrew-tap/contents/Formula/glyph.rb \
+            gh api repos/glyph-md/homebrew-tap/contents/Formula/glyph.rb \
               --method PUT \
               --field message="chore: add glyph linux formula $VERSION" \
               --field content="$(base64 -w0 /tmp/glyph.rb)"
@@ -372,16 +372,16 @@ jobs:
             scoop/glyph.json.template > /tmp/glyph.json
 
           # Get current file SHA for update (or empty for first push)
-          FILE_SHA=$(gh api repos/hamidfzm/scoop-bucket/contents/bucket/glyph.json --jq .sha 2>/dev/null || echo "")
+          FILE_SHA=$(gh api repos/glyph-md/scoop-bucket/contents/bucket/glyph.json --jq .sha 2>/dev/null || echo "")
 
           if [ -n "$FILE_SHA" ]; then
-            gh api repos/hamidfzm/scoop-bucket/contents/bucket/glyph.json \
+            gh api repos/glyph-md/scoop-bucket/contents/bucket/glyph.json \
               --method PUT \
               --field message="chore: update glyph to $VERSION" \
               --field content="$(base64 -w0 /tmp/glyph.json)" \
               --field sha="$FILE_SHA"
           else
-            gh api repos/hamidfzm/scoop-bucket/contents/bucket/glyph.json \
+            gh api repos/glyph-md/scoop-bucket/contents/bucket/glyph.json \
               --method PUT \
               --field message="chore: add glyph $VERSION" \
               --field content="$(base64 -w0 /tmp/glyph.json)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,8 @@ jobs:
             sudo apt install glyph
 
             # Debian (apt repo)
-            curl -fsSL https://glyph.md/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-            echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph.md/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+            curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+            echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
             sudo apt update && sudo apt install glyph
             ```
             Or download the `.deb` / `.AppImage` below.
@@ -161,8 +161,8 @@ jobs:
           sudo apt install glyph
 
           # Debian (apt repo)
-          curl -fsSL https://glyph.md/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph.md/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+          curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
           sudo apt update && sudo apt install glyph
           ```
           Or download the `.deb` / `.AppImage` below.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,8 @@ jobs:
             sudo apt install glyph
 
             # Debian (apt repo)
-            curl -fsSL https://hamidfzm.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-            echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://hamidfzm.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+            curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+            echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
             sudo apt update && sudo apt install glyph
             ```
             Or download the `.deb` / `.AppImage` below.
@@ -161,8 +161,8 @@ jobs:
           sudo apt install glyph
 
           # Debian (apt repo)
-          curl -fsSL https://hamidfzm.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://hamidfzm.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+          curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
           sudo apt update && sudo apt install glyph
           ```
           Or download the `.deb` / `.AppImage` below.
@@ -580,7 +580,7 @@ jobs:
           GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format long 2>/dev/null | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
 
           # Clone the apt repo
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/hamidfzm/apt-repo.git" /tmp/apt-repo
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/glyph-md/apt-repo.git" /tmp/apt-repo
           cd /tmp/apt-repo
 
           # Set up pool directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,8 @@ jobs:
             sudo apt install glyph
 
             # Debian (apt repo)
-            curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-            echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+            curl -fsSL https://glyph.md/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+            echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph.md/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
             sudo apt update && sudo apt install glyph
             ```
             Or download the `.deb` / `.AppImage` below.
@@ -161,8 +161,8 @@ jobs:
           sudo apt install glyph
 
           # Debian (apt repo)
-          curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+          curl -fsSL https://glyph.md/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph.md/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
           sudo apt update && sudo apt install glyph
           ```
           Or download the `.deb` / `.AppImage` below.

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ The [`samples/`](samples) directory is a tiny demo workspace — open it as a fo
 ### macOS (Homebrew)
 
 ```bash
-brew tap hamidfzm/tap
-brew trust hamidfzm/tap
+brew tap glyph-md/tap
+brew trust glyph-md/tap
 brew install --cask glyph
 ```
 
@@ -120,7 +120,7 @@ choco install glyph
 ### Windows (Scoop)
 
 ```powershell
-scoop bucket add hamidfzm https://github.com/hamidfzm/scoop-bucket
+scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
 scoop install glyph
 ```
 
@@ -139,7 +139,7 @@ yay -S glyph-md-bin
 ### Linux (Homebrew)
 
 ```bash
-brew tap hamidfzm/tap
+brew tap glyph-md/tap
 brew install glyph
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ sudo apt install glyph
 ### Debian
 
 ```bash
-curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+curl -fsSL https://glyph.md/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph.md/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
 sudo apt update
 sudo apt install glyph
 ```

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ sudo apt install glyph
 ### Debian
 
 ```bash
-curl -fsSL https://glyph.md/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph.md/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
 sudo apt update
 sudo apt install glyph
 ```

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ sudo apt install glyph
 ### Debian
 
 ```bash
-curl -fsSL https://hamidfzm.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://hamidfzm.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
 sudo apt update
 sudo apt install glyph
 ```


### PR DESCRIPTION
## Summary

The Homebrew tap and Scoop bucket have been transferred from the personal `hamidfzm` namespace to the `glyph-md` organization. This updates every reference in this repo to point at the new org. GitHub keeps automatic redirects from the old paths, so existing users are not broken.

Scope is **only** Homebrew and Scoop. apt-repo, PPA, AUR, Snap, and Chocolatey stay on `hamidfzm` for now.

> [!IMPORTANT]
> Do not merge until the website PR is ready so both land together. Also confirm `TAP_GITHUB_TOKEN` has write access to the `glyph-md` repos, or the release jobs that push the cask/formula/manifest will fail.

## Changes

- `README.md`: `brew tap glyph-md/tap` (macOS + Linux) and `scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket`
- `.github/workflows/release.yml`: same install snippets in the release body and generated notes, plus the `gh api repos/glyph-md/{homebrew-tap,scoop-bucket}` paths that publish the cask, Linux formula, and scoop manifest

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Docs + workflow YAML only; no app code changed. The publish paths are exercised by the next tagged release.

Refs #339
