### PR TITLE
feat(release): publish to winget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,9 @@ jobs:
 
             ### Windows
             ```powershell
+            # winget
+            winget install hamidfzm.Glyph
+
             # Chocolatey
             choco install glyph
 
@@ -139,6 +142,9 @@ jobs:
 
           ### Windows
           ```powershell
+          # winget
+          winget install hamidfzm.Glyph
+
           # Chocolatey
           choco install glyph
 
@@ -394,6 +400,43 @@ jobs:
               --field message="chore: add glyph $VERSION" \
               --field content="$(base64 -w0 /tmp/glyph.json)"
           fi
+
+  publish-winget:
+    needs: build
+    runs-on: windows-latest
+    steps:
+      # Submits a manifest-update PR to microsoft/winget-pkgs for
+      # hamidfzm.Glyph from the released MSI. Requires WINGET_GITHUB_TOKEN,
+      # a classic PAT with public_repo scope whose owner has a fork of
+      # microsoft/winget-pkgs; the package must already exist upstream
+      # (one-time bootstrap, see winget/README.md). Skips cleanly until the
+      # secret is set, so it never fails releases before setup (same gate
+      # pattern as publish-snap).
+      - name: Check for winget token
+        id: gate
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No WINGET_GITHUB_TOKEN secret; skipping winget publish."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Get version
+        if: steps.gate.outputs.enabled == 'true'
+        id: version
+        shell: bash
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - uses: vedantmgoyal9/winget-releaser@v2
+        if: steps.gate.outputs.enabled == 'true'
+        with:
+          identifier: hamidfzm.Glyph
+          version: ${{ steps.version.outputs.version }}
+          release-tag: ${{ github.ref_name }}
+          installers-regex: '_x64_en-US\.msi$'
+          token: ${{ secrets.WINGET_GITHUB_TOKEN }}
 
   publish-aur:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,22 +406,23 @@ jobs:
     runs-on: windows-latest
     steps:
       # Submits a manifest-update PR to microsoft/winget-pkgs for
-      # hamidfzm.Glyph from the released MSI. Requires WINGET_GITHUB_TOKEN,
-      # a classic PAT with public_repo scope whose owner has a fork of
-      # microsoft/winget-pkgs; the package must already exist upstream
-      # (one-time bootstrap, see winget/README.md). Skips cleanly until the
-      # secret is set, so it never fails releases before setup (same gate
-      # pattern as publish-snap).
+      # hamidfzm.Glyph from the released MSI. Reuses TAP_GITHUB_TOKEN (the
+      # classic PAT already used for the tap/bucket/apt repos; winget-releaser
+      # needs public_repo, which repo scope includes) and forks
+      # microsoft/winget-pkgs under the token owner if needed. The package
+      # must already exist upstream (one-time bootstrap, see winget/README.md).
+      # Skips cleanly until the secret is set, so it never fails releases
+      # before setup (same gate pattern as publish-snap).
       - name: Check for winget token
         id: gate
         shell: bash
         env:
