### PR TITLE
chore(packaging): surface newer features in choco and ppa descriptions

### DIFF
--- a/chocolatey/glyph.nuspec
+++ b/chocolatey/glyph.nuspec
@@ -14,6 +14,6 @@
     <releaseNotes>https://github.com/hamidfzm/glyph/releases</releaseNotes>
     <tags>markdown viewer glyph tauri</tags>
     <summary>Cross-platform markdown viewer</summary>
-    <description>A modern, cross-platform markdown viewer with GFM support, syntax highlighting, live reload, and platform-native styling.</description>
+    <description>A modern, cross-platform markdown viewer and editor with GFM support, syntax highlighting, Mermaid and D2 diagrams, live file watching, cloud sync, JavaScript plugins, and platform-native styling.</description>
   </metadata>
 </package>

--- a/ppa/debian/control
+++ b/ppa/debian/control
@@ -10,6 +10,7 @@ Package: glyph
 Architecture: amd64 arm64
 Depends: ${shlibs:Depends}, ${misc:Depends}, libwebkit2gtk-4.1-0, libgtk-3-0
 Description: Cross-platform markdown viewer
- A modern markdown viewer with GFM support, syntax highlighting,
- live file watching, table of contents sidebar, and platform-native styling.
+ A modern markdown viewer and editor with GFM support, syntax highlighting,
+ Mermaid and D2 diagrams, live file watching, table of contents sidebar,
+ cloud sync, JavaScript plugins, and platform-native styling.
  Built with Tauri v2, React 19, and TypeScript.


### PR DESCRIPTION
## Summary

Follow-up to #365, which refreshed the Snap Store description but not the other package metadata. This does the same for the Chocolatey and Debian/PPA descriptions.

## Changes

- **chocolatey/glyph.nuspec** — surface newer features (Mermaid/D2 diagrams, cloud sync, JavaScript plugins) in the description; fix "live reload" wording to "live file watching".
- **ppa/debian/control** — surface the same newer features in the long description.

Generic taglines (AUR/Homebrew/Scoop/Cargo) and the README are left as-is: the README already documents these features, and the taglines don't enumerate features.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Metadata-only change; no build impact.

## Screenshots

n/a