### PR TITLE
feat(plugins): install consent, declared permissions, and lifecycle race fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 - Window state persistence across restarts
 - Native menu bar with customizable keyboard shortcuts (remap any command in Settings → Hotkeys)
 - Update notifications: checks for a newer release on launch and shows a banner when one is available (toggle in Settings → Behavior)
-- Plugins (experimental): install JavaScript plugins that add palette commands and status bar items, browse and manage them from the command palette (Manage Plugins…); see the [plugin marketplace](https://github.com/glyph-md/plugins)
+- Plugins (experimental): install JavaScript plugins that extend rendering, palette commands, and the status bar; every install asks for confirmation and shows the plugin's declared permissions, and everything is managed from the command palette (Manage Plugins…); see the [plugin marketplace](https://github.com/glyph-md/plugins)
 
 ### Privacy
 - Local-first: your files never leave your machine unless you opt into Cloud Sync (per workspace, to a Git remote you control)

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -17,6 +17,9 @@ pub struct InstalledPlugin {
     pub api_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Capabilities the plugin declares; shown to the user before install.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub permissions: Vec<String>,
     /// Absolute path of the installed plugin folder.
     pub dir: String,
     /// Source text of the plugin's ESM entry file.
@@ -29,7 +32,24 @@ struct ManifestInfo {
     version: String,
     api_version: String,
     description: Option<String>,
+    permissions: Vec<String>,
     main: String,
+}
+
+/// Optional `permissions` array; when present it must be an array of strings.
+fn parse_permissions(value: &serde_json::Value) -> Result<Vec<String>, String> {
+    match value.get("permissions") {
+        None => Ok(Vec::new()),
+        Some(serde_json::Value::Array(items)) => items
+            .iter()
+            .map(|v| {
+                v.as_str()
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| "manifest \"permissions\" must be an array of strings".into())
+            })
+            .collect(),
+        Some(_) => Err("manifest \"permissions\" must be an array of strings".into()),
+    }
 }
 
 fn required_str(value: &serde_json::Value, key: &str) -> Result<String, String> {
@@ -78,6 +98,7 @@ fn parse_manifest(json: &str) -> Result<ManifestInfo, String> {
             .get("description")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string()),
+        permissions: parse_permissions(&value)?,
         main,
     })
 }
@@ -95,6 +116,7 @@ fn read_plugin_dir(dir: &Path) -> Result<InstalledPlugin, String> {
         version: info.version,
         api_version: info.api_version,
         description: info.description,
+        permissions: info.permissions,
         dir: dir.to_string_lossy().to_string(),
         main_source,
     })
@@ -476,6 +498,7 @@ mod tests {
             version: "1.0.0".into(),
             api_version: "^1.0.0".into(),
             description: None,
+            permissions: Vec::new(),
             dir: "d".into(),
             main_source: "s".into(),
         };
@@ -483,5 +506,33 @@ mod tests {
         assert!(json.contains("\"apiVersion\""));
         assert!(json.contains("\"mainSource\""));
         assert!(!json.contains("\"description\""));
+        assert!(!json.contains("\"permissions\""));
+    }
+
+    #[test]
+    fn parse_manifest_reads_permissions() {
+        let info = parse_manifest(
+            r#"{"id":"a.b","name":"n","version":"1.0.0","apiVersion":"^1.0.0","permissions":["workspace:read","network:example.com"]}"#,
+        )
+        .unwrap();
+        assert_eq!(info.permissions, ["workspace:read", "network:example.com"]);
+    }
+
+    #[test]
+    fn parse_manifest_defaults_permissions_to_empty() {
+        let info =
+            parse_manifest(r#"{"id":"a.b","name":"n","version":"1.0.0","apiVersion":"^1.0.0"}"#)
+                .unwrap();
+        assert!(info.permissions.is_empty());
+    }
+
+    #[test]
+    fn parse_manifest_rejects_non_string_permissions() {
+        for json in [
+            r#"{"id":"a.b","name":"n","version":"1.0.0","apiVersion":"^1.0.0","permissions":"workspace:read"}"#,
+            r#"{"id":"a.b","name":"n","version":"1.0.0","apiVersion":"^1.0.0","permissions":[1]}"#,
+        ] {
+            assert!(parse_manifest(json).is_err(), "should reject: {json}");
+        }
     }
 }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -14,6 +14,7 @@ import { useNativeKeybindings } from "@/hooks/useNativeKeybindings";
 import { useNativeMenuLabels } from "@/hooks/useNativeMenuLabels";
 import { useNativeMenuState } from "@/hooks/useNativeMenuState";
 import { usePlatform } from "@/hooks/usePlatform";
+import { usePluginWorkspaceSync } from "@/hooks/usePluginWorkspaceSync";
 import { usePrint } from "@/hooks/usePrint";
 import { useReadAloudController } from "@/hooks/useReadAloudController";
 import { useSettings } from "@/hooks/useSettings";
@@ -53,6 +54,9 @@ export function AppShell() {
   // Reveal the window (created hidden in tauri.conf.json) once settings/theme
   // are loaded, avoiding the white flash + geometry jump on launch.
   useWindowReveal();
+
+  // Keep the plugin host's workspace scope in sync with the open workspace.
+  usePluginWorkspaceSync();
 
   // Once-per-session check for a newer GitHub release; the banner shows only
   // when the user has the feature on and an update is actually available.

--- a/src/components/markdown/CodeBlockComponent.tsx
+++ b/src/components/markdown/CodeBlockComponent.tsx
@@ -43,7 +43,8 @@ export function CodeBlockComponent(props: ComponentPropsWithoutRef<"pre">) {
       const code = extractText(children.props.children).trim();
       return <CsvTable code={code} delimiter={"\t"} />;
     }
-    // Plugin-contributed fenced renderers handle any other language (e.g. d2).
+    // Plugin-contributed fenced renderers handle any language without a
+    // built-in handler above (e.g. a PlantUML plugin registering "plantuml").
     const lang = /\blanguage-([\w-]+)\b/.exec(className)?.[1];
     const custom = lang && fencedRenderers.find((r) => r.language === lang);
     if (custom) {

--- a/src/components/plugins/PluginStatusBarItems.test.tsx
+++ b/src/components/plugins/PluginStatusBarItems.test.tsx
@@ -26,6 +26,7 @@ function value(statusBarItems = createRegistry<StatusBarItemContribution>()): Pl
     installFromRegistry: async () => {},
     setEnabled: async () => {},
     uninstall: async () => {},
+    setWorkspaceRoot: () => {},
   };
 }
 

--- a/src/components/plugins/PluginsModal.test.tsx
+++ b/src/components/plugins/PluginsModal.test.tsx
@@ -47,6 +47,7 @@ function ctx(over: Partial<PluginsContextValue> = {}): PluginsContextValue {
     installFromRegistry: vi.fn(async () => {}),
     setEnabled: vi.fn(async () => {}),
     uninstall: vi.fn(async () => {}),
+    setWorkspaceRoot: vi.fn(),
     ...over,
   };
 }

