### PR TITLE
feat(plugins): run sandboxed plugins in an isolated worker

### DIFF
--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -20,6 +20,9 @@ pub struct InstalledPlugin {
     /// Capabilities the plugin declares; shown to the user before install.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub permissions: Vec<String>,
+    /// Run isolated in a worker instead of the app context.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub sandbox: bool,
     /// Absolute path of the installed plugin folder.
     pub dir: String,
     /// Source text of the plugin's ESM entry file.
@@ -33,6 +36,7 @@ struct ManifestInfo {
     api_version: String,
     description: Option<String>,
     permissions: Vec<String>,
+    sandbox: bool,
     main: String,
 }
 
@@ -99,6 +103,11 @@ fn parse_manifest(json: &str) -> Result<ManifestInfo, String> {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string()),
         permissions: parse_permissions(&value)?,
+        sandbox: match value.get("sandbox") {
+            None => false,
+            Some(serde_json::Value::Bool(b)) => *b,
+            Some(_) => return Err("manifest \"sandbox\" must be a boolean".into()),
+        },
         main,
     })
 }
@@ -117,6 +126,7 @@ fn read_plugin_dir(dir: &Path) -> Result<InstalledPlugin, String> {
         api_version: info.api_version,
         description: info.description,
         permissions: info.permissions,
+        sandbox: info.sandbox,
         dir: dir.to_string_lossy().to_string(),
         main_source,
     })
@@ -499,6 +509,7 @@ mod tests {
             api_version: "^1.0.0".into(),
             description: None,
             permissions: Vec::new(),
+            sandbox: false,
             dir: "d".into(),
             main_source: "s".into(),
         };
@@ -507,6 +518,24 @@ mod tests {
         assert!(json.contains("\"mainSource\""));
         assert!(!json.contains("\"description\""));
         assert!(!json.contains("\"permissions\""));
+        assert!(!json.contains("\"sandbox\""));
+    }
+
+    #[test]
+    fn parse_manifest_reads_sandbox_flag() {
+        let with_sandbox = |v: &str| {
+            format!(
+                r#"{{"id":"a.b","name":"n","version":"1.0.0","apiVersion":"^1.0.0","sandbox":{v}}}"#
+            )
+        };
+        assert!(parse_manifest(&with_sandbox("true")).unwrap().sandbox);
+        assert!(!parse_manifest(&with_sandbox("false")).unwrap().sandbox);
+        assert!(
+            !parse_manifest(r#"{"id":"a.b","name":"n","version":"1.0.0","apiVersion":"^1.0.0"}"#)
+                .unwrap()
+                .sandbox
+        );
+        assert!(parse_manifest(&with_sandbox("\"yes\"")).is_err());
     }
 
     #[test]

--- a/src/lib/plugins/host.test.ts
+++ b/src/lib/plugins/host.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { FakeWorker } from "@/test/fakeWorker";
 import { PLUGIN_API_VERSION } from "./apiVersion";
 import { createPluginHost } from "./host";
 import type { ModuleImporter } from "./loader";
@@ -379,5 +380,122 @@ describe("createPluginHost", () => {
 
     expect(host.statusBarItems.list()).toHaveLength(0);
     expect(host.listLoaded()).toHaveLength(0);
+  });
+
+  describe("sandboxed plugins", () => {
+    /** Spawner that captures the FakeWorker and auto-activates unless told not to. */
+    const spawnerFor =
+      (worker: FakeWorker, autoActivate = true) =>
+      () => {
+        if (autoActivate) queueMicrotask(() => worker.emit({ type: "activated" }));
+        return worker;
+      };
+    const boxed = (overrides: Partial<InstalledPlugin> = {}) =>
+      installed({ sandbox: true, ...overrides });
+
+    it("loads via the worker instead of importing the module", async () => {
+      const worker = new FakeWorker();
+      const host = createPluginHost(vi.fn(), undefined, undefined, undefined, spawnerFor(worker));
+      const importer = vi.fn();
+
+      await host.load(boxed(), importer as unknown as ModuleImporter);
+
+      expect(importer).not.toHaveBeenCalled();
+      expect(host.listLoaded().map((p) => p.id)).toEqual(["com.x.demo"]);
+      expect(worker.posted[0]).toMatchObject({ type: "init", source: "export default …" });
+    });
+
+    it("routes worker registrations into the registries and removes them on unload", async () => {
+      const worker = new FakeWorker();
+      const notify = vi.fn();
+      const host = createPluginHost(notify, undefined, undefined, undefined, spawnerFor(worker));
+
+      await host.load(boxed());
+      worker.emit({ type: "register-command", id: "c1", title: "Boxed cmd" });
+      worker.emit({ type: "add-styles", css: ".x{}" });
+      worker.emit({ type: "register-exporter", id: "e1", label: "E", extension: "txt" });
+      worker.emit({ type: "notify", message: "hi from box" });
+
+      expect(host.commands.list().map((c) => c.id)).toEqual(["c1"]);
+      expect(host.styles.list().map((s) => s.css)).toEqual([".x{}"]);
+      expect(host.exporters.list().map((e) => e.id)).toEqual(["e1"]);
+      expect(notify).toHaveBeenCalledWith("hi from box");
+
+      host.unload("com.x.demo");
+      expect(host.commands.list()).toHaveLength(0);
+      expect(host.styles.list()).toHaveLength(0);
+      expect(host.exporters.list()).toHaveLength(0);
+      expect(worker.terminated).toBe(true);
+    });
+
+    it("persists settings-set through the backend, merged over hydrated values", async () => {
+      const worker = new FakeWorker();
+      const backend = { load: vi.fn().mockResolvedValue({ size: 12 }), save: vi.fn() };
+      const host = createPluginHost(vi.fn(), undefined, undefined, backend, spawnerFor(worker));
+
+      await host.load(boxed());
+      // Snapshot before settings-set: the host hands the worker the hydrated object.
+      expect((worker.posted[0] as { settings: unknown }).settings).toEqual({ size: 12 });
+
+      worker.emit({ type: "settings-set", key: "theme", value: "dark" });
+      expect(backend.save).toHaveBeenCalledWith("com.x.demo", { size: 12, theme: "dark" });
+    });
+
+    it("routes translations and answers workspace calls with permission gating", async () => {
+      const worker = new FakeWorker();
+      const translations = vi.fn();
+      const host = createPluginHost(
+        vi.fn(),
+        translations,
+        () => null,
+        undefined,
+        spawnerFor(worker),
+      );
+
+      await host.load(boxed({ permissions: ["workspace:read"] }));
+      worker.emit({ type: "register-translations", locale: "fa", namespace: "n", resources: {} });
+      worker.emit({ type: "workspace-list", callId: 1 });
+
+      expect(translations).toHaveBeenCalledWith("fa", "n", {});
+      // workspace:read granted but no workspace open: an error result, not a hang.
+      await vi.waitFor(() =>
+        expect(worker.posted).toContainEqual(
+          expect.objectContaining({ type: "workspace-result", callId: 1, ok: false }),
+        ),
+      );
+    });
+
+    it("propagates activation errors and loads nothing", async () => {
+      const worker = new FakeWorker();
+      const spawn = () => {
+        queueMicrotask(() => worker.emit({ type: "error", message: "broken plugin" }));
+        return worker;
+      };
+      const host = createPluginHost(vi.fn(), undefined, undefined, undefined, spawn);
+
+      await expect(host.load(boxed())).rejects.toThrow("broken plugin");
+      expect(host.listLoaded()).toHaveLength(0);
+      expect(worker.terminated).toBe(true);
+    });
+
+    it("a sandbox load resolving after unloadAll rolls back and terminates", async () => {
+      const worker = new FakeWorker();
+      let activate!: () => void;
+      const spawn = () => {
+        activate = () => worker.emit({ type: "activated" });
+        return worker;
+      };
+      const host = createPluginHost(vi.fn(), undefined, undefined, undefined, spawn);
+
+      const pending = host.load(boxed());
+      // Let the load progress to spawning the worker, then tear down before activation.
+      await vi.waitFor(() => expect(activate).toBeDefined());
+      host.unloadAll();
+      activate();
+      await pending;
+
+      expect(host.listLoaded()).toHaveLength(0);
+      expect(worker.terminated).toBe(true);
+    });
   });
 });

