### PR TITLE
feat(viewer): right-click menu to copy link address or open in external browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 - Emoji shortcodes: `:smile:` → 😊, `:+1:` → 👍
 - Local and remote image display
 - Image lightbox: click any image to view it full-size over a dark backdrop, with zoom controls (fit, actual size, zoom in/out), arrow-key navigation between the document's images, and Escape or click-outside to close
-- External links open in system browser with optional confirmation dialog
+- External links open in system browser with optional confirmation dialog; right-click one to copy its address or open it in the external browser
 
 ### Editor
 - Markdown editor mode: syntax highlighting, line numbers, undo/redo history

--- a/src/hooks/useContextMenu.test.tsx
+++ b/src/hooks/useContextMenu.test.tsx
@@ -114,6 +114,44 @@ describe("useContextMenu", () => {
     expect(actionLabels(result.current.menu)).toContain("Select All");
   });
 
+  it("adds link actions when the target is inside an external link", () => {
+    const body = document.createElement("div");
+    body.className = "markdown-body";
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "https://example.com");
+    const strong = document.createElement("strong");
+    strong.textContent = "example";
+    anchor.appendChild(strong);
+    body.appendChild(anchor);
+    document.body.appendChild(body);
+    const { result } = renderHook(() => useContextMenu(baseActions));
+
+    act(() => {
+      fireContextMenu(strong);
+    });
+
+    const labels = actionLabels(result.current.menu);
+    expect(labels).toContain("Copy Link Address");
+    expect(labels).toContain("Open in External Browser");
+  });
+
+  it("shows no link actions for internal links (wikilinks render as href='#')", () => {
+    const body = document.createElement("div");
+    body.className = "markdown-body";
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "#");
+    anchor.textContent = "wikilink";
+    body.appendChild(anchor);
+    document.body.appendChild(body);
+    const { result } = renderHook(() => useContextMenu(baseActions));
+
+    act(() => {
+      fireContextMenu(anchor);
+    });
+
+    expect(actionLabels(result.current.menu)).toEqual(["Select All"]);
+  });
+
   it("close() clears the open menu", () => {
     const para = mountMarkdown();
     const { result } = renderHook(() => useContextMenu(baseActions));

--- a/src/hooks/useContextMenu.ts
+++ b/src/hooks/useContextMenu.ts
@@ -56,7 +56,15 @@ export function useContextMenu(actions: ContextMenuActions) {
       // Only the markdown viewer shows a themed menu; other chrome shows none.
       if (!isInsideMarkdownContent(e.target)) return;
       const selection = window.getSelection()?.toString().trim() ?? "";
-      setMenu({ x: e.clientX, y: e.clientY, items: buildContextMenuItems(actions, selection, t) });
+      // Raw attribute, not the resolved `href` property: resolution would turn
+      // relative workspace links into http://localhost/... URLs, which would
+      // wrongly pass the external-link filter in the builder.
+      const linkHref = (e.target as Element).closest("a[href]")?.getAttribute("href") ?? undefined;
+      setMenu({
+        x: e.clientX,
+        y: e.clientY,
+        items: buildContextMenuItems(actions, selection, t, linkHref),
+      });
     };
     document.addEventListener("contextmenu", handler);
     return () => document.removeEventListener("contextmenu", handler);

--- a/src/lib/contextMenuItems.test.ts
+++ b/src/lib/contextMenuItems.test.ts
@@ -1,3 +1,4 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "@/lib/i18n";
 import {
@@ -7,6 +8,8 @@ import {
   searchGoogle,
   selectAllContent,
 } from "./contextMenuItems";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn().mockResolvedValue(undefined) }));
 
 // English-bound translator so label assertions read the same source strings.
 const t = i18n.getFixedT("en", "common");
