### PR TITLE
fix(release): skip winget publish until package exists upstream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,21 +409,27 @@ jobs:
       # hamidfzm.Glyph from the released MSI. Reuses TAP_GITHUB_TOKEN (the
       # classic PAT already used for the tap/bucket/apt repos; winget-releaser
       # needs public_repo, which repo scope includes) and forks
-      # microsoft/winget-pkgs under the token owner if needed. The package
-      # must already exist upstream (one-time bootstrap, see winget/README.md).
-      # Skips cleanly until the secret is set, so it never fails releases
-      # before setup (same gate pattern as publish-snap).
-      - name: Check for winget token
+      # microsoft/winget-pkgs under the token owner if needed. Skips cleanly
+      # while the secret is missing or the package is not yet in winget-pkgs
+      # (the one-time bootstrap PR, see winget/README.md, may still be in
+      # Microsoft's moderation queue), so it never fails releases before
+      # setup; the first release after the bootstrap merges publishes
+      # automatically (probe-the-target gate, same pattern as publish-dnf).
+      - name: Check winget prerequisites
         id: gate
         shell: bash
         env:
           TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ -n "$TOKEN" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ -z "$TOKEN" ]; then
             echo "No TAP_GITHUB_TOKEN secret; skipping winget publish."
             echo "enabled=false" >> "$GITHUB_OUTPUT"
+          elif ! gh api repos/microsoft/winget-pkgs/contents/manifests/h/hamidfzm/Glyph >/dev/null 2>&1; then
+            echo "hamidfzm.Glyph not yet in winget-pkgs (bootstrap pending); skipping winget publish."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Get version
         if: steps.gate.outputs.enabled == 'true'


### PR DESCRIPTION
## Summary

Follow-up to #404. If a release is tagged while the winget bootstrap PR (microsoft/winget-pkgs#400339) is still in Microsoft's moderation queue, the `publish-winget` job fails red because winget-releaser can't update a package that doesn't exist yet. This makes the job skip cleanly instead, and self-heal: the first release after the bootstrap merges publishes automatically with no manual re-run.

## Changes

- The `publish-winget` gate now also probes `manifests/h/hamidfzm/Glyph` in `microsoft/winget-pkgs` and skips (with a log line) when absent, same probe-the-target pattern as `publish-dnf`
- Probe verified against live winget-pkgs: currently 404 (skip); flips to publish once the bootstrap PR merges

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Workflow YAML validated locally; gate probe exercised against the live GitHub API for both outcomes (404 today, and the equivalent existing-path query succeeds for packages already in winget-pkgs).

## Screenshots

N/A (CI only)