--- a/src/lib/plugins/host.ts
+++ b/src/lib/plugins/host.ts
@@ -2,6 +2,7 @@ import { PLUGIN_API_VERSION, satisfiesApiVersion } from "./apiVersion";
 import { type Disposer, DisposerBag } from "./disposer";
 import { importPluginModule, type ModuleImporter } from "./loader";
 import { createRegistry, type Registry } from "./registry";
+import { startSandbox, type WorkerSpawner } from "./sandbox/sandbox";
 import type {
   CommandContribution,
   ExporterContribution,
@@ -92,6 +93,9 @@ export function createPluginHost(
   // provider keeps this current so ctx.workspace stays scoped correctly.
   getWorkspaceRoot: () => string | null = () => null,
   settingsBackend: PluginSettingsBackend = noopSettingsBackend,
+  // How sandboxed plugins spawn their worker; injectable because jsdom has no
+  // Worker. Defaults to a real blob-URL Worker inside startSandbox.
+  workerSpawner?: WorkerSpawner,
 ): PluginHost {
   const commands = createRegistry<CommandContribution>();
   const statusBarItems = createRegistry<StatusBarItemContribution>();
@@ -188,6 +192,49 @@ export function createPluginHost(
       }
       const generation = (loadGeneration.get(plugin.id) ?? 0) + 1;
       loadGeneration.set(plugin.id, generation);
+
+      if (plugin.sandbox) {
+        const settings = await settingsBackend.load(plugin.id);
+        const bag = new DisposerBag();
+        const workspace = createWorkspaceApi(getWorkspaceRoot, plugin.permissions ?? []);
+        const terminate = await startSandbox(
+          plugin,
+          settings,
+          {
+            registerCommand: tracked(commands.register, bag),
+            addStyles(css) {
+              tracked(styles.register, bag)({ css });
+            },
+            registerExporter: tracked(exporters.register, bag),
+            notify,
+            registerTranslations,
+            settingsSet(key, value) {
+              settings[key] = value;
+              settingsBackend.save(plugin.id, settings);
+            },
+            workspaceRead: workspace.readFile,
+            workspaceList: workspace.listFiles,
+          },
+          workerSpawner,
+        );
+        bag.add(terminate);
+        if (loadGeneration.get(plugin.id) !== generation) {
+          bag.dispose();
+          return;
+        }
+        unload(plugin.id);
+        loaded.set(plugin.id, {
+          info: {
+            id: plugin.id,
+            name: plugin.name,
+            version: plugin.version,
+            description: plugin.description,
+          },
+          module: { activate: () => {} },
+          bag,
+        });
+        return;
+      }
 
       const [module, settings] = await Promise.all([
         importPluginModule(plugin.mainSource, importer),

--- a/src/lib/plugins/marketplace.test.ts
+++ b/src/lib/plugins/marketplace.test.ts
@@ -64,7 +64,7 @@ describe("installFromRegistry", () => {
     vi.mocked(invoke).mockResolvedValue(undefined);
 
     await installFromRegistry(
-      entry({ version: "2.0.0", description: "d", permissions: ["workspace:read"] }),
+      entry({ version: "2.0.0", description: "d", permissions: ["workspace:read"], sandbox: true }),
     );
 
     const [cmd, args] = vi.mocked(invoke).mock.calls.at(-1) ?? [];
@@ -77,6 +77,7 @@ describe("installFromRegistry", () => {
       apiVersion: "^1.0.0",
       description: "d",
       permissions: ["workspace:read"],
+      sandbox: true,
     });
   });
 

--- a/src/lib/plugins/marketplace.ts
+++ b/src/lib/plugins/marketplace.ts
@@ -24,6 +24,8 @@ export interface RegistryEntry {
    * silently ship different code than the reviewed index entry.
    */
   sha256?: string;
+  /** Run isolated in a worker; see the manifest `sandbox` flag. */
+  sandbox?: boolean;
 }
 
 /** Hex SHA-256 of UTF-8 text, via WebCrypto (available in the webview and Node). */
@@ -85,6 +87,7 @@ export async function installFromRegistry(entry: RegistryEntry): Promise<Install
     apiVersion: entry.apiVersion,
     description: entry.description,
     permissions: entry.permissions,
+    sandbox: entry.sandbox,
   });
   return invoke<InstalledPlugin>("install_plugin_files", { manifest, main });
 }

--- a/src/lib/plugins/sandbox/bootstrap.test.ts
+++ b/src/lib/plugins/sandbox/bootstrap.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildWorkerBootstrap } from "./bootstrap";
+import type { HostMessage, WorkerMessage } from "./protocol";
+
+/**
+ * Run the bootstrap source in-process: `onmessage`/`postMessage` become local
+ * bindings and `globalThis` is shadowed by a fake object, so the network fence
+ * mutates the fake instead of the test runtime. Dynamic import of the data:
+ * URL still goes through Node, which supports it natively.
+ */
+function bootWorker(fetchImpl: typeof fetch = vi.fn()) {
+  const posted: WorkerMessage[] = [];
+  const fakeGlobal: Record<string, unknown> = {
+    fetch: fetchImpl,
+    // new Function code has no dynamic-import callback under vitest's VM, so
+    // hand the bootstrap this module's importer instead.
+    __glyphSandboxImport: (url: string) => import(/* @vite-ignore */ url),
+  };
+  const run = new Function(
+    "postMessage",
+    "globalThis",
+    `let onmessage; ${buildWorkerBootstrap()}\nreturn onmessage;`,
+  );
+  const handler = run((m: WorkerMessage) => posted.push(m), fakeGlobal) as (event: {
+    data: HostMessage;
+  }) => Promise<void>;
+  return {
+    posted,
+    fakeGlobal,
+    send: (data: HostMessage) => handler({ data }),
+    typesPosted: () => posted.map((m) => m.type),
+  };
+}
+
+const init = (
+  source: string,
+  overrides: Partial<Extract<HostMessage, { type: "init" }>> = {},
+): HostMessage => ({
+  type: "init",
+  source,
+  apiVersion: "1.2.0",
+  permissions: [],
+  settings: {},
+  ...overrides,
+});
+
+const fullPlugin = `export default {
+  activate(ctx) {
+    ctx.commands.register({ id: "c1", title: "Cmd", run: () => ctx.notify("ran " + ctx.settings.get("who")) });
+    ctx.ui.addStyles("body{}");
+    ctx.registerTranslations("en", "ns", { k: "v" });
+    ctx.settings.set("who", "world");
+    ctx.exporters.register({ id: "e1", label: "Upper", extension: "txt", build: async (html) => html.toUpperCase() });
+  },
+}`;
+
+describe("worker bootstrap", () => {
+  it("activates a plugin and relays every registration to the host", async () => {
+    const w = bootWorker();
+    await w.send(init(fullPlugin));
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("activated"));
+    expect(w.posted).toContainEqual({ type: "register-command", id: "c1", title: "Cmd" });
+    expect(w.posted).toContainEqual({ type: "add-styles", css: "body{}" });
+    expect(w.posted).toContainEqual({
+      type: "register-translations",
+      locale: "en",
+      namespace: "ns",
+      resources: { k: "v" },
+    });
+    expect(w.posted).toContainEqual({ type: "settings-set", key: "who", value: "world" });
+    expect(w.posted).toContainEqual({
+      type: "register-exporter",
+      id: "e1",
+      label: "Upper",
+      extension: "txt",
+    });
+  });
+
+  it("runs commands on request, with settings visible to the plugin", async () => {
+    const w = bootWorker();
+    await w.send(init(fullPlugin));
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("activated"));
+    await w.send({ type: "run-command", id: "c1" });
+    // set("who","world") during activate updated the local snapshot.
+    await vi.waitFor(() =>
+      expect(w.posted).toContainEqual({ type: "notify", message: "ran world" }),
+    );
+    // Unknown command id is a no-op.
+    await w.send({ type: "run-command", id: "ghost" });
+  });
+
+  it("builds exports and reports build failures", async () => {
+    const w = bootWorker();
+    const plugin = `export default {
+      activate(ctx) {
+        ctx.exporters.register({ id: "ok", label: "U", extension: "txt", build: async (h) => h.toUpperCase() });
+        ctx.exporters.register({ id: "bad", label: "B", extension: "txt", build: async () => { throw new Error("nope"); } });
+      },
+    }`;
+    await w.send(init(plugin));
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("activated"));
+
+    await w.send({ type: "build-export", callId: 1, id: "ok", bodyHtml: "<p>" });
+    await w.send({ type: "build-export", callId: 2, id: "bad", bodyHtml: "" });
+    await vi.waitFor(() => {
+      expect(w.posted).toContainEqual({
+        type: "export-result",
+        callId: 1,
+        ok: true,
+        output: "<P>",
+      });
+      expect(w.posted).toContainEqual({
+        type: "export-result",
+        callId: 2,
+        ok: false,
+        error: "Error: nope",
+      });
+    });
+  });
+
+  it("resolves workspace calls via workspace-result round trips", async () => {
+    const w = bootWorker();
+    const plugin = `export default {
+      async activate(ctx) {
+        const text = await ctx.workspace.readFile("a.md");
+        ctx.notify("read:" + text);
+        try { await ctx.workspace.listFiles(); } catch (e) { ctx.notify("list:" + e.message); }
+      },
+    }`;
+    const activation = w.send(init(plugin));
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("workspace-read"));
+    const read = w.posted.find((m) => m.type === "workspace-read") as { callId: number };
+    await w.send({ type: "workspace-result", callId: read.callId, ok: true, value: "hello" });
+
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("workspace-list"));
+    const list = w.posted.find((m) => m.type === "workspace-list") as { callId: number };
+    await w.send({ type: "workspace-result", callId: list.callId, ok: false, error: "denied" });
+
+    await activation;
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("activated"));
+    expect(w.posted).toContainEqual({ type: "notify", message: "read:hello" });
+    expect(w.posted).toContainEqual({ type: "notify", message: "list:denied" });
+    // A result for an unknown call is ignored.
+    await w.send({ type: "workspace-result", callId: 999, ok: true, value: "" });
+  });
+
+  it("fences fetch to declared network hosts and removes other network APIs", async () => {
+    const realFetch = vi.fn().mockResolvedValue("response");
+    const w = bootWorker(realFetch as unknown as typeof fetch);
+    await w.send(init("export default { activate(){} }", { permissions: ["network:example.com"] }));
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("activated"));
+
+    const fenced = w.fakeGlobal.fetch as typeof fetch;
+    await expect(fenced("https://api.example.com/data")).resolves.toBe("response");
+    await expect(fenced(new Request("https://example.com/"))).resolves.toBe("response");
+    await expect(fenced("https://evil.com/")).rejects.toThrow("not covered");
+    await expect(fenced("garbage")).rejects.toThrow("not covered");
+    expect(w.fakeGlobal.XMLHttpRequest).toBeUndefined();
+    expect(w.fakeGlobal.WebSocket).toBeUndefined();
+    expect(w.fakeGlobal.importScripts).toBeUndefined();
+  });
+
+  it("reports a plugin without a default activate export as an error", async () => {
+    const w = bootWorker();
+    await w.send(init("export const nothing = 1;"));
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("error"));
+    const error = w.posted.find((m) => m.type === "error") as { message: string };
+    expect(error.message).toContain("activate");
+  });
+
+  it("reports an activate that throws", async () => {
+    const w = bootWorker();
+    await w.send(init("export default { activate() { throw new Error('bad start'); } }"));
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("error"));
+    const error = w.posted.find((m) => m.type === "error") as { message: string };
+    expect(error.message).toContain("bad start");
+  });
+});

