### PR TITLE
feat(plugins): pin the plugin API at 0.16.0 with exact matching until 1.0

### DIFF
--- a/src/components/plugins/PluginsModal.test.tsx
+++ b/src/components/plugins/PluginsModal.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { PluginsContext, type PluginsContextValue } from "@/contexts/PluginsContext";
+import { PLUGIN_API_VERSION } from "@/lib/plugins/apiVersion";
 import type { RegistryEntry } from "@/lib/plugins/marketplace";
 import { createRegistry } from "@/lib/plugins/registry";
 import type {
@@ -20,7 +21,7 @@ const installed: InstalledPlugin = {
   id: "a.b",
   name: "Alpha",
   version: "1.0.0",
-  apiVersion: "^1.0.0",
+  apiVersion: `^${PLUGIN_API_VERSION}`,
   description: "the alpha plugin",
   dir: "/p/a.b",
   mainSource: "export default {};",
@@ -31,7 +32,7 @@ const available: RegistryEntry = {
   name: "Charlie",
   description: "from the market",
   version: "2.0.0",
-  apiVersion: "^1.0.0",
+  apiVersion: `^${PLUGIN_API_VERSION}`,
   mainUrl: "https://example.test/c.js",
 };
 

--- a/src/contexts/PluginsProvider.test.tsx
+++ b/src/contexts/PluginsProvider.test.tsx
@@ -4,6 +4,7 @@ import { load } from "@tauri-apps/plugin-store";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRegistryEntries } from "@/hooks/usePluginRegistry";
+import { PLUGIN_API_VERSION } from "@/lib/plugins/apiVersion";
 import { loadPluginSettings, savePluginSettings } from "@/lib/plugins/settingsStore";
 import type { InstalledPlugin } from "@/lib/plugins/types";
 import { usePluginsOptional } from "./PluginsContext";
@@ -19,7 +20,7 @@ function installedPlugin(overrides: Partial<InstalledPlugin> = {}): InstalledPlu
     id: "com.x.demo",
     name: "Demo",
     version: "1.0.0",
-    apiVersion: "^1.0.0",
+    apiVersion: `^${PLUGIN_API_VERSION}`,
     dir: "/plugins/com.x.demo",
     mainSource: `export default {
       activate(ctx) {
@@ -205,7 +206,7 @@ describe("PluginsProvider", () => {
       id: "com.x.market",
       name: "Market",
       version: "1.0.0",
-      apiVersion: "^1.0.0",
+      apiVersion: `^${PLUGIN_API_VERSION}`,
       permissions: ["workspace:read"],
       mainUrl: "https://example.test/main.js",
     };
@@ -291,7 +292,7 @@ describe("PluginsProvider", () => {
       id: "com.x.market",
       name: "Market",
       version: "1.0.0",
-      apiVersion: "^1.0.0",
+      apiVersion: `^${PLUGIN_API_VERSION}`,
       mainUrl: "https://example.test/main.js",
     };
 
@@ -440,7 +441,7 @@ describe("PluginsProvider", () => {
       id: "com.x.market",
       name: "Market",
       version: "1.0.0",
-      apiVersion: "^1.0.0",
+      apiVersion: `^${PLUGIN_API_VERSION}`,
       mainUrl: "https://example.test/main.js",
     };
     vi.stubGlobal(

--- a/src/lib/plugins/apiVersion.test.ts
+++ b/src/lib/plugins/apiVersion.test.ts
@@ -22,6 +22,15 @@ describe("satisfiesApiVersion", () => {
     expect(satisfiesApiVersion("^2.0.0", "1.9.9")).toBe(false);
   });
 
+  it("requires the exact minor for a 0.x caret range (npm rule)", () => {
+    expect(satisfiesApiVersion("^0.16.0", "0.16.0")).toBe(true);
+    expect(satisfiesApiVersion("^0.16.0", "0.16.4")).toBe(true);
+    expect(satisfiesApiVersion("^0.16.2", "0.16.1")).toBe(false);
+    expect(satisfiesApiVersion("^0.15.1", "0.16.0")).toBe(false);
+    expect(satisfiesApiVersion("^0.16.0", "0.15.9")).toBe(false);
+    expect(satisfiesApiVersion("^0.16.0", "1.0.0")).toBe(false);
+  });
+
   it("treats unparseable input as incompatible", () => {
     expect(satisfiesApiVersion("latest", "1.0.0")).toBe(false);
     expect(satisfiesApiVersion("^1.0", "1.0.0")).toBe(false);

--- a/src/lib/plugins/apiVersion.test.ts
+++ b/src/lib/plugins/apiVersion.test.ts
@@ -22,12 +22,12 @@ describe("satisfiesApiVersion", () => {
     expect(satisfiesApiVersion("^2.0.0", "1.9.9")).toBe(false);
   });
 
-  it("requires the exact minor for a 0.x caret range (npm rule)", () => {
+  it("requires an exact match while the API major is 0, caret or not", () => {
+    expect(satisfiesApiVersion("0.16.0", "0.16.0")).toBe(true);
     expect(satisfiesApiVersion("^0.16.0", "0.16.0")).toBe(true);
-    expect(satisfiesApiVersion("^0.16.0", "0.16.4")).toBe(true);
-    expect(satisfiesApiVersion("^0.16.2", "0.16.1")).toBe(false);
+    expect(satisfiesApiVersion("^0.16.0", "0.16.4")).toBe(false);
     expect(satisfiesApiVersion("^0.15.1", "0.16.0")).toBe(false);
-    expect(satisfiesApiVersion("^0.16.0", "0.15.9")).toBe(false);
+    expect(satisfiesApiVersion("0.16.0", "0.15.9")).toBe(false);
     expect(satisfiesApiVersion("^0.16.0", "1.0.0")).toBe(false);
   });
 

--- a/src/lib/plugins/apiVersion.ts
+++ b/src/lib/plugins/apiVersion.ts
@@ -1,10 +1,14 @@
 /**
  * The version of the Glyph plugin API this build implements. Plugins declare a
  * compatible range in their manifest (`apiVersion`) and {@link satisfiesApiVersion}
- * gates loading on it. Bump the major only on a breaking change to the plugin
- * contract; bump the minor when adding backwards-compatible surface.
+ * gates loading on it.
+ *
+ * While the plugin contract is unstable (pre-0.16.0), this tracks the app
+ * version injected at build time, so plugins pin per app minor (`"^0.16.0"`)
+ * and every 0.x minor may break them. Cut over to an independent 1.0.0 when
+ * the contract is declared stable.
  */
-export const PLUGIN_API_VERSION = "1.3.0";
+export const PLUGIN_API_VERSION = __APP_VERSION__;
 
 interface SemVer {
   major: number;
@@ -25,9 +29,11 @@ function parse(version: string): SemVer | null {
 /**
  * Does the host API satisfy a plugin's required range? Supports an exact
  * version (`"1.2.3"`) or a caret range (`"^1.2.3"`: same major, with host
- * `minor.patch >= required`). Intentionally tiny: the plugin contract only
- * needs caret/exact, not the full semver grammar. Unparseable input is treated
- * as incompatible rather than throwing.
+ * `minor.patch >= required`). Caret on a 0.x version follows npm's rule: the
+ * minor is breaking, so it must match exactly (`"^0.16.0"` matches 0.16.x
+ * only). Intentionally tiny: the plugin contract only needs caret/exact, not
+ * the full semver grammar. Unparseable input is treated as incompatible
+ * rather than throwing.
  */
 export function satisfiesApiVersion(range: string, current: string = PLUGIN_API_VERSION): boolean {
   const host = parse(current);
@@ -41,6 +47,9 @@ export function satisfiesApiVersion(range: string, current: string = PLUGIN_API_
   if (host.major !== required.major) return false;
   if (!caret) {
     return host.minor === required.minor && host.patch === required.patch;
+  }
+  if (required.major === 0) {
+    return host.minor === required.minor && host.patch >= required.patch;
   }
   if (host.minor !== required.minor) return host.minor > required.minor;
   return host.patch >= required.patch;

--- a/src/lib/plugins/apiVersion.ts
+++ b/src/lib/plugins/apiVersion.ts
@@ -1,14 +1,15 @@
 /**
- * The version of the Glyph plugin API this build implements. Plugins declare a
- * compatible range in their manifest (`apiVersion`) and {@link satisfiesApiVersion}
- * gates loading on it.
+ * The version of the Glyph plugin API this build implements. Plugins declare
+ * the version they were built against in their manifest (`apiVersion`) and
+ * {@link satisfiesApiVersion} gates loading on it.
  *
- * While the plugin contract is unstable (pre-0.16.0), this tracks the app
- * version injected at build time, so plugins pin per app minor (`"^0.16.0"`)
- * and every 0.x minor may break them. Cut over to an independent 1.0.0 when
- * the contract is declared stable.
+ * The contract is unstable until it ships as 1.0.0: while the major is 0,
+ * plugins must match this version exactly (ranges grant nothing), and it is
+ * bumped by hand whenever the API decisions change. 0.16.0 marks the current
+ * decision set, aligned with the app release that first ships the plugin
+ * system as stable.
  */
-export const PLUGIN_API_VERSION = __APP_VERSION__;
+export const PLUGIN_API_VERSION = "0.16.0";
 
 interface SemVer {
   major: number;
@@ -29,11 +30,11 @@ function parse(version: string): SemVer | null {
 /**
  * Does the host API satisfy a plugin's required range? Supports an exact
  * version (`"1.2.3"`) or a caret range (`"^1.2.3"`: same major, with host
- * `minor.patch >= required`). Caret on a 0.x version follows npm's rule: the
- * minor is breaking, so it must match exactly (`"^0.16.0"` matches 0.16.x
- * only). Intentionally tiny: the plugin contract only needs caret/exact, not
- * the full semver grammar. Unparseable input is treated as incompatible
- * rather than throwing.
+ * `minor.patch >= required`). While the API major is 0 nothing is backwards
+ * compatible, so the required version must equal the host version exactly and
+ * a caret grants nothing. Intentionally tiny: the plugin contract only needs
+ * caret/exact, not the full semver grammar. Unparseable input is treated as
+ * incompatible rather than throwing.
  */
 export function satisfiesApiVersion(range: string, current: string = PLUGIN_API_VERSION): boolean {
   const host = parse(current);
@@ -45,11 +46,8 @@ export function satisfiesApiVersion(range: string, current: string = PLUGIN_API_
   if (!required) return false;
 
   if (host.major !== required.major) return false;
-  if (!caret) {
+  if (required.major === 0 || !caret) {
     return host.minor === required.minor && host.patch === required.patch;
-  }
-  if (required.major === 0) {
-    return host.minor === required.minor && host.patch >= required.patch;
   }
   if (host.minor !== required.minor) return host.minor > required.minor;
   return host.patch >= required.patch;

--- a/src/lib/plugins/marketplace.test.ts
+++ b/src/lib/plugins/marketplace.test.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { PLUGIN_API_VERSION } from "./apiVersion";
 import { fetchRegistry, findUpdates, installFromRegistry, type RegistryEntry } from "./marketplace";
 
 function entry(over: Partial<RegistryEntry> = {}): RegistryEntry {
@@ -7,7 +8,7 @@ function entry(over: Partial<RegistryEntry> = {}): RegistryEntry {
     id: "com.x.demo",
     name: "Demo",
     version: "1.0.0",
-    apiVersion: "^1.0.0",
+    apiVersion: `^${PLUGIN_API_VERSION}`,
     mainUrl: "https://example.test/main.js",
     ...over,
   };
@@ -74,7 +75,7 @@ describe("installFromRegistry", () => {
     expect(manifest).toMatchObject({
       id: "com.x.demo",
       version: "2.0.0",
-      apiVersion: "^1.0.0",
+      apiVersion: `^${PLUGIN_API_VERSION}`,
       description: "d",
       permissions: ["workspace:read"],
       sandbox: true,


### PR DESCRIPTION
## Summary

The plugin API carried its own 1.x version (1.2.0, with #403 bumping to 1.3.0), which promises a stability the unreleased system does not have. `PLUGIN_API_VERSION` is now a hand-bumped **0.16.0**, naming the current decision set and aligned with the app release that first ships the plugin system as stable. While the major is 0 nothing is backwards compatible: plugins must declare the exact host version, and a caret grants nothing. Normal caret semantics start at 1.0.0, when the contract is declared stable.

## Changes

- `PLUGIN_API_VERSION = "0.16.0"`, bumped by hand whenever API decisions change; the doc comment states the pre-1.0 policy
- `satisfiesApiVersion`: while the required major is 0, the version must equal the host exactly (caret or not); `>=1.x` caret behavior unchanged, tests for both
- Test fixtures in the provider/modal/marketplace suites derive their ranges from the constant instead of hardcoding `^1.0.0`

Merge-order note: #403 also touches this constant (bumps it to 1.3.0); whichever lands second has a one-line rebase, and 0.16.0 wins.

Follow-up ecosystem sync after merge (same delivery rule): hello-status manifest + `index.json` set to `"apiVersion": "0.16.0"`, template `types/glyph.d.ts` header, docs explain the exact-match pre-1.0 policy. Known accepted breakage: already-released 0.15.1 builds report API 1.1.0 and stop matching updated registry entries; the plugin system is experimental and unreleased as a stable feature.

## Testing

- `pnpm typecheck && pnpm check` green; plugin suites pass (145 tests) including the exact-match 0.x cases

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable.

Closes #415
