### PR TITLE
fix(security): stop the production CSP from blocking runtime-injected styles

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,8 +21,9 @@
       }
     ],
     "security": {
-      "csp": "default-src * asset: http://asset.localhost https://asset.localhost ipc: http://ipc.localhost data: blob: 'unsafe-inline'; script-src 'self' data: blob: 'wasm-unsafe-eval'",
+      "csp": "default-src * asset: http://asset.localhost https://asset.localhost ipc: http://ipc.localhost data: blob: 'unsafe-inline'; script-src 'self' data: blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'",
       "devCsp": null,
+      "dangerousDisableAssetCspModification": ["style-src"],
       "assetProtocol": {
         "enable": true,
         "scope": {


### PR DESCRIPTION
## Summary

The production CSP introduced in #370 silently blocks every `<style>` tag injected at runtime, which breaks the CodeMirror editor for **all documents** in edit and split mode on release builds (since v0.15.0): the editor renders as an empty pane with a few line numbers. The highlight.js theme in the viewer is blocked the same way.

Root cause: the config puts `'unsafe-inline'` in `default-src`, but Tauri's asset CSP modification nonces the inline style in `index.html` and synthesizes an explicit `style-src 'self' 'nonce-...'` directive into the shipped header. An explicit `style-src` overrides `default-src`, and the presence of a nonce voids `'unsafe-inline'` (per the CSP spec), so runtime style injection is rejected with no console error (`element.sheet` stays `null`). Without its stylesheet, CodeMirror loses its flex layout: the gutter stacks above the content and the document text lands thousands of pixels below the fold.

Dev builds were unaffected because `devCsp` is `null`, which is why this never showed up during development.

## Changes

- Declare `style-src 'self' 'unsafe-inline'` explicitly in the CSP instead of relying on `default-src` fallback.
- Add `"dangerousDisableAssetCspModification": ["style-src"]` so Tauri no longer appends the nonce to `style-src`. Script hash injection is untouched, so the `script-src` hardening from #370 fully remains.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

Verified end-to-end on Windows against a production-mode build (`tauri build --debug --no-bundle`) inspected over a CDP session:

- Before: shipped header contained `style-src 'self' 'nonce-...'`; CodeMirror's injected style tag had `sheet: null`; a probe `<style>` injected at runtime was rejected; `.cm-editor` computed `display: block` and the document text sat ~6,400px below the viewport.
- After: shipped header contains `style-src 'self' 'unsafe-inline'` with no nonce (script-src hashes still present); runtime style injection parses; the editor renders the document correctly (content beside the gutter, theme `maxWidth` and monospace font applied).
- Gates: `pnpm typecheck`, `pnpm check`, `pnpm test` (2227 passing), `cargo clippy --all-targets -- -D warnings` all green.

## Screenshots

Broken editor in the 0.15.1 release build (gutter above off-screen content):
the document is fully present in the DOM but starts below the fold; only unstyled line numbers are visible.
