### PR TITLE
chore(snap): refresh store listing title, description, and donation link

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,7 @@
 #
 # See the Tauri Snapcraft guide: https://v2.tauri.app/distribute/snapcraft/
 name: glyph
+title: Glyph
 base: core22
 adopt-info: glyph
 icon: src-tauri/icons/icon.png
@@ -26,10 +27,11 @@ description: |
   platform-native styling. Built with Tauri v2, React 19, and TypeScript.
 
   Features GitHub Flavored Markdown with syntax highlighting, KaTeX math,
-  Mermaid diagrams, multi-file tabs, a table-of-contents outline, live file
-  watching, wikilinks and backlinks, optional AI summarization
-  (Claude/OpenAI/Ollama), text-to-speech, and light/dark themes that follow
-  the system appearance.
+  Mermaid and D2 diagrams, multi-file tabs, a table-of-contents outline,
+  live file watching, wikilinks and backlinks, optional AI summarization
+  (Claude/OpenAI/Ollama), text-to-speech, cloud sync across devices, a
+  JavaScript plugin system, and light/dark themes that follow the system
+  appearance.
 
 grade: stable
 confinement: strict
@@ -37,6 +39,7 @@ license: MIT
 website: https://glyph-md.github.io
 issues: https://github.com/hamidfzm/glyph/issues
 source-code: https://github.com/hamidfzm/glyph
+donation: https://github.com/hamidfzm/glyph#sponsors
 compression: lzo
 
 apps:


### PR DESCRIPTION
## Summary

Refresh the project description across the packaging metadata so the newer features (D2 diagrams, cloud sync, JavaScript plugins) are surfaced where users discover the app.

The Snap Store listing fields in `snap/snapcraft.yaml` are the source of truth that `snapcraft upload` pushes on each release (title, summary, description, links); store-only fields (categories, featured banner) are set separately in the dashboard.

## Changes

- **snap/snapcraft.yaml** — add `title: Glyph` (store showed the lowercase snap name `glyph`), refresh the description (D2 diagrams, cloud sync, JavaScript plugins), and add `donation: https://github.com/hamidfzm/glyph#sponsors` so the listing's Donations field is populated.
- **chocolatey/glyph.nuspec** — surface the newer features in the description; fix "live reload" wording to "live file watching".
- **ppa/debian/control** — surface the newer features in the long description.

README already documents all three features, and the remaining package descriptions (AUR/Homebrew/Scoop/Cargo) are generic taglines that don't enumerate features, so they're left unchanged.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Metadata-only change; snap fields take effect on the next release when the `publish-snap` job runs `snapcraft upload`.

## Screenshots

n/a