### PR TITLE
refactor(contexts): split all providers from their context for Fast Refresh

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,6 @@
-import { SidebarLayoutProvider } from "@/contexts/SidebarLayoutContext";
+import { SidebarLayoutProvider } from "@/contexts/SidebarLayoutProvider";
 import { SyncConfigProvider } from "@/contexts/SyncConfigProvider";
-import { TabsProvider } from "@/contexts/TabsContext";
+import { TabsProvider } from "@/contexts/TabsProvider";
 import { useCodeThemeStyle } from "@/hooks/useCodeThemeStyle";
 import { useLocale } from "@/hooks/useLocale";
 import { useSettings } from "@/hooks/useSettings";

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import { SidebarLayoutProvider } from "@/contexts/SidebarLayoutContext";
-import { SyncConfigProvider } from "@/contexts/SyncConfigContext";
+import { SyncConfigProvider } from "@/contexts/SyncConfigProvider";
 import { TabsProvider } from "@/contexts/TabsContext";
 import { useCodeThemeStyle } from "@/hooks/useCodeThemeStyle";
 import { useLocale } from "@/hooks/useLocale";

--- a/src/components/layout/StatusBar.test.tsx
+++ b/src/components/layout/StatusBar.test.tsx
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SyncConfigProvider } from "@/contexts/SyncConfigContext";
+import { SyncConfigProvider } from "@/contexts/SyncConfigProvider";
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import type { FileTab, Workspace } from "@/hooks/useTabs";
 import { DEFAULT_SETTINGS } from "@/lib/settings";

--- a/src/components/markdown/MarkdownContent.tsx
+++ b/src/components/markdown/MarkdownContent.tsx
@@ -8,7 +8,7 @@ import remarkGemoji from "remark-gemoji";
 import remarkGfm from "remark-gfm";
 import { remarkAlert } from "remark-github-blockquote-alert";
 import remarkMath from "remark-math";
-import { LightboxProvider } from "@/contexts/LightboxContext";
+import { LightboxProvider } from "@/contexts/LightboxProvider";
 import { useWorkspaceRoot } from "@/contexts/TabsContext";
 import { useHighlightPlugin } from "@/hooks/useHighlightPlugin";
 import { useKatexPlugin } from "@/hooks/useKatexPlugin";

--- a/src/components/modals/SyncSettingsModal.test.tsx
+++ b/src/components/modals/SyncSettingsModal.test.tsx
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { SyncConfigProvider } from "@/contexts/SyncConfigContext";
+import { SyncConfigProvider } from "@/contexts/SyncConfigProvider";
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import type { Workspace } from "@/hooks/useTabs";
 import type { WorkspaceSyncConfig } from "@/lib/sync";

--- a/src/contexts/LightboxContext.test.tsx
+++ b/src/contexts/LightboxContext.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MarkdownImage } from "@/components/markdown/MarkdownImage";
-import { LightboxProvider, useLightbox } from "./LightboxContext";
+import { useLightbox } from "./LightboxContext";
+import { LightboxProvider } from "./LightboxProvider";
 
 function renderDoc() {
   return render(

--- a/src/contexts/LightboxContext.ts
+++ b/src/contexts/LightboxContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+// Context + hook for the image lightbox. Kept in a component-free module so the
+// provider file stays Fast-Refresh-eligible (a file that exports a component
+// plus a hook/context bails out of React Fast Refresh). The provider lives in
+// `LightboxProvider.tsx`.
+
+export interface LightboxContextValue {
+  /** Open the lightbox, starting at the clicked image. */
+  open: (img: HTMLImageElement) => void;
+}
+
+export const LightboxContext = createContext<LightboxContextValue | null>(null);
+
+/** Returns the lightbox API, or null when rendered outside a provider. */
+export function useLightbox(): LightboxContextValue | null {
+  return useContext(LightboxContext);
+}

--- a/src/contexts/LightboxProvider.tsx
+++ b/src/contexts/LightboxProvider.tsx
@@ -1,13 +1,7 @@
-import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { Lightbox } from "@/components/markdown/Lightbox";
 import type { LightboxImage } from "@/lib/lightbox";
-
-interface LightboxContextValue {
-  /** Open the lightbox, starting at the clicked image. */
-  open: (img: HTMLImageElement) => void;
-}
-
-const LightboxContext = createContext<LightboxContextValue | null>(null);
+import { LightboxContext, type LightboxContextValue } from "./LightboxContext";
 
 interface LightboxState {
   images: LightboxImage[];
@@ -53,9 +47,4 @@ export function LightboxProvider({ children }: { children: ReactNode }) {
       )}
     </LightboxContext.Provider>
   );
-}
-
-/** Returns the lightbox API, or null when rendered outside a provider. */
-export function useLightbox(): LightboxContextValue | null {
-  return useContext(LightboxContext);
 }