--- a/src/lib/plugins/sandbox/bootstrap.ts
+++ b/src/lib/plugins/sandbox/bootstrap.ts
@@ -1,0 +1,157 @@
+// Source text of the sandbox worker. It runs with no DOM and no Tauri invoke;
+// everything reaches the host through the protocol messages, and network
+// access is fenced to the plugin's declared `network:<host>` permissions by
+// replacing the worker's own fetch (WebSocket/XHR/importScripts are removed
+// outright). In production builds the page CSP also blocks remote dynamic
+// import inside the worker, so the fetch fence is not the only wall.
+//
+// Kept as a template string rather than a bundled file so the loader can spawn
+// it from a blob URL without any build-time coordination.
+
+export function buildWorkerBootstrap(): string {
+  return `
+"use strict";
+// Tests shim globalThis and run this source via new Function, where dynamic
+// import is unavailable; they inject an importer instead. In a real worker
+// the fallback import() is used.
+const importModule = globalThis.__glyphSandboxImport || ((u) => import(u));
+let callSeq = 0;
+const pendingHost = new Map(); // callId -> {resolve, reject}
+const commands = new Map();    // id -> run
+const exporters = new Map();   // id -> build
+let settings = {};
+
+function hostCall(message) {
+  return new Promise((resolve, reject) => {
+    const callId = ++callSeq;
+    pendingHost.set(callId, { resolve, reject });
+    postMessage({ ...message, callId });
+  });
+}
+
+// Network fence: exact declared host or a subdomain of it.
+function isNetworkAllowed(permissions, url) {
+  let host;
+  try { host = new URL(url).hostname; } catch { return false; }
+  return permissions.some((p) => {
+    if (!p.startsWith("network:")) return false;
+    const allowed = p.slice("network:".length);
+    return host === allowed || host.endsWith("." + allowed);
+  });
+}
+
+function installNetworkFence(permissions) {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (!isNetworkAllowed(permissions, url)) {
+      return Promise.reject(
+        new Error("network access to " + url + " is not covered by this plugin's permissions"),
+      );
+    }
+    return realFetch(input, init);
+  };
+  globalThis.XMLHttpRequest = undefined;
+  globalThis.WebSocket = undefined;
+  globalThis.importScripts = undefined;
+}
+
+function buildContext(init) {
+  settings = init.settings;
+  return {
+    apiVersion: init.apiVersion,
+    commands: {
+      register(command) {
+        commands.set(command.id, command.run);
+        postMessage({ type: "register-command", id: command.id, title: command.title });
+        return () => commands.delete(command.id);
+      },
+    },
+    ui: {
+      addStyles(css) {
+        postMessage({ type: "add-styles", css });
+        return () => {};
+      },
+    },
+    exporters: {
+      register(exporter) {
+        exporters.set(exporter.id, exporter.build);
+        postMessage({
+          type: "register-exporter",
+          id: exporter.id,
+          label: exporter.label,
+          extension: exporter.extension,
+        });
+        return () => exporters.delete(exporter.id);
+      },
+    },
+    workspace: {
+      readFile(path) {
+        return hostCall({ type: "workspace-read", path });
+      },
+      listFiles() {
+        return hostCall({ type: "workspace-list" });
+      },
+    },
+    settings: {
+      get(key) {
+        return settings[key];
+      },
+      set(key, value) {
+        settings[key] = value;
+        postMessage({ type: "settings-set", key, value });
+      },
+    },
+    notify(message) {
+      postMessage({ type: "notify", message: String(message) });
+    },
+    registerTranslations(locale, namespace, resources) {
+      postMessage({ type: "register-translations", locale, namespace, resources });
+    },
+  };
+}
+
+onmessage = async (event) => {
+  const msg = event.data;
+  try {
+    if (msg.type === "init") {
+      installNetworkFence(msg.permissions);
+      const url = "data:text/javascript;base64," +
+        btoa(String.fromCharCode(...new TextEncoder().encode(msg.source)));
+      const module = await importModule(url);
+      const plugin = module && module.default;
+      if (!plugin || typeof plugin.activate !== "function") {
+        throw new Error("plugin entry must default-export an object with an activate() function");
+      }
+      await plugin.activate(buildContext(msg));
+      postMessage({ type: "activated" });
+    } else if (msg.type === "run-command") {
+      const run = commands.get(msg.id);
+      if (run) await run();
+    } else if (msg.type === "build-export") {
+      const build = exporters.get(msg.id);
+      try {
+        const output = await build(msg.bodyHtml);
+        postMessage({
+          type: "export-result",
+          callId: msg.callId,
+          ok: true,
+          output: typeof output === "string" ? output : Array.from(output),
+        });
+      } catch (err) {
+        postMessage({ type: "export-result", callId: msg.callId, ok: false, error: String(err) });
+      }
+    } else if (msg.type === "workspace-result") {
+      const pending = pendingHost.get(msg.callId);
+      if (pending) {
+        pendingHost.delete(msg.callId);
+        if (msg.ok) pending.resolve(msg.value);
+        else pending.reject(new Error(msg.error));
+      }
+    }
+  } catch (err) {
+    postMessage({ type: "error", message: String(err) });
+  }
+};
+`;
+}

