### PR TITLE
feat(release): create an Announcements discussion for every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  discussions: write
 
 jobs:
   build:
@@ -188,6 +189,12 @@ jobs:
 
           printf '%s\n\n%s' "$BODY" "$CHANGELOG" > /tmp/release-body.md
           gh release edit "${{ github.ref_name }}" --repo "${{ github.repository }}" --notes-file /tmp/release-body.md
+
+          # Create the linked Announcements discussion after the notes are
+          # final, so the discussion body carries the full changelog.
+          RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" --jq .id)
+          gh api -X PATCH "repos/${{ github.repository }}/releases/$RELEASE_ID" \
+            -f discussion_category_name=Announcements
 
   publish-homebrew:
     needs: build


### PR DESCRIPTION
## Summary

Every release now automatically opens a linked GitHub Discussion in the **Announcements** category, carrying the full release notes (install instructions plus the generated changelog detailing every merged change).

## Changes

- `release.yml`: after the `update-release-notes` job finalizes the release body, PATCH the release with `discussion_category_name=Announcements` so GitHub creates the linked announcement discussion with the complete notes
- Grant the workflow token `discussions: write` so the linked discussion can be created

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Not platform-dependent (CI workflow change). Verified the repo has Discussions enabled with an Announcements category, and that the REST release-update endpoint accepts `discussion_category_name`. Will be exercised end-to-end by the next release.

## Screenshots

N/A
