### PR TITLE
feat(plugins): spell-check dictionary contribution point

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 - Live preview updates as you type
 - Wikilink autocomplete: type `[[` in a folder workspace to pick from existing notes; Tab/Enter to insert
 - Editor keymaps: choose Default, Vim, or VSCode bindings in Settings → Editor
-- Spell check: underline misspelled words while editing, with right-click suggestions; opt in under Settings → Editor
+- Spell check: underline misspelled words while editing, with right-click suggestions; opt in under Settings → Editor. English ships built in; add more languages by installing dictionary plugins from the marketplace
 
 ### Viewer
 - Jupyter notebooks: open `.ipynb` files directly; markdown cells render with full markdown (math, code, diagrams), code cells are syntax-highlighted, and image, HTML, plain-text, and colourised stream/traceback outputs show under each cell with `In [n]:` / `Out [n]:` prompts (read-only)
@@ -102,7 +102,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 - Window state persistence across restarts
 - Native menu bar with customizable keyboard shortcuts (remap any command in Settings → Hotkeys)
 - Update notifications: checks for a newer release on launch and shows a banner when one is available (toggle in Settings → Behavior)
-- Plugins (experimental): install JavaScript plugins that extend rendering, palette commands, the status bar, and app styling (custom CSS/themes ship as plugins); every install asks for confirmation and shows the plugin's declared permissions, and everything is managed from the Plugins… menu item (next to Settings) or the command palette (Manage Plugins…); browse the [plugin marketplace](https://github.com/glyph-md/plugins) or write your own with the [plugin docs](https://github.com/glyph-md/plugins/tree/main/docs)
+- Plugins (experimental): install JavaScript plugins that extend rendering, palette commands, the status bar, spell-check dictionaries, and app styling (custom CSS/themes ship as plugins); every install asks for confirmation and shows the plugin's declared permissions, and everything is managed from the Plugins… menu item (next to Settings) or the command palette (Manage Plugins…); browse the [plugin marketplace](https://github.com/glyph-md/plugins) or write your own with the [plugin docs](https://github.com/glyph-md/plugins/tree/main/docs)
 
 ### Privacy
 - Local-first: your files never leave your machine unless you opt into Cloud Sync (per workspace, to a Git remote you control)

--- a/src/components/modals/settings/EditorTab.test.tsx
+++ b/src/components/modals/settings/EditorTab.test.tsx
@@ -1,8 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SettingsContext, type SettingsContextValue } from "@/contexts/SettingsContext";
 import { DEFAULT_SETTINGS, type Settings } from "@/lib/settings";
+import {
+  clearDictionarySources,
+  registerDictionarySource,
+} from "@/lib/spellcheck/dictionarySources";
 import { EditorTab } from "./EditorTab";
 
 function setup(settings: Settings = DEFAULT_SETTINGS) {
@@ -21,6 +25,10 @@ function setup(settings: Settings = DEFAULT_SETTINGS) {
 }
 
 describe("EditorTab", () => {
+  beforeEach(() => {
+    clearDictionarySources();
+  });
+
   it("offers the keymap presets", () => {
     setup();
     expect(screen.getByText("Keymap")).toBeInTheDocument();
@@ -74,5 +82,42 @@ describe("EditorTab", () => {
     });
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "en" } });
     expect(updateSettings).toHaveBeenCalledWith("editor.spellCheckLanguage", "en");
+  });
+
+  it("lists plugin-contributed dictionaries and selecting one stores its code", () => {
+    registerDictionarySource({
+      language: "fa",
+      label: "فارسی (Persian)",
+      load: () => Promise.resolve({ aff: "", dic: "" }),
+    });
+    const { updateSettings } = setup({
+      ...DEFAULT_SETTINGS,
+      editor: { ...DEFAULT_SETTINGS.editor, spellCheck: true },
+    });
+
+    expect(screen.getByRole("option", { name: "فارسی (Persian)" })).toBeInTheDocument();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "fa" } });
+    expect(updateSettings).toHaveBeenCalledWith("editor.spellCheckLanguage", "fa");
+  });
+
+  it("a plugin dictionary for en replaces the built-in entry", () => {
+    registerDictionarySource({
+      language: "en",
+      label: "English (custom)",
+      load: () => Promise.resolve({ aff: "", dic: "" }),
+    });
+    setup({ ...DEFAULT_SETTINGS, editor: { ...DEFAULT_SETTINGS.editor, spellCheck: true } });
+
+    expect(screen.getByRole("option", { name: "English (custom)" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "English (US)" })).toBeNull();
+  });
+
+  it("keeps an orphaned stored language selectable after its plugin is gone", () => {
+    setup({
+      ...DEFAULT_SETTINGS,
+      editor: { ...DEFAULT_SETTINGS.editor, spellCheck: true, spellCheckLanguage: "fa" },
+    });
+    expect(screen.getByRole("combobox")).toHaveValue("fa");
+    expect(screen.getByRole("option", { name: "fa" })).toBeInTheDocument();
   });
 });