--- a/src/lib/plugins/sandbox/protocol.test.ts
+++ b/src/lib/plugins/sandbox/protocol.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isNetworkAllowed } from "./protocol";
+
+describe("isNetworkAllowed", () => {
+  it("allows the declared host and its subdomains", () => {
+    const perms = ["workspace:read", "network:example.com"];
+    expect(isNetworkAllowed(perms, "https://example.com/x")).toBe(true);
+    expect(isNetworkAllowed(perms, "https://api.example.com/x")).toBe(true);
+  });
+
+  it("rejects other hosts, lookalikes, and invalid URLs", () => {
+    const perms = ["network:example.com"];
+    expect(isNetworkAllowed(perms, "https://evil.com/")).toBe(false);
+    expect(isNetworkAllowed(perms, "https://notexample.com/")).toBe(false);
+    expect(isNetworkAllowed(perms, "not a url")).toBe(false);
+  });
+
+  it("rejects everything when no network permission is declared", () => {
+    expect(isNetworkAllowed([], "https://example.com/")).toBe(false);
+    expect(isNetworkAllowed(["workspace:read"], "https://example.com/")).toBe(false);
+  });
+});

--- a/src/lib/plugins/sandbox/protocol.ts
+++ b/src/lib/plugins/sandbox/protocol.ts
@@ -1,0 +1,61 @@
+// Message protocol between the host and a sandboxed plugin worker. The worker
+// only ever talks to the host through these messages; it has no DOM, no Tauri
+// invoke, and its network access is gated by declared `network:<host>`
+// permissions.
+
+/** Host -> worker. */
+export type HostMessage =
+  | {
+      type: "init";
+      source: string;
+      apiVersion: string;
+      permissions: string[];
+      settings: Record<string, unknown>;
+    }
+  | { type: "run-command"; id: string }
+  | { type: "build-export"; callId: number; id: string; bodyHtml: string }
+  | { type: "workspace-result"; callId: number; ok: boolean; value?: unknown; error?: string };
+
+/** Worker -> host. */
+export type WorkerMessage =
+  | { type: "activated" }
+  | { type: "error"; message: string }
+  | { type: "register-command"; id: string; title: string }
+  | { type: "add-styles"; css: string }
+  | {
+      type: "register-translations";
+      locale: string;
+      namespace: string;
+      resources: Record<string, unknown>;
+    }
+  | { type: "notify"; message: string }
+  | { type: "settings-set"; key: string; value: unknown }
+  | { type: "register-exporter"; id: string; label: string; extension: string }
+  | {
+      type: "export-result";
+      callId: number;
+      ok: boolean;
+      output?: string | number[];
+      error?: string;
+    }
+  | { type: "workspace-read"; callId: number; path: string }
+  | { type: "workspace-list"; callId: number };
+
+/**
+ * Is a URL reachable under the plugin's declared `network:<host>` permissions?
+ * Exact host match, or a subdomain of a declared host. No declarations means
+ * no network at all.
+ */
+export function isNetworkAllowed(permissions: readonly string[], url: string): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  return permissions.some((p) => {
+    if (!p.startsWith("network:")) return false;
+    const allowed = p.slice("network:".length);
+    return host === allowed || host.endsWith(`.${allowed}`);
+  });
+}

