### PR TITLE
fix(aur): download releases from the GitHub repo, not the homepage URL

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -9,8 +9,9 @@ license=('MIT')
 depends=('webkit2gtk-4.1' 'gtk3')
 provides=('glyph')
 conflicts=('glyph')
-source_x86_64=("${url}/releases/download/v${pkgver}/Glyph_${pkgver}_amd64.deb")
-source_aarch64=("${url}/releases/download/v${pkgver}/Glyph_${pkgver}_arm64.deb")
+# Releases live on the GitHub repo, not the homepage in url= above
+source_x86_64=("https://github.com/hamidfzm/glyph/releases/download/v${pkgver}/Glyph_${pkgver}_amd64.deb")
+source_aarch64=("https://github.com/hamidfzm/glyph/releases/download/v${pkgver}/Glyph_${pkgver}_arm64.deb")
 sha256sums_x86_64=('{{SHA256_AMD64}}')
 sha256sums_aarch64=('{{SHA256_ARM64}}')
 


### PR DESCRIPTION
## Summary

Since v0.15.1 the AUR package `glyph-md-bin` fails to install: PR #332 templated the PKGBUILD `url` field from package.json's homepage (`https://glyph-md.github.io`), but the `source_*` lines derive the download base from `${url}`, so makepkg tried to fetch the debs from `https://glyph-md.github.io/releases/download/...`, which does not exist. `.SRCINFO` already hardcodes the correct GitHub releases URL, which is why the AUR web page looked fine while installs 404ed.

Closes #386

## Changes

- Hardcode `https://github.com/hamidfzm/glyph/releases/download/...` in the PKGBUILD `source_x86_64`/`source_aarch64` lines, matching .SRCINFO. The `url` field keeps pointing at the homepage.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux (verified the templated URL resolves: the v0.15.1 debs download from the GitHub releases URL)

Note: merging this fixes future releases. The currently published AUR PKGBUILD (0.15.1) still carries the broken URL and needs a manual repush of the corrected PKGBUILD to `ssh://aur@aur.archlinux.org/glyph-md-bin.git`.

## Screenshots

N/A