-          TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
           if [ -n "$TOKEN" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No WINGET_GITHUB_TOKEN secret; skipping winget publish."
+            echo "No TAP_GITHUB_TOKEN secret; skipping winget publish."
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Get version
@@ -436,7 +437,7 @@ jobs:
           version: ${{ steps.version.outputs.version }}
           release-tag: ${{ github.ref_name }}
           installers-regex: '_x64_en-US\.msi$'
-          token: ${{ secrets.WINGET_GITHUB_TOKEN }}
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
 
   publish-aur:
     needs: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Run the **Create Release** workflow from GitHub Actions (`create-release.yml`) w
 3. Commit and push to `main`
 4. Create and push the `vX.Y.Z` tag, which triggers `release.yml`
 
-The release workflow builds all platforms and publishes to Homebrew, Chocolatey, Scoop, AUR, PPA, the Debian apt repo, and the Fedora/RHEL dnf repo.
+The release workflow builds all platforms and publishes to Homebrew, winget, Chocolatey, Scoop, AUR, PPA, the Debian apt repo, and the Fedora/RHEL dnf repo.
 
 Do **not** create releases manually with `gh release create` or push tags by hand. Use the workflow.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ brew install --cask glyph
 
 `brew trust` is required once because Glyph ships from a third-party tap; recent Homebrew refuses to load casks from untrusted taps.
 
+### Windows (winget)
+
+```powershell
+winget install hamidfzm.Glyph
+```
+
 ### Windows (Chocolatey)
 
 ```powershell

--- a/winget/README.md
+++ b/winget/README.md
@@ -1,0 +1,28 @@
+# winget bootstrap
+
+After the one-time bootstrap below, every release is automated: the
+`publish-winget` job in [release.yml](../.github/workflows/release.yml) uses
+[winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) to open a
+manifest-update PR against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs).
+
+## One-time setup
+
+1. Create a classic GitHub PAT with `public_repo` scope and add it to this
+   repo's Actions secrets as `WINGET_GITHUB_TOKEN`. The token owner needs a
+   fork of `microsoft/winget-pkgs` (winget-releaser creates one if missing).
+2. Submit the initial manifest, since winget-releaser can only update a
+   package that already exists upstream. Easiest path, from a Windows machine:
+
+   ```powershell
+   winget install wingetcreate
+   wingetcreate new https://github.com/hamidfzm/glyph/releases/download/v<VERSION>/Glyph_<VERSION>_x64_en-US.msi
+   ```
+
+   Use `hamidfzm.Glyph` as the package identifier and the metadata from the
+   templates in this directory ([version](hamidfzm.Glyph.yaml),
+   [installer](hamidfzm.Glyph.installer.yaml),
+   [locale](hamidfzm.Glyph.locale.en-US.yaml); `{{VERSION}}` and `{{SHA256}}`
+   are filled from the release). `wingetcreate` validates and opens the PR to
+   `microsoft/winget-pkgs` for you.
+3. Once that first PR is merged upstream, the `publish-winget` job handles
+   every subsequent release automatically.

--- a/winget/README.md
+++ b/winget/README.md
@@ -7,9 +7,11 @@ manifest-update PR against [microsoft/winget-pkgs](https://github.com/microsoft/
 
 ## One-time setup
 
-1. Create a classic GitHub PAT with `public_repo` scope and add it to this
-   repo's Actions secrets as `WINGET_GITHUB_TOKEN`. The token owner needs a
-   fork of `microsoft/winget-pkgs` (winget-releaser creates one if missing).
+1. The job reuses the existing `TAP_GITHUB_TOKEN` secret (the classic PAT
+   already used for the Homebrew tap, Scoop bucket, and apt repo; its `repo`
+   scope covers the `public_repo` winget-releaser needs). The token owner
+   needs a fork of `microsoft/winget-pkgs` (winget-releaser creates one if
+   missing). Nothing to set up if that secret exists.
 2. Submit the initial manifest, since winget-releaser can only update a
    package that already exists upstream. Easiest path, from a Windows machine:
 

--- a/winget/hamidfzm.Glyph.installer.yaml
+++ b/winget/hamidfzm.Glyph.installer.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: hamidfzm.Glyph
+PackageVersion: "{{VERSION}}"
+InstallerType: wix
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/hamidfzm/glyph/releases/download/v{{VERSION}}/Glyph_{{VERSION}}_x64_en-US.msi
+    InstallerSha256: "{{SHA256}}"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/winget/hamidfzm.Glyph.locale.en-US.yaml
+++ b/winget/hamidfzm.Glyph.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: hamidfzm.Glyph
+PackageVersion: "{{VERSION}}"
+PackageLocale: en-US
+Publisher: hamidfzm
+PublisherUrl: https://github.com/hamidfzm
+PublisherSupportUrl: https://github.com/hamidfzm/glyph/issues
+PackageName: Glyph
+PackageUrl: https://glyph-md.github.io
+License: MIT
+LicenseUrl: https://github.com/hamidfzm/glyph/blob/main/LICENSE
+ShortDescription: Cross-platform markdown viewer
+Description: A modern, cross-platform markdown viewer with GFM support, syntax highlighting, live reload, and platform-native styling.
+Moniker: glyph
+Tags:
+  - markdown
+  - viewer
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/winget/hamidfzm.Glyph.yaml
+++ b/winget/hamidfzm.Glyph.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: hamidfzm.Glyph
+PackageVersion: "{{VERSION}}"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Adds winget (Windows Package Manager) publishing to the release pipeline. Closes #308.

## Changes

- New `publish-winget` job in `release.yml` using `vedantmgoyal9/winget-releaser@v2`: opens a manifest-update PR to `microsoft/winget-pkgs` for `hamidfzm.Glyph` from the released x64 MSI on every tag
- Reuses the existing `TAP_GITHUB_TOKEN` classic PAT (its `repo` scope covers the required `public_repo`), gated on the secret's presence (same skip-cleanly pattern as `publish-snap`) so releases never fail if it's missing
- Bootstrap manifest templates and one-time setup instructions in `winget/` (README documents the initial `wingetcreate` submission)
- `winget install hamidfzm.Glyph` added to the release-body install instructions (both copies), `README.md`, and the CLAUDE.md release list

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Workflow and manifest YAML validated locally with a YAML parser. The job itself only runs on a version tag; end-to-end verification happens on the next release once the bootstrap manifest is merged upstream.

## Screenshots

N/A (CI/docs only)