@@ -134,6 +137,44 @@ describe("buildContextMenuItems", () => {
     const search = items.find((i) => i.kind === "action" && i.label.startsWith("Search Google"));
     if (search?.kind === "action") search.onSelect();
     expect(open).toHaveBeenCalledWith("https://www.google.com/search?q=term", "_blank");
+  });
+
+  it("prepends link actions for an external http(s) link", () => {
+    const items = buildContextMenuItems({}, "", t, "https://example.com/page");
+    const labels = actionLabels(items);
+    expect(labels.slice(0, 2)).toEqual(["Copy Link Address", "Open in External Browser"]);
+  });
+
+  it("Copy Link Address puts the full URL on the clipboard", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const items = buildContextMenuItems({}, "", t, "http://example.com/a?b=c");
+    const copy = find(items, "Copy Link Address");
+    if (copy?.kind === "action") copy.onSelect();
+    expect(writeText).toHaveBeenCalledWith("http://example.com/a?b=c");
+  });
+
+  it("Open in External Browser routes through the opener plugin", () => {
+    const items = buildContextMenuItems({}, "", t, "https://example.com");
+    const open = find(items, "Open in External Browser");
+    if (open?.kind === "action") open.onSelect();
+    expect(openUrl).toHaveBeenCalledWith("https://example.com");
+  });
+
+  it("omits link actions for internal targets and when no link is present", () => {
+    for (const href of ["#heading", "./notes/other.md", "#", "mailto:a@b.c", undefined]) {
+      const items = buildContextMenuItems({}, "", t, href);
+      expect(actionLabels(items)).toEqual(["Select All"]);
+    }
+  });
+
+  it("keeps text actions alongside link actions when a link is right-clicked over a selection", () => {
+    const items = buildContextMenuItems({}, "picked", t, "https://example.com");
+    const labels = actionLabels(items);
+    expect(labels).toContain("Copy Link Address");
+    expect(labels).toContain("Open in External Browser");
+    expect(labels).toContain("Copy");
+    expect(labels.some((l) => l.startsWith("Search Google"))).toBe(true);
   });
 
   it("Stop Reading invokes ttsStop", () => {

--- a/src/lib/contextMenuItems.ts
+++ b/src/lib/contextMenuItems.ts
@@ -40,7 +40,9 @@ export type ContextMenuItem =
 const SELECTION_PREVIEW_MAX = 30;
 // Link actions only apply to external web URLs. Internal targets (wikilinks
 // render as href="#", heading anchors, relative workspace paths) have no
-// meaningful "copy address" or "open in browser" semantics.
+// meaningful "copy address" or "open in browser" semantics. Other schemes that
+// are "external" for click-through (mailto: etc.) are deliberately excluded
+// too: "Open in External Browser" would be a misleading label for them.
 export function isExternalHttpUrl(href: string): boolean {
   return /^https?:\/\//i.test(href);
 }
@@ -48,8 +50,8 @@ export function isExternalHttpUrl(href: string): boolean {
 // translated separately via `contextMenu.aiVerb.<id>`.
 const AI_ACTIONS = ["summarize", "explain", "translate", "simplify"] as const;
 
-/** Copy text to the clipboard. The text is captured up front (not read live)
- *  so it survives focus moving from the document selection to the menu. */
+/** Copy text (a captured selection, a link href) to the clipboard. The text is
+ *  captured up front (not read live) so it survives focus moving to the menu. */
 export function copySelection(text: string): void {
   // Best-effort: the clipboard write can reject when the window isn't focused
   // or permission is denied. There's no meaningful recovery for a copy gesture,

--- a/src/lib/contextMenuItems.ts
+++ b/src/lib/contextMenuItems.ts
@@ -2,6 +2,7 @@
 // the hook and the component so the menu's contents are pure, easy to unit test,
 // and free of any React or OS-native menu API.
 
+import { openUrl } from "@tauri-apps/plugin-opener";
 import type { TFunction } from "i18next";
 import type { ReactNode } from "react";
 
@@ -37,6 +38,12 @@ export type ContextMenuItem =
   | ContextMenuSubmenuItem;
 
 const SELECTION_PREVIEW_MAX = 30;
+// Link actions only apply to external web URLs. Internal targets (wikilinks
+// render as href="#", heading anchors, relative workspace paths) have no
+// meaningful "copy address" or "open in browser" semantics.
+export function isExternalHttpUrl(href: string): boolean {
+  return /^https?:\/\//i.test(href);
+}
 // Canonical action ids passed to the AI controller; the visible verb is
 // translated separately via `contextMenu.aiVerb.<id>`.
 const AI_ACTIONS = ["summarize", "explain", "translate", "simplify"] as const;
@@ -86,7 +93,25 @@ export function buildContextMenuItems(
   actions: ContextMenuActions,
   selection: string,
   t: TFunction<"common">,
+  linkHref?: string,
 ): ContextMenuItem[] {
+  const link: ContextMenuItem[] = [];
+  if (linkHref && isExternalHttpUrl(linkHref)) {
+    link.push(
+      {
+        kind: "action",
+        label: t("contextMenu.copyLinkAddress"),
+        onSelect: () => copySelection(linkHref),
+      },
+      {
+        kind: "action",
+        label: t("contextMenu.openInBrowser"),
+        // Best-effort like copySelection: no meaningful recovery for the gesture.
+        onSelect: () => void openUrl(linkHref).catch(() => undefined),
+      },
+    );
+  }
+
   const text: ContextMenuItem[] = [];
   if (selection) {
     text.push({
@@ -142,5 +167,5 @@ export function buildContextMenuItems(
     }
   }
 
-  return joinGroups([text, tts, ai]);
+  return joinGroups([link, text, tts, ai]);
 }

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -73,6 +73,8 @@
   },
   "contextMenu": {
     "copy": "Kopieren",
+    "copyLinkAddress": "Linkadresse kopieren",
+    "openInBrowser": "In externem Browser öffnen",
     "selectAll": "Alles auswählen",
     "searchGoogle": "Bei Google nach \"{{query}}\" suchen",
     "stopReading": "Vorlesen stoppen",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -73,6 +73,8 @@
   },
   "contextMenu": {
     "copy": "Copy",
+    "copyLinkAddress": "Copy Link Address",
+    "openInBrowser": "Open in External Browser",
     "selectAll": "Select All",
     "searchGoogle": "Search Google for \"{{query}}\"",
     "stopReading": "Stop Reading",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -73,6 +73,8 @@
   },
   "contextMenu": {
     "copy": "Copiar",
+    "copyLinkAddress": "Copiar dirección del enlace",
+    "openInBrowser": "Abrir en el navegador externo",
     "selectAll": "Seleccionar todo",
     "searchGoogle": "Buscar \"{{query}}\" en Google",
     "stopReading": "Detener lectura",

--- a/src/locales/fa/common.json
+++ b/src/locales/fa/common.json
@@ -73,6 +73,8 @@
   },
   "contextMenu": {
     "copy": "کپی",
+    "copyLinkAddress": "کپی نشانی پیوند",
+    "openInBrowser": "باز کردن در مرورگر خارجی",
     "selectAll": "انتخاب همه",
     "searchGoogle": "جستجوی «{{query}}» در گوگل",
     "stopReading": "توقف خواندن",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -73,6 +73,8 @@
   },
   "contextMenu": {
     "copy": "复制",
+    "copyLinkAddress": "复制链接地址",
+    "openInBrowser": "在外部浏览器中打开",
     "selectAll": "全选",
     "searchGoogle": "用 Google 搜索 \"{{query}}\"",
     "stopReading": "停止朗读",


### PR DESCRIPTION
## Summary

Right-clicking an external `http(s)` link in the rendered markdown now shows "Copy Link Address" and "Open in External Browser" at the top of the themed context menu. Internal targets (wikilinks, `#` heading anchors, relative workspace files, `mailto:`) keep the existing menu unchanged.

Closes #352

## Changes

- `src/hooks/useContextMenu.ts`: capture the right-clicked anchor via `closest("a[href]")` and pass its raw `href` attribute to the menu builder. The raw attribute (not the resolved property) is used so relative workspace links don't resolve to `http://localhost/...` and wrongly pass the external filter.
- `src/lib/contextMenuItems.ts`: new `isExternalHttpUrl` helper and a link-actions group prepended when the href is external. Copy reuses the best-effort `copySelection` helper; Open routes through `openUrl` from `@tauri-apps/plugin-opener` (already permitted in capabilities).
- i18n: `contextMenu.copyLinkAddress` and `contextMenu.openInBrowser` added to all five locales (en, de, es, fa, zh).
- Tests: builder tests for the link branch (external link group ordering, clipboard content, opener call, internal/absent hrefs, link actions coexisting with text actions over a selection) and hook tests for href extraction from nested elements and wikilink (`href="#"`) exclusion.
- `README.md`: extended the external-links feature bullet.

No new dependencies, Rust commands, or capability grants.

## Testing

- [x] `pnpm typecheck`, `pnpm check`, `pnpm test` (2017 tests) and `cargo clippy --all-targets -- -D warnings` all pass
- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A (context menu uses the existing themed menu component and styling)
