### PR TITLE
feat(plugins): verify marketplace downloads against a declared sha256

### DIFF
--- a/src/lib/plugins/marketplace.test.ts
+++ b/src/lib/plugins/marketplace.test.ts
@@ -84,4 +84,35 @@ describe("installFromRegistry", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
     await expect(installFromRegistry(entry())).rejects.toThrow(/download failed/);
   });
+
+  // SHA-256 of "export default {};", uppercase to prove comparison is case-insensitive.
+  const GOOD_SHA = "9f085b1079ab38f776bbb3930dfd067a838ca3e0483aff8625f88837e8ed964c";
+
+  it("installs when the download matches the declared sha256", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("export default {};") }),
+    );
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    await installFromRegistry(entry({ sha256: GOOD_SHA.toUpperCase() }));
+
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith("install_plugin_files", expect.anything());
+  });
+
+  it("refuses to install when the download does not match the declared sha256", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("export default { tampered: true };"),
+      }),
+    );
+    vi.mocked(invoke).mockReset();
+
+    await expect(installFromRegistry(entry({ sha256: GOOD_SHA }))).rejects.toThrow(
+      /checksum mismatch/,
+    );
+    expect(vi.mocked(invoke)).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/plugins/marketplace.ts
+++ b/src/lib/plugins/marketplace.ts
@@ -18,6 +18,18 @@ export interface RegistryEntry {
   permissions?: string[];
   /** Direct URL to the plugin's built ESM entry file. */
   mainUrl: string;
+  /**
+   * SHA-256 of the entry file (hex). When present, the download is verified
+   * before anything is installed, so a tampered or moved `mainUrl` cannot
+   * silently ship different code than the reviewed index entry.
+   */
+  sha256?: string;
+}
+
+/** Hex SHA-256 of UTF-8 text, via WebCrypto (available in the webview and Node). */
+async function sha256Hex(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 export interface RegistryUpdate {
@@ -58,6 +70,12 @@ export async function installFromRegistry(entry: RegistryEntry): Promise<Install
   const res = await fetch(entry.mainUrl);
   if (!res.ok) throw new Error(`download failed: ${res.status}`);
   const main = await res.text();
+  if (entry.sha256) {
+    const actual = await sha256Hex(main);
+    if (actual !== entry.sha256.toLowerCase()) {
+      throw new Error(`checksum mismatch for ${entry.id}: expected ${entry.sha256}, got ${actual}`);
+    }
+  }
   // The registry entry is the source of truth for metadata, so synthesize the
   // manifest from it rather than fetching a second file.
   const manifest = JSON.stringify({


### PR DESCRIPTION
## Summary

Phase E of the plugin roadmap (#109): marketplace installs are now verified. A registry entry may declare `sha256` (hex digest of its `mainUrl` file); when present, the downloaded code is hashed and compared **before** anything touches disk, so a tampered or silently-replaced `mainUrl` cannot ship different code than the reviewed index entry.

Companion hardening already live on glyph-md/plugins: a "Validate index" workflow (schema validation via ajv, sorted unique ids, https-only `mainUrl`) runs on every push/PR, and `index.schema.json` accepts the new optional `sha256` field.

## Changes

- `RegistryEntry.sha256?: string`; `installFromRegistry` hashes the download with WebCrypto and refuses on mismatch (comparison is case-insensitive; absent field keeps today's behavior for unpinned entries).
- Tests: match installs, mismatch throws with `install_plugin_files` never invoked, absent field skips verification (existing tests).

## Testing

- `pnpm typecheck`, `pnpm check`, full suite via pre-commit: green.
- [ ] Tested on macOS
- [x] Tested on Windows (suite)
- [ ] Tested on Linux

Part of #109.

## Screenshots

_N/A._