--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -2,8 +2,9 @@ import { load } from "@tauri-apps/plugin-store";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { useContext } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_SETTINGS } from "../lib/settings";
-import { SettingsContext, SettingsProvider } from "./SettingsContext";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
+import { SettingsContext } from "./SettingsContext";
+import { SettingsProvider } from "./SettingsProvider";
 
 const mockedLoad = vi.mocked(load);
 const realMatchMedia = window.matchMedia;

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -1,0 +1,21 @@
+import { createContext } from "react";
+import { DEFAULT_SETTINGS, type Settings } from "@/lib/settings";
+
+// Context for app settings. Kept in a component-free module so the provider
+// file stays Fast-Refresh-eligible (a file that exports a component plus a
+// context bails out of React Fast Refresh). The provider lives in
+// `SettingsProvider.tsx`; the consumer hook is `@/hooks/useSettings`.
+
+export interface SettingsContextValue {
+  settings: Settings;
+  updateSettings: (path: string, value: unknown) => void;
+  resetSettings: () => void;
+  loaded: boolean;
+}
+
+export const SettingsContext = createContext<SettingsContextValue>({
+  settings: DEFAULT_SETTINGS,
+  updateSettings: () => {},
+  resetSettings: () => {},
+  loaded: false,
+});

--- a/src/contexts/SettingsProvider.tsx
+++ b/src/contexts/SettingsProvider.tsx
@@ -1,27 +1,14 @@
 import { load, type Store } from "@tauri-apps/plugin-store";
