### PR TITLE
fix(ci): use full gpg path in rpm signing macro for publish-dnf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -750,10 +750,14 @@ jobs:
           # unprotected key, which is what the apt-repo job also assumes).
           printf '%s' "$GPG_PASSPHRASE" > /tmp/gpg-pass
           # rpm --addsign shells out to gpg; force batch/loopback so it never
-          # blocks on a pinentry prompt in CI.
+          # blocks on a pinentry prompt in CI. rpm execs the macro's first
+          # token as a literal binary path (no PATH search), so it must be
+          # %{__gpg}; the bare "gpg" after it is argv[0], matching rpm's
+          # stock macro shape.
           cat > "$HOME/.rpmmacros" <<EOF
           %_gpg_name $GPG_KEY_ID
-          %__gpg_sign_cmd gpg --batch --no-verbose --no-armor --pinentry-mode loopback --passphrase-file /tmp/gpg-pass --no-secmem-warning -u "%{_gpg_name}" --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}
+          %__gpg /usr/bin/gpg
+          %__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --pinentry-mode loopback --passphrase-file /tmp/gpg-pass --no-secmem-warning -u "%{_gpg_name}" --sign --detach-sign --output %{__signature_filename} %{__plaintext_filename}
           EOF
       - name: Clone rpm-repo, sign RPMs, and rebuild metadata
         if: steps.gate.outputs.enabled == 'true'


### PR DESCRIPTION
## Summary

The `publish-dnf` job in the v0.15.0 release run failed at `rpm --addsign` with `error: Could not exec gpg: No such file or directory` (see [failed job](https://github.com/hamidfzm/glyph/actions/runs/28717732790/job/85162373554)).

rpm execs the first token of `%__gpg_sign_cmd` as a literal binary path with no PATH lookup. Our custom macro started with bare `gpg`, so the exec failed. rpm's stock macro shape is `%{__gpg} gpg ...`, where `%{__gpg}` is the full path and the second `gpg` is argv[0].

## Changes

- Prefix `%__gpg_sign_cmd` with `%{__gpg}` and define `%__gpg /usr/bin/gpg` explicitly in the generated `.rpmmacros`.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Verified against the failing job log; the fix takes effect on the next tagged release since `release.yml` runs from the tag's commit. Re-running the v0.15.0 job will not pick this up.
