### PR TITLE
docs(rules): read the full issue/PR thread before posting comments

### DIFF
--- a/.claude/rules/github.md
+++ b/.claude/rules/github.md
@@ -1,0 +1,7 @@
+# GitHub Interaction Rules
+
+Rules for commenting on and updating GitHub issues and PRs.
+
+- **Always read the whole thread before posting.** Before adding any comment to an issue or PR, fetch and read all existing comments and the activity timeline (`gh issue view N --comments`, `gh api repos/<owner>/<repo>/issues/N/comments`, and the timeline events for label/close/reference activity). Update your understanding from what's actually there: the author may have already posted a draft themselves, another comment may have answered the question, or the state (closed, released, superseded) may have changed since your context was built.
+- **Never duplicate an existing comment.** If a drafted comment overlaps with something already posted, post only the new information.
+- **One apology per thread, maximum.** If the thread already contains an apology, don't apologize again; go straight to the update.


### PR DESCRIPTION
## Summary

Adds a GitHub interaction rules file so AI-driven comments never duplicate what's already in a thread. Motivated by issue #386, where a follow-up comment repeated an apology that was already posted.

## Changes

- New `.claude/rules/github.md`: always read all comments and activity on an issue/PR before posting, never duplicate existing content, and at most one apology per thread.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Docs-only change, no runtime surface.

## Screenshots

N/A