### PR TITLE
fix(menu): make the AI submenu open where clicked and hide the doc menu in chat

### DIFF
--- a/src/components/menu/ContextMenu.test.tsx
+++ b/src/components/menu/ContextMenu.test.tsx
@@ -93,6 +93,15 @@ describe("ContextMenu", () => {
     expect(screen.queryByRole("menuitem", { name: "Summarize Document" })).toBeNull();
 
     fireEvent.click(screen.getByRole("menuitem", { name: "AI" }));
+
+    // The nested panel must anchor to its trigger row (absolute), never to the
+    // viewport (fixed): `start-full` against the viewport put the whole
+    // submenu off-screen, which read as the AI menu doing nothing.
+    const panels = screen.getAllByRole("menu");
+    const submenuPanel = panels[panels.length - 1];
+    expect(submenuPanel.className).toContain("absolute");
+    expect(submenuPanel.className).not.toContain("fixed");
+
     fireEvent.click(screen.getByRole("menuitem", { name: "Summarize Document" }));
     expect(onSelect).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();

--- a/src/components/menu/ContextMenu.tsx
+++ b/src/components/menu/ContextMenu.tsx
@@ -107,7 +107,7 @@ export function ContextMenu({ menu, onClose }: ContextMenuProps) {
       ref={rootRef}
       role="menu"
       aria-orientation="vertical"
-      className={SURFACE_CLASS}
+      className={`fixed ${SURFACE_CLASS}`}
       style={{ top: pos.y, left: pos.x }}
       onContextMenu={(e) => e.preventDefault()}
     >

--- a/src/components/menu/SubmenuItem.tsx
+++ b/src/components/menu/SubmenuItem.tsx
@@ -31,7 +31,7 @@ export function SubmenuItem({
         </span>
       </button>
       {open && (
-        <div role="menu" className={`${SURFACE_CLASS} top-0 start-full -mt-1 ms-1`}>
+        <div role="menu" className={`absolute ${SURFACE_CLASS} top-0 start-full -mt-1 ms-1`}>
           {item.items.map((sub) => (
             <ActionButton key={sub.label} item={sub} onSelect={() => onRun(sub.onSelect)} />
           ))}

--- a/src/components/menu/contextMenuStyles.ts
+++ b/src/components/menu/contextMenuStyles.ts
@@ -3,8 +3,12 @@
 
 // The menu surface (root panel and submenu panels): themed with the app's own
 // fonts and CSS color variables so it matches the UI instead of the OS menu.
+// Positioning is deliberately NOT part of this class: the root panel is
+// viewport-fixed while submenu panels anchor absolutely to their trigger row,
+// so each surface declares its own (a `fixed` here once sent submenus
+// off-screen, since their start-full offset resolved against the viewport).
 export const SURFACE_CLASS =
-  "fixed z-50 min-w-[12rem] p-1 rounded-[var(--glyph-radius)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[0_10px_30px_rgba(0,0,0,0.22)] text-[13px] text-[var(--color-text-primary)] select-none";
+  "z-50 min-w-[12rem] p-1 rounded-[var(--glyph-radius)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[0_10px_30px_rgba(0,0,0,0.22)] text-[13px] text-[var(--color-text-primary)] select-none";
 
 // A single menu row (action button or submenu trigger).
 export const ITEM_CLASS =

--- a/src/hooks/useContextMenu.test.tsx
+++ b/src/hooks/useContextMenu.test.tsx
@@ -47,6 +47,29 @@ describe("useContextMenu", () => {
     expect(actionLabels(result.current.menu)).toContain("Select All");
   });
 
+  it("shows no themed menu over assistant replies in the AI chat panel", () => {
+    // Chat replies render with .markdown-body too, but the document-targeted
+    // menu is wrong there; the panel has its own per-message actions.
+    const panel = document.createElement("aside");
+    panel.className = "ai-chat-panel";
+    const reply = document.createElement("div");
+    reply.className = "markdown-body ai-msg-markdown";
+    const para = document.createElement("p");
+    para.textContent = "assistant reply";
+    reply.appendChild(para);
+    panel.appendChild(reply);
+    document.body.appendChild(panel);
+    const { result } = renderHook(() => useContextMenu(baseActions));
+
+    let event: MouseEvent;
+    act(() => {
+      event = fireContextMenu(para);
+    });
+
+    expect(event!.defaultPrevented).toBe(true);
+    expect(result.current.menu).toBeNull();
+  });
+
   it("suppresses the native menu outside the markdown body without showing a themed menu", () => {
     const chrome = document.createElement("div");
     chrome.textContent = "Sidebar label";

--- a/src/hooks/useContextMenu.ts
+++ b/src/hooks/useContextMenu.ts
@@ -22,11 +22,15 @@ function isEditableTarget(target: EventTarget | null): boolean {
 }
 
 // The themed text menu (Copy / Search / Read Aloud / AI) only makes sense over
-// rendered prose. Other surfaces own their own menus: the file tree shows file
-// actions, and the rest of the chrome falls through to the native menu.
+// the document's rendered prose. Other surfaces own their own menus: the file
+// tree shows file actions, and the rest of the chrome falls through to the
+// native menu. Assistant replies in the AI chat panel also render with
+// `.markdown-body`, but the document-targeted menu is wrong there (Select All
+// and the AI actions operate on the document, not the message; per-message
+// Copy / Read Aloud buttons cover the chat), so the panel is excluded.
 function isInsideMarkdownContent(target: EventTarget | null): boolean {
   if (!(target instanceof Element)) return false;
-  return target.closest(".markdown-body") !== null;
+  return target.closest(".markdown-body") !== null && target.closest(".ai-chat-panel") === null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two right-click menu fixes around the AI feature:

1. **The AI submenu appeared to do nothing.** `SURFACE_CLASS` baked `position: fixed` into the shared menu-surface style, so the nested submenu panel's `top-0 start-full` offsets resolved against the viewport instead of the trigger row, rendering the whole panel off-screen (at 100% of the viewport width). Clicking "AI ›" looked dead. Positioning now lives at each call site: the root panel stays viewport-fixed, submenu panels anchor absolutely to their row.
2. **The document menu leaked into the AI chat panel.** Assistant replies render with `.markdown-body`, so right-clicking them opened the themed document menu whose actions target the document, not the message (Select All grabs the viewer, AI verbs run on the doc). The chat panel has per-message Copy / Read Aloud, so the themed menu is excluded there; the composer keeps the native editable menu.

## Changes

- `contextMenuStyles.ts`: `SURFACE_CLASS` no longer carries positioning; `ContextMenu` adds `fixed`, `SubmenuItem` adds `absolute`.
- `useContextMenu`: targets inside `.ai-chat-panel` don't open the themed menu.
- Tests: submenu panel asserts absolute (not fixed) positioning; right-click on a chat reply suppresses the native menu without opening the themed one.

## Testing

- `pnpm typecheck && pnpm check && pnpm test` pass (full gates via pre-commit hook).
- [ ] Tested on macOS
- [x] Tested on Windows (AI submenu now opens beside the row; chat right-click shows no doc menu)
- [ ] Tested on Linux

## Screenshots

Not applicable.