### PR TITLE
fix(ci): make cargo-audit read its ignore list and skip quick-xml DoS advisories

### DIFF
--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -18,4 +18,19 @@ ignore = [
     # something we can force via Cargo.toml. Revisit when Tauri's HTML/CSS
     # pipeline upgrades to newer `cssparser`/`selectors`.
     "RUSTSEC-2026-0097",
+
+    # RUSTSEC-2026-0194 (quadratic time on duplicate start-tag attribute names)
+    # and RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in
+    # `NsReader`) are XML-parsing denial-of-service issues in `quick-xml` 0.38.
+    #
+    # Not reachable in Glyph: `quick-xml` is a transitive dependency of `plist`
+    # (via `tauri`), which Glyph only exercises to read the app's own, trusted
+    # macOS `Info.plist`. No attacker-controlled XML is ever fed to `quick-xml`,
+    # so the DoS conditions cannot be triggered.
+    #
+    # Upstream fix is quick-xml >= 0.41, but the newest `plist` (1.9.0) still
+    # caps quick-xml at 0.39.4, so the patched version is not yet reachable from
+    # our tree. Revisit when `plist`/`tauri` move to quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]


### PR DESCRIPTION
## Summary

The Security workflow's Cargo Audit job began failing on `main` and every open PR on 2026-07-02, when two new `quick-xml` advisories (RUSTSEC-2026-0194, RUSTSEC-2026-0195) landed in the RustSec DB.

Root cause: `cargo-audit` auto-loads its config from `.cargo/audit.toml`, not `./audit.toml`. Our ignore file lived at `src-tauri/audit.toml`, so it was never read. `main` had stayed green only because its single entry, RUSTSEC-2026-0097, is an informational advisory that does not fail the build. The new quick-xml entries are real vulnerabilities, so they failed.

## Changes

- Move `src-tauri/audit.toml` to `src-tauri/.cargo/audit.toml`, the path `cargo-audit` actually reads. This also makes the pre-existing RUSTSEC-2026-0097 ignore effective.
- Add RUSTSEC-2026-0194 and RUSTSEC-2026-0195 to the ignore list, with justification: `quick-xml` is transitive via `plist` (macOS `Info.plist` handling in `tauri`) and only ever parses the app's own trusted `Info.plist`, so the XML-parsing DoS is not reachable. The patched `quick-xml >= 0.41` is not yet available through any `plist` release (newest, 1.9.0, still caps at `quick-xml 0.39.4`).

Verified locally that `cargo audit` run from `src-tauri/` exits 0 with the config in the new location (the two quick-xml vulnerabilities move into the allowed list; only pre-existing informational warnings remain).

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] `cargo audit` passes locally (exit 0) from `src-tauri/`

## Notes

No dependency or runtime code changes. Once merged, the other open PRs go green after they pick up `main`.
