### PR TITLE
docs: drop the Keyboard Shortcuts table from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,27 +222,6 @@ pnpm check                      # Lint + format + organize imports
 cd src-tauri && cargo clippy    # Lint Rust
 ```
 
-## Keyboard Shortcuts
-
-| Shortcut | Action |
-|----------|--------|
-| `Cmd+O` / `Ctrl+O` | Open file(s) |
-| `Cmd+Shift+O` / `Ctrl+Shift+O` | Open folder |
-| `Cmd+K` / `Ctrl+K` | Command palette (files, headings, app actions) |
-| `Cmd+G` / `Ctrl+G` | Open workspace graph |
-| `Cmd+P` / `Ctrl+P` | Print / Export to PDF |
-| `Cmd+F` / `Ctrl+F` | Find in document |
-| `Cmd+=` / `Ctrl+=` | Zoom in |
-| `Cmd+-` / `Ctrl+-` | Zoom out |
-| `Cmd+0` / `Ctrl+0` | Reset zoom |
-| `Cmd+Z` / `Ctrl+Z` | Undo last in-document edit (e.g. task checkbox toggle) |
-| `Cmd+Shift+Z` / `Ctrl+Shift+Z` (also `Ctrl+Y` on Windows/Linux) | Redo |
-| `Cmd+B` / `Ctrl+B` | Toggle files sidebar |
-| `Cmd+\` / `Ctrl+\` | Toggle outline sidebar |
-| `Cmd+,` / `Ctrl+,` | Settings |
-| `Cmd+W` / `Ctrl+W` | Close tab |
-| `Cmd+Shift+W` / `Ctrl+Shift+W` | Close window |
-
 ## Comparison with Other Markdown Apps
 
 Glyph is built around speed, native feel, and offline-first usage. The tables below compare its current capabilities against widely used markdown apps. Items marked "planned" track to issues on the [roadmap](https://github.com/hamidfzm/glyph/issues).


### PR DESCRIPTION
## Summary

Removes the **Keyboard Shortcuts** table from the README. The table duplicates what the in-app native menus and the Settings → Editor keybindings already show, and it drifts out of sync as shortcuts change.

## Changes

- Delete the `## Keyboard Shortcuts` section and its table from `README.md`.

## Testing

- Docs-only change; no code touched. The pre-commit gate (`pnpm typecheck`, `pnpm test`, `cargo test`, `cargo clippy`) passed on commit.

## Screenshots

N/A (README content removal).
