### PR TITLE
feat(ci): publish signed DNF/RPM repo for Fedora users

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -785,6 +785,10 @@ jobs:
           gpg --armor --export "$GPG_KEY_ID" > gpg.key
           cp "$GITHUB_WORKSPACE/dnf/glyph.repo" glyph.repo
 
+          # Serve the RPMs and repodata as raw files: .nojekyll turns off the
+          # Pages Jekyll build, which otherwise fails on this non-site repo.
+          touch .nojekyll
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,12 @@ jobs:
             curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
             echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
             sudo apt update && sudo apt install glyph
+
+            # Fedora/RHEL (dnf)
+            sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
+            sudo dnf install glyph
             ```
-            Or download the `.deb` / `.AppImage` below.
+            Or download the `.deb` / `.rpm` / `.AppImage` below.
           releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}
@@ -164,8 +168,12 @@ jobs:
           curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
           echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
           sudo apt update && sudo apt install glyph
+
+          # Fedora/RHEL (dnf)
+          sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
+          sudo dnf install glyph
           ```
-          Or download the `.deb` / `.AppImage` below.
+          Or download the `.deb` / `.rpm` / `.AppImage` below.
 
           ---
 
@@ -686,3 +694,101 @@ jobs:
         with:
           snap: ${{ steps.build.outputs.snap }}
           release: stable
+
+  publish-dnf:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # The signed DNF repo lives in glyph-md/rpm-repo (GitHub Pages), mirroring
+      # the apt-repo. Skip cleanly until that repo exists, so a missing target
+      # never fails the release (gated like publish-snap, though this probes the
+      # repo via the API rather than checking a secret's presence). Note:
+      # TAP_GITHUB_TOKEN must have access to rpm-repo, otherwise this 404s and the
+      # job stays a silent no-op even once the repo is created.
+      - name: Check rpm-repo exists
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          if gh api repos/glyph-md/rpm-repo >/dev/null 2>&1; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No glyph-md/rpm-repo; skipping DNF publish."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install packaging tools
+        if: steps.gate.outputs.enabled == 'true'
+        timeout-minutes: 8
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: sudo apt-get update && sudo apt-get install -y createrepo-c rpm gnupg
+      - name: Get version
+        if: steps.gate.outputs.enabled == 'true'
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Download RPM packages
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release download "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "Glyph-${VERSION}-1.x86_64.rpm" \
+            --pattern "Glyph-${VERSION}-1.aarch64.rpm"
+      - name: Import GPG key
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format long 2>/dev/null | grep sec | head -1 | awk '{print $2}' | cut -d'/' -f2)
+          echo "GPG_KEY_ID=$GPG_KEY_ID" >> "$GITHUB_ENV"
+          # Passphrase file for loopback signing (empty file is harmless for an
+          # unprotected key, which is what the apt-repo job also assumes).
+          printf '%s' "$GPG_PASSPHRASE" > /tmp/gpg-pass
+          # rpm --addsign shells out to gpg; force batch/loopback so it never
+          # blocks on a pinentry prompt in CI.
+          cat > "$HOME/.rpmmacros" <<EOF
+          %_gpg_name $GPG_KEY_ID
+          %__gpg_sign_cmd gpg --batch --no-verbose --no-armor --pinentry-mode loopback --passphrase-file /tmp/gpg-pass --no-secmem-warning -u "%{_gpg_name}" --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}
+          EOF
+      - name: Clone rpm-repo, sign RPMs, and rebuild metadata
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/glyph-md/rpm-repo.git" /tmp/rpm-repo
+          cd /tmp/rpm-repo
+
+          # Flat repo at the Pages root: RPMs sit next to repodata/, matching the
+          # baseurl in dnf/glyph.repo. Copy in this release's packages (overwrite
+          # if re-running the same tag), then sign only those two files, not the
+          # whole history, so prior releases' RPMs are left untouched (mirrors how
+          # publish-debian only handles the current version's debs).
+          cp "$GITHUB_WORKSPACE/Glyph-${VERSION}-1.x86_64.rpm" .
+          cp "$GITHUB_WORKSPACE/Glyph-${VERSION}-1.aarch64.rpm" .
+          rpm --addsign "Glyph-${VERSION}-1.x86_64.rpm" "Glyph-${VERSION}-1.aarch64.rpm"
+
+          # Regenerate repodata over all versions (full rebuild is idempotent).
+          createrepo_c --revision "$VERSION" .
+
+          # repo_gpgcheck=1 verifies a detached signature of repomd.xml.
+          gpg --batch --yes --pinentry-mode loopback --passphrase-file /tmp/gpg-pass \
+            --default-key "$GPG_KEY_ID" --detach-sign --armor repodata/repomd.xml
+
+          # Ship the public key and the .repo drop-in at the root.
+          gpg --armor --export "$GPG_KEY_ID" > gpg.key
+          cp "$GITHUB_WORKSPACE/dnf/glyph.repo" glyph.repo
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || {
+            git commit -m "chore: update packages to $VERSION"
+            git push
+          }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Run the **Create Release** workflow from GitHub Actions (`create-release.yml`) w
 3. Commit and push to `main`
 4. Create and push the `vX.Y.Z` tag, which triggers `release.yml`
 