--- a/src/components/modals/settings/EditorTab.tsx
+++ b/src/components/modals/settings/EditorTab.tsx
@@ -1,7 +1,11 @@
-import { Fragment } from "react";
+import { Fragment, useSyncExternalStore } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "@/hooks/useSettings";
 import type { EditorKeymap } from "@/lib/settings";
+import {
+  listDictionarySources,
+  subscribeDictionarySources,
+} from "@/lib/spellcheck/dictionarySources";
 import { Segmented } from "./Segmented";
 import { Toggle } from "./Toggle";
 
@@ -57,6 +61,25 @@ export function EditorTab() {
     { value: "vscode", label: t("editor.keymapOptions.vscode") },
   ];
 
+  // Built-in English plus every plugin-contributed dictionary, live-updating
+  // as plugins load and unload. A plugin may override "en" itself; dedupe by
+  // language with the plugin's entry winning, like the speller does.
+  const pluginDictionaries = useSyncExternalStore(
+    subscribeDictionarySources,
+    listDictionarySources,
+  );
+  const languageOptions = [
+    ...(pluginDictionaries.some((d) => d.language === "en")
+      ? []
+      : [{ language: "en", label: t("editor.spellCheck.languages.en") }]),
+    ...pluginDictionaries.map((d) => ({ language: d.language, label: d.label })),
+  ];
+  // A language whose plugin was uninstalled stays selectable (and stored), so
+  // the choice survives a disable/enable cycle instead of silently resetting.
+  const orphanedLanguage = languageOptions.some((o) => o.language === editor.spellCheckLanguage)
+    ? null
+    : editor.spellCheckLanguage;
+
   return (
     <Fragment>
       <div className="settings-section">
@@ -111,7 +134,12 @@ export function EditorTab() {
               value={editor.spellCheckLanguage}
               onChange={(e) => updateSettings("editor.spellCheckLanguage", e.target.value)}
             >
-              <option value="en">{t("editor.spellCheck.languages.en")}</option>
+              {languageOptions.map((option) => (
+                <option key={option.language} value={option.language}>
+                  {option.label}
+                </option>
+              ))}
+              {orphanedLanguage && <option value={orphanedLanguage}>{orphanedLanguage}</option>}
             </select>
           </div>
         )}

--- a/src/lib/plugins/apiVersion.ts
+++ b/src/lib/plugins/apiVersion.ts
@@ -4,7 +4,7 @@
  * gates loading on it. Bump the major only on a breaking change to the plugin
  * contract; bump the minor when adding backwards-compatible surface.
  */
