### PR TITLE
docs: link the plugin docs hub from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 - Window state persistence across restarts
 - Native menu bar with customizable keyboard shortcuts (remap any command in Settings → Hotkeys)
 - Update notifications: checks for a newer release on launch and shows a banner when one is available (toggle in Settings → Behavior)
-- Plugins (experimental): install JavaScript plugins that extend rendering, palette commands, the status bar, and app styling (custom CSS/themes ship as plugins); every install asks for confirmation and shows the plugin's declared permissions, and everything is managed from the command palette (Manage Plugins…); see the [plugin marketplace](https://github.com/glyph-md/plugins)
+- Plugins (experimental): install JavaScript plugins that extend rendering, palette commands, the status bar, and app styling (custom CSS/themes ship as plugins); every install asks for confirmation and shows the plugin's declared permissions, and everything is managed from the command palette (Manage Plugins…); browse the [plugin marketplace](https://github.com/glyph-md/plugins) or write your own with the [plugin docs](https://github.com/glyph-md/plugins/tree/main/docs)
 
 ### Privacy
 - Local-first: your files never leave your machine unless you opt into Cloud Sync (per workspace, to a Git remote you control)


### PR DESCRIPTION
## Summary

Links the plugin documentation hub from the README's plugin bullet. The hub itself now lives in [glyph-md/plugins/docs](https://github.com/glyph-md/plugins/tree/main/docs) and was built out per the spec:

- New pages: [ecosystem.md](https://github.com/glyph-md/plugins/blob/main/docs/ecosystem.md) (repo map + version flow), [plugin-catalog.md](https://github.com/glyph-md/plugins/blob/main/docs/plugin-catalog.md) (entry per published plugin), [contributing.md](https://github.com/glyph-md/plugins/blob/main/docs/contributing.md) (contributing to the plugin system, host code map, gates), [recipes.md](https://github.com/glyph-md/plugins/blob/main/docs/recipes.md) (worked example for every API 1.2 contribution point, sandbox included)
- [docs/README.md](https://github.com/glyph-md/plugins/blob/main/docs/README.md) is now an audience-routed hub index
- Marketplace README links the hub
- Stretch criterion done: `validate.yml` on glyph-md/plugins now fails when an `index.json` id has no catalog entry (in addition to the existing schema/ordering/https checks)
- Existing four pages were already current for API 1.2 (sandbox section landed with #395)

Skipped the optional GitHub Wiki mirror: the first wiki page cannot be created via API, and the docs/ folder is the PR-reviewable source of truth per the spec.

## Changes

- `README.md`: the plugins feature bullet now links the plugin docs hub alongside the marketplace

## Testing

Docs-only change; no code paths affected.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable.

Closes #387
