### PR TITLE
chore(git): enforce branch naming convention with a pre-push hook

### DIFF
--- a/.claude/rules/worktrees.md
+++ b/.claude/rules/worktrees.md
@@ -11,6 +11,7 @@ Glyph follows GitHub Flow with one git worktree per branch. There is no `develop
 
 - `main` is the only long-lived branch. It is always green and releasable.
 - Every change lands on a short-lived branch cut from the latest `main`: `feat/<slug>`, `fix/<slug>`, or `chore/<slug>` / `docs/<slug>` / `refactor/<slug>` as the change warrants.
+- **Those prefixes are the only allowed branch names.** A worktree auto-created by tooling may start life under a different name (e.g. `claude/<slug>`); rename it with `git branch -m <old> feat/<slug>` **before the first push**. The `.husky/pre-push` hook rejects pushes from any branch that doesn't match the convention.
 - Each branch lives in its own worktree under `.claude/worktrees/<slug>/`, so several branches can be checked out at once without stashing. `.claude/worktrees/` is gitignored, so nothing inside a worktree directory is itself committed to the parent repo.
 - Branches merge into `main` only through a PR, with linear history (squash or rebase, no merge commits), per [CONTRIBUTING.md](../../CONTRIBUTING.md).
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,20 @@
+# Pre-push gate: enforce the branch naming convention (CONTRIBUTING.md,
+# .claude/rules/worktrees.md). Every short-lived branch is <type>/<slug>;
+# anything else (including tool-generated names like claude/<slug>) must be
+# renamed before it reaches origin:
+#
+#   git branch -m <old> feat/<slug>
+#
+# Tag pushes and detached-HEAD pushes are allowed through (releases push tags).
+
+branch="$(git symbolic-ref --short -q HEAD)" || exit 0
+
+case "$branch" in
+  main | feat/* | fix/* | chore/* | docs/* | refactor/*) ;;
+  *)
+    echo "pre-push: branch name '$branch' violates the naming convention." >&2
+    echo "Allowed: main, feat/<slug>, fix/<slug>, chore/<slug>, docs/<slug>, refactor/<slug>." >&2
+    echo "Rename first: git branch -m $branch feat/<slug>" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds a `.husky/pre-push` hook that rejects pushes from any branch whose name breaks the convention in CONTRIBUTING.md and `.claude/rules/worktrees.md`. Allowed: `main`, `feat/<slug>`, `fix/<slug>`, `chore/<slug>`, `docs/<slug>`, `refactor/<slug>`. Anything else (notably tool-generated worktree branches like `claude/<slug>`) must be renamed with `git branch -m` before its first push; the hook prints exactly that instruction.

Motivation: the RTL feature was accidentally pushed as `claude/rtl-ltr-language-support-0f1b48`, and since GitHub cannot change a PR's head branch, fixing it meant closing #400 and recreating it as #412. The hook makes that mistake impossible to repeat.

## Changes

- `.husky/pre-push`: branch-name gate; tag pushes and detached-HEAD pushes pass through (releases push tags)
- `.claude/rules/worktrees.md`: states the allowed prefixes are exhaustive and that auto-created worktree branches are renamed before the first push

## Testing

- Verified locally: pushing from a `chore/*` branch passes; a `claude/*` name is rejected with the rename instruction
- No app code touched; pre-commit gate (typecheck, Biome, vitest, cargo test, clippy) passed on commit

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable (git hook only).
