### PR TITLE
feat(security): enforce a production CSP in the webview

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' data: blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob: https: http:; media-src 'self' asset: http://asset.localhost https://asset.localhost https: http:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'none'; frame-src 'none'",
+      "csp": "default-src * asset: http://asset.localhost https://asset.localhost ipc: http://ipc.localhost data: blob: 'unsafe-inline'; script-src 'self' data: blob: 'wasm-unsafe-eval'",
       "devCsp": null,
       "assetProtocol": {
         "enable": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' data: blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'none'; frame-src 'none'",
+      "csp": "default-src 'self'; script-src 'self' data: blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob: https: http:; media-src 'self' asset: http://asset.localhost https://asset.localhost https: http:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'none'; frame-src 'none'",
       "devCsp": null,
       "assetProtocol": {
         "enable": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
       }
     ],
     "security": {
-      "csp": null,
+      "csp": "default-src 'self'; script-src 'self' data: blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'none'; frame-src 'none'",
+      "devCsp": null,
       "assetProtocol": {
         "enable": true,
         "scope": {


### PR DESCRIPTION
## Summary

Final Phase B goal of the plugin system (#109): replace `csp: null` with an enforced policy in production builds. Scope deliberately narrow: **lock `script-src`, allow everything else.** Dev (`devCsp: null`) stays unrestricted so Vite HMR keeps working.

This blocks the actual injection vector (remote/injected `<script>` execution) as defense in depth behind `rehype-sanitize`, without risking regressions in a content app that legitimately loads remote images, media, fonts, and user-configured network endpoints (AI providers, marketplace downloads).

## Changes

One field in `tauri.conf.json`:

```
default-src * asset: http://asset.localhost https://asset.localhost ipc: http://ipc.localhost data: blob: 'unsafe-inline';
script-src 'self' data: blob: 'wasm-unsafe-eval'
```

- `default-src` permissive: remote images/badges/video in markdown, KaTeX fonts, asset-protocol workspace files, Tauri IPC, marketplace/AI/update-check fetches, inline styles: all unaffected.
- `script-src` locked to: the app bundle (`'self'`), the plugin loader (`data:` ESM imports), and D2 (`blob:` worker + `'wasm-unsafe-eval'`). Remote script URLs and injected inline scripts are refused by the webview. Tauri appends nonces/hashes for its own init scripts automatically.

Per-plugin `network:` gating is out of scope: a page-wide CSP cannot distinguish plugins in the same-context model; that lands with the Worker sandbox (Phase E in #109).

## Testing

- `cargo check` validates the config; full pre-commit gate green.
- Unit tests cannot exercise a webview CSP, so a production build (`pnpm tauri build`) needs one manual pass before merge:
  - [ ] app boots, workspace + tabs work (IPC)
  - [ ] doc renders with highlight, KaTeX, mermaid, **D2** (WASM/worker), remote badge images
  - [ ] Manage Plugins: install Hello Status from the marketplace; its command + status bar item work (data: import)
  - [ ] AI request and update check work
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Part of #109.

## Screenshots

_N/A (no visual change when everything works)._
