### PR TITLE
fix(tests): raise lazy chunk-load test timeouts to stop flaky suite runs

### DIFF
--- a/src/components/canvas/lazyCanvas.test.tsx
+++ b/src/components/canvas/lazyCanvas.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { CHUNK_LOAD_TIMEOUT_MS } from "@/test/chunkLoadTimeout";
 import { CanvasEditor, CanvasViewer } from "./lazyCanvas";
 
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
@@ -12,20 +13,18 @@ const board = JSON.stringify({
 // Thin Suspense wrappers that code-split the canvas renderer. The dynamic import
 // resolves asynchronously, so each test waits for the real component to appear,
 // exercising both the fallback and resolved paths.
-// The first dynamic import can be slow when the full suite runs under machine
-// load, so these tests get a longer timeout than the 5s default.
-describe("lazyCanvas", () => {
-  it("lazily renders the CanvasViewer", { timeout: 15000 }, async () => {
+describe("lazyCanvas", { timeout: CHUNK_LOAD_TIMEOUT_MS }, () => {
+  it("lazily renders the CanvasViewer", async () => {
     render(<CanvasViewer content={board} />);
     await waitFor(() => expect(screen.getByText("lazy node")).toBeInTheDocument(), {
-      timeout: 15000,
+      timeout: CHUNK_LOAD_TIMEOUT_MS,
     });
   });
 
-  it("lazily renders the CanvasEditor", { timeout: 15000 }, async () => {
+  it("lazily renders the CanvasEditor", async () => {
     render(<CanvasEditor content={board} onChange={vi.fn()} />);
     await waitFor(() => expect(screen.getByText("lazy node")).toBeInTheDocument(), {
-      timeout: 15000,
+      timeout: CHUNK_LOAD_TIMEOUT_MS,
     });
   });
 });

--- a/src/components/canvas/lazyCanvas.test.tsx
+++ b/src/components/canvas/lazyCanvas.test.tsx
@@ -12,18 +12,20 @@ const board = JSON.stringify({
 // Thin Suspense wrappers that code-split the canvas renderer. The dynamic import
 // resolves asynchronously, so each test waits for the real component to appear,
 // exercising both the fallback and resolved paths.
+// The first dynamic import can be slow when the full suite runs under machine
+// load, so these tests get a longer timeout than the 5s default.
 describe("lazyCanvas", () => {
-  it("lazily renders the CanvasViewer", async () => {
+  it("lazily renders the CanvasViewer", { timeout: 15000 }, async () => {
     render(<CanvasViewer content={board} />);
     await waitFor(() => expect(screen.getByText("lazy node")).toBeInTheDocument(), {
-      timeout: 5000,
+      timeout: 15000,
     });
   });
 
-  it("lazily renders the CanvasEditor", async () => {
+  it("lazily renders the CanvasEditor", { timeout: 15000 }, async () => {
     render(<CanvasEditor content={board} onChange={vi.fn()} />);
     await waitFor(() => expect(screen.getByText("lazy node")).toBeInTheDocument(), {
-      timeout: 5000,
+      timeout: 15000,
     });
   });
 });

--- a/src/components/graph/lazyGraph.test.tsx
+++ b/src/components/graph/lazyGraph.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { CHUNK_LOAD_TIMEOUT_MS } from "@/test/chunkLoadTimeout";
 import { GraphView } from "./lazyGraph";
 
 // Stub the heavy underlying module so the lazy wrapper resolves to a trivial
@@ -10,12 +11,14 @@ vi.mock("./GraphView", () => ({
   ),
 }));
 
-describe("lazyGraph", () => {
+describe("lazyGraph", { timeout: CHUNK_LOAD_TIMEOUT_MS }, () => {
   it("lazily renders the underlying GraphView once its chunk resolves", async () => {
     render(
       <GraphView workspaceFiles={["/a.md", "/b.md"]} wikilinkRefs={[]} onOpenFile={vi.fn()} />,
     );
-    await waitFor(() => expect(screen.getByTestId("real-graph")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId("real-graph")).toBeInTheDocument(), {
+      timeout: CHUNK_LOAD_TIMEOUT_MS,
+    });
     expect(screen.getByTestId("real-graph")).toHaveTextContent("2");
   });
 });

--- a/src/components/modals/settings/lazySettings.test.tsx
+++ b/src/components/modals/settings/lazySettings.test.tsx
@@ -3,9 +3,10 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { SettingsContext, type SettingsContextValue } from "@/contexts/SettingsContext";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
+import { CHUNK_LOAD_TIMEOUT_MS } from "@/test/chunkLoadTimeout";
 import { SettingsModal } from "./lazySettings";
 
-describe("lazySettings", () => {
+describe("lazySettings", { timeout: CHUNK_LOAD_TIMEOUT_MS }, () => {
   it("lazy-loads and renders the settings modal", async () => {
     const value: SettingsContextValue = {
       settings: DEFAULT_SETTINGS,
@@ -19,6 +20,8 @@ describe("lazySettings", () => {
     render(<SettingsModal open onClose={vi.fn()} />, { wrapper });
 
     // Resolves once the dynamically imported chunk has loaded.
-    expect(await screen.findByText("Settings")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Settings", undefined, { timeout: CHUNK_LOAD_TIMEOUT_MS }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/notebook/lazyNotebook.test.tsx
+++ b/src/components/notebook/lazyNotebook.test.tsx
@@ -12,23 +12,25 @@ const props = { searchOpen: false as const, onSearchClose: () => {} };
 // These thin Suspense wrappers code-split the notebook renderer into its own
 // chunk. The dynamic import resolves asynchronously, so each test waits for the
 // real component to appear, which exercises both the fallback and resolved paths.
+// The first dynamic import can be slow when the full suite runs under machine
+// load, so these tests get a longer timeout than the 5s default.
 describe("lazyNotebook", () => {
-  it("lazily renders the NotebookViewer", async () => {
+  it("lazily renders the NotebookViewer", { timeout: 15000 }, async () => {
     render(<NotebookViewer content={notebook} {...props} />);
     await waitFor(() => expect(screen.getByText("lazy heading")).toBeInTheDocument(), {
-      timeout: 5000,
+      timeout: 15000,
     });
   });
 
-  it("lazily renders the NotebookSource", async () => {
+  it("lazily renders the NotebookSource", { timeout: 15000 }, async () => {
     const { container } = render(<NotebookSource content={notebook} {...props} />);
-    await waitFor(() => expect(container.querySelector("code")).toBeTruthy(), { timeout: 5000 });
+    await waitFor(() => expect(container.querySelector("code")).toBeTruthy(), { timeout: 15000 });
   });
 
-  it("lazily renders the NotebookSplit", async () => {
+  it("lazily renders the NotebookSplit", { timeout: 15000 }, async () => {
     const { container } = render(<NotebookSplit content={notebook} {...props} />);
     await waitFor(() => expect(container.querySelector(".split-view")).toBeTruthy(), {
-      timeout: 5000,
+      timeout: 15000,
     });
   });
 });

--- a/src/components/notebook/lazyNotebook.test.tsx
+++ b/src/components/notebook/lazyNotebook.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { CHUNK_LOAD_TIMEOUT_MS } from "@/test/chunkLoadTimeout";
 import { NotebookSource, NotebookSplit, NotebookViewer } from "./lazyNotebook";
 
 const notebook = JSON.stringify({
@@ -12,25 +13,25 @@ const props = { searchOpen: false as const, onSearchClose: () => {} };
 // These thin Suspense wrappers code-split the notebook renderer into its own
 // chunk. The dynamic import resolves asynchronously, so each test waits for the
 // real component to appear, which exercises both the fallback and resolved paths.
-// The first dynamic import can be slow when the full suite runs under machine
-// load, so these tests get a longer timeout than the 5s default.
-describe("lazyNotebook", () => {
-  it("lazily renders the NotebookViewer", { timeout: 15000 }, async () => {
+describe("lazyNotebook", { timeout: CHUNK_LOAD_TIMEOUT_MS }, () => {
+  it("lazily renders the NotebookViewer", async () => {
     render(<NotebookViewer content={notebook} {...props} />);
     await waitFor(() => expect(screen.getByText("lazy heading")).toBeInTheDocument(), {
-      timeout: 15000,
+      timeout: CHUNK_LOAD_TIMEOUT_MS,
     });
   });
 
-  it("lazily renders the NotebookSource", { timeout: 15000 }, async () => {
+  it("lazily renders the NotebookSource", async () => {
     const { container } = render(<NotebookSource content={notebook} {...props} />);
-    await waitFor(() => expect(container.querySelector("code")).toBeTruthy(), { timeout: 15000 });
+    await waitFor(() => expect(container.querySelector("code")).toBeTruthy(), {
+      timeout: CHUNK_LOAD_TIMEOUT_MS,
+    });
   });
 
-  it("lazily renders the NotebookSplit", { timeout: 15000 }, async () => {
+  it("lazily renders the NotebookSplit", async () => {
     const { container } = render(<NotebookSplit content={notebook} {...props} />);
     await waitFor(() => expect(container.querySelector(".split-view")).toBeTruthy(), {
-      timeout: 15000,
+      timeout: CHUNK_LOAD_TIMEOUT_MS,
     });
   });
 });

--- a/src/test/chunkLoadTimeout.ts
+++ b/src/test/chunkLoadTimeout.ts
@@ -1,0 +1,4 @@
+// Suspense chunk-load tests wait on a dynamic import, whose first resolution
+// can be slow when the full suite runs under machine load. Tests that render a
+// lazy wrapper use this instead of the 5s vitest default.
+export const CHUNK_LOAD_TIMEOUT_MS = 15_000;


### PR DESCRIPTION
## Summary

The "lazily renders the CanvasViewer" and "lazily renders the NotebookViewer" tests intermittently timed out at the default 5000ms when the full suite ran under machine load (they pass in isolation in under 3s). They are Suspense chunk-load tests whose first dynamic import is slow when many vitest workers compete. This raises the timeouts so the cold-load path has headroom.

## Changes

- Give every test in `lazyCanvas.test.tsx` and `lazyNotebook.test.tsx` a 15s per-test timeout via `it(name, { timeout: 15000 }, fn)` (each test lazy-loads a different module, so any of them can pay the slow first-import cost)
- Raise the inner `waitFor` timeouts from 5s to 15s to match, since `waitFor` gives up at its own limit regardless of the test timeout

## Testing

Ran the full `pnpm test` suite twice (197 files, 2017 tests, all green both times), plus `pnpm typecheck` and `pnpm check`.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A (test-only change)