### PR TITLE
feat(plugins): show permissions and sandbox badge on every Manage Plugins row

### DIFF
--- a/src/components/plugins/PluginPermissionsLine.tsx
+++ b/src/components/plugins/PluginPermissionsLine.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from "react-i18next";
+
+/**
+ * The trust line shown under every plugin row, installed or marketplace:
+ * declared permissions (an explicit "None" when the plugin asks for nothing)
+ * and a marker for sandboxed plugins.
+ */
+export function PluginPermissionsLine({
+  permissions,
+  sandbox,
+}: {
+  permissions?: string[];
+  sandbox?: boolean;
+}) {
+  const { t } = useTranslation("plugins");
+  return (
+    <div className="text-xs text-[var(--color-text-secondary)] truncate">
+      {t("permissionsLabel")}: {permissions?.length ? permissions.join(", ") : t("permissionsNone")}
+      {sandbox && <> · {t("sandboxBadge")}</>}
+    </div>
+  );
+}

--- a/src/components/plugins/PluginsModal.test.tsx
+++ b/src/components/plugins/PluginsModal.test.tsx
@@ -114,6 +114,32 @@ describe("PluginsModal", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows an explicit None for plugins without permissions, on both lists", () => {
+    renderModal(ctx());
+    // One installed (Alpha, no permissions) and one marketplace entry (Charlie, none declared).
+    expect(screen.getAllByText((_, el) => el?.textContent === "Permissions: None")).toHaveLength(2);
+  });
+
+  it("shows a marketplace entry's permissions and sandbox badge before install", () => {
+    renderModal(
+      ctx({
+        registry: [{ ...available, permissions: ["network:api.example.com"], sandbox: true }],
+      }),
+    );
+    expect(
+      screen.getByText(
+        (_, el) => el?.textContent === "Permissions: network:api.example.com · Sandboxed",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("marks sandboxed installed plugins", () => {
+    renderModal(ctx({ installed: [{ ...installed, sandbox: true }] }));
+    expect(
+      screen.getByText((_, el) => el?.textContent === "Permissions: None · Sandboxed"),
+    ).toBeInTheDocument();
+  });
+
   it("toggles an installed plugin's active state", () => {
     const value = ctx();
     renderModal(value);

--- a/src/components/plugins/PluginsModal.tsx
+++ b/src/components/plugins/PluginsModal.tsx
@@ -92,11 +92,11 @@ export function PluginsModal({ onClose }: { onClose: () => void }) {
                         {p.description}
                       </div>
                     )}
-                    {p.permissions && p.permissions.length > 0 && (
-                      <div className="text-xs text-[var(--color-text-secondary)] truncate">
-                        {t("permissionsLabel")}: {p.permissions.join(", ")}
-                      </div>
-                    )}
+                    <div className="text-xs text-[var(--color-text-secondary)] truncate">
+                      {t("permissionsLabel")}:{" "}
+                      {p.permissions?.length ? p.permissions.join(", ") : t("permissionsNone")}
+                      {p.sandbox && <> · {t("sandboxBadge")}</>}
+                    </div>
                     {settingsPanel && enabled && (
                       <div className="mt-2 text-xs text-[var(--color-text-primary)]">
                         <PluginMountSlot contribution={settingsPanel} />
@@ -142,6 +142,11 @@ export function PluginsModal({ onClose }: { onClose: () => void }) {
                       {e.description}
                     </div>
                   )}
+                  <div className="text-xs text-[var(--color-text-secondary)] truncate">
+                    {t("permissionsLabel")}:{" "}
+                    {e.permissions?.length ? e.permissions.join(", ") : t("permissionsNone")}
+                    {e.sandbox && <> · {t("sandboxBadge")}</>}
+                  </div>
                 </div>
                 <button
                   type="button"

--- a/src/components/plugins/PluginsModal.tsx
+++ b/src/components/plugins/PluginsModal.tsx
@@ -4,6 +4,7 @@ import { ModalCloseIcon } from "@/components/icons/ModalCloseIcon";
 import { usePluginsOptional } from "@/contexts/PluginsContext";
 import { useRegistryEntries } from "@/hooks/usePluginRegistry";
 import { PluginMountSlot } from "./PluginMountSlot";
+import { PluginPermissionsLine } from "./PluginPermissionsLine";
 
 const rowClass =
   "flex items-start gap-3 py-3 border-b border-[var(--color-border)] last:border-b-0";
@@ -92,11 +93,7 @@ export function PluginsModal({ onClose }: { onClose: () => void }) {
                         {p.description}
                       </div>
                     )}
-                    <div className="text-xs text-[var(--color-text-secondary)] truncate">
-                      {t("permissionsLabel")}:{" "}
-                      {p.permissions?.length ? p.permissions.join(", ") : t("permissionsNone")}
-                      {p.sandbox && <> · {t("sandboxBadge")}</>}
-                    </div>
+                    <PluginPermissionsLine permissions={p.permissions} sandbox={p.sandbox} />
                     {settingsPanel && enabled && (
                       <div className="mt-2 text-xs text-[var(--color-text-primary)]">
                         <PluginMountSlot contribution={settingsPanel} />
@@ -142,11 +139,7 @@ export function PluginsModal({ onClose }: { onClose: () => void }) {
                       {e.description}
                     </div>
                   )}
-                  <div className="text-xs text-[var(--color-text-secondary)] truncate">
-                    {t("permissionsLabel")}:{" "}
-                    {e.permissions?.length ? e.permissions.join(", ") : t("permissionsNone")}
-                    {e.sandbox && <> · {t("sandboxBadge")}</>}
-                  </div>
+                  <PluginPermissionsLine permissions={e.permissions} sandbox={e.sandbox} />
                 </div>
                 <button
                   type="button"

--- a/src/locales/de/plugins.json
+++ b/src/locales/de/plugins.json
@@ -13,5 +13,7 @@
   "consentTitle": "Plugin installieren?",
   "consentBody": "\"{{name}}\" führt JavaScript in Glyph mit Zugriff auf die Plugin-API aus.",
   "consentPermissions": "Es fordert an:",
-  "permissionsLabel": "Berechtigungen"
+  "permissionsLabel": "Berechtigungen",
+  "permissionsNone": "Keine",
+  "sandboxBadge": "Sandbox"
 }

--- a/src/locales/en/plugins.json
+++ b/src/locales/en/plugins.json
@@ -13,5 +13,7 @@
   "consentTitle": "Install plugin?",
   "consentBody": "\"{{name}}\" will run JavaScript inside Glyph with access to the plugin API.",
   "consentPermissions": "It requests:",
-  "permissionsLabel": "Permissions"
+  "permissionsLabel": "Permissions",
+  "permissionsNone": "None",
+  "sandboxBadge": "Sandboxed"
 }

--- a/src/locales/es/plugins.json
+++ b/src/locales/es/plugins.json
@@ -13,5 +13,7 @@
   "consentTitle": "¿Instalar complemento?",
   "consentBody": "\"{{name}}\" ejecutará JavaScript dentro de Glyph con acceso a la API de complementos.",
   "consentPermissions": "Solicita:",
-  "permissionsLabel": "Permisos"
+  "permissionsLabel": "Permisos",
+  "permissionsNone": "Ninguno",
+  "sandboxBadge": "Aislado"
 }

--- a/src/locales/fa/plugins.json
+++ b/src/locales/fa/plugins.json
@@ -13,5 +13,7 @@
   "consentTitle": "افزونه نصب شود؟",
   "consentBody": "«{{name}}» جاوااسکریپت را درون Glyph با دسترسی به API افزونه اجرا می‌کند.",
   "consentPermissions": "درخواست می‌کند:",
-  "permissionsLabel": "دسترسی‌ها"
+  "permissionsLabel": "دسترسی‌ها",
+  "permissionsNone": "ندارد",
+  "sandboxBadge": "ایزوله"
 }

--- a/src/locales/zh/plugins.json
+++ b/src/locales/zh/plugins.json
@@ -13,5 +13,7 @@
   "consentTitle": "安装插件？",
   "consentBody": "“{{name}}”将在 Glyph 中运行 JavaScript 并访问插件 API。",
   "consentPermissions": "它请求：",
-  "permissionsLabel": "权限"
+  "permissionsLabel": "权限",
+  "permissionsNone": "无",
+  "sandboxBadge": "沙盒"
 }


### PR DESCRIPTION
## Summary

The Manage Plugins modal only showed permissions for installed plugins that declared at least one, and marketplace entries showed none at all: the first time a user saw what a plugin asks for was the native consent dialog mid-install. A plugin with no permissions showed nothing, which reads as "unknown" rather than "needs nothing".

## Changes

- Every row (installed and marketplace) now carries a permissions line; plugins with no declared permissions show an explicit "None"
- Rows for `sandbox: true` plugins/entries get a "Sandboxed" marker
- New `plugins` namespace keys (`permissionsNone`, `sandboxBadge`) in all five locales; locale parity test stays green
- Modal tests for the none case, the marketplace permissions + badge, and the sandboxed installed row

The fuller Obsidian-style browser (search, categories, detail pane rendering each plugin's README) is scoped in #408; this is the immediate trust-visibility fix.

## Testing

- `pnpm typecheck && pnpm check` green; plugins + locales suites pass (28 tests)

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable (text rows in the existing modal).

Closes #410