-export const PLUGIN_API_VERSION = "1.2.0";
+export const PLUGIN_API_VERSION = "1.3.0";
 
 interface SemVer {
   major: number;

--- a/src/lib/plugins/host.test.ts
+++ b/src/lib/plugins/host.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { clearDictionarySources, getDictionarySource } from "@/lib/spellcheck/dictionarySources";
 import { FakeWorker } from "@/test/fakeWorker";
 import { PLUGIN_API_VERSION } from "./apiVersion";
 import { createPluginHost } from "./host";
@@ -497,5 +498,27 @@ describe("createPluginHost", () => {
       expect(host.listLoaded()).toHaveLength(0);
       expect(worker.terminated).toBe(true);
     });
+  });
+});
+
+describe("spellcheck dictionary contributions", () => {
+  it("registers through the plugin's bag and unload removes the dictionary", async () => {
+    clearDictionarySources();
+    const host = createPluginHost(vi.fn());
+    const module: PluginModule = {
+      activate(ctx) {
+        ctx.spellcheck.registerDictionary({
+          language: "fa",
+          label: "Persian",
+          load: () => Promise.resolve({ aff: "AFF", dic: "DIC" }),
+        });
+      },
+    };
+
+    await host.load(installed(), importerFor(module));
+    expect(getDictionarySource("fa")?.label).toBe("Persian");
+
+    host.unload("com.x.demo");
+    expect(getDictionarySource("fa")).toBeUndefined();
   });
 });

--- a/src/lib/plugins/host.ts
+++ b/src/lib/plugins/host.ts
@@ -1,3 +1,4 @@
+import { registerDictionarySource } from "@/lib/spellcheck/dictionarySources";
 import { PLUGIN_API_VERSION, satisfiesApiVersion } from "./apiVersion";
 import { type Disposer, DisposerBag } from "./disposer";
 import { importPluginModule, type ModuleImporter } from "./loader";
@@ -144,6 +145,10 @@ export function createPluginHost(
     },
     workspace: createWorkspaceApi(getWorkspaceRoot, plugin.permissions ?? []),
     exporters: { register: tracked(exporters.register, bag) },
