### PR TITLE
feat(markdown): support RTL/LTR mixed text direction in the viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 - Inline HTML: `<kbd>`, `<sub>`, `<sup>`, `<details>`, inline `<svg>` drawings, alignment attributes (sanitised allowlist)
 - YAML frontmatter: title, author, date, and tags render as a metadata block above the document; tags get a per-tag colour
 - Emoji shortcodes: `:smile:` → 😊, `:+1:` → 👍
+- Bidirectional text: RTL languages (Persian, Arabic, Hebrew) render right-to-left per paragraph, mixed RTL/LTR documents just work, and fully-RTL documents flip the whole layout (lists, quotes, tables); code always stays left-to-right
 - Feature toggles: turn optional syntax off per taste in Settings → Markdown (GFM extras, math, alerts, emoji, wikilinks); disabled syntax renders as plain text
 - Local and remote image display
 - Image lightbox: click any image to view it full-size over a dark backdrop, with zoom controls (fit, actual size, zoom in/out), arrow-key navigation between the document's images, and Escape or click-outside to close

--- a/samples/README.md
+++ b/samples/README.md
@@ -21,6 +21,7 @@ This document demonstrates all the rendering features supported by Glyph. The YA
 - [CSV / TSV Tables](#csv--tsv-tables)
 - [Footnotes](#footnotes)
 - [Emoji Shortcodes](#emoji-shortcodes)
+- [Bidirectional Text](#bidirectional-text)
 - [Blockquotes](#blockquotes)
 - [Raw HTML](#raw-html)
 - [Images](#images)
@@ -226,6 +227,21 @@ Footnotes can contain **rich text** and even code[^3].
 Glyph converts GitHub-style emoji shortcodes to Unicode:
 
 :wave: Hello! :rocket: Ship it! :tada: Celebration! :bug: Found a bug :white_check_mark: Tests passing :heart: Love it :thumbsup: Approved
+
+## Bidirectional Text
+
+Each paragraph resolves its own direction from its first strong character, so RTL and LTR text mix freely in one document.
+
+این بند به فارسی نوشته شده و از راست به چپ نمایش داده می‌شود، حتی وقتی بقیه سند انگلیسی است.
+
+هذه الفقرة مكتوبة بالعربية وتعرض من اليمين إلى اليسار.
+
+Mixed inline text works too: the word سلام means "hello" in Persian, and code like `let x = 1` stays left-to-right even inside an RTL paragraph.
+
+- فهرست‌ها هم پشتیبانی می‌شوند
+- Bullet items keep their own direction per line
+
+> نقل‌قول‌ها نیز جهت خود را از متن می‌گیرند.
 
 ## Blockquotes
 

--- a/src/components/markdown/MarkdownViewer.test.tsx
+++ b/src/components/markdown/MarkdownViewer.test.tsx
@@ -188,6 +188,13 @@ describe("MarkdownViewer search", () => {
   });
 });
 
+describe("MarkdownViewer text direction", () => {
+  it("resolves the document base direction automatically", () => {
+    const { container } = renderMd("# سلام دنیا");
+    expect(container.querySelector(".markdown-body")?.getAttribute("dir")).toBe("auto");
+  });
+});
+
 describe("MarkdownViewer MDX notice", () => {
   it("shows the notice for .mdx files", () => {
     const { getByRole } = renderMd("# Title", { filePath: "/docs/page.mdx" });

--- a/src/components/markdown/MarkdownViewer.tsx
+++ b/src/components/markdown/MarkdownViewer.tsx
@@ -98,7 +98,11 @@ export function MarkdownViewer({
             {t("mdxNotice.body")}
           </div>
         )}
-        <div ref={contentRef} className="markdown-body px-8 py-6">
+        {/* dir="auto" resolves the document's base direction from its first
+            strong character, so a fully-RTL file lays out RTL (list markers,
+            blockquote borders, tables). Mixed-direction blocks are handled
+            per-element via `unicode-bidi: plaintext` in markdown.css. */}
+        <div ref={contentRef} className="markdown-body px-8 py-6" dir="auto">
           <MarkdownContent
             content={content}
             filePath={filePath}

--- a/src/hooks/useExport.test.ts
+++ b/src/hooks/useExport.test.ts
@@ -89,7 +89,9 @@ describe("useExport", () => {
     expect(save).toHaveBeenCalledWith(expect.objectContaining({ defaultPath: "note.html" }));
     const call = vi.mocked(invoke).mock.calls.find((c) => c[0] === "write_file");
     expect(call).toBeTruthy();
-    expect((call?.[1] as { content: string }).content).toContain('<div class="markdown-body">');
+    expect((call?.[1] as { content: string }).content).toContain(
+      '<div class="markdown-body" dir="auto">',
+    );
   });
 
   it("does not write when the save dialog is cancelled", async () => {

--- a/src/lib/export/docx.test.ts
+++ b/src/lib/export/docx.test.ts
@@ -1,5 +1,11 @@
+import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
 import { buildDocx } from "./docx";
+
+async function documentXml(bytes: Uint8Array): Promise<string> {
+  const zip = await JSZip.loadAsync(bytes);
+  return zip.file("word/document.xml")!.async("string");
+}
 
 describe("buildDocx", () => {
   it("produces a non-empty .docx (zip) byte stream", async () => {
@@ -21,5 +27,25 @@ describe("buildDocx", () => {
       '<p><a href="https://example.com">link</a></p>';
     const bytes = await buildDocx(html, { title: "Doc" });
     expect(bytes.length).toBeGreaterThan(100);
+  });
+
+  it("marks RTL blocks bidirectional and leaves LTR blocks alone", async () => {
+    const rtl = await documentXml(
+      await buildDocx("<h1>سرفصل</h1><p>سلام دنیا</p><ul><li>مورد</li></ul>", { title: "Doc" }),
+    );
+    expect(rtl).toContain("<w:bidi/>");
+
+    const ltr = await documentXml(
+      await buildDocx("<h1>Title</h1><p>Hello</p><ul><li>item</li></ul>", { title: "Doc" }),
+    );
+    expect(ltr).not.toContain("<w:bidi/>");
+  });
+
+  it("keeps code blocks LTR even in an RTL document", async () => {
+    const xml = await documentXml(
+      await buildDocx("<p>سلام</p><pre>let x = 1</pre>", { title: "Doc" }),
+    );
+    // Exactly one bidi paragraph: the Persian one, not the code block.
+    expect(xml.match(/<w:bidi\/>/g)).toHaveLength(1);
   });
 });

--- a/src/lib/export/epub.test.ts
+++ b/src/lib/export/epub.test.ts
@@ -71,6 +71,17 @@ describe("buildEpub", () => {
     expect(nav).toContain("Intro");
   });
 
+  it("resolves the chapter's base direction automatically for RTL documents", async () => {
+    const bytes = await buildEpub({
+      bodyHtml: "<p>سلام دنیا</p>",
+      css: "",
+      entries: [],
+      metadata: META,
+    });
+    const chapter = await (await loadEpub(bytes)).file("OEBPS/chapter.xhtml")?.async("string");
+    expect(chapter).toContain('<div class="markdown-body" dir="auto">');
+  });
+
   it("emits well-formed XHTML for the chapter (void tags self-closed)", async () => {
     const bytes = await buildEpub({
       bodyHtml: "<p>line<br>break</p><hr>",

--- a/src/lib/export/epub.ts
+++ b/src/lib/export/epub.ts
@@ -94,7 +94,7 @@ function buildChapter(title: string, bodyHtml: string, bodyClass: string): strin
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head><meta charset="utf-8"/><title>${escapeXml(title)}</title><link rel="stylesheet" type="text/css" href="style.css"/></head>
 <body>
-<div class="${bodyClass}">
+<div class="${bodyClass}" dir="auto">
 ${toXhtml(bodyHtml)}
 </div>
 </body>

--- a/src/lib/export/html.test.ts
+++ b/src/lib/export/html.test.ts
@@ -12,7 +12,7 @@ describe("buildHtmlDocument", () => {
     expect(out).toContain("<!doctype html>");
     expect(out).toContain("<title>My Doc</title>");
     expect(out).toContain("<style>\n.markdown-body{color:red}");
-    expect(out).toContain('<div class="markdown-body">');
+    expect(out).toContain('<div class="markdown-body" dir="auto">');
     expect(out).toContain("<p>hello</p>");
     expect(out).not.toContain('<html lang="en" class="dark">');
   });
@@ -50,7 +50,7 @@ describe("buildHtmlDocument", () => {
       dark: false,
       bodyClass: "notebook-body",
     });
-    expect(out).toContain('<div class="notebook-body">');
+    expect(out).toContain('<div class="notebook-body" dir="auto">');
   });
 
   it("syncs to the reader's system theme via prefers-color-scheme", () => {

--- a/src/lib/export/html.ts
+++ b/src/lib/export/html.ts
@@ -86,7 +86,9 @@ export function buildHtmlDocument({
   const stylesheetLink = stylesheetHref
     ? `\n<link rel="stylesheet" href="${escapeXml(stylesheetHref)}">`
     : "";
-  const content = `<div class="${bodyClass}">
+  // dir="auto" mirrors the viewer: a fully-RTL document resolves an RTL base
+  // direction; per-block bidi comes from the bundled markdown.css rules.
+  const content = `<div class="${bodyClass}" dir="auto">
 ${bodyHtml}
 </div>`;
   const body = navHtml

--- a/src/lib/export/htmlToDocx.ts
+++ b/src/lib/export/htmlToDocx.ts
@@ -9,6 +9,7 @@ import {
   TextRun,
   WidthType,
 } from "docx";
+import { isRtlText } from "@/lib/textDirection";
 import { inlineRuns } from "./docxInline";
 
 export const OL_REFERENCE = "glyph-ordered";
@@ -47,6 +48,15 @@ function childElements(el: Element, tag: string): Element[] {
   return Array.from(el.children).filter((c) => c.tagName.toLowerCase() === tag);
 }
 
+// Word renders an RTL paragraph (direction + right alignment) when w:bidi is
+// set; each block decides from its own first strong character, mirroring the
+// viewer's per-block `unicode-bidi: plaintext`. Code blocks stay LTR.
+// `undefined` (not `false`) keeps LTR paragraphs free of an explicit
+// `w:bidi val="false"` element.
+function isRtl(el: Element): true | undefined {
+  return isRtlText(el.textContent) || undefined;
+}
+
 function codeBlock(el: Element): Paragraph {
   // textContent is never null for an element; the assertion avoids a dead branch.
   const lines = el.textContent!.replace(/\n$/, "").split("\n");
@@ -62,7 +72,12 @@ function quoteBlocks(el: Element): Block[] {
   const paras = childElements(el, "p");
   const sources = paras.length > 0 ? paras : [el];
   return sources.map(
-    (p) => new Paragraph({ indent: { left: INDENT_STEP }, children: inlineRuns(p) }),
+    (p) =>
+      new Paragraph({
+        indent: { left: INDENT_STEP },
+        bidirectional: isRtl(p),
+        children: inlineRuns(p),
+      }),
   );
 }
 
@@ -76,7 +91,12 @@ function tableBlock(el: Element): Table {
         children: cells.map((cell) => {
           const header = cell.tagName.toLowerCase() === "th";
           return new TableCell({
-            children: [new Paragraph({ children: inlineRuns(cell, { bold: header }) })],
+            children: [
+              new Paragraph({
+                bidirectional: isRtl(cell),
+                children: inlineRuns(cell, { bold: header }),
+              }),
+            ],
           });
         }),
       }),
@@ -117,7 +137,9 @@ function listBlocks(listEl: Element, ordered: boolean, level: number, ctx: Ctx):
     const listProps: IParagraphOptions = ordered
       ? { numbering: { reference: OL_REFERENCE, level, instance } }
       : { bullet: { level } };
-    out.push(new Paragraph({ ...listProps, children: inlineRuns(clone) }));
+    out.push(
+      new Paragraph({ ...listProps, bidirectional: isRtl(clone), children: inlineRuns(clone) }),
+    );
     for (const sublist of nested) {
       out.push(...listBlocks(sublist, sublist.tagName.toLowerCase() === "ol", level + 1, ctx));
     }
@@ -128,18 +150,31 @@ function listBlocks(listEl: Element, ordered: boolean, level: number, ctx: Ctx):
 function blocksForNode(node: Node, ctx: Ctx): Block[] {
   if (node.nodeType === 3) {
     const text = (node as Text).data.trim();
-    return text ? [new Paragraph({ children: [new TextRun(text)] })] : [];
+    return text
+      ? [
+          new Paragraph({
+            bidirectional: isRtlText(text) || undefined,
+            children: [new TextRun(text)],
+          }),
+        ]
+      : [];
   }
   if (node.nodeType !== 1) return [];
   const el = node as Element;
   const tag = el.tagName.toLowerCase();
 
   if (HEADING_BY_TAG[tag]) {
-    return [new Paragraph({ heading: HEADING_BY_TAG[tag], children: inlineRuns(el) })];
+    return [
+      new Paragraph({
+        heading: HEADING_BY_TAG[tag],
+        bidirectional: isRtl(el),
+        children: inlineRuns(el),
+      }),
+    ];
   }
   if (tag === "p") {
     const children = inlineRuns(el);
-    return children.length ? [new Paragraph({ children })] : [];
+    return children.length ? [new Paragraph({ bidirectional: isRtl(el), children })] : [];
   }
   if (tag === "ul" || tag === "ol") return listBlocks(el, tag === "ol", 0, ctx);
   if (tag === "blockquote") return quoteBlocks(el);
@@ -155,7 +190,7 @@ function blocksForNode(node: Node, ctx: Ctx): Block[] {
 
   // Unknown element: render its inline content as a paragraph.
   const children = inlineRuns(el);
-  return children.length ? [new Paragraph({ children })] : [];
+  return children.length ? [new Paragraph({ bidirectional: isRtl(el), children })] : [];
 }
 
 /**

--- a/src/lib/export/prepareContent.test.ts
+++ b/src/lib/export/prepareContent.test.ts
@@ -221,6 +221,49 @@ describe("prepareContent", () => {
     expect(result?.html).not.toContain('data-dark="1"');
   });
 
+  it("rasterizes blocks containing RTL text for PDF (browser bidi is exact)", async () => {
+    rasterizeElementMock.mockClear();
+    setBody("<p>سلام دنیا</p><p>plain english</p>");
+    const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
+    expect(rasterizeElementMock).toHaveBeenCalledTimes(1);
+    expect(result?.html).toContain("data:image/png;base64,MATH");
+    expect(result?.html).not.toContain("سلام");
+    // The LTR paragraph stays selectable text.
+    expect(result?.html).toContain("plain english");
+  });
+
+  it("rasterizes an RTL list once at its outermost block", async () => {
+    rasterizeElementMock.mockClear();
+    setBody("<ul><li>مورد یک</li><li>مورد دو</li></ul>");
+    const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
+    expect(rasterizeElementMock).toHaveBeenCalledTimes(1);
+    expect(result?.html).not.toContain("<ul>");
+  });
+
+  it("keeps RTL code blocks as text (never rasterized)", async () => {
+    rasterizeElementMock.mockClear();
+    setBody("<pre>msg = 'سلام'</pre>");
+    const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
+    expect(rasterizeElementMock).not.toHaveBeenCalled();
+    expect(result?.html).toContain("سلام");
+  });
+
+  it("keeps the original block when RTL rasterization fails", async () => {
+    rasterizeElementMock.mockClear();
+    rasterizeElementMock.mockRejectedValueOnce(new Error("canvas tainted"));
+    setBody("<p>سلام دنیا</p>");
+    const result = await prepareContent({ entries: ENTRIES, includeToc: false, pdf: true });
+    expect(result?.html).toContain("سلام دنیا");
+  });
+
+  it("leaves RTL text alone for non-PDF exports", async () => {
+    rasterizeElementMock.mockClear();
+    setBody("<p>سلام دنیا</p>");
+    const result = await prepareContent({ entries: ENTRIES, includeToc: false });
+    expect(rasterizeElementMock).not.toHaveBeenCalled();
+    expect(result?.html).toContain("سلام دنیا");
+  });
+
   it("does not touch math or diagrams for non-PDF exports", async () => {
     rasterizeElementMock.mockClear();
     renderMermaidMock.mockClear();

--- a/src/lib/export/prepareContent.ts
+++ b/src/lib/export/prepareContent.ts
@@ -1,5 +1,6 @@
 import type { TocEntry } from "@/hooks/useTableOfContents";
 import { renderD2 } from "@/lib/d2Render";
+import { containsRtlText } from "@/lib/textDirection";
 import { rasterizeElement, renderMermaidLightSvg, restoreMermaidTheme } from "./rasterize";
 import { buildTocElement } from "./toc";
 
@@ -64,6 +65,36 @@ async function preparePdfRichContent(liveBody: Element, clone: Element): Promise
 
   if (mermaidRendered) {
     await restoreMermaidTheme(liveBody.ownerDocument.documentElement.classList.contains("dark"));
+  }
+}
+
+// pdfmake positions each word individually left-to-right and does no bidi
+// reordering or Arabic shaping (and its bundled font has no Arabic/Hebrew
+// glyphs), so RTL text can't render as PDF text. Instead, any block containing
+// RTL characters is captured from the live DOM as an image, the same treatment
+// block math gets: the webview's bidi rendering is exact. Outermost matching
+// blocks only, so a list with one RTL item rasterizes once. Code blocks are
+// not candidates and stay selectable text.
+const RTL_BLOCK_SELECTOR = "p, h1, h2, h3, h4, h5, h6, ul, ol, blockquote, table";
+
+async function rasterizeRtlBlocks(liveBody: Element, clone: Element): Promise<void> {
+  const live = liveBody.querySelectorAll<HTMLElement>(RTL_BLOCK_SELECTOR);
+  if (live.length === 0) return;
+  const cloned = clone.querySelectorAll(RTL_BLOCK_SELECTOR);
+  const background = getComputedStyle(liveBody).backgroundColor || "#ffffff";
+  for (let i = 0; i < live.length; i++) {
+    const el = live[i];
+    // Skip nested matches (an RTL <li> is covered by its list, a table cell's
+    // paragraph by its table).
+    if (el.parentElement?.closest(RTL_BLOCK_SELECTOR)) continue;
+    if (!containsRtlText(el.textContent)) continue;
+    try {
+      const img = clone.ownerDocument.createElement("img");
+      img.setAttribute("src", await rasterizeElement(el, background));
+      cloned[i].replaceWith(img);
+    } catch {
+      // Leave the original block; the walker degrades to logical-order text.
+    }
   }
 }
 
@@ -152,6 +183,10 @@ export async function prepareContent({
   if (pdf) {
     inlineCodeColors(body, clone);
     await preparePdfRichContent(body, clone);
+    // After the math/diagram pass: both passes match live and clone nodes by
+    // querySelectorAll index, and this one replaces whole blocks that may
+    // contain the elements the first pass looks for.
+    await rasterizeRtlBlocks(body, clone);
   }
   for (const el of Array.from(clone.querySelectorAll(STRIP_SELECTOR))) {
     el.remove();

--- a/src/lib/textDirection.test.ts
+++ b/src/lib/textDirection.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { isRtlText } from "./textDirection";
+
+describe("isRtlText", () => {
+  it("detects Persian, Arabic, and Hebrew as RTL", () => {
+    expect(isRtlText("سلام دنیا")).toBe(true);
+    expect(isRtlText("مرحبا بالعالم")).toBe(true);
+    expect(isRtlText("שלום עולם")).toBe(true);
+  });
+
+  it("detects Latin text as LTR", () => {
+    expect(isRtlText("Hello world")).toBe(false);
+  });
+
+  it("skips leading digits and punctuation to the first letter", () => {
+    expect(isRtlText('1. "سلام"')).toBe(true);
+    expect(isRtlText("1. hello")).toBe(false);
+  });
+
+  it("resolves LTR when there are no letters at all", () => {
+    expect(isRtlText("123 !?")).toBe(false);
+    expect(isRtlText("")).toBe(false);
+    expect(isRtlText(null)).toBe(false);
+    expect(isRtlText(undefined)).toBe(false);
+  });
+
+  it("follows the first strong character in mixed text", () => {
+    expect(isRtlText("سلام means hello")).toBe(true);
+    expect(isRtlText("hello یعنی سلام")).toBe(false);
+  });
+});

--- a/src/lib/textDirection.test.ts
+++ b/src/lib/textDirection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isRtlText } from "./textDirection";
+import { containsRtlText, isRtlText } from "./textDirection";
 
 describe("isRtlText", () => {
   it("detects Persian, Arabic, and Hebrew as RTL", () => {
@@ -27,5 +27,19 @@ describe("isRtlText", () => {
   it("follows the first strong character in mixed text", () => {
     expect(isRtlText("سلام means hello")).toBe(true);
     expect(isRtlText("hello یعنی سلام")).toBe(false);
+  });
+});
+
+describe("containsRtlText", () => {
+  it("finds RTL characters anywhere in the text", () => {
+    expect(containsRtlText("hello یعنی سلام")).toBe(true);
+    expect(containsRtlText("שלום in the middle")).toBe(true);
+  });
+
+  it("is false for pure LTR or empty text", () => {
+    expect(containsRtlText("hello")).toBe(false);
+    expect(containsRtlText("")).toBe(false);
+    expect(containsRtlText(null)).toBe(false);
+    expect(containsRtlText(undefined)).toBe(false);
   });
 });

--- a/src/lib/textDirection.ts
+++ b/src/lib/textDirection.ts
@@ -11,3 +11,8 @@ export function isRtlText(text: string | null | undefined): boolean {
   const first = text?.match(/\p{L}/u);
   return first ? RTL_CHAR.test(first[0]) : false;
 }
+
+/** Whether text contains any RTL character at all, regardless of position. */
+export function containsRtlText(text: string | null | undefined): boolean {
+  return text ? RTL_CHAR.test(text) : false;
+}

--- a/src/lib/textDirection.ts
+++ b/src/lib/textDirection.ts
@@ -1,0 +1,13 @@
+// RTL Unicode blocks: Hebrew, Arabic, Syriac, Thaana, NKo, Samaritan, Mandaic,
+// Arabic Extended, and the Arabic/Hebrew presentation forms.
+const RTL_CHAR = /[֐-߿ࡠ-ࣿיִ-﷽ﹰ-ﻼ]/;
+
+/**
+ * Whether text reads right-to-left, decided by its first letter (the same
+ * first-strong-character heuristic as HTML's `dir="auto"`). Digits,
+ * punctuation, and whitespace are skipped; text with no letters resolves LTR.
+ */
+export function isRtlText(text: string | null | undefined): boolean {
+  const first = text?.match(/\p{L}/u);
+  return first ? RTL_CHAR.test(first[0]) : false;
+}

--- a/src/styles/ai-chat.css
+++ b/src/styles/ai-chat.css
@@ -107,11 +107,9 @@
 }
 
 /* Assistant replies mix languages (e.g. a Persian translation under English
-   headings); each block resolves its own direction from its first strong
-   character. */
-.ai-msg-markdown :is(p, li, h1, h2, h3, h4, h5, h6) {
-  unicode-bidi: plaintext;
-}
+   headings); each block resolves its own direction via the shared
+   `unicode-bidi: plaintext` rule in markdown.css (the reply container carries
+   .markdown-body). */
 
 /* Per-message actions, revealed on hover to keep the transcript quiet. */
 .ai-msg-actions {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -81,6 +81,23 @@
   margin: 0 0 1em;
 }
 
+/* Bidirectional text. Each block resolves its own direction from its first
+   strong character, so an RTL paragraph in an LTR document (and vice versa)
+   renders in its natural direction, mirroring the AI chat behaviour in
+   ai-chat.css. The viewer container carries dir="auto" so a fully-RTL
+   document also flips the layout (list markers, blockquote borders, tables). */
+.markdown-body :is(p, li, h1, h2, h3, h4, h5, h6, th, td) {
+  unicode-bidi: plaintext;
+}
+
+/* Code and math are always left-to-right, even inside an RTL document. */
+.markdown-body pre,
+.markdown-body code,
+.markdown-body .katex {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
 .markdown-body a {
   color: var(--color-accent);
   text-decoration: none;
@@ -181,7 +198,11 @@
   padding: 0.5em 1em;
   border-inline-start: 4px solid var(--color-accent);
   background: var(--color-surface-secondary);
-  border-radius: 0 var(--glyph-radius-sm) var(--glyph-radius-sm) 0;
+  /* Logical corners: square against the accent border, rounded on the far
+     side, in both LTR and RTL. */
+  border-radius: 0;
+  border-start-end-radius: var(--glyph-radius-sm);
+  border-end-end-radius: var(--glyph-radius-sm);
   color: var(--color-text-secondary);
 }
 
@@ -192,7 +213,9 @@
   padding: 0.5em 1em;
   border-inline-start: 4px solid var(--alert-accent, var(--color-accent));
   background: color-mix(in srgb, var(--alert-accent, var(--color-accent)) 8%, transparent);
-  border-radius: 0 var(--glyph-radius-sm) var(--glyph-radius-sm) 0;
+  border-radius: 0;
+  border-start-end-radius: var(--glyph-radius-sm);
+  border-end-end-radius: var(--glyph-radius-sm);
   color: var(--color-text-primary);
 }
 


### PR DESCRIPTION
## Summary

Rendered markdown now supports bidirectional text, in the viewer and in every export format. RTL languages (Persian, Arabic, Hebrew) render right-to-left per block, mixed RTL/LTR documents resolve each paragraph independently, and fully-RTL documents flip the whole layout. This mirrors the fix already shipped in the AI chat panel.

Closes #398

## Changes

Viewer:

- `MarkdownViewer.tsx`: `dir="auto"` on `.markdown-body`, so a fully-RTL document resolves an RTL base direction (list markers, blockquote borders, and tables flip)
- `markdown.css`: `unicode-bidi: plaintext` on `p`, `li`, headings, and table cells, so each block resolves its own direction from its first strong character; `pre`, inline `code`, and KaTeX output are forced LTR
- `markdown.css`: blockquote and alert corner rounding converted to logical properties so the rounded side follows the accent border under RTL
- `ai-chat.css`: removed the now-redundant per-block rule (chat replies carry `.markdown-body` and inherit the shared rule)
- Note embeds, notebook markdown outputs, and canvas text cards inherit the behavior via `.markdown-body`

Exports (all four formats):

- **HTML / EPUB**: the wrappers rebuilt around `prepareContent`'s inner HTML now carry `dir="auto"`; the bundled CSS already includes the per-block rules via `collectStyles`
- **DOCX**: no CSS, so the walker sets `w:bidi` per paragraph (headings, paragraphs, list items, quotes, table cells) from the first strong character; Word renders those paragraphs RTL and right-aligned. Code blocks stay LTR
- **PDF**: pdfmake positions each word individually left-to-right, does no bidi reordering or Arabic shaping, and its bundled font has no Arabic/Hebrew glyphs, so RTL can't render as PDF text. Blocks containing RTL characters are instead captured from the live DOM as images during the PDF prepare pass, the same treatment block math already gets, so the webview's exact bidi rendering carries into the PDF. Code blocks stay selectable LTR text; rasterization failures fall back to the old behavior. Canvas-board PDF and selectable vector RTL text are tracked in #402
- **Print**: uses the live DOM, inherits the viewer behavior as-is
- New shared helpers `isRtlText` / `containsRtlText` in `src/lib/textDirection.ts` (first-strong-character heuristic, same as `dir="auto"`)

Docs:

- README feature bullet and a Bidirectional Text showcase section in `samples/README.md`

## Testing

- New tests: viewer `dir="auto"`; the `textDirection` heuristics (Persian/Arabic/Hebrew, mixed text, digits, empty); HTML/EPUB wrapper direction; DOCX `w:bidi` on RTL blocks and absent on LTR and code blocks (asserted on the packed OOXML); PDF rasterization of RTL paragraphs and lists, code blocks excluded, failure fallback, and non-PDF exports untouched
- `pnpm typecheck && pnpm check && pnpm test` green
- `cargo clippy --all-targets -- -D warnings` green

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

The `samples/README.md` Bidirectional Text section demonstrates the behavior (Persian and Arabic paragraphs, mixed inline text, RTL list items and blockquote).