--- a/src/components/plugins/PluginsModal.test.tsx
+++ b/src/components/plugins/PluginsModal.test.tsx
@@ -67,6 +67,17 @@ describe("PluginsModal", () => {
     expect(screen.getByText("Charlie")).toBeInTheDocument();
   });
 
+  it("shows an installed plugin's declared permissions", () => {
+    renderModal(
+      ctx({ installed: [{ ...installed, permissions: ["workspace:read", "network:api.test"] }] }),
+    );
+    expect(
+      screen.getByText(
+        (_, el) => el?.textContent === "Permissions: workspace:read, network:api.test",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("toggles an installed plugin's active state", () => {
     const value = ctx();
     renderModal(value);

--- a/src/components/plugins/PluginsModal.tsx
+++ b/src/components/plugins/PluginsModal.tsx
@@ -88,6 +88,11 @@ export function PluginsModal({ onClose }: { onClose: () => void }) {
                         {p.description}
                       </div>
                     )}
+                    {p.permissions && p.permissions.length > 0 && (
+                      <div className="text-xs text-[var(--color-text-secondary)] truncate">
+                        {t("permissionsLabel")}: {p.permissions.join(", ")}
+                      </div>
+                    )}
                   </div>
                   {update && (
                     <button

--- a/src/contexts/PluginsContext.ts
+++ b/src/contexts/PluginsContext.ts
@@ -28,6 +28,8 @@ export interface PluginsContextValue {
   setEnabled: (id: string, enabled: boolean) => Promise<void>;
   /** Unload and delete an installed plugin from disk. */
   uninstall: (id: string) => Promise<void>;
+  /** Mirror the opened workspace root into the host (for ctx.workspace). */
+  setWorkspaceRoot: (root: string | null) => void;
 }
 
 export const PluginsContext = createContext<PluginsContextValue | null>(null);

--- a/src/contexts/PluginsProvider.test.tsx
+++ b/src/contexts/PluginsProvider.test.tsx
@@ -202,6 +202,91 @@ describe("PluginsProvider", () => {
     expect(vi.mocked(invoke)).not.toHaveBeenCalledWith("install_plugin_files", expect.anything());
   });
 
+  it("routes ctx.workspace reads through the synced workspace root", async () => {
+    const reader = installedPlugin({
+      permissions: ["workspace:read"],
+      mainSource: `export default {
+        activate(ctx) {
+          ctx.commands.register({
+            id: "demo.read",
+            title: "Read",
+            async run() { await ctx.workspace.readFile("sub/a.md"); },
+          });
+        },
+      };`,
+    });
+    vi.mocked(invoke).mockImplementation((cmd) =>
+      Promise.resolve(cmd === "list_plugins" ? [reader] : undefined),
+    );
+
+    function WorkspaceProbe() {
+      const p = usePluginsOptional();
+      const commands = useRegistryEntries(p?.commands ?? null);
+      return (
+        <div>
+          <button type="button" onClick={() => p?.setWorkspaceRoot("/ws")}>
+            setroot
+          </button>
+          <button type="button" onClick={() => void commands[0]?.run()}>
+            read
+          </button>
+          <span data-testid="ready">{commands.length}</span>
+        </div>
+      );
+    }
+
+    render(
+      <PluginsProvider>
+        <WorkspaceProbe />
+      </PluginsProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("ready")).toHaveTextContent("1"));
+
+    screen.getByRole("button", { name: "setroot" }).click();
+    screen.getByRole("button", { name: "read" }).click();
+
+    await waitFor(() =>
+      expect(vi.mocked(invoke)).toHaveBeenCalledWith("read_file", { path: "/ws/sub/a.md" }),
+    );
+  });
+
+  it("shows an error toast when a marketplace download fails", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(invoke).mockImplementation((cmd) =>
+      Promise.resolve(cmd === "list_plugins" ? [] : undefined),
+    );
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    const entry = {
+      id: "com.x.market",
+      name: "Market",
+      version: "1.0.0",
+      apiVersion: "^1.0.0",
+      mainUrl: "https://example.test/main.js",
+    };
+
+    function InstallProbe() {
+      const plugins = usePluginsOptional();
+      return (
+        <button type="button" onClick={() => void plugins?.installFromRegistry(entry)}>
+          market
+        </button>
+      );
+    }
+
+    render(
+      <PluginsProvider>
+        <InstallProbe />
+      </PluginsProvider>,
+    );
+    screen.getByRole("button", { name: "market" }).click();
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Plugin error: download failed: 500"),
+    );
+    vi.unstubAllGlobals();
+    spy.mockRestore();
+  });
+
   it("keeps a plugin disabled and reports the error when re-enabling fails", async () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     const broken = installedPlugin({ mainSource: "export default {" });

--- a/src/contexts/PluginsProvider.test.tsx
+++ b/src/contexts/PluginsProvider.test.tsx
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { open } from "@tauri-apps/plugin-dialog";
+import { ask, open } from "@tauri-apps/plugin-dialog";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRegistryEntries } from "@/hooks/usePluginRegistry";
@@ -135,6 +135,70 @@ describe("PluginsProvider", () => {
     await waitFor(() =>
       expect(vi.mocked(invoke)).not.toHaveBeenCalledWith("install_plugin", expect.anything()),
     );
+  });
+
+  it("aborts a folder install when consent is declined", async () => {
+    vi.mocked(invoke).mockImplementation((cmd) =>
+      Promise.resolve(cmd === "list_plugins" ? [] : undefined),
+    );
+    vi.mocked(open).mockResolvedValue("/somewhere/plugin-folder");
+    vi.mocked(ask).mockResolvedValueOnce(false);
+
+    function InstallProbe() {
+      const plugins = usePluginsOptional();
+      return (
+        <button type="button" onClick={() => void plugins?.installFromFolder()}>
+          install
+        </button>
+      );
+    }
+
+    render(
+      <PluginsProvider>
+        <InstallProbe />
+      </PluginsProvider>,
+    );
+    screen.getByRole("button", { name: "install" }).click();
+
+    await waitFor(() => expect(vi.mocked(ask)).toHaveBeenCalled());
+    expect(vi.mocked(invoke)).not.toHaveBeenCalledWith("install_plugin", expect.anything());
+  });
+
+  it("aborts a marketplace install when consent is declined, and lists permissions in the prompt", async () => {
+    vi.mocked(invoke).mockImplementation((cmd) =>
+      Promise.resolve(cmd === "list_plugins" ? [] : undefined),
+    );
+    vi.mocked(ask).mockResolvedValueOnce(false);
+    const entry = {
+      id: "com.x.market",
+      name: "Market",
+      version: "1.0.0",
+      apiVersion: "^1.0.0",
+      permissions: ["workspace:read"],
+      mainUrl: "https://example.test/main.js",
+    };
+
+    function InstallProbe() {
+      const plugins = usePluginsOptional();
+      return (
+        <button type="button" onClick={() => void plugins?.installFromRegistry(entry)}>
+          market
+        </button>
+      );
+    }
+
+    render(
+      <PluginsProvider>
+        <InstallProbe />
+      </PluginsProvider>,
+    );
+    screen.getByRole("button", { name: "market" }).click();
+
+    await waitFor(() => expect(vi.mocked(ask)).toHaveBeenCalled());
+    const [message] = vi.mocked(ask).mock.calls.at(-1) ?? [];
+    expect(message).toContain("Market");
+    expect(message).toContain("workspace:read");
+    expect(vi.mocked(invoke)).not.toHaveBeenCalledWith("install_plugin_files", expect.anything());
   });
 
   it("shows an error toast when install fails", async () => {

--- a/src/contexts/PluginsProvider.test.tsx
+++ b/src/contexts/PluginsProvider.test.tsx
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { ask, open } from "@tauri-apps/plugin-dialog";
+import { load } from "@tauri-apps/plugin-store";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRegistryEntries } from "@/hooks/usePluginRegistry";
@@ -199,6 +200,187 @@ describe("PluginsProvider", () => {
     expect(message).toContain("Market");
     expect(message).toContain("workspace:read");
     expect(vi.mocked(invoke)).not.toHaveBeenCalledWith("install_plugin_files", expect.anything());
+  });
+
+  it("keeps a plugin disabled and reports the error when re-enabling fails", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const broken = installedPlugin({ mainSource: "export default {" });
+    vi.mocked(invoke).mockImplementation((cmd) =>
+      Promise.resolve(cmd === "list_plugins" ? [broken] : undefined),
+    );
+
+    function ManageProbe() {
+      const p = usePluginsOptional();
+      if (!p) return null;
+      return (
+        <div>
+          <span data-testid="installed">{p.installed.map((x) => x.id).join(",")}</span>
+          <span data-testid="loaded">{p.loaded.map((x) => x.id).join(",")}</span>
+          <button type="button" onClick={() => void p.setEnabled("com.x.demo", true)}>
+            on
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <PluginsProvider>
+        <ManageProbe />
+      </PluginsProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("installed")).toHaveTextContent("com.x.demo"));
+
+    screen.getByRole("button", { name: "on" }).click();
+
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Plugin error:"));
+    expect(screen.getByTestId("loaded").textContent).toBe("");
+    spy.mockRestore();
+  });
+
+  it("keeps the plugin installed and reports the error when uninstall fails", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(invoke).mockImplementation((cmd) => {
+      if (cmd === "list_plugins") return Promise.resolve([installedPlugin()]);
+      if (cmd === "uninstall_plugin") return Promise.reject(new Error("locked file"));
+      return Promise.resolve(undefined);
+    });
+
+    function ManageProbe() {
+      const p = usePluginsOptional();
+      if (!p) return null;
+      return (
+        <div>
+          <span data-testid="installed">{p.installed.map((x) => x.id).join(",")}</span>
+          <button type="button" onClick={() => void p.uninstall("com.x.demo")}>
+            rm
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <PluginsProvider>
+        <ManageProbe />
+      </PluginsProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId("installed")).toHaveTextContent("com.x.demo"));
+
+    screen.getByRole("button", { name: "rm" }).click();
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Plugin error: locked file"),
+    );
+    expect(screen.getByTestId("installed")).toHaveTextContent("com.x.demo");
+    spy.mockRestore();
+  });
+
+  it("skips disabled plugins at startup and re-enables one on reinstall", async () => {
+    // Once: only the startup loadDisabled sees the pre-disabled store; later
+    // calls (saveDisabled, other tests) fall through to the setup default.
+    vi.mocked(load).mockResolvedValueOnce({
+      get: vi.fn().mockResolvedValue(["com.x.demo"]),
+      set: vi.fn(),
+    } as never);
+    vi.mocked(invoke).mockImplementation((cmd) => {
+      if (cmd === "list_plugins") return Promise.resolve([installedPlugin()]);
+      if (cmd === "install_plugin") return Promise.resolve(installedPlugin());
+      return Promise.resolve(undefined);
+    });
+    vi.mocked(open).mockResolvedValue("/somewhere/plugin-folder");
+
+    function ManageProbe() {
+      const p = usePluginsOptional();
+      if (!p) return null;
+      return (
+        <div>
+          <span data-testid="loaded">{p.loaded.map((x) => x.id).join(",")}</span>
+          <span data-testid="disabled">{p.disabled.join(",")}</span>
+          <button type="button" onClick={() => void p.installFromFolder()}>
+            install
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <PluginsProvider>
+        <ManageProbe />
+      </PluginsProvider>,
+    );
+
+    // Disabled at startup: on disk, not loaded.
+    await waitFor(() => expect(screen.getByTestId("disabled")).toHaveTextContent("com.x.demo"));
+    expect(screen.getByTestId("loaded").textContent).toBe("");
+
+    // Reinstalling implies consent + enable: the disabled marker clears.
+    screen.getByRole("button", { name: "install" }).click();
+    await waitFor(() => expect(screen.getByTestId("loaded")).toHaveTextContent("com.x.demo"));
+    expect(screen.getByTestId("disabled").textContent).toBe("");
+  });
+
+  it("surfaces the registry, installs from it, and expires the toast", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const entry = {
+      id: "com.x.market",
+      name: "Market",
+      version: "1.0.0",
+      apiVersion: "^1.0.0",
+      mainUrl: "https://example.test/main.js",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockImplementation((url: string) =>
+          Promise.resolve(
+            url === "https://example.test/main.js"
+              ? { ok: true, text: () => Promise.resolve("export default { activate(){} };") }
+              : { ok: true, json: () => Promise.resolve({ plugins: [entry] }) },
+          ),
+        ),
+    );
+    vi.mocked(invoke).mockImplementation((cmd) => {
+      if (cmd === "list_plugins") return Promise.resolve([]);
+      if (cmd === "install_plugin_files")
+        return Promise.resolve(installedPlugin({ id: entry.id, name: entry.name }));
+      return Promise.resolve(undefined);
+    });
+
+    function MarketProbe() {
+      const p = usePluginsOptional();
+      if (!p) return null;
+      return (
+        <div>
+          <span data-testid="registry">{p.registry.map((e) => e.id).join(",")}</span>
+          <span data-testid="loaded">{p.loaded.map((x) => x.id).join(",")}</span>
+          <button
+            type="button"
+            onClick={() => p.registry[0] && void p.installFromRegistry(p.registry[0])}
+          >
+            market
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <PluginsProvider>
+        <MarketProbe />
+      </PluginsProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("registry")).toHaveTextContent("com.x.market"));
+    screen.getByRole("button", { name: "market" }).click();
+
+    await waitFor(() => expect(screen.getByTestId("loaded")).toHaveTextContent("com.x.market"));
+    expect(screen.getByRole("status")).toHaveTextContent("Installed plugin: Market v1.0.0");
+
+    // The toast auto-expires.
+    vi.advanceTimersByTime(4100);
+    await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument());
+
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it("shows an error toast when install fails", async () => {

--- a/src/contexts/PluginsProvider.tsx
+++ b/src/contexts/PluginsProvider.tsx
@@ -40,8 +40,19 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
     }, TOAST_DURATION_MS);
   }, []);
 
+  // The opened workspace root, mirrored from TabsContext by
+  // usePluginWorkspaceSync (this provider mounts above TabsProvider, so it
+  // cannot read that context directly). A ref, not state: only ctx.workspace
+  // calls read it, and they always want the current value.
+  const workspaceRootRef = useRef<string | null>(null);
+  const setWorkspaceRoot = useCallback((root: string | null) => {
+    workspaceRootRef.current = root;
+  }, []);
+
   // One host per provider; pushToast is stable so the closure stays valid.
-  const [host] = useState(() => createPluginHost(pushToast, registerTranslations));
+  const [host] = useState(() =>
+    createPluginHost(pushToast, registerTranslations, () => workspaceRootRef.current),
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -213,6 +224,7 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
         installFromRegistry,
         setEnabled,
         uninstall,
+        setWorkspaceRoot,
       }}
     >
       {children}

