### PR TITLE
fix(sidebar): dedupe same-line backlinks and stop file tree overlap

### DIFF
--- a/src/components/layout/FileTree.tsx
+++ b/src/components/layout/FileTree.tsx
@@ -418,7 +418,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: container only suppresses the native menu for empty-area right-clicks; keyboard users create via the menu reached from focusable rows
-    <div data-filetree-root className="min-h-20 flex-1" onContextMenu={handleRootContextMenu}>
+    <div data-filetree-root className="min-h-full" onContextMenu={handleRootContextMenu}>
       <ul className="space-y-0.5">{entries.map((entry) => renderEntry(entry, 0, childProps))}</ul>
       <ContextMenu menu={menu} onClose={closeMenu} />
     </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -120,27 +120,32 @@ export function Sidebar({ side }: SidebarProps) {
           </>
         }
       />
-      <FileTree
-        ref={fileTreeRef}
-        root={ws.root}
-        nodes={ws.nodes}
-        expanded={ws.expanded}
-        activeFilePath={activeFile?.path}
-        onToggle={onToggleExpand}
-        onOpenFile={onOpenFile}
-        onCreateNote={createNote}
-        onCreateCanvas={createCanvas}
-        onCreateFolder={createFolder}
-        onRename={renamePath}
-        onDuplicate={duplicatePath}
-        onMove={(path) => handleMove(ws.root, path)}
-        onReveal={(path) => {
-          void revealItemInDir(path);
-        }}
-        onDelete={deletePath}
-      />
+      {/* The tree scrolls inside its own region so a long file list can't spill
+          over the backlinks block pinned below it (visible when the panel is
+          short, e.g. with devtools open). */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <FileTree
+          ref={fileTreeRef}
+          root={ws.root}
+          nodes={ws.nodes}
+          expanded={ws.expanded}
+          activeFilePath={activeFile?.path}
+          onToggle={onToggleExpand}
+          onOpenFile={onOpenFile}
+          onCreateNote={createNote}
+          onCreateCanvas={createCanvas}
+          onCreateFolder={createFolder}
+          onRename={renamePath}
+          onDuplicate={duplicatePath}
+          onMove={(path) => handleMove(ws.root, path)}
+          onReveal={(path) => {
+            void revealItemInDir(path);
+          }}
+          onDelete={deletePath}
+        />
+      </div>
       {backlinks.length > 0 && (
-        <div className="mt-4 pt-3 border-t border-[var(--color-border)]">
+        <div className="mt-4 pt-3 border-t border-[var(--color-border)] shrink-0">
           <BacklinksSection backlinks={backlinks} workspaceRoot={ws.root} onOpen={onOpenFile} />
         </div>
       )}

--- a/src/lib/backlinks.test.ts
+++ b/src/lib/backlinks.test.ts
@@ -33,12 +33,27 @@ describe("filterBacklinks", () => {
 
   it("respects target syntax variants", () => {
     const refs = [
-      ref("/workspace/Index.md", "Cooking|kitchen"),
-      ref("/workspace/Index.md", "Cooking#Recipes"),
-      ref("/workspace/Index.md", "Cooking.md"),
+      ref("/workspace/Index.md", "Cooking|kitchen", 1),
+      ref("/workspace/Index.md", "Cooking#Recipes", 2),
+      ref("/workspace/Index.md", "Cooking.md", 3),
     ];
     const result = filterBacklinks(refs, workspaceFiles, "/workspace/Notes/Cooking.md");
     expect(result).toHaveLength(3);
+  });
+
+  it("collapses several same-line links to the current file into one row", () => {
+    // A single source line can mention the same target twice; the panel should
+    // surface it once (and never emit duplicate `source:line` React keys).
+    const refs = [
+      ref("/workspace/Index.md", "Cooking", 3),
+      ref("/workspace/Index.md", "Cooking|kitchen", 3),
+      ref("/workspace/Index.md", "Cooking", 9),
+    ];
+    const result = filterBacklinks(refs, workspaceFiles, "/workspace/Notes/Cooking.md");
+    expect(result.map((b) => [b.source, b.line])).toEqual([
+      ["/workspace/Index.md", 3],
+      ["/workspace/Index.md", 9],
+    ]);
   });
 
   it("ignores refs whose target resolves elsewhere", () => {

--- a/src/lib/backlinks.ts
+++ b/src/lib/backlinks.ts
@@ -27,6 +27,11 @@ export function filterBacklinks(
 
   const out: Backlink[] = [];
   const files = workspaceFiles as string[];
+  // One row per (source, line): a single line can hold several wikilinks to the
+  // same target (e.g. a sentence that mentions [[Graph View]] twice), which
+  // would otherwise surface as duplicate rows sharing the same snippet — and
+  // collide on the `source:line` React key in `BacklinksSection`.
+  const seen = new Set<string>();
   for (const ref of refs) {
     if (ref.source === currentFilePath) continue;
     // Strip the optional `|alias` — the resolver only cares about the target
@@ -35,6 +40,9 @@ export function filterBacklinks(
     const target = pipe >= 0 ? ref.target.slice(0, pipe) : ref.target;
     const resolved = resolveWikilink(target, files, ref.source);
     if (resolved.path === currentFilePath) {
+      const key = `${ref.source}:${ref.line}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
       out.push({ source: ref.source, line: ref.line, snippet: ref.snippet });
     }
   }


### PR DESCRIPTION
## Summary

Two pre-existing sidebar bugs, surfaced while testing a demo workspace and split out of the D2 PR (#343) per review.

- **Backlinks duplicate React key.** A single source line can link to the current note more than once (e.g. a sentence that mentions \`[[Graph View]]\` twice), which produced two backlink rows keyed \`source:line\` and a React duplicate-key warning. \`filterBacklinks\` now collapses to one row per \`(source, line)\` — the intended one-row-per-mention behaviour.
- **File tree / backlinks overlap.** The tree had no scroll region, so a long file list painted over the backlinks block pinned below it (most visible when the panel is short, e.g. devtools open). The tree now scrolls inside its own \`min-h-0\` overflow region.

## Testing

- \`pnpm typecheck && pnpm check && pnpm test\` (added a \`filterBacklinks\` dedup test).