--- a/src/lib/plugins/sandbox/sandbox.test.ts
+++ b/src/lib/plugins/sandbox/sandbox.test.ts
@@ -91,6 +91,12 @@ describe("startSandbox", () => {
     expect(worker.terminated).toBe(true);
   });
 
+  it("ignores worker failures after activation", async () => {
+    const { worker } = await startActivated();
+    worker.onerror?.("late failure");
+    expect(worker.terminated).toBe(false);
+  });
+
   it("logs errors after activation instead of rejecting", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { worker } = await startActivated();
@@ -157,6 +163,11 @@ describe("startSandbox", () => {
     const second = exporter.build("b");
     worker.emit({ type: "export-result", callId: 2, ok: false, error: "no bytes" });
     await expect(second).rejects.toThrow("no bytes");
+
+    // An ok result with no output still rejects instead of resolving undefined.
+    const third = exporter.build("c");
+    worker.emit({ type: "export-result", callId: 3, ok: true });
+    await expect(third).rejects.toThrow("export failed");
 
     // Unknown callId is ignored rather than crashing the bridge.
     worker.emit({ type: "export-result", callId: 99, ok: true, output: "x" });

--- a/src/lib/plugins/sandbox/sandbox.test.ts
+++ b/src/lib/plugins/sandbox/sandbox.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from "vitest";
+import { FakeWorker } from "@/test/fakeWorker";
+import { PLUGIN_API_VERSION } from "../apiVersion";
+import type { ExporterContribution, InstalledPlugin } from "../types";
+import type { SandboxHostApi } from "./sandbox";
+import { startSandbox } from "./sandbox";
+
+const plugin: InstalledPlugin = {
+  id: "com.x.boxed",
+  name: "Boxed",
+  version: "1.0.0",
+  apiVersion: `^${PLUGIN_API_VERSION}`,
+  permissions: ["network:example.com"],
+  sandbox: true,
+  dir: "/plugins/com.x.boxed",
+  mainSource: "export default { activate(){} };",
+};
+
+function apiStub(): SandboxHostApi {
+  return {
+    registerCommand: vi.fn(),
+    addStyles: vi.fn(),
+    registerExporter: vi.fn(),
+    notify: vi.fn(),
+    registerTranslations: vi.fn(),
+    settingsSet: vi.fn(),
+    workspaceRead: vi.fn().mockResolvedValue("file text"),
+    workspaceList: vi.fn().mockResolvedValue(["/ws/a.md"]),
+  };
+}
+
+function start(api = apiStub()) {
+  const worker = new FakeWorker();
+  const promise = startSandbox(plugin, { theme: "dark" }, api, () => worker);
+  return { worker, api, promise };
+}
+
+async function startActivated(api = apiStub()) {
+  const { worker, promise } = start(api);
+  worker.emit({ type: "activated" });
+  return { worker, api, dispose: await promise };
+}
+
+describe("startSandbox", () => {
+  it("spawns a real Worker from a blob URL when no spawner is injected", async () => {
+    const worker = new FakeWorker();
+    const createObjectURL = vi.fn(() => "blob:bootstrap");
+    // jsdom has neither Worker nor URL.createObjectURL; stub both.
+    // A function expression so `new Worker(...)` can construct it.
+    const workerCtor = vi.fn(function fakeWorkerCtor() {
+      return worker;
+    });
+    vi.stubGlobal("Worker", workerCtor);
+    const originalCreateObjectURL = URL.createObjectURL;
+    URL.createObjectURL = createObjectURL;
+    try {
+      const promise = startSandbox(plugin, {}, apiStub());
+      worker.emit({ type: "activated" });
+      await promise;
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(workerCtor).toHaveBeenCalledWith("blob:bootstrap");
+      expect(worker.posted[0]).toMatchObject({ type: "init" });
+    } finally {
+      URL.createObjectURL = originalCreateObjectURL;
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("sends init with source, permissions, and settings, then resolves on activated", async () => {
+    const { worker } = await startActivated();
+    expect(worker.posted[0]).toEqual({
+      type: "init",
+      source: plugin.mainSource,
+      apiVersion: PLUGIN_API_VERSION,
+      permissions: ["network:example.com"],
+      settings: { theme: "dark" },
+    });
+  });
+
+  it("rejects and terminates on an activation error", async () => {
+    const { worker, promise } = start();
+    worker.emit({ type: "error", message: "boom" });
+    await expect(promise).rejects.toThrow("boom");
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("rejects and terminates when the worker itself fails", async () => {
+    const { worker, promise } = start();
+    worker.onerror?.("script error");
+    await expect(promise).rejects.toThrow("sandbox worker failed");
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("logs errors after activation instead of rejecting", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { worker } = await startActivated();
+    worker.emit({ type: "error", message: "later" });
+    expect(consoleError).toHaveBeenCalledWith("Sandboxed plugin com.x.boxed error:", "later");
+    consoleError.mockRestore();
+  });
+
+  it("the disposer terminates the worker", async () => {
+    const { worker, dispose } = await startActivated();
+    dispose();
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("bridges register-command; running it posts run-command", async () => {
+    const { worker, api } = await startActivated();
+    worker.emit({ type: "register-command", id: "c1", title: "Do it" });
+    const [command] = vi.mocked(api.registerCommand).mock.calls[0];
+    expect(command.title).toBe("Do it");
+    command.run();
+    expect(worker.posted).toContainEqual({ type: "run-command", id: "c1" });
+  });
+
+  it("bridges styles, notify, translations, and settings-set", async () => {
+    const { worker, api } = await startActivated();
+    worker.emit({ type: "add-styles", css: "body{color:red}" });
+    worker.emit({ type: "notify", message: "hi" });
+    worker.emit({
+      type: "register-translations",
+      locale: "de",
+      namespace: "ns",
+      resources: { k: "v" },
+    });
+    worker.emit({ type: "settings-set", key: "a", value: 1 });
+    expect(api.addStyles).toHaveBeenCalledWith("body{color:red}");
+    expect(api.notify).toHaveBeenCalledWith("hi");
+    expect(api.registerTranslations).toHaveBeenCalledWith("de", "ns", { k: "v" });
+    expect(api.settingsSet).toHaveBeenCalledWith("a", 1);
+  });
+
+  it("round-trips an exporter build through the worker", async () => {
+    const { worker, api } = await startActivated();
+    worker.emit({ type: "register-exporter", id: "e1", label: "Text", extension: "txt" });
+    const [exporter] = vi.mocked(api.registerExporter).mock.calls[0] as [ExporterContribution];
+
+    const building = exporter.build("<p>hi</p>");
+    const request = worker.posted.find((m) => m.type === "build-export");
+    expect(request).toMatchObject({ id: "e1", bodyHtml: "<p>hi</p>" });
+    const callId = (request as { callId: number }).callId;
+
+    worker.emit({ type: "export-result", callId, ok: true, output: "done" });
+    await expect(building).resolves.toBe("done");
+  });
+
+  it("delivers byte-array export output as Uint8Array and rejects failures", async () => {
+    const { worker, api } = await startActivated();
+    worker.emit({ type: "register-exporter", id: "e1", label: "Bin", extension: "bin" });
+    const [exporter] = vi.mocked(api.registerExporter).mock.calls[0] as [ExporterContribution];
+
+    const first = exporter.build("a");
+    worker.emit({ type: "export-result", callId: 1, ok: true, output: [1, 2] });
+    await expect(first).resolves.toEqual(new Uint8Array([1, 2]));
+
+    const second = exporter.build("b");
+    worker.emit({ type: "export-result", callId: 2, ok: false, error: "no bytes" });
+    await expect(second).rejects.toThrow("no bytes");
+
+    // Unknown callId is ignored rather than crashing the bridge.
+    worker.emit({ type: "export-result", callId: 99, ok: true, output: "x" });
+  });
+
+  it("answers workspace-read and workspace-list with workspace-result", async () => {
+    const { worker, api } = await startActivated();
+    worker.emit({ type: "workspace-read", callId: 1, path: "notes.md" });
+    worker.emit({ type: "workspace-list", callId: 2 });
+    await vi.waitFor(() => {
+      expect(worker.posted).toContainEqual({
+        type: "workspace-result",
+        callId: 1,
+        ok: true,
+        value: "file text",
+      });
+      expect(worker.posted).toContainEqual({
+        type: "workspace-result",
+        callId: 2,
+        ok: true,
+        value: ["/ws/a.md"],
+      });
+    });
+    expect(api.workspaceRead).toHaveBeenCalledWith("notes.md");
+  });
+
+  it("relays workspace failures as error results", async () => {
+    const api = apiStub();
+    vi.mocked(api.workspaceRead).mockRejectedValue(new Error("requires workspace:read"));
+    vi.mocked(api.workspaceList).mockRejectedValue(new Error("no workspace"));
+    const { worker } = await startActivated(api);
+    worker.emit({ type: "workspace-read", callId: 1, path: "x.md" });
+    worker.emit({ type: "workspace-list", callId: 2 });
+    await vi.waitFor(() => {
+      expect(worker.posted).toContainEqual({
+        type: "workspace-result",
+        callId: 1,
+        ok: false,
+        error: "Error: requires workspace:read",
+      });
+      expect(worker.posted).toContainEqual({
+        type: "workspace-result",
+        callId: 2,
+        ok: false,
+        error: "Error: no workspace",
+      });
+    });
+  });
+});

--- a/src/lib/plugins/sandbox/sandbox.ts
+++ b/src/lib/plugins/sandbox/sandbox.ts
@@ -1,0 +1,165 @@
+import { PLUGIN_API_VERSION } from "../apiVersion";
+import type { Disposer } from "../disposer";
+import type { ExporterContribution, InstalledPlugin } from "../types";
+import { buildWorkerBootstrap } from "./bootstrap";
+import type { HostMessage, WorkerMessage } from "./protocol";
+
+/** The subset of Worker the bridge needs; injectable for tests (jsdom has no Worker). */
+export interface WorkerLike {
+  postMessage(message: HostMessage): void;
+  terminate(): void;
+  onmessage: ((event: { data: WorkerMessage }) => void) | null;
+  onerror: ((event: unknown) => void) | null;
+}
+
+export type WorkerSpawner = (bootstrapSource: string) => WorkerLike;
+
+/** What the sandbox is allowed to do on the host side. All calls are already
+ * routed through the owning plugin's DisposerBag by the host. */
+export interface SandboxHostApi {
+  registerCommand(command: { id: string; title: string; run: () => void }): void;
+  addStyles(css: string): void;
+  registerExporter(exporter: ExporterContribution): void;
+  notify(message: string): void;
+  registerTranslations(locale: string, namespace: string, resources: Record<string, unknown>): void;
+  settingsSet(key: string, value: unknown): void;
+  workspaceRead(path: string): Promise<string>;
+  workspaceList(): Promise<string[]>;
+}
+
+const defaultSpawner: WorkerSpawner = (source) =>
+  new Worker(URL.createObjectURL(new Blob([source], { type: "text/javascript" }))) as WorkerLike;
+
+/**
+ * Run a sandboxed plugin in a dedicated worker and bridge its protocol
+ * messages onto the host API. Resolves once the worker reports `activated`;
+ * rejects on `error` or worker failure. The returned disposer terminates the
+ * worker (the host's DisposerBag removes the registered contributions).
+ */
+export function startSandbox(
+  plugin: InstalledPlugin,
+  settings: Record<string, unknown>,
+  api: SandboxHostApi,
+  spawn: WorkerSpawner = defaultSpawner,
+): Promise<Disposer> {
+  const worker = spawn(buildWorkerBootstrap());
+  let exportSeq = 0;
+  const pendingExports = new Map<
+    number,
+    { resolve: (v: string | Uint8Array) => void; reject: (e: Error) => void }
+  >();
+
+  return new Promise<Disposer>((resolve, reject) => {
+    let activated = false;
+    const fail = (err: Error) => {
+      worker.terminate();
+      reject(err);
+    };
+
+    worker.onerror = (event) => {
+      if (!activated) fail(new Error(`sandbox worker failed: ${String(event)}`));
+    };
+
+    worker.onmessage = ({ data }) => {
+      switch (data.type) {
+        case "activated":
+          activated = true;
+          resolve(() => worker.terminate());
+          break;
+        case "error":
+          if (!activated) fail(new Error(data.message));
+          else console.error(`Sandboxed plugin ${plugin.id} error:`, data.message);
+          break;
+        case "register-command":
+          api.registerCommand({
+            id: data.id,
+            title: data.title,
+            run: () => worker.postMessage({ type: "run-command", id: data.id }),
+          });
+          break;
+        case "add-styles":
+          api.addStyles(data.css);
+          break;
+        case "register-translations":
+          api.registerTranslations(data.locale, data.namespace, data.resources);
+          break;
+        case "notify":
+          api.notify(data.message);
+          break;
+        case "settings-set":
+          api.settingsSet(data.key, data.value);
+          break;
+        case "register-exporter":
+          api.registerExporter({
+            id: data.id,
+            label: data.label,
+            extension: data.extension,
+            build: (bodyHtml) =>
+              new Promise((res, rej) => {
+                const callId = ++exportSeq;
+                pendingExports.set(callId, { resolve: res, reject: rej });
+                worker.postMessage({ type: "build-export", callId, id: data.id, bodyHtml });
+              }),
+          });
+          break;
+        case "export-result": {
+          const pending = pendingExports.get(data.callId);
+          if (!pending) break;
+          pendingExports.delete(data.callId);
+          if (data.ok && data.output !== undefined) {
+            pending.resolve(
+              typeof data.output === "string" ? data.output : new Uint8Array(data.output),
+            );
+          } else {
+            pending.reject(new Error(data.error ?? "export failed"));
+          }
+          break;
+        }
+        case "workspace-read":
+          api.workspaceRead(data.path).then(
+            (value) =>
+              worker.postMessage({
+                type: "workspace-result",
+                callId: data.callId,
+                ok: true,
+                value,
+              }),
+            (err) =>
+              worker.postMessage({
+                type: "workspace-result",
+                callId: data.callId,
+                ok: false,
+                error: String(err),
+              }),
+          );
+          break;
+        case "workspace-list":
+          api.workspaceList().then(
+            (value) =>
+              worker.postMessage({
+                type: "workspace-result",
+                callId: data.callId,
+                ok: true,
+                value,
+              }),
+            (err) =>
+              worker.postMessage({
+                type: "workspace-result",
+                callId: data.callId,
+                ok: false,
+                error: String(err),
+              }),
+          );
+          break;
+      }
+    };
+
+    worker.postMessage({
+      type: "init",
+      source: plugin.mainSource,
+      apiVersion: PLUGIN_API_VERSION,
+      permissions: plugin.permissions ?? [],
+      settings,
+    });
+  });
+}

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -35,6 +35,13 @@ export interface PluginManifest {
   main?: string;
   /** Capabilities requested; shown on the consent screen before first enable. */
   permissions?: PluginPermission[];
+  /**
+   * Run in a dedicated worker instead of the app context. Sandboxed plugins
+   * get no DOM and network fenced to their `network:` permissions, but only
+   * the non-UI API subset: commands, styles, exporters, workspace, settings,
+   * notify, and translations. No markdown pipeline or panel mounts.
+   */
+  sandbox?: boolean;
 }
 
 /**
@@ -50,6 +57,8 @@ export interface InstalledPlugin {
   description?: string;
   /** Capabilities the plugin declares; shown to the user before install. */
   permissions?: string[];
+  /** Run isolated in a worker; see {@link PluginManifest.sandbox}. */
+  sandbox?: boolean;
   /** Absolute path of the installed plugin folder. */
   dir: string;
   /** Source text of the plugin's ESM entry file. */

--- a/src/test/fakeWorker.ts
+++ b/src/test/fakeWorker.ts
@@ -1,0 +1,25 @@
+import type { HostMessage, WorkerMessage } from "@/lib/plugins/sandbox/protocol";
+import type { WorkerLike } from "@/lib/plugins/sandbox/sandbox";
+
+/**
+ * In-memory stand-in for the sandbox worker (jsdom has no Worker). Tests read
+ * what the host posted from `posted` and drive the bridge with `emit`.
+ */
+export class FakeWorker implements WorkerLike {
+  posted: HostMessage[] = [];
+  terminated = false;
+  onmessage: ((event: { data: WorkerMessage }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+
+  postMessage(message: HostMessage): void {
+    this.posted.push(message);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  emit(data: WorkerMessage): void {
+    this.onmessage?.({ data });
+  }
+}


### PR DESCRIPTION
## Summary

Adds an isolated Web Worker execution tier for plugins (Phase E3 of the plugin system, part of #109). A plugin that declares `"sandbox": true` in its manifest runs in a dedicated worker with no DOM and no Tauri access; every capability crosses a typed postMessage protocol, and network access inside the worker is fenced to the plugin's declared `network:<host>` permissions.

## Changes

- `src/lib/plugins/sandbox/protocol.ts`: typed host/worker message protocol plus the `isNetworkAllowed` host-matching rule (exact host or subdomain of a declared `network:` permission).
- `src/lib/plugins/sandbox/bootstrap.ts`: the worker's bootstrap source. On `init` it fences `fetch` to the declared hosts, removes `XMLHttpRequest`/`WebSocket`/`importScripts`, imports the plugin from a `data:` URL, and builds a ctx whose calls post protocol messages back to the host.
- `src/lib/plugins/sandbox/sandbox.ts`: host-side bridge. Spawns the worker (injectable spawner so jsdom tests need no real Worker), resolves on `activated`, terminates on activation failure, and routes worker registrations onto a narrow `SandboxHostApi`. Exporter builds and workspace reads round-trip through callIds.
- `src/lib/plugins/host.ts`: `load()` takes the sandbox path for `plugin.sandbox`, wiring the bridge into the plugin's own DisposerBag (unload terminates the worker and removes exactly its contributions) and keeping the existing settings hydration and generation guards.
- `src/lib/plugins/types.ts` / `marketplace.ts`: optional `sandbox` flag on the manifest, installed plugin, and registry entry (passed through to the synthesized manifest on install).
- `src-tauri/src/commands/plugins.rs`: parses an optional boolean `sandbox` manifest field (rejects non-boolean), serialized camelCase and omitted when false.

Sandboxed plugins get the non-UI API subset: commands, `ui.addStyles`, exporters, workspace read/list (still permission-gated on the host side), settings, notify, and translations. Markdown pipeline plugins and DOM mounts cannot cross a worker boundary and stay main-context only.

Known limitation: in dev builds the CSP is disabled, so a sandboxed plugin could bypass the fetch fence via dynamic `import()` of a remote URL; the production CSP (`script-src 'self' data: blob: 'wasm-unsafe-eval'`) blocks that.

## Testing

- 106 plugin tests, including: the bootstrap source executed in-process (protocol round-trips, network fence, activation failures), the bridge driven by a FakeWorker (all message types, exporter/workspace round-trips, terminate-on-dispose), and host integration (registry routing, settings persistence, unloadAll racing an in-flight sandbox load).
- Rust manifest parsing tests for the `sandbox` field.
- Gates: `pnpm typecheck && pnpm check && pnpm test` and `cargo clippy --all-targets -- -D warnings` all green; full coverage run with the new files at 100% patch coverage.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable (no UI changes).
