### PR TITLE
fix(tests): satisfy noUnsafeOptionalChaining under Biome 2.5.3

### DIFF
--- a/src/components/modals/SyncSettingsModal.test.tsx
+++ b/src/components/modals/SyncSettingsModal.test.tsx
@@ -797,7 +797,7 @@ describe("SyncSettingsModal", () => {
       expect(calls).toContain("sync_set_config");
     });
     const setConfigCall = vi.mocked(invoke).mock.calls.find((c) => c[0] === "sync_set_config");
-    expect((setConfigCall?.[1] as { config: { remoteUrl: string } }).config.remoteUrl).toBe("");
+    expect((setConfigCall![1] as { config: { remoteUrl: string } }).config.remoteUrl).toBe("");
     const allCalls = vi.mocked(invoke).mock.calls.map((c) => c[0]);
     expect(allCalls).not.toContain("sync_set_origin");
   });

--- a/src/hooks/useExport.test.ts
+++ b/src/hooks/useExport.test.ts
@@ -89,7 +89,7 @@ describe("useExport", () => {
     expect(save).toHaveBeenCalledWith(expect.objectContaining({ defaultPath: "note.html" }));
     const call = vi.mocked(invoke).mock.calls.find((c) => c[0] === "write_file");
     expect(call).toBeTruthy();
-    expect((call?.[1] as { content: string }).content).toContain('<div class="markdown-body">');
+    expect((call![1] as { content: string }).content).toContain('<div class="markdown-body">');
   });
 
   it("does not write when the save dialog is cancelled", async () => {
@@ -113,7 +113,7 @@ describe("useExport", () => {
     const call = vi.mocked(invoke).mock.calls.find((c) => c[0] === "write_binary_file");
     expect(call).toBeTruthy();
     // Bytes are sent as a plain number array so Rust's Vec<u8> can deserialize.
-    const contents = (call?.[1] as { contents: number[] }).contents;
+    const contents = (call![1] as { contents: number[] }).contents;
     expect(Array.isArray(contents)).toBe(true);
     expect(contents.length).toBeGreaterThan(0);
   });
@@ -128,7 +128,7 @@ describe("useExport", () => {
 
     const call = vi.mocked(invoke).mock.calls.find((c) => c[0] === "write_binary_file");
     expect(call).toBeTruthy();
-    expect((call?.[1] as { contents: Uint8Array }).contents.length).toBeGreaterThan(0);
+    expect((call![1] as { contents: Uint8Array }).contents.length).toBeGreaterThan(0);
   });
 
   it("writes PDF bytes via write_binary_file (no print dialog)", async () => {
@@ -141,7 +141,7 @@ describe("useExport", () => {
 
     const call = vi.mocked(invoke).mock.calls.find((c) => c[0] === "write_binary_file");
     expect(call).toBeTruthy();
-    expect((call?.[1] as { contents: Uint8Array }).contents.length).toBeGreaterThan(0);
+    expect((call![1] as { contents: Uint8Array }).contents.length).toBeGreaterThan(0);
     // It must not fall back to the print path.
     expect(vi.mocked(invoke).mock.calls.some((c) => c[0] === "print_document")).toBe(false);
   });
@@ -189,7 +189,7 @@ describe("useExport", () => {
     expect(buildBoardMock).toHaveBeenCalled();
     const call = vi.mocked(invoke).mock.calls.find((c) => c[0] === "write_file");
     expect(call).toBeTruthy();
-    const content = (call?.[1] as { content: string }).content;
+    const content = (call![1] as { content: string }).content;
     expect(content).toContain("glyph-canvas-export");
     expect(content).toContain('class="glyph-canvas-page"');
   });
@@ -215,7 +215,7 @@ describe("useExport", () => {
     expect(buildDocumentMock).not.toHaveBeenCalled();
     const call = vi.mocked(invoke).mock.calls.find((c) => c[0] === "write_binary_file");
     expect(call).toBeTruthy();
-    expect((call?.[1] as { contents: number[] }).contents).toEqual([1, 2, 3]);
+    expect((call![1] as { contents: number[] }).contents).toEqual([1, 2, 3]);
   });
 
   it("skips the PDF write when the board model is empty", async () => {

--- a/src/lib/plugins/runExporter.test.ts
+++ b/src/lib/plugins/runExporter.test.ts
@@ -55,7 +55,7 @@ describe("runExporter", () => {
     );
     const call = vi.mocked(invoke).mock.calls.find((c) => c[0] === "write_file");
     expect(call?.[1]).toMatchObject({ path: "/out.html" });
-    expect((call?.[1] as { content: string }).content).toContain("<deck>");
+    expect((call![1] as { content: string }).content).toContain("<deck>");
   });
 
   it("writes binary output via write_binary_file", async () => {


### PR DESCRIPTION
## Summary

Biome **2.5.3** (which the dev-dependencies bump in #405 pulls in) added detection that flags `(call?.[1] as T).prop`: if the optional chain short-circuits to `undefined`, the trailing property access throws a `TypeError`. This currently fails the lint CI job with 8 `lint/correctness/noUnsafeOptionalChaining` errors, all in test files. Our pinned 2.5.2 doesn't flag them, so the failures only surface on #405.

> Note on annotations: these live in files the dep-bump PR doesn't touch, so GitHub renders them only in the Actions log, not as inline diff annotations.

## Changes

- Replace the optional chain with a non-null assertion (`call![1]`) at each flagged site. Every one already asserts the value is present on the line above (`expect(call).toBeTruthy()`), so the assertion matches existing intent, no behavior change.
  - `src/hooks/useExport.test.ts` (6 sites)
  - `src/components/modals/SyncSettingsModal.test.tsx` (1 site)
  - `src/lib/plugins/runExporter.test.ts` (1 site)

## Testing

- `npx @biomejs/biome@2.5.3 lint --error-on-warnings src/` clean
- `pnpm typecheck` clean
- The 3 affected test files: 60 passed

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A