+    // Dictionaries live in the spellcheck module's own registry (the speller
+    // and the settings UI read it directly); only the disposal is routed
+    // through the plugin's bag here.
+    spellcheck: { registerDictionary: tracked(registerDictionarySource, bag) },
     settings: {
       get: (key) => settings[key] as never,
       set(key, value) {

--- a/src/lib/plugins/loader.test.ts
+++ b/src/lib/plugins/loader.test.ts
@@ -22,6 +22,7 @@ describe("importPluginModule", () => {
         addStyles: vi.fn(),
       },
       exporters: { register: vi.fn() },
+      spellcheck: { registerDictionary: vi.fn() },
       settings: { get: vi.fn(), set: vi.fn() },
       markdown: {
         registerRemarkPlugin: vi.fn(),
@@ -50,6 +51,7 @@ describe("importPluginModule", () => {
         addStyles: vi.fn(),
       },
       exporters: { register: vi.fn() },
+      spellcheck: { registerDictionary: vi.fn() },
       settings: { get: vi.fn(), set: vi.fn() },
       markdown: {
         registerRemarkPlugin: vi.fn(),

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -1,6 +1,9 @@
 import type { ComponentType } from "react";
 import type { Options } from "react-markdown";
+import type { DictionaryContribution } from "@/lib/spellcheck/dictionarySources";
 import type { Disposer } from "./disposer";
+
+export type { DictionaryContribution } from "@/lib/spellcheck/dictionarySources";
 
 /** Capability a plugin requests; surfaced for user consent before enabling. */
 export type PluginPermission = "workspace:read" | "workspace:write" | `network:${string}`;
@@ -152,6 +155,17 @@ export interface PluginSettingsApi {
   set(key: string, value: unknown): void;
 }
 
+export interface SpellcheckRegistryApi {
+  /**
+   * Contribute a spell-check dictionary for a language. It appears in the
+   * Settings language picker under `label`, and `load` runs only when the user
+   * selects the language. Registering an already-known code (including the
+   * built-in "en") replaces it; the disposer removes the dictionary and drops
+   * any cached checker built from it.
+   */
+  registerDictionary(dictionary: DictionaryContribution): Disposer;
+}
+
 export interface MarkdownRegistryApi {
   /** Add a remark plugin (runs after the built-in remark plugins). */
   registerRemarkPlugin(plugin: MarkdownPlugin): Disposer;
@@ -186,6 +200,7 @@ export interface GlyphPluginContext {
   readonly markdown: MarkdownRegistryApi;
   readonly workspace: WorkspaceApi;
   readonly exporters: ExportersRegistryApi;
+  readonly spellcheck: SpellcheckRegistryApi;
   readonly settings: PluginSettingsApi;
   notify(message: string): void;
   /**

--- a/src/lib/spellcheck/dictionarySources.test.ts
+++ b/src/lib/spellcheck/dictionarySources.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearDictionarySources,
+  type DictionaryContribution,
+  getDictionarySource,
+  listDictionarySources,
+  registerDictionarySource,
+  subscribeDictionarySources,
+} from "./dictionarySources";
+
+function contribution(overrides: Partial<DictionaryContribution> = {}): DictionaryContribution {
+  return {
+    language: "fa",
+    label: "فارسی (Persian)",
+    load: () => Promise.resolve({ aff: "AFF", dic: "DIC" }),
+    ...overrides,
+  };
+}
+
+describe("dictionarySources", () => {
+  beforeEach(() => {
+    clearDictionarySources();
+  });
+
+  it("registers a dictionary and lists it until disposed", () => {
+    const dispose = registerDictionarySource(contribution());
+    expect(getDictionarySource("fa")?.label).toBe("فارسی (Persian)");
+    expect(listDictionarySources().map((d) => d.language)).toEqual(["fa"]);
+
+    dispose();
+    expect(getDictionarySource("fa")).toBeUndefined();
+    expect(listDictionarySources()).toEqual([]);
+  });
+
+  it("a later registration for the same language replaces the earlier one", () => {
+    const disposeFirst = registerDictionarySource(contribution({ label: "First" }));
+    registerDictionarySource(contribution({ label: "Second" }));
+    expect(getDictionarySource("fa")?.label).toBe("Second");
+
+    // Disposing the superseded registration must not remove the newer one.
+    disposeFirst();
+    expect(getDictionarySource("fa")?.label).toBe("Second");
+  });
+
+  it("notifies subscribers with the language on register and dispose", () => {
+    const listener = vi.fn();
+    subscribeDictionarySources(listener);
+
+    const dispose = registerDictionarySource(contribution());
+    expect(listener).toHaveBeenCalledWith("fa");
+
+    listener.mockClear();
+    dispose();
+    expect(listener).toHaveBeenCalledWith("fa");
+  });
+
+  it("unsubscribing stops notifications", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeDictionarySources(listener);
+    unsubscribe();
+    registerDictionarySource(contribution());
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable snapshot between changes", () => {
+    registerDictionarySource(contribution());
+    expect(listDictionarySources()).toBe(listDictionarySources());
+  });
+});

--- a/src/lib/spellcheck/dictionarySources.ts
+++ b/src/lib/spellcheck/dictionarySources.ts
@@ -1,0 +1,72 @@
+import type { Disposer } from "@/lib/plugins/disposer";
+
+/** Hunspell dictionary sources, resolved lazily when the language is used. */
+export interface DictionarySources {
+  aff: string;
+  dic: string;
+}
+
+/** A spell-check dictionary contributed for one language (usually by a plugin). */
+export interface DictionaryContribution {
+  /** Language code stored in the editor setting, e.g. "fa". */
+  language: string;
+  /** Label shown in the Settings language picker, e.g. "فارسی (Persian)". */
+  label: string;
+  /** Produce the dictionary text; called only once the language is selected. */
+  load: () => Promise<DictionarySources>;
+}
+
+// Module-level so the speller (plain module) and the settings UI (React) read
+// the same registry without threading it through props or context. Keyed by
+// language: a later registration for the same code replaces the earlier one.
+const sources = new Map<string, DictionaryContribution>();
+const listeners = new Set<(language: string) => void>();
+let snapshot: readonly DictionaryContribution[] = [];
+
+function notify(language: string): void {
+  snapshot = [...sources.values()];
+  for (const listener of listeners) listener(language);
+}
+
+/**
+ * Add a dictionary for a language; the returned disposer removes it. Both the
+ * registration and its disposal notify subscribers, so the speller cache and
+ * the language picker stay current across plugin load/unload/update.
+ */
+export function registerDictionarySource(contribution: DictionaryContribution): Disposer {
+  sources.set(contribution.language, contribution);
+  notify(contribution.language);
+  return () => {
+    if (sources.get(contribution.language) === contribution) {
+      sources.delete(contribution.language);
+      notify(contribution.language);
+    }
+  };
+}
+
+export function getDictionarySource(language: string): DictionaryContribution | undefined {
+  return sources.get(language);
+}
+
+/**
+ * Current contributions in registration order. The same array reference is
+ * returned until the registry changes, so it is safe as a
+ * `useSyncExternalStore` snapshot.
+ */
+export function listDictionarySources(): readonly DictionaryContribution[] {
+  return snapshot;
+}
+
+/** Observe changes; listeners receive the affected language code. */
+export function subscribeDictionarySources(listener: (language: string) => void): Disposer {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Test seam: reset to a pristine registry between tests.
+export function clearDictionarySources(): void {
+  sources.clear();
+  snapshot = [];
+}

--- a/src/lib/spellcheck/speller.test.ts
+++ b/src/lib/spellcheck/speller.test.ts
@@ -5,6 +5,7 @@ const { nspellMock } = vi.hoisted(() => ({
 }));
 vi.mock("nspell", () => ({ default: nspellMock }));
 
+import { clearDictionarySources, registerDictionarySource } from "./dictionarySources";
 import { clearSpellerCache, getSpeller } from "./speller";
 
 function okResponse() {
@@ -13,6 +14,7 @@ function okResponse() {
 
 describe("getSpeller", () => {
   beforeEach(() => {
+    clearDictionarySources();
     clearSpellerCache();
     nspellMock.mockClear();
     vi.stubGlobal("fetch", vi.fn(okResponse));
@@ -61,5 +63,31 @@ describe("getSpeller", () => {
     vi.stubGlobal("fetch", recovered);
     await getSpeller("en");
     expect(recovered).toHaveBeenCalled();
+  });
+
+  it("prefers a registered dictionary source over the bundled assets", async () => {
+    const load = vi.fn(() => Promise.resolve({ aff: "FA-AFF", dic: "FA-DIC" }));
+    registerDictionarySource({ language: "fa", label: "Persian", load });
+
+    await getSpeller("fa");
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(nspellMock).toHaveBeenCalledWith("FA-AFF", "FA-DIC");
+  });
+
+  it("drops the cached checker when the language's source changes", async () => {
+    const dispose = registerDictionarySource({
+      language: "fa",
+      label: "Persian",
+      load: () => Promise.resolve({ aff: "A1", dic: "D1" }),
+    });
+    await getSpeller("fa");
+    expect(nspellMock).toHaveBeenCalledTimes(1);
+
+    // Unregistering invalidates; the next request falls back to bundled assets.
+    dispose();
+    await getSpeller("fa");
+    expect(fetch).toHaveBeenCalledTimes(2); // aff + dic from public/
+    expect(nspellMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/spellcheck/speller.ts
+++ b/src/lib/spellcheck/speller.ts
@@ -1,4 +1,5 @@
 import nspell from "nspell";
+import { getDictionarySource, subscribeDictionarySources } from "./dictionarySources";
 
 // A loaded spell checker instance for one language.
 export type Speller = ReturnType<typeof nspell>;
@@ -23,6 +24,13 @@ async function fetchText(url: string): Promise<string> {
 }
 
 async function loadSpeller(language: string): Promise<Speller> {
+  // A plugin-registered dictionary wins over the bundled assets, so plugins
+  // can both add new languages and override a shipped one.
+  const source = getDictionarySource(language);
+  if (source) {
+    const { aff, dic } = await source.load();
+    return nspell(aff, dic);
+  }
   const base = `${DICTIONARY_BASE}/${language}`;
   const [aff, dic] = await Promise.all([
     fetchText(`${base}/index.aff`),
@@ -30,6 +38,10 @@ async function loadSpeller(language: string): Promise<Speller> {
   ]);
   return nspell(aff, dic);
 }
+
+// When a plugin registers, replaces, or removes a language, any cached checker
+// for it is stale; drop it so the next request rebuilds from the new source.
+subscribeDictionarySources((language) => cache.delete(language));
 
 export function getSpeller(language: string): Promise<Speller> {
   let pending = cache.get(language);

--- a/src/lib/spellcheck/wordScanner.test.ts
+++ b/src/lib/spellcheck/wordScanner.test.ts
@@ -60,4 +60,12 @@ describe("scanWords", () => {
     // No closing fence, so the leading --- is not frontmatter and its lines are checked.
     expect(wordsOf("---\ntitel: xyz\nmore wrods")).toEqual(["titel", "xyz", "more", "wrods"]);
   });
+
+  it("keeps ZWNJ-joined Persian words as single tokens", () => {
+    // The zero-width non-joiner sits inside words like "mi-ravam"; splitting on
+    // it would flag both halves against any Persian dictionary.
+    const ZWNJ = "\u200C";
+    const doc = `می${ZWNJ}روم و نمی${ZWNJ}دانم`;
+    expect(wordsOf(doc)).toEqual([`می${ZWNJ}روم`, `نمی${ZWNJ}دانم`]);
+  });
 });

--- a/src/lib/spellcheck/wordScanner.ts
+++ b/src/lib/spellcheck/wordScanner.ts
@@ -22,10 +22,12 @@ const EXCLUDED_NODES = new Set([
   "CommentBlock",
 ]);
 
-// Letters (incl. combining marks) with internal apostrophes and hyphens, so
-// "don't" and "well-being" stay single tokens. No digits, so "utf8" won't match
-// as one word.
-const WORD_RE = /\p{L}[\p{L}\p{M}'’]*(?:-\p{L}[\p{L}\p{M}'’]*)*/gu;
+// Letters (incl. combining marks) with internal apostrophes, hyphens, and the
+// zero-width non-joiner (U+200C), so "don't", "well-being", and ZWNJ-joined
+// Persian words (mi + ZWNJ + ravam) stay single tokens. ZWNJ is a format
+// character, not a letter, so it needs listing explicitly. No digits, so
+// "utf8" won't match as one word.
+const WORD_RE = /\p{L}[\p{L}\p{M}\u200C'’]*(?:-\p{L}[\p{L}\p{M}\u200C'’]*)*/gu;
 
 function isAllCaps(word: string): boolean {
   return word === word.toUpperCase() && word !== word.toLowerCase();


### PR DESCRIPTION
## Summary

Adds a spell-check dictionary contribution point to the plugin API, so language dictionaries ship as marketplace plugins instead of being bundled. English stays built in; `ctx.spellcheck.registerDictionary({ language, label, load })` adds a language to the Settings picker, loads its dictionary lazily on first selection, and cleans up (including the cached checker) when the plugin unloads. First consumer is the Persian dictionary plugin, published separately to glyph-md/plugins.

Closes #399

## Changes

- `ctx.spellcheck.registerDictionary(...)` on the plugin context, routed through the plugin's disposer bag like every other contribution point (`src/lib/plugins/types.ts`, `host.ts`)
- New module registry `src/lib/spellcheck/dictionarySources.ts`; the speller consults it before the bundled `public/dictionaries/<lang>/` assets (plugins can override English too), and source changes invalidate that language's cached checker
- Settings → Editor language picker is dynamic: built-in English plus registered dictionaries, live via `useSyncExternalStore`; an orphaned stored code stays selectable after an uninstall
- Word scanner allows ZWNJ (U+200C) inside tokens, so joined words in Persian and similar scripts check as whole words instead of being split and mis-flagged
- `PLUGIN_API_VERSION` 1.2.0 → 1.3.0 (additive minor)
- README: spell-check and plugins bullets mention dictionary plugins

Sandboxed plugins deliberately do not get this contribution point yet (the loader would have to cross the worker bridge); tracked as out of scope on the issue.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] `pnpm typecheck`, `pnpm check`, `pnpm test` (2414 passing) green; `cargo clippy` clean
- [x] Patch coverage verified locally: all changed files at 100% lines, new code at 100% branches

Covered by tests: registry register/replace/dispose/subscribe semantics, speller fallback order and cache invalidation, host lifecycle (unload removes the dictionary), dynamic picker incl. en-override and orphaned language, ZWNJ tokenization.

## Screenshots

Settings → Editor picker fills from installed dictionary plugins; no visual change with none installed.