-import { createContext, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import {
   CONTENT_WIDTH_MAP,
   DEFAULT_SETTINGS,
   FONT_FAMILY_MAP,
   LINE_HEIGHT_MAP,
   type Settings,
-} from "../lib/settings";
-import { deepMerge, setNestedValue } from "../lib/settingsObject";
-
-export interface SettingsContextValue {
-  settings: Settings;
-  updateSettings: (path: string, value: unknown) => void;
-  resetSettings: () => void;
-  loaded: boolean;
-}
-
-export const SettingsContext = createContext<SettingsContextValue>({
-  settings: DEFAULT_SETTINGS,
-  updateSettings: () => {},
-  resetSettings: () => {},
-  loaded: false,
-});
+} from "@/lib/settings";
+import { deepMerge, setNestedValue } from "@/lib/settingsObject";
+import { SettingsContext } from "./SettingsContext";
 
 function applyTheme(theme: Settings["appearance"]["theme"]) {
   if (theme === "system") {

--- a/src/contexts/SidebarLayoutContext.test.tsx
+++ b/src/contexts/SidebarLayoutContext.test.tsx
@@ -2,7 +2,8 @@ import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
-import { SidebarLayoutProvider, useSidebarLayoutContext } from "./SidebarLayoutContext";
+import { useSidebarLayoutContext } from "./SidebarLayoutContext";
+import { SidebarLayoutProvider } from "./SidebarLayoutProvider";
 
 // SidebarLayoutProvider reads settings from SettingsContext, which defaults to
 // DEFAULT_SETTINGS when no SettingsProvider is mounted.

--- a/src/contexts/SidebarLayoutContext.ts
+++ b/src/contexts/SidebarLayoutContext.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext } from "react";
+import type { useSidebarLayout } from "@/hooks/useSidebarLayout";
+import type { SidebarLayout } from "@/lib/settings";
+
+// Context + hook for the sidebar layout. Kept in a component-free module so the
+// provider file stays Fast-Refresh-eligible (a file that exports a component
+// plus a hook/context bails out of React Fast Refresh). The provider lives in
+// `SidebarLayoutProvider.tsx`.
+
+type SidebarLayoutApi = ReturnType<typeof useSidebarLayout>;
+
+export interface SidebarLayoutContextValue extends SidebarLayoutApi {
+  sidebarLayout: SidebarLayout;
+  swapSidebarSides: boolean;
+  sidebarWidth: number | undefined;
+}
+
+export const SidebarLayoutContext = createContext<SidebarLayoutContextValue | null>(null);
+
+export function useSidebarLayoutContext(): SidebarLayoutContextValue {
+  const ctx = useContext(SidebarLayoutContext);
+  if (!ctx) throw new Error("useSidebarLayoutContext must be used inside <SidebarLayoutProvider>");
+  return ctx;
+}

--- a/src/contexts/SidebarLayoutProvider.tsx
+++ b/src/contexts/SidebarLayoutProvider.tsx
@@ -1,17 +1,7 @@
-import { createContext, type ReactNode, useContext, useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import { useSettings } from "@/hooks/useSettings";
 import { useSidebarLayout } from "@/hooks/useSidebarLayout";
-import type { SidebarLayout } from "@/lib/settings";
-
-type SidebarLayoutApi = ReturnType<typeof useSidebarLayout>;
-
-export interface SidebarLayoutContextValue extends SidebarLayoutApi {
-  sidebarLayout: SidebarLayout;
-  swapSidebarSides: boolean;
-  sidebarWidth: number | undefined;
-}
-
-export const SidebarLayoutContext = createContext<SidebarLayoutContextValue | null>(null);
+import { SidebarLayoutContext, type SidebarLayoutContextValue } from "./SidebarLayoutContext";
 
 export function SidebarLayoutProvider({ children }: { children: ReactNode }) {
   const { settings, updateSettings } = useSettings();
@@ -37,10 +27,4 @@ export function SidebarLayoutProvider({ children }: { children: ReactNode }) {
   );
 
   return <SidebarLayoutContext.Provider value={value}>{children}</SidebarLayoutContext.Provider>;
-}
-
-export function useSidebarLayoutContext(): SidebarLayoutContextValue {
-  const ctx = useContext(SidebarLayoutContext);
-  if (!ctx) throw new Error("useSidebarLayoutContext must be used inside <SidebarLayoutProvider>");
-  return ctx;
 }

--- a/src/contexts/SyncConfigContext.test.tsx
+++ b/src/contexts/SyncConfigContext.test.tsx
@@ -5,7 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SyncStatusIndicator } from "@/components/layout/SyncStatusIndicator";
 import type { Workspace } from "@/hooks/useTabs";
 import type { WorkspaceSyncConfig } from "@/lib/sync";
-import { SyncConfigProvider, useSyncConfigContext } from "./SyncConfigContext";
+import { useSyncConfigContext } from "./SyncConfigContext";
+import { SyncConfigProvider } from "./SyncConfigProvider";
 import { TabsContext, type TabsContextValue } from "./TabsContext";
 
 beforeEach(() => {

--- a/src/contexts/SyncConfigContext.ts
+++ b/src/contexts/SyncConfigContext.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from "react";
+import type { useSyncConfig } from "@/hooks/useSyncConfig";
+
+// Context + hook for the active workspace's sync config. Kept in a component-free
+// module so the provider file stays Fast-Refresh-eligible (a file that exports a
+// component plus a hook/context bails out of React Fast Refresh). The provider
+// lives in `SyncConfigProvider.tsx`.
+
+type SyncConfigApi = ReturnType<typeof useSyncConfig>;
+
+export interface SyncConfigContextValue extends SyncConfigApi {
+  /** Active folder workspace root, or null when no folder tab is active. */
+  workspacePath: string | null;
+}
+
+export const SyncConfigContext = createContext<SyncConfigContextValue | null>(null);
+
+export function useSyncConfigContext(): SyncConfigContextValue {
+  const ctx = useContext(SyncConfigContext);
+  if (!ctx) throw new Error("useSyncConfigContext must be used inside <SyncConfigProvider>");
+  return ctx;
+}

--- a/src/contexts/SyncConfigProvider.tsx
+++ b/src/contexts/SyncConfigProvider.tsx
@@ -1,5 +1,6 @@
-import { createContext, type ReactNode, useContext, useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import { useSyncConfig } from "@/hooks/useSyncConfig";
+import { SyncConfigContext, type SyncConfigContextValue } from "./SyncConfigContext";
 import { useTabsContext } from "./TabsContext";
 
 // Single source of truth for the active workspace's sync config. Both the
@@ -7,16 +8,6 @@ import { useTabsContext } from "./TabsContext";
 // disabling sync (or running one) in the modal is reflected on the pill
 // immediately — they share one `useSyncConfig` instance instead of each
 // holding a stale copy.
-
-type SyncConfigApi = ReturnType<typeof useSyncConfig>;
-
-export interface SyncConfigContextValue extends SyncConfigApi {
-  /** Active folder workspace root, or null when no folder tab is active. */
-  workspacePath: string | null;
-}
-
-export const SyncConfigContext = createContext<SyncConfigContextValue | null>(null);
-
 export function SyncConfigProvider({ children }: { children: ReactNode }) {
   const { workspace } = useTabsContext();
   const workspacePath = workspace?.root ?? null;
@@ -28,10 +19,4 @@ export function SyncConfigProvider({ children }: { children: ReactNode }) {
   );
 
   return <SyncConfigContext.Provider value={value}>{children}</SyncConfigContext.Provider>;
-}
-
-export function useSyncConfigContext(): SyncConfigContextValue {
-  const ctx = useContext(SyncConfigContext);
-  if (!ctx) throw new Error("useSyncConfigContext must be used inside <SyncConfigProvider>");
-  return ctx;
 }

--- a/src/contexts/TabsContext.test.tsx
+++ b/src/contexts/TabsContext.test.tsx
@@ -5,10 +5,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   TabsContext,
   type TabsContextValue,
-  TabsProvider,
   useTabsContext,
   useWorkspaceRoot,
 } from "./TabsContext";
+import { TabsProvider } from "./TabsProvider";
 
 // Mock invoke so opening a file resolves with content/metadata. `read_file`
 // echoes a marker derived from the path so we can assert which file is active.

--- a/src/contexts/TabsContext.ts
+++ b/src/contexts/TabsContext.ts
@@ -1,0 +1,42 @@
+import { createContext, useContext } from "react";
+import type { TocEntry } from "@/hooks/useTableOfContents";
+import type { useTabs } from "@/hooks/useTabs";
+import type { WorkspaceNotice } from "@/hooks/useWorkspaceNotice";
+import type { Backlink } from "@/lib/backlinks";
+
+// Context + hooks for the tabs/workspace state. Kept in a component-free module
+// so the provider file stays Fast-Refresh-eligible (a file that exports a
+// component plus a hook/context bails out of React Fast Refresh). The provider
+// lives in `TabsProvider.tsx`.
+
+type TabsApi = ReturnType<typeof useTabs>;
+
+export interface TabsContextValue extends TabsApi {
+  // Derived from the active file + edit mode. View mode renders saved content;
+  // edit/split renders the in-memory editContent so preview reflects typing.
+  displayContent: string | null;
+  tocEntries: TocEntry[];
+  backlinks: Backlink[];
+  // Notice shown for a workspace event (#262): a refusal, or a persistent
+  // warning when a folder is opened inside a parent git repo. A translation
+  // key + values so the banner re-localizes live (see WorkspaceNoticeBanner).
+  workspaceNotice: WorkspaceNotice | null;
+  dismissWorkspaceNotice: () => void;
+}
+
+export const TabsContext = createContext<TabsContextValue | null>(null);
+
+export function useTabsContext(): TabsContextValue {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error("useTabsContext must be used inside <TabsProvider>");
+  return ctx;
+}
+
+// The opened workspace folder's root (or undefined when only loose files are
+// open), read straight from the tabs context. Uses optional chaining rather
+// than useTabsContext so the shared renderers (notebooks, canvas, print, and
+// isolated tests) can read it with no provider and simply skip workspace
+// resolution.
+export function useWorkspaceRoot(): string | undefined {
+  return useContext(TabsContext)?.workspace?.root;
+}

--- a/src/contexts/TabsProvider.tsx
+++ b/src/contexts/TabsProvider.tsx
@@ -1,28 +1,12 @@
-import { createContext, type ReactNode, useContext, useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import { useSettings } from "@/hooks/useSettings";
-import { type TocEntry, useTableOfContents } from "@/hooks/useTableOfContents";
+import { useTableOfContents } from "@/hooks/useTableOfContents";
 import { useTabs } from "@/hooks/useTabs";
-import { useWorkspaceNotice, type WorkspaceNotice } from "@/hooks/useWorkspaceNotice";
-import { type Backlink, filterBacklinks } from "@/lib/backlinks";
+import { useWorkspaceNotice } from "@/hooks/useWorkspaceNotice";
+import { filterBacklinks } from "@/lib/backlinks";
 import { displayContentFor, tocContentFor } from "@/lib/displayContent";
 import { EDITOR_MODE } from "@/lib/settings";
-
-type TabsApi = ReturnType<typeof useTabs>;
-
-export interface TabsContextValue extends TabsApi {
-  // Derived from the active file + edit mode. View mode renders saved content;
-  // edit/split renders the in-memory editContent so preview reflects typing.
-  displayContent: string | null;
-  tocEntries: TocEntry[];
-  backlinks: Backlink[];
-  // Notice shown for a workspace event (#262): a refusal, or a persistent
-  // warning when a folder is opened inside a parent git repo. A translation
-  // key + values so the banner re-localizes live (see WorkspaceNoticeBanner).
-  workspaceNotice: WorkspaceNotice | null;
-  dismissWorkspaceNotice: () => void;
-}
-
-export const TabsContext = createContext<TabsContextValue | null>(null);
+import { TabsContext, type TabsContextValue } from "./TabsContext";
 
 export function TabsProvider({ children }: { children: ReactNode }) {
   const { settings, updateSettings } = useSettings();
@@ -77,19 +61,4 @@ export function TabsProvider({ children }: { children: ReactNode }) {
   );
 
   return <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
-}
-
-export function useTabsContext(): TabsContextValue {
-  const ctx = useContext(TabsContext);
-  if (!ctx) throw new Error("useTabsContext must be used inside <TabsProvider>");
-  return ctx;
-}
-
-// The opened workspace folder's root (or undefined when only loose files are
-// open), read straight from the tabs context. Uses optional chaining rather
-// than useTabsContext so the shared renderers (notebooks, canvas, print, and
-// isolated tests) can read it with no provider and simply skip workspace
-// resolution.
-export function useWorkspaceRoot(): string | undefined {
-  return useContext(TabsContext)?.workspace?.root;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./components/App";
 import { ErrorFallback } from "./components/ErrorFallback";
-import { SettingsProvider } from "./contexts/SettingsContext";
+import { SettingsProvider } from "./contexts/SettingsProvider";
 import "./styles/app.css";
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## Summary

A file that exports a component **plus** a hook/context bails out of React Fast Refresh, the `"…Context" export is incompatible` HMR warning, which forces full reloads during development.

Split every context provider in `src/contexts/` so the provider file exports only its component. Each `XContext.ts` holds the context object, value type, and consumer hook(s); each `XProvider.tsx` holds just the `XProvider` component. Most consumers import the hook/context and are untouched (the `XContext` path is preserved), only provider importers move to `XProvider`. Also satisfies the one-component-per-file rule.

Providers split:

- `SyncConfig` → `SyncConfigContext.ts` + `SyncConfigProvider.tsx`
- `Lightbox` → `LightboxContext.ts` (+ `useLightbox`) + `LightboxProvider.tsx`
- `SidebarLayout` → `SidebarLayoutContext.ts` (+ `useSidebarLayoutContext`) + `SidebarLayoutProvider.tsx`
- `Tabs` → `TabsContext.ts` (+ `useTabsContext`, `useWorkspaceRoot`) + `TabsProvider.tsx`
- `Settings` → `SettingsContext.ts` + `SettingsProvider.tsx`

## Testing

- `pnpm typecheck && pnpm check && pnpm test`.