### PR TITLE
chore: bump version to 0.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glyph",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "homepage": "https://glyph-md.github.io",
   "type": "module",
   "packageManager": "pnpm@10.34.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1568,7 +1568,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glyph"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "git2",
  "notify",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyph"
-version = "0.15.1"
+version = "0.15.2"
 description = "A cross-platform markdown viewer"
 authors = ["hamidfzm"]
 edition = "2021"


### PR DESCRIPTION
## Summary

Sync main's version with the v0.15.2 hotfix release. The 0.15.2 tag was cut from a hotfix branch off v0.15.1 (containing only the AUR PKGBUILD URL fix from #417), so the version bump never landed on main. This aligns package.json, Cargo.toml, and Cargo.lock with the released version.

## Changes

- Bump version 0.15.1 to 0.15.2 in package.json, src-tauri/Cargo.toml, and src-tauri/Cargo.lock

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Version-only change; pre-commit gates (typecheck, tests, clippy) passed.

## Screenshots

N/A