--- a/src/contexts/PluginsProvider.tsx
+++ b/src/contexts/PluginsProvider.tsx
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
-import { open } from "@tauri-apps/plugin-dialog";
+import { ask, open } from "@tauri-apps/plugin-dialog";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { type PluginToast, PluginToasts } from "@/components/plugins/PluginToasts";
 import { PluginsContext } from "@/contexts/PluginsContext";
 import { registerTranslations } from "@/lib/i18n";
@@ -23,6 +24,7 @@ const TOAST_DURATION_MS = 4000;
  * management modal drives.
  */
 export function PluginsProvider({ children }: { children: ReactNode }) {
+  const { t } = useTranslation("plugins");
   const [toasts, setToasts] = useState<PluginToast[]>([]);
   const [installed, setInstalled] = useState<InstalledPlugin[]>([]);
   const [disabled, setDisabled] = useState<string[]>([]);
@@ -81,20 +83,28 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
 
   const updates = useMemo(() => findUpdates(installed, registry), [installed, registry]);
 
+  // Functional updates throughout: concurrent operations would otherwise close
+  // over the same stale `disabled` array and clobber each other's persisted
+  // change. Persisting inside the updater keeps state and store in lockstep.
+  const persistDisabled = useCallback((update: (prev: string[]) => string[]) => {
+    setDisabled((prev) => {
+      const next = update(prev);
+      if (next !== prev) void saveDisabled(next);
+      return next;
+    });
+  }, []);
+
   // Record a freshly installed/updated plugin: on disk, enabled, and loaded.
   const afterInstall = useCallback(
     (plugin: InstalledPlugin) => {
       setInstalled((prev) => [...prev.filter((p) => p.id !== plugin.id), plugin]);
-      setDisabled((prev) => {
-        if (!prev.includes(plugin.id)) return prev;
-        const next = prev.filter((d) => d !== plugin.id);
-        void saveDisabled(next);
-        return next;
-      });
+      persistDisabled((prev) =>
+        prev.includes(plugin.id) ? prev.filter((d) => d !== plugin.id) : prev,
+      );
       setLoaded(host.listLoaded());
       pushToast(`Installed plugin: ${plugin.name} v${plugin.version}`);
     },
-    [host, pushToast],
+    [host, pushToast, persistDisabled],
   );
 
   const reportFailure = useCallback(
@@ -105,9 +115,27 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
     [pushToast],
   );
 
+  // Native yes/no consent before any code is installed. Installing implies
+  // consent, so re-enabling an already-installed plugin never re-prompts.
+  const confirmInstall = useCallback(
+    (name: string, permissions?: string[]) => {
+      const requests = permissions?.length
+        ? `\n\n${t("consentPermissions")}\n${permissions.map((p) => `- ${p}`).join("\n")}`
+        : "";
+      return ask(`${t("consentBody", { name })}${requests}`, {
+        title: t("consentTitle"),
+        kind: "warning",
+      });
+    },
+    [t],
+  );
+
   const installFromFolder = useCallback(async () => {
     const dir = await open({ directory: true, multiple: false, title: "Select a plugin folder" });
     if (typeof dir !== "string") return; // cancelled
+    // Folder installs read the manifest during install, so consent names the
+    // folder; declared permissions still show afterwards in Manage Plugins.
+    if (!(await confirmInstall(dir))) return;
     try {
       const plugin = await invoke<InstalledPlugin>("install_plugin", { srcDir: dir });
       await host.load(plugin);
@@ -115,10 +143,11 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
     } catch (err) {
       reportFailure(err);
     }
-  }, [host, afterInstall, reportFailure]);
+  }, [host, afterInstall, reportFailure, confirmInstall]);
 
   const installFromRegistry = useCallback(
     async (entry: RegistryEntry) => {
+      if (!(await confirmInstall(entry.name, entry.permissions))) return;
       try {
         const plugin = await downloadAndInstall(entry);
         await host.load(plugin);
@@ -127,7 +156,7 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
         reportFailure(err);
       }
     },
-    [host, afterInstall, reportFailure],
+    [host, afterInstall, reportFailure, confirmInstall],
   );
 
   const setEnabled = useCallback(
@@ -141,18 +170,14 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
           reportFailure(err);
           return;
         }
