### PR TITLE
feat(export): embed diagrams and SVG images as vectors in PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 - Zoom in/out: `Cmd/Ctrl+=/-/0` with zoom level in status bar
 - Table of Contents sidebar with active heading tracking
 - Print: `Cmd/Ctrl+P` with configurable page breaks, optional TOC, and theme-color control
-- Export to HTML, Word (DOCX), EPUB, and PDF via `File → Export`: works for markdown documents and Jupyter notebooks, writes a file directly (no print dialog), and reuses the rendered output (math, code highlighting, tables, images inlined) so files are self-contained and offline. Task-list checkboxes are read-only in exports; exported HTML follows the reader's light/dark system preference.
+- Export to HTML, Word (DOCX), EPUB, and PDF via `File → Export`: works for markdown documents and Jupyter notebooks, writes a file directly (no print dialog), and reuses the rendered output (math, code highlighting, tables, images inlined) so files are self-contained and offline. Mermaid and D2 diagrams and SVG images embed in the PDF as true vectors, so they stay crisp at any zoom. Task-list checkboxes are read-only in exports; exported HTML follows the reader's light/dark system preference.
 - Live reload: file watcher auto-updates on external changes
 - Undo / redo for in-document edits: `Cmd/Ctrl+Z` and `Cmd/Ctrl+Shift+Z` reverse task-list checkbox toggles and other programmatic edits per tab
 - Drag and drop markdown files, notebooks, canvases, or folders to open

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -159,7 +159,8 @@ export function useExport({
         const prepared = await prepareContent({
           entries,
           includeToc,
-          // PDF needs inlined code colors + rasterized math/diagrams.
+          // PDF needs inlined code colors, rasterized math, and diagrams
+          // re-rendered light as inline SVG for vector embedding.
           pdf: format === "pdf",
         });
         // The body can vanish if the file is closed during the (async) save

--- a/src/lib/export/htmlToPdf.test.ts
+++ b/src/lib/export/htmlToPdf.test.ts
@@ -36,32 +36,6 @@ describe("convertHtmlToPdf", () => {
     expect(json).not.toContain('"svg"');
   });
 
-  it("sizes a vector SVG from its width attribute, capped at the content width", () => {
-    const [sized] = convertHtmlToPdf('<svg width="120" height="60"><rect/></svg>') as [
-      { svg: string; width: number },
-    ];
-    expect(sized.width).toBe(120);
-    expect(sized.svg).toContain("<rect");
-    // The sanitizer strips xmlns from diagram SVGs; the embed restores it.
-    expect(sized.svg).toContain('xmlns="http://www.w3.org/2000/svg"');
-
-    const [capped] = convertHtmlToPdf('<svg width="2000"><rect/></svg>') as [
-      { svg: string; width: number },
-    ];
-    expect(capped.width).toBe(515);
-  });
-
-  it("sizes a vector SVG from its viewBox when width is missing or relative", () => {
-    // Mermaid emits width="100%" plus a viewBox; the viewBox wins.
-    const [node] = convertHtmlToPdf('<svg width="100%" viewBox="0 0 240 80"><rect/></svg>') as [
-      { svg: string; width: number },
-    ];
-    expect(node.width).toBe(240);
-    // No usable size at all falls back to the full content width.
-    const [fallback] = convertHtmlToPdf("<svg><rect/></svg>") as [{ svg: string; width: number }];
-    expect(fallback.width).toBe(515);
-  });
-
   it("embeds a data:image/svg+xml image as a vector svg node", () => {
     const markup = '<svg width="90" height="30"><circle r="9"/></svg>';
     const uri = `data:image/svg+xml,${encodeURIComponent(markup)}`;

--- a/src/lib/export/htmlToPdf.test.ts
+++ b/src/lib/export/htmlToPdf.test.ts
@@ -18,13 +18,62 @@ describe("convertHtmlToPdf", () => {
     expect(content.some((c) => typeof c === "object" && c !== null && "table" in c)).toBe(true);
   });
 
-  it("reduces KaTeX to its LaTeX source and drops SVG diagrams", () => {
+  it("reduces KaTeX to its LaTeX source; a block-level SVG embeds as a vector node", () => {
     const content = convertHtmlToPdf(
       '<p><span class="katex"><annotation encoding="application/x-tex">x^2</annotation></span></p>' +
         "<svg><path/></svg>",
     );
-    // The paragraph keeps the LaTeX; the bare <svg> contributes no block.
-    expect(JSON.stringify(content)).toContain("x^2");
+    const json = JSON.stringify(content);
+    expect(json).toContain("x^2");
+    expect(json).toContain('"svg"');
+  });
+
+  it("skips an SVG at inline position (only block-level SVG embeds)", () => {
+    const content = convertHtmlToPdf("<p>before<svg><rect/></svg>after</p>");
+    const json = JSON.stringify(content);
+    expect(json).toContain("before");
+    expect(json).toContain("after");
+    expect(json).not.toContain('"svg"');
+  });
+
+  it("sizes a vector SVG from its width attribute, capped at the content width", () => {
+    const [sized] = convertHtmlToPdf('<svg width="120" height="60"><rect/></svg>') as [
+      { svg: string; width: number },
+    ];
+    expect(sized.width).toBe(120);
+    expect(sized.svg).toContain("<rect");
+    // The sanitizer strips xmlns from diagram SVGs; the embed restores it.
+    expect(sized.svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+
+    const [capped] = convertHtmlToPdf('<svg width="2000"><rect/></svg>') as [
+      { svg: string; width: number },
+    ];
+    expect(capped.width).toBe(515);
+  });
+
+  it("sizes a vector SVG from its viewBox when width is missing or relative", () => {
+    // Mermaid emits width="100%" plus a viewBox; the viewBox wins.
+    const [node] = convertHtmlToPdf('<svg width="100%" viewBox="0 0 240 80"><rect/></svg>') as [
+      { svg: string; width: number },
+    ];
+    expect(node.width).toBe(240);
+    // No usable size at all falls back to the full content width.
+    const [fallback] = convertHtmlToPdf("<svg><rect/></svg>") as [{ svg: string; width: number }];
+    expect(fallback.width).toBe(515);
+  });
+
+  it("embeds a data:image/svg+xml image as a vector svg node", () => {
+    const markup = '<svg width="90" height="30"><circle r="9"/></svg>';
+    const uri = `data:image/svg+xml,${encodeURIComponent(markup)}`;
+    const [node] = convertHtmlToPdf(`<p><img src="${uri}"></p>`) as [
+      { svg: string; width: number },
+    ];
+    expect(node.svg).toContain("<circle");
+    expect(node.width).toBe(90);
+
+    const base64 = `data:image/svg+xml;base64,${btoa(markup)}`;
+    const [b64Node] = convertHtmlToPdf(`<img src="${base64}">`) as [{ svg: string }];
+    expect(b64Node.svg).toContain("<circle");
   });
 
   it("always returns at least one node for empty input", () => {

--- a/src/lib/export/htmlToPdf.ts
+++ b/src/lib/export/htmlToPdf.ts
@@ -1,9 +1,7 @@
 import type { Content, TableCell } from "pdfmake/interfaces";
-import { decodeSvgDataUrl, ensureSvgXmlns } from "@/lib/svgDataUrl";
+import { decodeSvgDataUrl } from "@/lib/svgDataUrl";
 import { decodeDataUri } from "./imageSize";
-
-// Page content width for an A4 page with default pdfmake margins (~40pt each).
-const CONTENT_WIDTH = 515;
+import { CONTENT_WIDTH, svgNode } from "./svgPdfNode";
 
 interface InlineStyle {
   bold?: boolean;
@@ -139,34 +137,6 @@ function codeRuns(pre: Element, baseColor?: string): Content[] {
     if (!last.text) runs.pop();
   }
   return runs.length ? runs : [{ text: "" }];
-}
-
-// Intrinsic width of an <svg>, from its width attribute (ignoring relative
-// values like "100%", which Mermaid emits) or the viewBox. Null when neither
-// yields a usable number.
-function svgWidth(el: Element): number | null {
-  const attr = el.getAttribute("width")?.trim();
-  if (attr && !attr.endsWith("%")) {
-    const w = Number.parseFloat(attr);
-    if (Number.isFinite(w) && w > 0) return w;
-  }
-  const viewBox = el
-    .getAttribute("viewBox")
-    ?.trim()
-    .split(/[\s,]+/);
-  if (viewBox?.length === 4) {
-    const w = Number.parseFloat(viewBox[2]);
-    if (Number.isFinite(w) && w > 0) return w;
-  }
-  return null;
-}
-
-// Embed an <svg> element as a pdfmake vector node, scaled down to the page
-// content width when wider. `ensureSvgXmlns` mirrors the data-URL path: the
-// sanitizer strips the namespace from D2/Mermaid output.
-function svgNode(el: Element): Content {
-  const width = Math.min(svgWidth(el) ?? CONTENT_WIDTH, CONTENT_WIDTH);
-  return { svg: ensureSvgXmlns(el.outerHTML), width, margin: [0, 0, 0, 8] };
 }
 
 function imageNode(el: Element): Content | null {

--- a/src/lib/export/htmlToPdf.ts
+++ b/src/lib/export/htmlToPdf.ts
@@ -1,4 +1,5 @@
 import type { Content, TableCell } from "pdfmake/interfaces";
+import { decodeSvgDataUrl, ensureSvgXmlns } from "@/lib/svgDataUrl";
 import { decodeDataUri } from "./imageSize";
 
 // Page content width for an A4 page with default pdfmake margins (~40pt each).
@@ -50,8 +51,9 @@ function styledText(text: string, style: InlineStyle): Content {
 
 // Flatten an element's inline descendants into pdfmake text fragments. Anchors
 // become links; `<br>` becomes a newline; KaTeX falls back to its LaTeX source;
-// raw SVG (Mermaid) is skipped. Inline images degrade to their alt text — block
-// images are handled separately and embedded.
+// an SVG at inline position is skipped (block-level SVG embeds as a vector
+// node). Inline images degrade to their alt text — block images are handled
+// separately and embedded.
 function inlinePdf(node: Node, style: InlineStyle = {}): Content[] {
   const out: Content[] = [];
   for (const child of Array.from(node.childNodes)) {
@@ -139,10 +141,44 @@ function codeRuns(pre: Element, baseColor?: string): Content[] {
   return runs.length ? runs : [{ text: "" }];
 }
 
+// Intrinsic width of an <svg>, from its width attribute (ignoring relative
+// values like "100%", which Mermaid emits) or the viewBox. Null when neither
+// yields a usable number.
+function svgWidth(el: Element): number | null {
+  const attr = el.getAttribute("width")?.trim();
+  if (attr && !attr.endsWith("%")) {
+    const w = Number.parseFloat(attr);
+    if (Number.isFinite(w) && w > 0) return w;
+  }
+  const viewBox = el
+    .getAttribute("viewBox")
+    ?.trim()
+    .split(/[\s,]+/);
+  if (viewBox?.length === 4) {
+    const w = Number.parseFloat(viewBox[2]);
+    if (Number.isFinite(w) && w > 0) return w;
+  }
+  return null;
+}
+
+// Embed an <svg> element as a pdfmake vector node, scaled down to the page
+// content width when wider. `ensureSvgXmlns` mirrors the data-URL path: the
+// sanitizer strips the namespace from D2/Mermaid output.
+function svgNode(el: Element): Content {
+  const width = Math.min(svgWidth(el) ?? CONTENT_WIDTH, CONTENT_WIDTH);
+  return { svg: ensureSvgXmlns(el.outerHTML), width, margin: [0, 0, 0, 8] };
+}
+
 function imageNode(el: Element): Content | null {
   const src = el.getAttribute("src") ?? "";
+  // An SVG image (inlined by prepareContent as a data: URL) embeds as vectors.
+  const svgMarkup = decodeSvgDataUrl(src);
+  if (svgMarkup !== null) {
+    const svgEl = new DOMParser().parseFromString(svgMarkup, "text/html").body.querySelector("svg");
+    return svgEl ? svgNode(svgEl) : null;
+  }
   const decoded = decodeDataUri(src);
-  // pdfmake embeds PNG and JPEG; other formats are skipped.
+  // pdfmake embeds PNG and JPEG; other raster formats are skipped.
   if (!decoded || (decoded.type !== "png" && decoded.type !== "jpg")) return null;
   const width = Math.min(decoded.width, CONTENT_WIDTH);
   return { image: src, width, margin: [0, 0, 0, 8] };
@@ -271,7 +307,7 @@ function blocksForNode(node: Node, ctx: Ctx): Content[] {
     ];
   }
   if (tag === "table") return [tableNode(el)];
-  if (tag === "svg") return [];
+  if (tag === "svg") return [svgNode(el)];
   if (tag === "img") {
     const img = imageNode(el);
     return img ? [img] : [];
@@ -289,9 +325,9 @@ function blocksForNode(node: Node, ctx: Ctx): Content[] {
 }
 
 /**
- * Walk a prepared HTML fragment into a pdfmake content array. Reuses the docx
- * walker's structure and fidelity tradeoffs: math becomes LaTeX source and SVG
- * diagrams are dropped, since a vector PDF has no faithful equivalent.
+ * Walk a prepared HTML fragment into a pdfmake content array. Block-level SVG
+ * (light-rendered diagrams, SVG images) embeds as vector `svg` nodes; inline
+ * math falls back to its LaTeX source, matching the docx walker.
  */
 export function convertHtmlToPdf(bodyHtml: string): Content[] {
   const doc = new DOMParser().parseFromString(bodyHtml, "text/html");

--- a/src/lib/export/pdf.test.ts
+++ b/src/lib/export/pdf.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildPdf } from "./pdf";
 
 describe("buildPdf", () => {
@@ -22,5 +22,50 @@ describe("buildPdf", () => {
       '<p><a href="https://example.com">link</a></p>';
     const bytes = await buildPdf(html, { title: "Doc" });
     expect(bytes.length).toBeGreaterThan(100);
+  });
+
+  it("embeds a vector SVG diagram through the real engine", async () => {
+    // Exercises pdfmake's actual svg-to-pdfkit path with a diagram-shaped SVG.
+    const html =
+      "<h1>Diagram</h1>" +
+      '<svg width="120" height="60" viewBox="0 0 120 60">' +
+      '<rect x="4" y="4" width="112" height="52" fill="#ffdfb5" stroke="#0d32b2"/>' +
+      '<text x="60" y="35" text-anchor="middle" fill="#0d32b2">node</text>' +
+      "</svg>";
+    const bytes = await buildPdf(html, { title: "Doc" });
+    expect(Array.from(bytes.slice(0, 4))).toEqual([0x25, 0x50, 0x44, 0x46]);
+  });
+});
+
+describe("buildPdf raster fallback", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("retries once with rasterized SVGs when the vector build throws", async () => {
+    const getBuffer = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("unsupported svg"))
+      .mockResolvedValue(new ArrayBuffer(8));
+    const createPdf = vi.fn(() => ({ getBuffer }));
+    vi.doMock("./pdfEngine", () => ({ pdfEngine: () => ({ createPdf }) }));
+    const rasterizeSvgsInHtml = vi.fn(async () => "<p>rasterized</p>");
+    vi.doMock("./rasterize", () => ({ rasterizeSvgsInHtml }));
+
+    const { buildPdf: build } = await import("./pdf");
+    const bytes = await build("<svg><rect/></svg>", { title: "Doc" });
+
+    expect(rasterizeSvgsInHtml).toHaveBeenCalledWith("<svg><rect/></svg>");
+    expect(createPdf).toHaveBeenCalledTimes(2);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+  });
+
+  it("propagates the error when the raster retry also fails", async () => {
+    const getBuffer = vi.fn().mockRejectedValue(new Error("engine down"));
+    vi.doMock("./pdfEngine", () => ({ pdfEngine: () => ({ createPdf: () => ({ getBuffer }) }) }));
+    vi.doMock("./rasterize", () => ({ rasterizeSvgsInHtml: vi.fn(async (h: string) => h) }));
+
+    const { buildPdf: build } = await import("./pdf");
+    await expect(build("<p>x</p>", { title: "Doc" })).rejects.toThrow("engine down");
   });
 });

--- a/src/lib/export/pdf.ts
+++ b/src/lib/export/pdf.ts
@@ -1,19 +1,14 @@
 import type { TDocumentDefinitions } from "pdfmake/interfaces";
 import { convertHtmlToPdf } from "./htmlToPdf";
 import { pdfEngine } from "./pdfEngine";
+import { rasterizeSvgsInHtml } from "./rasterize";
 
 export interface PdfMetadata {
   title: string;
   author?: string;
 }
 
-/**
- * Build a vector PDF from prepared body HTML — selectable text, embedded
- * PNG/JPEG images, real tables and lists. Math is reduced to its LaTeX source
- * and SVG diagrams are dropped (a vector PDF has no faithful equivalent), the
- * same tradeoffs as the DOCX export. Produced directly, with no print dialog.
- */
-export async function buildPdf(bodyHtml: string, meta: PdfMetadata): Promise<Uint8Array> {
+async function renderPdf(bodyHtml: string, meta: PdfMetadata): Promise<Uint8Array> {
   const docDefinition: TDocumentDefinitions = {
     info: { title: meta.title, author: meta.author },
     content: convertHtmlToPdf(bodyHtml),
@@ -23,4 +18,22 @@ export async function buildPdf(bodyHtml: string, meta: PdfMetadata): Promise<Uin
 
   const buffer = await pdfEngine().createPdf(docDefinition).getBuffer();
   return new Uint8Array(buffer);
+}
+
+/**
+ * Build a vector PDF from prepared body HTML — selectable text, embedded
+ * PNG/JPEG images, real tables and lists, and diagrams/SVG images as true
+ * vector `svg` nodes. Math is reduced to its LaTeX source or a raster image
+ * (vector math is #256). Produced directly, with no print dialog.
+ *
+ * pdfmake's SVG renderer (svg-to-pdfkit) can't draw every SVG feature (some
+ * filters, CSS, markers), so a failed vector build retries once with every
+ * SVG rasterized to PNG — one exotic diagram never sinks the whole export.
+ */
+export async function buildPdf(bodyHtml: string, meta: PdfMetadata): Promise<Uint8Array> {
+  try {
+    return await renderPdf(bodyHtml, meta);
+  } catch {
+    return renderPdf(await rasterizeSvgsInHtml(bodyHtml), meta);
+  }
 }

--- a/src/lib/export/prepareContent.test.ts
+++ b/src/lib/export/prepareContent.test.ts
@@ -2,17 +2,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TocEntry } from "@/hooks/useTableOfContents";
 import { prepareContent } from "./prepareContent";
 
-// Rasterization needs a real layout/canvas engine; mock the helpers so the
+// Rendering needs a real layout/canvas/WASM engine; mock the helpers so the
 // orchestration is testable without them.
 const rasterizeElementMock = vi.fn(async () => "data:image/png;base64,MATH");
-const rasterizeMermaidMock = vi.fn(async () => "data:image/png;base64,MERMAID");
-const rasterizeD2Mock = vi.fn(async () => "data:image/png;base64,D2");
+const renderMermaidMock = vi.fn(async () => '<svg data-diagram="mermaid-light"></svg>');
+const renderD2Mock = vi.fn(async () => '<svg data-diagram="d2-light"></svg>');
 const restoreMermaidMock = vi.fn(async () => {});
 vi.mock("./rasterize", () => ({
   rasterizeElement: () => rasterizeElementMock(),
-  rasterizeMermaidLight: () => rasterizeMermaidMock(),
-  rasterizeD2Light: () => rasterizeD2Mock(),
+  renderMermaidLightSvg: () => renderMermaidMock(),
   restoreMermaidTheme: () => restoreMermaidMock(),
+}));
+vi.mock("@/lib/d2Render", () => ({
+  renderD2: () => renderD2Mock(),
 }));
 
 const ENTRIES: TocEntry[] = [{ id: "intro", text: "Intro", level: 1 }];
@@ -105,50 +107,51 @@ describe("prepareContent", () => {
     expect(result?.html).toContain("rgb(40, 42, 54)");
   });
 
-  it("rasterizes block math (as-is) and Mermaid (light re-render) for PDF", async () => {
+  it("rasterizes block math and swaps Mermaid for its light vector SVG for PDF", async () => {
     rasterizeElementMock.mockClear();
-    rasterizeMermaidMock.mockClear();
+    renderMermaidMock.mockClear();
     restoreMermaidMock.mockClear();
     setBody(
       '<p><span class="katex-display">math</span></p>' +
         '<div class="mermaid-diagram" data-mermaid-source="graph TD; A-->B"><svg></svg></div>',
     );
     const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
-    expect(rasterizeElementMock).toHaveBeenCalledTimes(1); // block math
-    expect(rasterizeMermaidMock).toHaveBeenCalledTimes(1); // diagram re-rendered light
+    expect(rasterizeElementMock).toHaveBeenCalledTimes(1); // block math stays raster
+    expect(renderMermaidMock).toHaveBeenCalledTimes(1); // diagram re-rendered light
     expect(restoreMermaidMock).toHaveBeenCalledTimes(1); // app theme restored after
     expect(result?.html).toContain("data:image/png;base64,MATH");
-    expect(result?.html).toContain("data:image/png;base64,MERMAID");
+    expect(result?.html).toContain('data-diagram="mermaid-light"'); // inline vector SVG, not a PNG
     expect(result?.html).not.toContain("katex-display");
     expect(result?.html).not.toContain("mermaid-diagram");
   });
 
-  it("rasterizes a D2 diagram (light re-render) for PDF", async () => {
-    rasterizeD2Mock.mockClear();
+  it("swaps a D2 diagram for its light vector SVG for PDF", async () => {
+    renderD2Mock.mockClear();
     setBody('<div class="d2-diagram" data-d2-source="a -> b"><svg></svg></div>');
     const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
-    expect(rasterizeD2Mock).toHaveBeenCalledTimes(1);
-    expect(result?.html).toContain("data:image/png;base64,D2");
+    expect(renderD2Mock).toHaveBeenCalledTimes(1);
+    expect(result?.html).toContain('data-diagram="d2-light"');
     expect(result?.html).not.toContain("d2-diagram");
+    expect(result?.html).not.toContain("data:image/png");
   });
 
   it("leaves a D2 diagram untouched when its source is missing", async () => {
-    rasterizeD2Mock.mockClear();
+    renderD2Mock.mockClear();
     setBody('<div class="d2-diagram"><svg></svg></div>');
     const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
-    expect(rasterizeD2Mock).not.toHaveBeenCalled();
+    expect(renderD2Mock).not.toHaveBeenCalled();
     expect(result?.html).toContain("d2-diagram");
   });
 
   it("leaves a Mermaid diagram untouched when its source is missing", async () => {
-    rasterizeMermaidMock.mockClear();
+    renderMermaidMock.mockClear();
     setBody('<div class="mermaid-diagram"><svg></svg></div>');
     const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
-    expect(rasterizeMermaidMock).not.toHaveBeenCalled();
+    expect(renderMermaidMock).not.toHaveBeenCalled();
     expect(result?.html).toContain("mermaid-diagram");
   });
 
-  it("keeps the original node when rasterization fails", async () => {
+  it("keeps the original node when math rasterization fails", async () => {
     rasterizeElementMock.mockClear();
     rasterizeElementMock.mockRejectedValueOnce(new Error("canvas tainted"));
     setBody('<span class="katex-display">E=mc^2</span>');
@@ -158,13 +161,34 @@ describe("prepareContent", () => {
     expect(result?.html).not.toContain("data:image/png");
   });
 
-  it("does not rasterize for non-PDF exports", async () => {
+  it("drops a diagram whose light re-render fails (never embeds the dark SVG)", async () => {
+    renderMermaidMock.mockClear();
+    renderMermaidMock.mockRejectedValueOnce(new Error("bad source"));
+    setBody(
+      '<div class="mermaid-diagram" data-mermaid-source="broken"><svg data-dark="1"></svg></div>' +
+        "<p>after</p>",
+    );
+    const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
+    expect(result?.html).not.toContain("mermaid-diagram");
+    expect(result?.html).not.toContain('data-dark="1"');
+    expect(result?.html).toContain("after");
+  });
+
+  it("drops a diagram whose light render returns no svg", async () => {
+    renderD2Mock.mockResolvedValueOnce("plain text, not svg");
+    setBody('<div class="d2-diagram" data-d2-source="a -> b"><svg data-dark="1"></svg></div>');
+    const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
+    expect(result?.html).not.toContain("d2-diagram");
+    expect(result?.html).not.toContain('data-dark="1"');
+  });
+
+  it("does not touch math or diagrams for non-PDF exports", async () => {
     rasterizeElementMock.mockClear();
-    rasterizeMermaidMock.mockClear();
+    renderMermaidMock.mockClear();
     setBody('<span class="katex-display">math</span>');
     await prepareContent({ entries: ENTRIES, includeToc: false });
     expect(rasterizeElementMock).not.toHaveBeenCalled();
-    expect(rasterizeMermaidMock).not.toHaveBeenCalled();
+    expect(renderMermaidMock).not.toHaveBeenCalled();
   });
 
   it("injects a table of contents when requested", async () => {

--- a/src/lib/export/prepareContent.test.ts
+++ b/src/lib/export/prepareContent.test.ts
@@ -16,6 +16,15 @@ vi.mock("./rasterize", () => ({
 vi.mock("@/lib/d2Render", () => ({
   renderD2: () => renderD2Mock(),
 }));
+// DOMPurify does not run faithfully under happy-dom (it drops the <svg>
+// wrapper), so mock it pass-through and assert the sanitize wiring instead;
+// real stripping is DOMPurify's job in the webview.
+const sanitizeMock = vi.fn((svg: string, _opts?: { FORBID_TAGS?: string[] }) => svg);
+vi.mock("dompurify", () => ({
+  default: {
+    sanitize: (svg: string, opts?: { FORBID_TAGS?: string[] }) => sanitizeMock(svg, opts),
+  },
+}));
 
 const ENTRIES: TocEntry[] = [{ id: "intro", text: "Intro", level: 1 }];
 
@@ -159,6 +168,19 @@ describe("prepareContent", () => {
     // Fallback: the math element survives (the walker turns it into LaTeX text).
     expect(result?.html).toContain("katex-display");
     expect(result?.html).not.toContain("data:image/png");
+  });
+
+  it("sanitizes the re-rendered diagram SVG before it re-enters the DOM", async () => {
+    sanitizeMock.mockClear();
+    setBody(
+      '<div class="mermaid-diagram" data-mermaid-source="graph TD; A-->B"><svg></svg></div>' +
+        '<div class="d2-diagram" data-d2-source="a -> b"><svg></svg></div>',
+    );
+    await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
+    expect(sanitizeMock).toHaveBeenCalledTimes(2);
+    for (const call of sanitizeMock.mock.calls) {
+      expect(call[1]).toEqual({ FORBID_TAGS: ["foreignObject"] });
+    }
   });
 
   it("drops a diagram whose light re-render fails (never embeds the dark SVG)", async () => {

--- a/src/lib/export/prepareContent.ts
+++ b/src/lib/export/prepareContent.ts
@@ -46,7 +46,14 @@ async function preparePdfRichContent(liveBody: Element, clone: Element): Promise
       const svg = isMermaid ? await renderMermaidLightSvg(source) : await renderD2(source, false);
       if (isMermaid) mermaidRendered = true;
       const wrap = clone.ownerDocument.createElement("div");
-      wrap.innerHTML = svg;
+      // The diagram source is user-authored, and unlike D2 (sanitized in
+      // d2Render) Mermaid's output is raw, so sanitize at the sink before it
+      // re-enters the DOM and later flows into pdfmake's SVG parser. DOMPurify
+      // keeps <style> blocks and style attributes, which Mermaid's colors need;
+      // <foreignObject> is forbidden as the SVG-embedded-HTML vector (and
+      // pdfmake can't draw it anyway).
+      const { default: DOMPurify } = await import("dompurify");
+      wrap.innerHTML = DOMPurify.sanitize(svg, { FORBID_TAGS: ["foreignObject"] });
       const svgEl = wrap.querySelector("svg");
       if (!svgEl) throw new Error("no svg in rendered diagram");
       cloned[i].replaceWith(svgEl);

--- a/src/lib/export/prepareContent.ts
+++ b/src/lib/export/prepareContent.ts
@@ -1,10 +1,6 @@
 import type { TocEntry } from "@/hooks/useTableOfContents";
-import {
-  rasterizeD2Light,
-  rasterizeElement,
-  rasterizeMermaidLight,
-  restoreMermaidTheme,
-} from "./rasterize";
+import { renderD2 } from "@/lib/d2Render";
+import { rasterizeElement, renderMermaidLightSvg, restoreMermaidTheme } from "./rasterize";
 import { buildTocElement } from "./toc";
 
 export interface PrepareOptions {
@@ -13,18 +9,20 @@ export interface PrepareOptions {
   // Overridable for tests; defaults to the live document.
   doc?: Document;
   // PDF export needs extra work the vector walker can't do itself: inline the
-  // rendered syntax-highlight colors onto code spans, and rasterize block math
-  // and Mermaid diagrams (which pdfmake can't draw) to embedded images.
+  // rendered syntax-highlight colors onto code spans, rasterize block math to
+  // an embedded image, and re-render diagrams light as inline SVG so pdfmake
+  // embeds them as vectors.
   pdf?: boolean;
 }
 
-// Rasterize each block-math (`.katex-display`), Mermaid, and D2 diagram in the
-// live DOM to a PNG and swap the matching clone node for an <img>. Runs only for
-// PDF (HTML/EPUB render these natively). Block math is captured as rendered;
-// Mermaid and D2 are re-rendered light so they don't end up as a dark box on the
-// white page. On any failure the original node is left so the walker falls back
-// (math → LaTeX, diagram → dropped).
-async function rasterizeRichContent(liveBody: Element, clone: Element): Promise<void> {
+// For PDF export: swap each Mermaid / D2 diagram in the clone for its
+// light-theme vector `<svg>` (the walker embeds SVG natively; see htmlToPdf),
+// and rasterize block math (`.katex-display`) to a PNG <img> (vector math is
+// #256). Diagrams re-render light so they don't sit as a dark box on the white
+// page. A math failure leaves the original node (the walker falls back to the
+// LaTeX source); a diagram whose light re-render fails is removed so the dark
+// on-screen SVG never leaks into the PDF.
+async function preparePdfRichContent(liveBody: Element, clone: Element): Promise<void> {
   const selector = ".katex-display, .mermaid-diagram, .d2-diagram";
   const live = liveBody.querySelectorAll<HTMLElement>(selector);
   if (live.length === 0) return;
@@ -34,25 +32,26 @@ async function rasterizeRichContent(liveBody: Element, clone: Element): Promise<
 
   for (let i = 0; i < live.length; i++) {
     const el = live[i];
+    const isMath = el.classList.contains("katex-display");
     try {
-      let dataUrl: string;
-      if (el.classList.contains("mermaid-diagram")) {
-        const source = el.getAttribute("data-mermaid-source");
-        if (!source) continue; // can't re-render without the source; leave as-is
-        dataUrl = await rasterizeMermaidLight(source);
-        mermaidRendered = true;
-      } else if (el.classList.contains("d2-diagram")) {
-        const source = el.getAttribute("data-d2-source");
-        if (!source) continue; // can't re-render without the source; leave as-is
-        dataUrl = await rasterizeD2Light(source);
-      } else {
-        dataUrl = await rasterizeElement(el, mathBackground);
+      if (isMath) {
+        const img = clone.ownerDocument.createElement("img");
+        img.setAttribute("src", await rasterizeElement(el, mathBackground));
+        cloned[i].replaceWith(img);
+        continue;
       }
-      const img = clone.ownerDocument.createElement("img");
-      img.setAttribute("src", dataUrl);
-      cloned[i].replaceWith(img);
+      const isMermaid = el.classList.contains("mermaid-diagram");
+      const source = el.getAttribute(isMermaid ? "data-mermaid-source" : "data-d2-source");
+      if (!source) continue; // no source to re-render; the on-screen SVG embeds as-is
+      const svg = isMermaid ? await renderMermaidLightSvg(source) : await renderD2(source, false);
+      if (isMermaid) mermaidRendered = true;
+      const wrap = clone.ownerDocument.createElement("div");
+      wrap.innerHTML = svg;
+      const svgEl = wrap.querySelector("svg");
+      if (!svgEl) throw new Error("no svg in rendered diagram");
+      cloned[i].replaceWith(svgEl);
     } catch {
-      // Leave the original node; the walker falls back.
+      if (!isMath) cloned[i].remove();
     }
   }
 
@@ -141,7 +140,7 @@ export async function prepareContent({
   const clone = body.cloneNode(true) as HTMLElement;
   if (pdf) {
     inlineCodeColors(body, clone);
-    await rasterizeRichContent(body, clone);
+    await preparePdfRichContent(body, clone);
   }
   for (const el of Array.from(clone.querySelectorAll(STRIP_SELECTOR))) {
     el.remove();

--- a/src/lib/export/rasterize.test.ts
+++ b/src/lib/export/rasterize.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rasterizeSvgsInHtml, renderMermaidLightSvg, restoreMermaidTheme } from "./rasterize";
+
+const initialize = vi.fn();
+const renderMermaid = vi.fn();
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: (...args: unknown[]) => initialize(...args),
+    render: (...args: unknown[]) => renderMermaid(...args),
+  },
+}));
+
+describe("renderMermaidLightSvg", () => {
+  beforeEach(() => {
+    initialize.mockReset();
+    renderMermaid.mockReset();
+  });
+
+  it("re-renders light with SVG text labels and returns the markup", async () => {
+    renderMermaid.mockResolvedValue({ svg: "<svg data-light='1'></svg>" });
+    const svg = await renderMermaidLightSvg("graph TD; A-->B");
+    expect(svg).toBe("<svg data-light='1'></svg>");
+    expect(initialize).toHaveBeenCalledWith({
+      startOnLoad: false,
+      theme: "default",
+      flowchart: { htmlLabels: false },
+    });
+  });
+
+  it("passes a fresh id per render (Mermaid keeps state per id)", async () => {
+    renderMermaid.mockResolvedValue({ svg: "<svg/>" });
+    await renderMermaidLightSvg("graph TD; A-->B");
+    await renderMermaidLightSvg("graph TD; A-->B");
+    const ids = renderMermaid.mock.calls.map((c) => c[0]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("restoreMermaidTheme re-initializes with the app theme and HTML labels", async () => {
+    await restoreMermaidTheme(true);
+    expect(initialize).toHaveBeenCalledWith({
+      startOnLoad: false,
+      theme: "dark",
+      flowchart: { htmlLabels: true },
+    });
+  });
+});
+
+describe("rasterizeSvgsInHtml", () => {
+  // `toPng` is injected: the real svgToPng needs a browser canvas.
+  const toPng = vi.fn(async (_svg: string) => "data:image/png;base64,RASTER");
+
+  beforeEach(() => {
+    toPng.mockClear();
+  });
+
+  it("replaces <svg> elements with PNG <img> tags", async () => {
+    const html = '<p>before</p><svg width="10"><rect/></svg><p>after</p>';
+    const out = await rasterizeSvgsInHtml(html, toPng);
+    expect(out).not.toContain("<svg");
+    expect(out).toContain('src="data:image/png;base64,RASTER"');
+    expect(out).toContain("before");
+    expect(out).toContain("after");
+    // The markup handed to the rasterizer regains its xmlns (required for
+    // decoding via a standalone <img>).
+    expect(toPng.mock.calls[0][0]).toContain('xmlns="http://www.w3.org/2000/svg"');
+  });
+
+  it("rewrites data:image/svg+xml image sources to PNG", async () => {
+    const uri = `data:image/svg+xml,${encodeURIComponent("<svg><rect/></svg>")}`;
+    const out = await rasterizeSvgsInHtml(`<img src="${uri}">`, toPng);
+    expect(out).toContain('src="data:image/png;base64,RASTER"');
+    expect(out).not.toContain("svg+xml");
+  });
+
+  it("leaves raster images untouched", async () => {
+    const html = '<img src="data:image/png;base64,KEEP">';
+    expect(await rasterizeSvgsInHtml(html, toPng)).toContain("KEEP");
+    expect(toPng).not.toHaveBeenCalled();
+  });
+
+  it("drops an element whose rasterization fails instead of aborting", async () => {
+    toPng.mockRejectedValueOnce(new Error("no canvas"));
+    const out = await rasterizeSvgsInHtml("<svg><rect/></svg><p>kept</p>", toPng);
+    expect(out).not.toContain("<svg");
+    expect(out).not.toContain("<img");
+    expect(out).toContain("kept");
+  });
+});

--- a/src/lib/export/rasterize.ts
+++ b/src/lib/export/rasterize.ts
@@ -1,8 +1,10 @@
-// Rasterization helpers for PDF export. Math is captured from the live DOM as
-// rendered; Mermaid and D2 are re-rendered in the light theme so PDF diagrams
-// are always light (the on-screen SVG bakes in the app theme's colors).
+// Rendering helpers for PDF export. Block math is captured from the live DOM
+// as a raster image (vector math is #256); diagrams re-render in the light
+// theme as SVG strings so the PDF embeds them as true vectors (the on-screen
+// SVG bakes in the app theme's colors). `rasterizeSvgsInHtml` is the fallback
+// for SVGs pdfmake's renderer rejects.
 
-import { renderD2 } from "@/lib/d2Render";
+import { decodeSvgDataUrl, ensureSvgXmlns } from "@/lib/svgDataUrl";
 
 let mermaidId = 0;
 
@@ -14,22 +16,14 @@ export async function rasterizeElement(el: HTMLElement, backgroundColor: string)
 }
 
 // Re-render a Mermaid source in the light theme with SVG text labels (no
-// `<foreignObject>`, which would taint the canvas), and rasterize to a PNG on a
-// white background. Always light, regardless of the app theme.
-export async function rasterizeMermaidLight(source: string): Promise<string> {
+// `<foreignObject>`, which pdfmake's SVG renderer can't draw and which would
+// taint a canvas in the raster fallback). Returns the SVG markup. Always
+// light, regardless of the app theme.
+export async function renderMermaidLightSvg(source: string): Promise<string> {
   const { default: mermaid } = await import("mermaid");
   mermaid.initialize({ startOnLoad: false, theme: "default", flowchart: { htmlLabels: false } });
   const { svg } = await mermaid.render(`glyph-export-mermaid-${mermaidId++}`, source);
-  return svgToPng(svg);
-}
-
-// Re-render a D2 source in the light theme and rasterize to a PNG on a white
-// background. Always light, regardless of the app theme. Unlike Mermaid there's
-// no global theme to restore (D2 takes the theme per render call), and the
-// sanitized SVG already has no `<foreignObject>` to taint the canvas.
-export async function rasterizeD2Light(source: string): Promise<string> {
-  const svg = await renderD2(source, false);
-  return svgToPng(svg);
+  return svg;
 }
 
 // Restore Mermaid's (global) config to the app theme after export-time renders,
@@ -43,7 +37,40 @@ export async function restoreMermaidTheme(dark: boolean): Promise<void> {
   });
 }
 
-function svgToPng(svg: string): Promise<string> {
+/**
+ * Replace every `<svg>` element and `data:image/svg+xml` image in an HTML
+ * fragment with a PNG `<img>`. This is the PDF exporter's fallback when
+ * pdfmake's SVG renderer rejects a vector diagram: the retry must salvage the
+ * export, so a per-element failure drops that element rather than aborting.
+ * `toPng` is injectable for tests (the default needs a real canvas).
+ */
+export async function rasterizeSvgsInHtml(
+  html: string,
+  toPng: (svg: string) => Promise<string> = svgToPng,
+): Promise<string> {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  for (const el of Array.from(doc.body.querySelectorAll("svg"))) {
+    try {
+      const img = doc.createElement("img");
+      img.setAttribute("src", await toPng(ensureSvgXmlns(el.outerHTML)));
+      el.replaceWith(img);
+    } catch {
+      el.remove();
+    }
+  }
+  for (const img of Array.from(doc.body.querySelectorAll("img"))) {
+    const markup = decodeSvgDataUrl(img.getAttribute("src") ?? "");
+    if (markup === null) continue;
+    try {
+      img.setAttribute("src", await toPng(ensureSvgXmlns(markup)));
+    } catch {
+      img.remove();
+    }
+  }
+  return doc.body.innerHTML;
+}
+
+export function svgToPng(svg: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const url = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml;charset=utf-8" }));
     const image = new Image();

--- a/src/lib/export/svgPdfNode.test.ts
+++ b/src/lib/export/svgPdfNode.test.ts
@@ -35,6 +35,20 @@ describe("svgNode", () => {
     expect(fallback.width).toBe(CONTENT_WIDTH);
   });
 
+  it("ignores an unparseable width attribute and falls through to the viewBox", () => {
+    const node = svgNode(svgEl('<svg width="auto" viewBox="0 0 64 32"><rect/></svg>')) as {
+      width: number;
+    };
+    expect(node.width).toBe(64);
+  });
+
+  it("ignores a degenerate viewBox (zero or non-numeric width)", () => {
+    const zero = svgNode(svgEl('<svg viewBox="0 0 0 80"><rect/></svg>')) as { width: number };
+    expect(zero.width).toBe(CONTENT_WIDTH);
+    const junk = svgNode(svgEl('<svg viewBox="0 0 abc 80"><rect/></svg>')) as { width: number };
+    expect(junk.width).toBe(CONTENT_WIDTH);
+  });
+
   it("keeps an existing xmlns untouched", () => {
     const node = svgNode(
       svgEl('<svg xmlns="http://www.w3.org/2000/svg" width="10"><g/></svg>'),

--- a/src/lib/export/svgPdfNode.test.ts
+++ b/src/lib/export/svgPdfNode.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { CONTENT_WIDTH, svgNode } from "./svgPdfNode";
+
+function svgEl(markup: string): Element {
+  const div = document.createElement("div");
+  div.innerHTML = markup;
+  const el = div.querySelector("svg");
+  if (!el) throw new Error("no svg in markup");
+  return el;
+}
+
+describe("svgNode", () => {
+  it("sizes from the width attribute, capped at the content width", () => {
+    const sized = svgNode(svgEl('<svg width="120" height="60"><rect/></svg>')) as {
+      svg: string;
+      width: number;
+    };
+    expect(sized.width).toBe(120);
+    expect(sized.svg).toContain("<rect");
+    // The sanitizer strips xmlns from diagram SVGs; the embed restores it.
+    expect(sized.svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+
+    const capped = svgNode(svgEl('<svg width="2000"><rect/></svg>')) as { width: number };
+    expect(capped.width).toBe(CONTENT_WIDTH);
+  });
+
+  it("sizes from the viewBox when width is missing or relative", () => {
+    // Mermaid emits width="100%" plus a viewBox; the viewBox wins.
+    const node = svgNode(svgEl('<svg width="100%" viewBox="0 0 240 80"><rect/></svg>')) as {
+      width: number;
+    };
+    expect(node.width).toBe(240);
+    // No usable size at all falls back to the full content width.
+    const fallback = svgNode(svgEl("<svg><rect/></svg>")) as { width: number };
+    expect(fallback.width).toBe(CONTENT_WIDTH);
+  });
+
+  it("keeps an existing xmlns untouched", () => {
+    const node = svgNode(
+      svgEl('<svg xmlns="http://www.w3.org/2000/svg" width="10"><g/></svg>'),
+    ) as { svg: string };
+    expect(node.svg.match(/xmlns="http:\/\/www\.w3\.org\/2000\/svg"/g)).toHaveLength(1);
+  });
+});

--- a/src/lib/export/svgPdfNode.ts
+++ b/src/lib/export/svgPdfNode.ts
@@ -1,0 +1,37 @@
+// Convert an <svg> element into a pdfmake vector `svg` content node. Split out
+// of htmlToPdf.ts (already past the size cap) so the walker stays focused on
+// HTML structure.
+
+import type { Content } from "pdfmake/interfaces";
+import { ensureSvgXmlns } from "@/lib/svgDataUrl";
+
+// Page content width for an A4 page with default pdfmake margins (~40pt each).
+export const CONTENT_WIDTH = 515;
+
+// Intrinsic width of an <svg>, from its width attribute (ignoring relative
+// values like "100%", which Mermaid emits) or the viewBox. Null when neither
+// yields a usable number.
+function svgWidth(el: Element): number | null {
+  const attr = el.getAttribute("width")?.trim();
+  if (attr && !attr.endsWith("%")) {
+    const w = Number.parseFloat(attr);
+    if (Number.isFinite(w) && w > 0) return w;
+  }
+  const viewBox = el
+    .getAttribute("viewBox")
+    ?.trim()
+    .split(/[\s,]+/);
+  if (viewBox?.length === 4) {
+    const w = Number.parseFloat(viewBox[2]);
+    if (Number.isFinite(w) && w > 0) return w;
+  }
+  return null;
+}
+
+// Embed an <svg> element as a pdfmake vector node, scaled down to the page
+// content width when wider. `ensureSvgXmlns` mirrors the data-URL path: the
+// sanitizer strips the namespace from D2/Mermaid output.
+export function svgNode(el: Element): Content {
+  const width = Math.min(svgWidth(el) ?? CONTENT_WIDTH, CONTENT_WIDTH);
+  return { svg: ensureSvgXmlns(el.outerHTML), width, margin: [0, 0, 0, 8] };
+}

--- a/src/lib/svgDataUrl.test.ts
+++ b/src/lib/svgDataUrl.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { svgToDataUrl } from "./svgDataUrl";
+import { decodeSvgDataUrl, ensureSvgXmlns, svgToDataUrl } from "./svgDataUrl";
 
 describe("svgToDataUrl", () => {
   it("wraps markup in an svg data URL", () => {
@@ -28,5 +28,34 @@ describe("svgToDataUrl", () => {
     const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>';
     const decoded = decodeURIComponent(svgToDataUrl(svg).slice("data:image/svg+xml,".length));
     expect(decoded).toBe(svg);
+  });
+});
+
+describe("ensureSvgXmlns", () => {
+  it("adds the namespace only when absent", () => {
+    expect(ensureSvgXmlns("<svg><g/></svg>")).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><g/></svg>',
+    );
+    const withNs = '<svg xmlns="http://www.w3.org/2000/svg"><g/></svg>';
+    expect(ensureSvgXmlns(withNs)).toBe(withNs);
+  });
+});
+
+describe("decodeSvgDataUrl", () => {
+  it("round-trips a URI-encoded svg data URL", () => {
+    const svg = "<svg><text>a&b #c</text></svg>";
+    expect(decodeSvgDataUrl(svgToDataUrl(svg))).toBe(ensureSvgXmlns(svg));
+  });
+
+  it("decodes a base64 svg data URL", () => {
+    const svg = "<svg><rect/></svg>";
+    expect(decodeSvgDataUrl(`data:image/svg+xml;base64,${btoa(svg)}`)).toBe(svg);
+  });
+
+  it("returns null for non-SVG data URLs and malformed input", () => {
+    expect(decodeSvgDataUrl("data:image/png;base64,AAAA")).toBeNull();
+    expect(decodeSvgDataUrl("data:image/svg+xml")).toBeNull(); // no comma
+    expect(decodeSvgDataUrl("data:image/svg+xml,%")).toBeNull(); // bad URI encoding
+    expect(decodeSvgDataUrl("https://example.com/x.svg")).toBeNull();
   });
 });

--- a/src/lib/svgDataUrl.ts
+++ b/src/lib/svgDataUrl.ts
@@ -1,18 +1,31 @@
 const SVG_NS = "http://www.w3.org/2000/svg";
 
+// A standalone `<img>` parses SVG as XML, so the root needs an `xmlns`
+// declaration or it renders blank. Inline SVG (innerHTML) doesn't need it, and
+// renderers/sanitizers routinely drop it — D2 and Mermaid diagrams come back
+// without it — so add it back when absent.
+export function ensureSvgXmlns(svg: string): string {
+  return /<svg[^>]*\sxmlns\s*=/.test(svg) ? svg : svg.replace(/<svg\b/, `<svg xmlns="${SVG_NS}"`);
+}
+
 // Turn SVG markup into a `data:` URL usable as an `<img src>`. We render SVGs
 // this way (image viewer, diagram lightbox) instead of routing them through the
 // asset protocol so they display reliably and need no extra request — the
 // markup is already in hand. URL-encoding (not base64) keeps it readable and
 // handles arbitrary unicode in the SVG.
-//
-// A standalone `<img>` parses the SVG as XML, so the root needs an `xmlns`
-// declaration or it renders blank. Inline SVG (innerHTML) doesn't need it, and
-// renderers/sanitizers routinely drop it — D2 and Mermaid diagrams come back
-// without it — so add it back when absent.
 export function svgToDataUrl(svg: string): string {
-  const withNs = /<svg[^>]*\sxmlns\s*=/.test(svg)
-    ? svg
-    : svg.replace(/<svg\b/, `<svg xmlns="${SVG_NS}"`);
-  return `data:image/svg+xml,${encodeURIComponent(withNs)}`;
+  return `data:image/svg+xml,${encodeURIComponent(ensureSvgXmlns(svg))}`;
+}
+
+// Decode a `data:image/svg+xml` URL (base64 or URI-encoded) back to its SVG
+// markup. Returns null for non-SVG data URLs or an undecodable payload.
+export function decodeSvgDataUrl(src: string): string | null {
+  const comma = src.indexOf(",");
+  if (!/^data:image\/svg\+xml/i.test(src) || comma < 0) return null;
+  const payload = src.slice(comma + 1);
+  try {
+    return /;base64/i.test(src.slice(0, comma)) ? atob(payload) : decodeURIComponent(payload);
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

PDF export embedded Mermaid/D2 diagrams as 2x PNG rasters (blurry when zoomed) and silently dropped SVG images. pdfmake supports vector `svg` nodes (the canvas exporter already uses them), so this routes diagrams and SVG images through true vector embedding, with a raster retry so an SVG the renderer cannot draw never fails the whole export.

Closes #348

## Changes

- **`prepareContent.ts` (pdf path)**: each `.mermaid-diagram` / `.d2-diagram` is swapped for its **light-theme inline `<svg>`** (new `renderMermaidLightSvg`; D2 reuses `renderD2(source, false)`) instead of a PNG `<img>`. A failed light re-render removes the node so the dark on-screen SVG never leaks onto the white page. Block math stays rasterized (vector math is #256). The on-screen Mermaid theme is restored afterward, as before.
- **`htmlToPdf.ts`**: block-level `<svg>` becomes a pdfmake `{ svg, width, margin }` vector node, sized from the `width` attribute (relative values like Mermaid's `100%` are ignored) or the `viewBox`, capped at the page content width. `data:image/svg+xml` images, previously dropped entirely, also embed as vector nodes. Inline-position SVG is still skipped.
- **`pdf.ts`**: `buildPdf` retries once with every SVG rasterized to PNG (`rasterizeSvgsInHtml`) when the vector build throws, since svg-to-pdfkit cannot draw every SVG feature.
- **`svgDataUrl.ts`**: new shared `ensureSvgXmlns` and `decodeSvgDataUrl` helpers, reused by the embed, fallback, and existing data-URL paths.
- **`rasterize.ts`**: dead PNG diagram helpers (`rasterizeMermaidLight`, `rasterizeD2Light`) removed; `svgToPng` exported for the fallback.
- README: PDF export bullet mentions vector diagrams/SVG.

HTML, EPUB, DOCX, and print exports are unchanged (`pdf: true` is only set for PDF, covered by tests).

## Testing

Gates pass locally on Windows: `pnpm typecheck`, `pnpm check`, `pnpm test` (2019 passing), `cargo clippy --all-targets -- -D warnings`.

New/updated tests: diagrams become inline light SVG (not PNG) in the pdf `prepareContent` path and failed re-renders drop the node; `htmlToPdf` emits `svg` nodes for block `<svg>` and `data:image/svg+xml` images with width/viewBox/cap sizing; `buildPdf` retries through `rasterizeSvgsInHtml` when the vector build throws and propagates a second failure; `rasterizeSvgsInHtml` replaces SVGs and svg-data-URL images with PNGs and drops per-element failures; `decodeSvgDataUrl`/`ensureSvgXmlns` round-trips. One test pushes a diagram-shaped SVG through the **real** pdfmake/svg-to-pdfkit engine and gets valid PDF bytes back.

**Visual QA still required before merge** (cannot be verified headlessly): export a document containing a Mermaid diagram, a D2 diagram, and an SVG image to PDF, zoom in, and confirm crispness and **Mermaid label/colors** (its `<style>`-block CSS is the known svg-to-pdfkit risk; D2 and plain SVG use inline styles). If Mermaid colors render wrong, follow up by inlining its computed styles or keeping Mermaid on raster.

- [ ] Visual QA: D2 + Mermaid + SVG image exported to PDF, zoomed, colors verified
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A (PDF output; see visual QA checklist).