-The release workflow builds all platforms and publishes to Homebrew, Chocolatey, Scoop, AUR, PPA, and the Debian apt repo.
+The release workflow builds all platforms and publishes to Homebrew, Chocolatey, Scoop, AUR, PPA, the Debian apt repo, and the Fedora/RHEL dnf repo.
 
 Do **not** create releases manually with `gh release create` or push tags by hand — use the workflow.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ Run the **Create Release** workflow from GitHub Actions (`create-release.yml`) w
 3. Commit and push to `main`
 4. Create and push the `vX.Y.Z` tag, which triggers `release.yml`
 
-The release workflow builds all platforms and publishes to Homebrew, Chocolatey, Scoop, AUR, PPA, and the Debian apt repo.
+The release workflow builds all platforms and publishes to Homebrew, Chocolatey, Scoop, AUR, PPA, the Debian apt repo, and the Fedora/RHEL dnf repo.
 
 Do **not** create releases manually with `gh release create` or push tags by hand — use the workflow.
 

--- a/README.md
+++ b/README.md
@@ -162,13 +162,23 @@ sudo apt update
 sudo apt install glyph
 ```
 
+### Fedora / RHEL (DNF)
+
+```bash
+sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
+sudo dnf install glyph
+```
+
 ### Linux (manual)
 
-Download the `.deb` or `.AppImage` from [Releases](https://github.com/hamidfzm/glyph/releases).
+Download the `.deb`, `.rpm`, or `.AppImage` from [Releases](https://github.com/hamidfzm/glyph/releases).
 
 ```bash
 # Debian/Ubuntu
 sudo dpkg -i glyph_*.deb
+
+# Fedora/RHEL
+sudo dnf install ./Glyph-*.rpm
 
 # AppImage
 chmod +x Glyph_*.AppImage

--- a/dnf/glyph.repo
+++ b/dnf/glyph.repo
@@ -1,0 +1,7 @@
+[glyph]
+name=Glyph
+baseurl=https://glyph-md.github.io/rpm-repo
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://glyph-md.github.io/rpm-repo/gpg.key


### PR DESCRIPTION
## Summary

Adds a supported install path for Fedora/RHEL users via a self-hosted, GPG-signed DNF/RPM repository, mirroring the existing self-hosted apt repo. Every release already builds `.rpm` artifacts (`Glyph-<version>-1.x86_64.rpm`, `Glyph-<version>-1.aarch64.rpm`) through Tauri `targets: "all"`, but they had no repo, so there was no `dnf install` or automatic updates. This publishes them to `glyph-md/rpm-repo` (GitHub Pages) at `https://glyph-md.github.io/rpm-repo`.

Users can now:

```bash
sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
sudo dnf install glyph
```

## Changes

- Add a `publish-dnf` job to `release.yml`: downloads the release RPMs, GPG-signs them with the existing key (`rpm --addsign` via loopback), rebuilds metadata with `createrepo_c`, signs `repomd.xml` (for `repo_gpgcheck`), and commits RPMs + `repodata/` + `gpg.key` + `glyph.repo` to `glyph-md/rpm-repo`.
- Gate the job on the target repo existing (via `gh api`), so it is a clean no-op until the repo is present, exactly like `publish-snap`. It never fails a release.
- Add `dnf/glyph.repo` drop-in (`gpgcheck=1`, `repo_gpgcheck=1`, baseurl/gpgkey pointing at the Pages repo).
- Document the `dnf` install path in `README.md` and in both release-notes blocks in `release.yml`.
- Update the platform list in `CONTRIBUTING.md` and `CLAUDE.md` to include the Fedora/RHEL dnf repo.

The `glyph-md/rpm-repo` GitHub Pages repo has already been created and Pages enabled, so the job activates on the next release. It reuses existing secrets (`GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `TAP_GITHUB_TOKEN`); no new dependency and no app-code change.

## Testing

CI/docs-only change. Local gates all pass on this branch (rebased on current `main`):

- `pnpm typecheck` ✅
- `pnpm check` (Biome) ✅
- `pnpm test` (2010 tests) ✅
- `cargo clippy --all-targets -- -D warnings` ✅

The `publish-dnf` job itself only runs on a `v*` tag push; it is gated to no-op if the target repo is absent, so it cannot break a release. No per-platform app behavior changes.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A (CI + docs change).

Closes #361