-        const next = disabled.filter((d) => d !== id);
-        setDisabled(next);
-        await saveDisabled(next);
+        persistDisabled((prev) => (prev.includes(id) ? prev.filter((d) => d !== id) : prev));
       } else {
         host.unload(id);
-        const next = disabled.includes(id) ? disabled : [...disabled, id];
-        setDisabled(next);
-        await saveDisabled(next);
+        persistDisabled((prev) => (prev.includes(id) ? prev : [...prev, id]));
       }
       setLoaded(host.listLoaded());
     },
-    [installed, disabled, host, reportFailure],
+    [installed, host, reportFailure, persistDisabled],
   );
 
   const uninstall = useCallback(
@@ -165,12 +190,10 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
         return;
       }
       setInstalled((prev) => prev.filter((p) => p.id !== id));
-      const next = disabled.filter((d) => d !== id);
-      setDisabled(next);
-      await saveDisabled(next);
+      persistDisabled((prev) => (prev.includes(id) ? prev.filter((d) => d !== id) : prev));
       setLoaded(host.listLoaded());
     },
-    [disabled, host, reportFailure],
+    [host, reportFailure, persistDisabled],
   );
 
   return (

--- a/src/hooks/useAppCommands.test.ts
+++ b/src/hooks/useAppCommands.test.ts
@@ -213,6 +213,7 @@ describe("useAppCommands", () => {
       installFromRegistry: vi.fn(async () => {}),
       setEnabled: vi.fn(async () => {}),
       uninstall: vi.fn(async () => {}),
+      setWorkspaceRoot: vi.fn(),
     };
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(PluginsContext.Provider, { value }, children);

--- a/src/hooks/usePluginWorkspaceSync.ts
+++ b/src/hooks/usePluginWorkspaceSync.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { usePluginsOptional } from "@/contexts/PluginsContext";
+import { useWorkspaceRoot } from "@/contexts/TabsContext";
+
+/**
+ * Mirror the opened workspace root into the plugin host so `ctx.workspace`
+ * stays scoped to it. Needed because PluginsProvider mounts above TabsProvider
+ * and cannot read the tabs context itself. No-op without a PluginsProvider.
+ */
+export function usePluginWorkspaceSync(): void {
+  const plugins = usePluginsOptional();
+  const root = useWorkspaceRoot();
+
+  useEffect(() => {
+    plugins?.setWorkspaceRoot(root ?? null);
+  }, [plugins, root]);
+}

--- a/src/lib/plugins/host.test.ts
+++ b/src/lib/plugins/host.test.ts
@@ -187,6 +187,33 @@ describe("createPluginHost", () => {
     expect(register).toHaveBeenCalledWith("de", "myplugin", { hello: "Hallo" });
   });
 
+  it("gates ctx.workspace on the plugin's declared permissions", async () => {
+    const host = createPluginHost(vi.fn(), undefined, () => "/ws");
+    let denied: unknown;
+    let allowedCall: Promise<string[]> | undefined;
+    const withPermission: PluginModule = {
+      activate(ctx) {
+        allowedCall = ctx.workspace.listFiles();
+        allowedCall.catch(() => {}); // resolved via mocked invoke in tests
+      },
+    };
+    const withoutPermission: PluginModule = {
+      async activate(ctx) {
+        denied = await ctx.workspace.listFiles().catch((e: unknown) => e);
+      },
+    };
+
+    await host.load(
+      installed({ id: "p.allowed", permissions: ["workspace:read"] }),
+      importerFor(withPermission),
+    );
+    await host.load(installed({ id: "p.denied" }), importerFor(withoutPermission));
+
+    expect(allowedCall).toBeDefined();
+    expect(denied).toBeInstanceOf(Error);
+    expect(String(denied)).toMatch(/workspace:read/);
+  });
+
   it("only the newest of two overlapping loads for one id commits; the stale one rolls back", async () => {
     const host = createPluginHost(vi.fn());
     const staleDeactivate = vi.fn();
@@ -212,6 +239,28 @@ describe("createPluginHost", () => {
     expect(host.commands.list().map((c) => c.id)).toEqual(["fresh.cmd"]);
     expect(host.listLoaded().map((p) => p.version)).toEqual(["2.0.0"]);
     expect(staleDeactivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs but survives when a superseded load's deactivate throws", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const host = createPluginHost(vi.fn());
+    const stale: PluginModule = {
+      activate() {},
+      deactivate() {
+        throw new Error("bad rollback");
+      },
+    };
+    const fresh: PluginModule = { activate() {} };
+
+    const first = deferredImporterFor(stale);
+    const firstLoad = host.load(installed(), first.importer);
+    await host.load(installed(), importerFor(fresh));
+    first.resolve();
+    await firstLoad;
+
+    expect(host.listLoaded()).toHaveLength(1);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 
   it("a load resolving after unloadAll rolls back instead of leaking", async () => {

--- a/src/lib/plugins/host.test.ts
+++ b/src/lib/plugins/host.test.ts
@@ -187,6 +187,20 @@ describe("createPluginHost", () => {
     expect(register).toHaveBeenCalledWith("de", "myplugin", { hello: "Hallo" });
   });
 
+  it("defaults ctx.workspace to no-workspace-open when no root getter is supplied", async () => {
+    const host = createPluginHost(vi.fn());
+    let error: unknown;
+    const module: PluginModule = {
+      async activate(ctx) {
+        error = await ctx.workspace.listFiles().catch((e: unknown) => e);
+      },
+    };
+
+    await host.load(installed({ permissions: ["workspace:read"] }), importerFor(module));
+
+    expect(String(error)).toMatch(/no workspace/);
+  });
+
   it("gates ctx.workspace on the plugin's declared permissions", async () => {
     const host = createPluginHost(vi.fn(), undefined, () => "/ws");
     let denied: unknown;

--- a/src/lib/plugins/host.test.ts
+++ b/src/lib/plugins/host.test.ts
@@ -21,6 +21,21 @@ function importerFor(module: PluginModule): ModuleImporter {
   return vi.fn().mockResolvedValue({ default: module });
 }
 
+/** An importer whose resolution the test controls, for overlap/race cases. */
+function deferredImporterFor(module: PluginModule): {
+  importer: ModuleImporter;
+  resolve: () => void;
+} {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  return {
+    importer: () => gate.then(() => ({ default: module })),
+    resolve: release,
+  };
+}
+
 describe("createPluginHost", () => {
   it("activates a plugin and exposes its contributions", async () => {
     const host = createPluginHost(vi.fn());
@@ -170,6 +185,67 @@ describe("createPluginHost", () => {
     await host.load(installed(), importerFor(module));
 
     expect(register).toHaveBeenCalledWith("de", "myplugin", { hello: "Hallo" });
+  });
+
+  it("only the newest of two overlapping loads for one id commits; the stale one rolls back", async () => {
+    const host = createPluginHost(vi.fn());
+    const staleDeactivate = vi.fn();
+    const stale: PluginModule = {
+      activate(ctx) {
+        ctx.commands.register({ id: "stale.cmd", title: "Stale", run: () => {} });
+      },
+      deactivate: staleDeactivate,
+    };
+    const fresh: PluginModule = {
+      activate(ctx) {
+        ctx.commands.register({ id: "fresh.cmd", title: "Fresh", run: () => {} });
+      },
+    };
+
+    const first = deferredImporterFor(stale);
+    const firstLoad = host.load(installed({ version: "1.0.0" }), first.importer);
+    // Second load for the same id starts before the first resolves.
+    await host.load(installed({ version: "2.0.0" }), importerFor(fresh));
+    first.resolve();
+    await firstLoad;
+
+    expect(host.commands.list().map((c) => c.id)).toEqual(["fresh.cmd"]);
+    expect(host.listLoaded().map((p) => p.version)).toEqual(["2.0.0"]);
+    expect(staleDeactivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("a load resolving after unloadAll rolls back instead of leaking", async () => {
+    const host = createPluginHost(vi.fn());
+    const module: PluginModule = {
+      activate(ctx) {
+        ctx.commands.register({ id: "late.cmd", title: "Late", run: () => {} });
+      },
+    };
+    const gate = deferredImporterFor(module);
+    const pending = host.load(installed(), gate.importer);
+
+    host.unloadAll();
+    gate.resolve();
+    await pending;
+
+    expect(host.commands.list()).toHaveLength(0);
+    expect(host.listLoaded()).toHaveLength(0);
+  });
+
+  it("can load again after unloadAll (StrictMode remount)", async () => {
+    const host = createPluginHost(vi.fn());
+    const make = (): PluginModule => ({
+      activate(ctx) {
+        ctx.commands.register({ id: "again.cmd", title: "Again", run: () => {} });
+      },
+    });
+
+    await host.load(installed(), importerFor(make()));
+    host.unloadAll();
+    await host.load(installed(), importerFor(make()));
+
+    expect(host.commands.list().map((c) => c.id)).toEqual(["again.cmd"]);
+    expect(host.listLoaded()).toHaveLength(1);
   });
 
   it("unloadAll tears down every plugin", async () => {

--- a/src/lib/plugins/host.ts
+++ b/src/lib/plugins/host.ts
@@ -11,6 +11,7 @@ import type {
   PluginModule,
   StatusBarItemContribution,
 } from "./types";
+import { createWorkspaceApi } from "./workspaceApi";
 
 export interface LoadedPluginInfo {
   id: string;
@@ -61,6 +62,9 @@ export function createPluginHost(
   // without i18next). Defaults to a no-op. Translations persist past unload,
   // which is harmless (just unused strings in memory).
   registerTranslations: GlyphPluginContext["registerTranslations"] = () => {},
+  // Where the opened workspace lives right now; null when none is open. The
+  // provider keeps this current so ctx.workspace stays scoped correctly.
+  getWorkspaceRoot: () => string | null = () => null,
 ): PluginHost {
   const commands = createRegistry<CommandContribution>();
   const statusBarItems = createRegistry<StatusBarItemContribution>();
@@ -79,7 +83,7 @@ export function createPluginHost(
       return dispose;
     };
 
-  const buildContext = (bag: DisposerBag): GlyphPluginContext => ({
+  const buildContext = (bag: DisposerBag, permissions: readonly string[]): GlyphPluginContext => ({
     apiVersion: PLUGIN_API_VERSION,
     commands: { register: tracked(commands.register, bag) },
     ui: { addStatusBarItem: tracked(statusBarItems.register, bag) },
@@ -90,6 +94,7 @@ export function createPluginHost(
         return tracked(fencedRenderers.register, bag)({ language, render });
       },
     },
+    workspace: createWorkspaceApi(getWorkspaceRoot, permissions),
     notify,
     registerTranslations,
   });
@@ -131,7 +136,7 @@ export function createPluginHost(
       const module = await importPluginModule(plugin.mainSource, importer);
       const bag = new DisposerBag();
       try {
-        await module.activate(buildContext(bag));
+        await module.activate(buildContext(bag, plugin.permissions ?? []));
       } catch (err) {
         bag.dispose(); // roll back anything registered before the throw
         throw err;

--- a/src/lib/plugins/host.ts
+++ b/src/lib/plugins/host.ts
@@ -106,6 +106,13 @@ export function createPluginHost(
     }
   };
 
+  // Guards against overlapping load() calls for the same id (rapid re-enable
+  // or double-clicked update) and against loads that resolve after teardown:
+  // only the newest generation commits; anything stale rolls itself back.
+  // unloadAll bumps every generation instead of latching a closed flag, so a
+  // StrictMode remount (same host instance) can still load plugins afterwards.
+  const loadGeneration = new Map<string, number>();
+
   return {
     commands,
     statusBarItems,
@@ -118,7 +125,9 @@ export function createPluginHost(
           `${plugin.name} requires plugin API ${plugin.apiVersion}, but this Glyph provides ${PLUGIN_API_VERSION}`,
         );
       }
-      unload(plugin.id);
+      const generation = (loadGeneration.get(plugin.id) ?? 0) + 1;
+      loadGeneration.set(plugin.id, generation);
+
       const module = await importPluginModule(plugin.mainSource, importer);
       const bag = new DisposerBag();
       try {
@@ -127,6 +136,20 @@ export function createPluginHost(
         bag.dispose(); // roll back anything registered before the throw
         throw err;
       }
+      // Superseded by a newer load, or the host has been torn down: undo this
+      // activation instead of committing a leaked instance.
+      if (loadGeneration.get(plugin.id) !== generation) {
+        bag.dispose();
+        try {
+          module.deactivate?.();
+        } catch (err) {
+          console.error(`Plugin ${plugin.id} threw in deactivate():`, err);
+        }
+        return;
+      }
+      // The previous instance stays live while the new one downloads and
+      // activates; swap only at commit time.
+      unload(plugin.id);
       loaded.set(plugin.id, {
         info: {
           id: plugin.id,
@@ -140,6 +163,10 @@ export function createPluginHost(
     },
     unload,
     unloadAll() {
+      // Invalidate in-flight loads too, not just committed instances.
+      for (const [id, generation] of loadGeneration) {
+        loadGeneration.set(id, generation + 1);
+      }
       for (const id of [...loaded.keys()]) unload(id);
     },
     listLoaded() {

--- a/src/lib/plugins/loader.test.ts
+++ b/src/lib/plugins/loader.test.ts
@@ -21,6 +21,7 @@ describe("importPluginModule", () => {
         registerRehypePlugin: vi.fn(),
         registerFencedRenderer: vi.fn(),
       },
+      workspace: { readFile: vi.fn(), listFiles: vi.fn() },
       notify,
       registerTranslations: vi.fn(),
     });
@@ -41,6 +42,7 @@ describe("importPluginModule", () => {
         registerRehypePlugin: vi.fn(),
         registerFencedRenderer: vi.fn(),
       },
+      workspace: { readFile: vi.fn(), listFiles: vi.fn() },
       notify,
       registerTranslations: vi.fn(),
     });

--- a/src/lib/plugins/marketplace.test.ts
+++ b/src/lib/plugins/marketplace.test.ts
@@ -63,7 +63,9 @@ describe("installFromRegistry", () => {
     );
     vi.mocked(invoke).mockResolvedValue(undefined);
 
-    await installFromRegistry(entry({ version: "2.0.0", description: "d" }));
+    await installFromRegistry(
+      entry({ version: "2.0.0", description: "d", permissions: ["workspace:read"] }),
+    );
 
     const [cmd, args] = vi.mocked(invoke).mock.calls.at(-1) ?? [];
     expect(cmd).toBe("install_plugin_files");
@@ -74,6 +76,7 @@ describe("installFromRegistry", () => {
       version: "2.0.0",
       apiVersion: "^1.0.0",
       description: "d",
+      permissions: ["workspace:read"],
     });
   });
 

--- a/src/lib/plugins/marketplace.ts
+++ b/src/lib/plugins/marketplace.ts
@@ -14,6 +14,8 @@ export interface RegistryEntry {
   description?: string;
   version: string;
   apiVersion: string;
+  /** Capabilities the plugin declares; shown to the user before install. */
+  permissions?: string[];
   /** Direct URL to the plugin's built ESM entry file. */
   mainUrl: string;
 }
@@ -64,6 +66,7 @@ export async function installFromRegistry(entry: RegistryEntry): Promise<Install
     version: entry.version,
     apiVersion: entry.apiVersion,
     description: entry.description,
+    permissions: entry.permissions,
   });
   return invoke<InstalledPlugin>("install_plugin_files", { manifest, main });
 }

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -102,11 +102,24 @@ export interface MarkdownRegistryApi {
  * registration returns a {@link Disposer}; the host collects them and runs
  * them on unload, so a plugin that only registers needs no `deactivate`.
  */
+/**
+ * Mediated, read-only access to the opened workspace. Requires the plugin to
+ * declare the `workspace:read` permission; paths are workspace-relative and
+ * confined to the workspace root.
+ */
+export interface WorkspaceApi {
+  /** Read a file inside the workspace (workspace-relative path). */
+  readFile(path: string): Promise<string>;
+  /** List the workspace's markdown files (absolute paths). */
+  listFiles(): Promise<string[]>;
+}
+
 export interface GlyphPluginContext {
   readonly apiVersion: string;
   readonly commands: CommandRegistryApi;
   readonly ui: UiRegistryApi;
   readonly markdown: MarkdownRegistryApi;
+  readonly workspace: WorkspaceApi;
   notify(message: string): void;
   /**
    * Register (or extend) translations for a locale + namespace. A plugin ships

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -48,6 +48,8 @@ export interface InstalledPlugin {
   version: string;
   apiVersion: string;
   description?: string;
+  /** Capabilities the plugin declares; shown to the user before install. */
+  permissions?: string[];
   /** Absolute path of the installed plugin folder. */
   dir: string;
   /** Source text of the plugin's ESM entry file. */

--- a/src/lib/plugins/workspaceApi.test.ts
+++ b/src/lib/plugins/workspaceApi.test.ts
@@ -1,0 +1,56 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createWorkspaceApi } from "./workspaceApi";
+
+describe("createWorkspaceApi", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+    vi.mocked(invoke).mockResolvedValue(undefined);
+  });
+
+  it("rejects every call without the workspace:read permission", async () => {
+    const api = createWorkspaceApi(() => "/ws", []);
+    await expect(api.readFile("a.md")).rejects.toThrow(/workspace:read/);
+    await expect(api.listFiles()).rejects.toThrow(/workspace:read/);
+    expect(vi.mocked(invoke)).not.toHaveBeenCalled();
+  });
+
+  it("rejects when no workspace is open", async () => {
+    const api = createWorkspaceApi(() => null, ["workspace:read"]);
+    await expect(api.readFile("a.md")).rejects.toThrow(/no workspace/);
+    expect(vi.mocked(invoke)).not.toHaveBeenCalled();
+  });
+
+  it("reads a workspace-relative file through the Rust command", async () => {
+    vi.mocked(invoke).mockResolvedValue("# hi");
+    const api = createWorkspaceApi(() => "/ws", ["workspace:read"]);
+
+    await expect(api.readFile("sub/a.md")).resolves.toBe("# hi");
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith("read_file", { path: "/ws/sub/a.md" });
+  });
+
+  it("rejects paths outside the workspace without invoking", async () => {
+    const api = createWorkspaceApi(() => "/ws", ["workspace:read"]);
+    await expect(api.readFile("../outside.md")).rejects.toThrow(/outside the workspace/);
+    expect(vi.mocked(invoke)).not.toHaveBeenCalled();
+  });
+
+  it("lists workspace markdown files", async () => {
+    vi.mocked(invoke).mockResolvedValue(["/ws/a.md"]);
+    const api = createWorkspaceApi(() => "/ws", ["workspace:read"]);
+
+    await expect(api.listFiles()).resolves.toEqual(["/ws/a.md"]);
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith("list_markdown_files", { path: "/ws" });
+  });
+
+  it("tracks a root that changes between calls", async () => {
+    let root = "/ws-one";
+    const api = createWorkspaceApi(() => root, ["workspace:read"]);
+    await api.readFile("a.md");
+    expect(vi.mocked(invoke)).toHaveBeenLastCalledWith("read_file", { path: "/ws-one/a.md" });
+
+    root = "/ws-two";
+    await api.readFile("a.md");
+    expect(vi.mocked(invoke)).toHaveBeenLastCalledWith("read_file", { path: "/ws-two/a.md" });
+  });
+});

--- a/src/lib/plugins/workspaceApi.ts
+++ b/src/lib/plugins/workspaceApi.ts
@@ -1,0 +1,36 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { WorkspaceApi } from "./types";
+import { resolveInsideRoot } from "./workspacePath";
+
+/**
+ * The mediated file door for plugins: reads go through the host's Rust
+ * commands, are confined to the opened workspace, and require the plugin to
+ * have declared the `workspace:read` permission (which the user saw and
+ * accepted at install time). No workspace open means no access.
+ */
+export function createWorkspaceApi(
+  getRoot: () => string | null,
+  permissions: readonly string[],
+): WorkspaceApi {
+  const requireRoot = (): string => {
+    if (!permissions.includes("workspace:read")) {
+      throw new Error('this plugin did not declare the "workspace:read" permission');
+    }
+    const root = getRoot();
+    if (!root) throw new Error("no workspace is open");
+    return root;
+  };
+
+  return {
+    async readFile(path) {
+      const root = requireRoot();
+      const resolved = resolveInsideRoot(root, path);
+      if (!resolved) throw new Error(`path is outside the workspace: ${path}`);
+      return invoke<string>("read_file", { path: resolved });
+    },
+    async listFiles() {
+      const root = requireRoot();
+      return invoke<string[]>("list_markdown_files", { path: root });
+    },
+  };
+}

--- a/src/lib/plugins/workspacePath.test.ts
+++ b/src/lib/plugins/workspacePath.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveInsideRoot } from "./workspacePath";
+
+describe("resolveInsideRoot", () => {
+  it("resolves simple and nested relative paths", () => {
+    expect(resolveInsideRoot("/ws", "notes.md")).toBe("/ws/notes.md");
+    expect(resolveInsideRoot("/ws", "sub/deep/notes.md")).toBe("/ws/sub/deep/notes.md");
+    expect(resolveInsideRoot("/ws/", "notes.md")).toBe("/ws/notes.md");
+  });
+
+  it("uses backslashes when the root does", () => {
+    expect(resolveInsideRoot("C:\\ws", "sub/notes.md")).toBe("C:\\ws\\sub\\notes.md");
+    expect(resolveInsideRoot("C:\\ws\\", "sub\\notes.md")).toBe("C:\\ws\\sub\\notes.md");
+  });
+
+  it("collapses . and safe .. segments", () => {
+    expect(resolveInsideRoot("/ws", "./a/./b.md")).toBe("/ws/a/b.md");
+    expect(resolveInsideRoot("/ws", "a/../b.md")).toBe("/ws/b.md");
+  });
+
+  it("rejects escapes above the root", () => {
+    expect(resolveInsideRoot("/ws", "../secret")).toBeNull();
+    expect(resolveInsideRoot("/ws", "a/../../secret")).toBeNull();
+    expect(resolveInsideRoot("/ws", "..\\secret")).toBeNull();
+  });
+
+  it("rejects absolute inputs", () => {
+    expect(resolveInsideRoot("/ws", "/etc/passwd")).toBeNull();
+    expect(resolveInsideRoot("C:\\ws", "C:\\Windows\\system.ini")).toBeNull();
+    expect(resolveInsideRoot("C:\\ws", "\\\\server\\share")).toBeNull();
+  });
+
+  it("rejects paths that resolve to the root itself", () => {
+    expect(resolveInsideRoot("/ws", "")).toBeNull();
+    expect(resolveInsideRoot("/ws", ".")).toBeNull();
+    expect(resolveInsideRoot("/ws", "a/..")).toBeNull();
+  });
+});

--- a/src/lib/plugins/workspacePath.ts
+++ b/src/lib/plugins/workspacePath.ts
@@ -1,0 +1,29 @@
+// Path containment for the plugin workspace API: a plugin may only read files
+// inside the opened workspace, whatever separators or `..` segments it sends.
+
+/**
+ * Resolve `relPath` against `root` and return the absolute path, or `null`
+ * when the input is absolute or escapes the root. Handles both `/` and `\`
+ * separators; the result uses the platform separator found in `root`.
+ */
+export function resolveInsideRoot(root: string, relPath: string): string | null {
+  // Absolute inputs (posix, Windows drive, or UNC) are rejected outright: the
+  // API is documented as workspace-relative.
+  if (/^([a-zA-Z]:|[\\/])/.test(relPath)) return null;
+
+  const segments: string[] = [];
+  for (const part of relPath.split(/[\\/]+/)) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (segments.length === 0) return null; // escape above the root
+      segments.pop();
+      continue;
+    }
+    segments.push(part);
+  }
+  if (segments.length === 0) return null; // "" / "." / "a/.." resolve to the root itself
+
+  const sep = root.includes("\\") ? "\\" : "/";
+  const base = root.endsWith(sep) ? root.slice(0, -sep.length) : root;
+  return `${base}${sep}${segments.join(sep)}`;
+}

--- a/src/locales/de/plugins.json
+++ b/src/locales/de/plugins.json
@@ -9,5 +9,9 @@
   "enable": "{{name}} aktivieren",
   "noInstalled": "Keine Plugins installiert.",
   "noAvailable": "Keine Plugins verfügbar.",
-  "updateTo": "Auf v{{version}} aktualisieren"
+  "updateTo": "Auf v{{version}} aktualisieren",
+  "consentTitle": "Plugin installieren?",
+  "consentBody": "\"{{name}}\" führt JavaScript in Glyph mit Zugriff auf die Plugin-API aus.",
+  "consentPermissions": "Es fordert an:",
+  "permissionsLabel": "Berechtigungen"
 }

--- a/src/locales/en/plugins.json
+++ b/src/locales/en/plugins.json
@@ -9,5 +9,9 @@
   "enable": "Enable {{name}}",
   "noInstalled": "No plugins installed.",
   "noAvailable": "No plugins available.",
-  "updateTo": "Update to v{{version}}"
+  "updateTo": "Update to v{{version}}",
+  "consentTitle": "Install plugin?",
+  "consentBody": "\"{{name}}\" will run JavaScript inside Glyph with access to the plugin API.",
+  "consentPermissions": "It requests:",
+  "permissionsLabel": "Permissions"
 }

--- a/src/locales/es/plugins.json
+++ b/src/locales/es/plugins.json
@@ -9,5 +9,9 @@
   "enable": "Activar {{name}}",
   "noInstalled": "No hay complementos instalados.",
   "noAvailable": "No hay complementos disponibles.",
-  "updateTo": "Actualizar a v{{version}}"
+  "updateTo": "Actualizar a v{{version}}",
+  "consentTitle": "¿Instalar complemento?",
+  "consentBody": "\"{{name}}\" ejecutará JavaScript dentro de Glyph con acceso a la API de complementos.",
+  "consentPermissions": "Solicita:",
+  "permissionsLabel": "Permisos"
 }

--- a/src/locales/fa/plugins.json
+++ b/src/locales/fa/plugins.json
@@ -9,5 +9,9 @@
   "enable": "فعال‌سازی {{name}}",
   "noInstalled": "هیچ افزونه‌ای نصب نشده است.",
   "noAvailable": "افزونه‌ای در دسترس نیست.",
-  "updateTo": "به‌روزرسانی به نسخهٔ {{version}}"
+  "updateTo": "به‌روزرسانی به نسخهٔ {{version}}",
+  "consentTitle": "افزونه نصب شود؟",
+  "consentBody": "«{{name}}» جاوااسکریپت را درون Glyph با دسترسی به API افزونه اجرا می‌کند.",
+  "consentPermissions": "درخواست می‌کند:",
+  "permissionsLabel": "دسترسی‌ها"
 }

--- a/src/locales/zh/plugins.json
+++ b/src/locales/zh/plugins.json
@@ -9,5 +9,9 @@
   "enable": "启用 {{name}}",
   "noInstalled": "尚未安装插件。",
   "noAvailable": "暂无可用插件。",
-  "updateTo": "更新到 v{{version}}"
+  "updateTo": "更新到 v{{version}}",
+  "consentTitle": "安装插件？",
+  "consentBody": "“{{name}}”将在 Glyph 中运行 JavaScript 并访问插件 API。",
+  "consentPermissions": "它请求：",
+  "permissionsLabel": "权限"
 }


### PR DESCRIPTION
## Summary

Phase B of the plugin system (#109): a consent gate before any plugin code is installed, declared-permissions passthrough end to end, plus fixes for the lifecycle races found by the post-Phase-A code review.

## Changes

**Consent + permissions**
- Native confirm dialog (`ask`) before both install paths (folder + marketplace); declining aborts before anything touches disk. Installing implies consent, so re-enabling never re-prompts.
- `permissions` array parsed from `manifest.json` in Rust (strict: array of strings or the manifest is rejected), carried on `InstalledPlugin`, `RegistryEntry`, and the synthesized marketplace manifest.
- Marketplace installs list the entry's declared permissions in the consent prompt; Manage Plugins shows each installed plugin's permissions.
- New i18n keys in all 5 locales.

**Review fixes (from the phase review of #263/#296/#350)**
- [high] `host.load` double-activation race: overlapping loads for one id (rapid re-enable, double-clicked update) both activated and one leaked its registrations forever. Now a per-id generation guard commits only the newest load; stale ones roll back and deactivate. The old instance also stays live until the new one is ready.
- [med] Unmount race: a load resolving after `unloadAll()` committed into a torn-down host. `unloadAll` now invalidates in-flight generations (without latching closed, so StrictMode remounts still work).
- [low] `setEnabled`/`uninstall` stale-closure on `disabled` could clobber concurrent persisted changes; now functional updates via one `persistDisabled` helper (also adopted by `afterInstall`).
- [low] Stale comment in `CodeBlockComponent` claiming d2 is plugin-contributed.

**Scoped workspace API (ctx.workspace)**
- New `ctx.workspace.readFile(relPath)` / `ctx.workspace.listFiles()`: mediated through the existing Rust commands, gated on the declared `workspace:read` permission, and path-confined to the opened workspace (`..`/absolute escapes rejected by a pure resolver with tests). No workspace open = no access. The workspace root is mirrored into the host by a new `usePluginWorkspaceSync` hook (PluginsProvider mounts above TabsProvider).

**Coverage**
- Filled the Codecov gaps: host stale-deactivate branch, provider re-enable failure, uninstall failure, disabled-at-startup + reinstall re-enable, registry fetch/install success, toast expiry. Provider is now ~99% lines, host 100%.

## Testing

- New tests: overlapping-load race, load-after-unloadAll rollback, reload-after-unloadAll (StrictMode), consent declined for both install paths (with permissions listed in the prompt), permissions in modal, permissions in synthesized manifest, Rust manifest permissions (valid/default/rejected).
- `pnpm typecheck`, `pnpm check`, full `pnpm test`, `cargo test` (24 plugin tests), `cargo clippy -D warnings`: green via the pre-commit gate.
- [ ] Tested on macOS
- [x] Tested on Windows (suite)
- [ ] Tested on Linux

Part of #109.

## Screenshots

_N/A (native confirm dialog + a permissions line in Manage Plugins)._

