### PR TITLE
feat(plugins): marketplace browser with search, categories, and detail pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 - Window state persistence across restarts
 - Native menu bar with customizable keyboard shortcuts (remap any command in Settings → Hotkeys)
 - Update notifications: checks for a newer release on launch and shows a banner when one is available (toggle in Settings → Behavior)
-- Plugins (experimental): install JavaScript plugins that extend rendering, palette commands, the status bar, spell-check dictionaries, and app styling (custom CSS/themes ship as plugins); every install asks for confirmation and shows the plugin's declared permissions, and everything is managed from the Plugins… menu item (next to Settings) or the command palette (Manage Plugins…); browse the [plugin marketplace](https://github.com/glyph-md/plugins) or write your own with the [plugin docs](https://github.com/glyph-md/plugins/tree/main/docs)
+- Plugins (experimental): install JavaScript plugins that extend rendering, palette commands, the status bar, spell-check dictionaries, and app styling (custom CSS/themes ship as plugins); every install asks for confirmation and shows the plugin's declared permissions, and everything is managed from the Plugins… menu item (next to Settings) or the command palette (Manage Plugins…); browse the marketplace right in the app (search, categories, official badges, and a details page per plugin) or write your own with the [plugin docs](https://github.com/glyph-md/plugins/tree/main/docs)
 
 ### Privacy
 - Local-first: your files never leave your machine unless you opt into Cloud Sync (per workspace, to a Git remote you control)

--- a/src/components/plugins/PluginDetail.tsx
+++ b/src/components/plugins/PluginDetail.tsx
@@ -1,0 +1,95 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { type RegistryEntry, registryReadmeUrl } from "@/lib/plugins/marketplace";
+import { PluginPermissionsLine } from "./PluginPermissionsLine";
+
+const btnClass =
+  "px-2 py-1 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]";
+
+/**
+ * Marketplace details view for one plugin: header with badges and actions,
+ * plus the plugin's registry README rendered below. Links open externally.
+ */
+export function PluginDetail({
+  entry,
+  onBack,
+  onInstall,
+}: {
+  entry: RegistryEntry;
+  onBack: () => void;
+  onInstall: (entry: RegistryEntry) => void;
+}) {
+  const { t } = useTranslation("plugins");
+  const [readme, setReadme] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setReadme(null);
+    setFailed(false);
+    fetch(registryReadmeUrl(entry.id))
+      .then((res) => (res.ok ? res.text() : Promise.reject(new Error(String(res.status)))))
+      .then((text) => {
+        if (!cancelled) setReadme(text);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [entry.id]);
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <button type="button" className={btnClass} onClick={onBack}>
+          {t("back")}
+        </button>
+        <div className="flex-1 min-w-0 text-sm text-[var(--color-text-primary)] truncate">
+          {entry.name} <span className="text-[var(--color-text-secondary)]">v{entry.version}</span>
+          {entry.official && (
+            <span className="ml-2 px-1.5 py-0.5 text-[10px] uppercase rounded bg-[var(--color-surface-secondary)] text-[var(--color-text-secondary)]">
+              {t("officialBadge")}
+            </span>
+          )}
+        </div>
+        <button type="button" className={btnClass} onClick={() => onInstall(entry)}>
+          {t("install")}
+        </button>
+      </div>
+      <PluginPermissionsLine permissions={entry.permissions} sandbox={entry.sandbox} />
+      <div className="mt-3 text-sm markdown-body">
+        {failed ? (
+          <p className="text-[var(--color-text-secondary)]">{t("detailsError")}</p>
+        ) : readme === null ? (
+          <p className="text-[var(--color-text-secondary)]">{t("detailsLoading")}</p>
+        ) : (
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              a: ({ href, children }) => (
+                <a
+                  href={href}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    // ReactMarkdown only renders anchors for real links, so
+                    // href is present; a bad value just rejects and is ignored.
+                    void openUrl(String(href)).catch(() => undefined);
+                  }}
+                >
+                  {children}
+                </a>
+              ),
+            }}
+          >
+            {readme}
+          </ReactMarkdown>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/plugins/PluginMarketplace.test.tsx
+++ b/src/components/plugins/PluginMarketplace.test.tsx
@@ -1,0 +1,222 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PluginsContext, type PluginsContextValue } from "@/contexts/PluginsContext";
+import { PLUGIN_API_VERSION } from "@/lib/plugins/apiVersion";
+import type { RegistryEntry } from "@/lib/plugins/marketplace";
+import { createRegistry } from "@/lib/plugins/registry";
+import type {
+  CommandContribution,
+  ExporterContribution,
+  FencedRendererContribution,
+  MarkdownPlugin,
+  SettingsPanelContribution,
+  SidebarPanelContribution,
+  StatusBarItemContribution,
+  StyleContribution,
+} from "@/lib/plugins/types";
+import { PluginMarketplace } from "./PluginMarketplace";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn(async () => {}) }));
+
+function entry(over: Partial<RegistryEntry> = {}): RegistryEntry {
+  return {
+    id: "com.x.demo",
+    name: "Demo",
+    description: "from the market",
+    version: "1.0.0",
+    apiVersion: PLUGIN_API_VERSION,
+    packageUrl: "https://example.test/demo.zip",
+    sha256: "aa",
+    category: "tools",
+    ...over,
+  };
+}
+
+function ctx(over: Partial<PluginsContextValue> = {}): PluginsContextValue {
+  return {
+    commands: createRegistry<CommandContribution>(),
+    statusBarItems: createRegistry<StatusBarItemContribution>(),
+    remarkPlugins: createRegistry<MarkdownPlugin>(),
+    rehypePlugins: createRegistry<MarkdownPlugin>(),
+    fencedRenderers: createRegistry<FencedRendererContribution>(),
+    sidebarPanels: createRegistry<SidebarPanelContribution>(),
+    settingsPanels: createRegistry<SettingsPanelContribution>(),
+    styles: createRegistry<StyleContribution>(),
+    exporters: createRegistry<ExporterContribution>(),
+    installed: [],
+    disabled: [],
+    loaded: [],
+    registry: [
+      entry(),
+      entry({
+        id: "com.x.dict",
+        name: "Dictionary",
+        category: "language",
+        official: true,
+        keywords: ["farsi"],
+      }),
+    ],
+    updates: [],
+    installFromFolder: vi.fn(async () => {}),
+    installFromRegistry: vi.fn(async () => {}),
+    setEnabled: vi.fn(async () => {}),
+    uninstall: vi.fn(async () => {}),
+    setWorkspaceRoot: vi.fn(),
+    ...over,
+  };
+}
+
+function renderMarket(value = ctx()) {
+  render(
+    <PluginsContext.Provider value={value}>
+      <PluginMarketplace />
+    </PluginsContext.Provider>,
+  );
+  return value;
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("# Demo readme") }),
+  );
+  return () => vi.unstubAllGlobals();
+});
+
+describe("PluginMarketplace", () => {
+  it("lists entries with the official badge where declared", () => {
+    renderMarket();
+    expect(screen.getByText("Demo")).toBeInTheDocument();
+    expect(screen.getByText("Dictionary")).toBeInTheDocument();
+    expect(screen.getAllByText("Official")).toHaveLength(1);
+  });
+
+  it("filters by search text, matching keywords too", () => {
+    renderMarket();
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "farsi" } });
+    expect(screen.queryByText("Demo")).not.toBeInTheDocument();
+    expect(screen.getByText("Dictionary")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "nothing-matches" } });
+    expect(screen.getByText("No plugins available.")).toBeInTheDocument();
+  });
+
+  it("filters by category", () => {
+    renderMarket();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "language" } });
+    expect(screen.queryByText("Demo")).not.toBeInTheDocument();
+    expect(screen.getByText("Dictionary")).toBeInTheDocument();
+  });
+
+  it("hides installed plugins from the listing", () => {
+    renderMarket(
+      ctx({
+        installed: [
+          {
+            id: "com.x.demo",
+            name: "Demo",
+            version: "1.0.0",
+            apiVersion: PLUGIN_API_VERSION,
+            dir: "/p",
+            mainSource: "",
+          },
+        ],
+      }),
+    );
+    expect(screen.queryByText("Demo")).not.toBeInTheDocument();
+    expect(screen.getByText("Dictionary")).toBeInTheDocument();
+  });
+
+  it("installs from the row button", () => {
+    const value = renderMarket();
+    fireEvent.click(screen.getAllByRole("button", { name: "Install" })[0]);
+    expect(value.installFromRegistry).toHaveBeenCalled();
+  });
+
+  it("opens the details view with the fetched README and returns via Back", async () => {
+    renderMarket();
+    fireEvent.click(screen.getByText("Dictionary"));
+    expect(await screen.findByText("Demo readme")).toBeInTheDocument();
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+  });
+
+  it("installs from the details view and leaves it", async () => {
+    const value = renderMarket();
+    fireEvent.click(screen.getByText("Dictionary"));
+    await screen.findByText("Demo readme");
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    expect(value.installFromRegistry).toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByRole("searchbox")).toBeInTheDocument());
+  });
+
+  it("renders nothing without a PluginsProvider", () => {
+    const { container } = render(<PluginMarketplace />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("opens README links externally instead of navigating", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("[docs](https://example.test/docs)"),
+      }),
+    );
+    renderMarket();
+    fireEvent.click(screen.getByText("Dictionary"));
+    fireEvent.click(await screen.findByRole("link", { name: "docs" }));
+    expect(vi.mocked(openUrl)).toHaveBeenCalledWith("https://example.test/docs");
+
+    // An opener failure is swallowed, not surfaced.
+    vi.mocked(openUrl).mockRejectedValueOnce(new Error("no handler"));
+    fireEvent.click(screen.getByRole("link", { name: "docs" }));
+    await waitFor(() => expect(vi.mocked(openUrl)).toHaveBeenCalledTimes(2));
+  });
+
+  it("ignores a README failure that lands after leaving the details view", async () => {
+    let rejectFetch!: (reason: unknown) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(
+        new Promise((_resolve, reject) => {
+          rejectFetch = reject;
+        }),
+      ),
+    );
+    renderMarket();
+    fireEvent.click(screen.getByText("Dictionary"));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    rejectFetch(new Error("offline"));
+    await waitFor(() => expect(screen.getByRole("searchbox")).toBeInTheDocument());
+    expect(screen.queryByText("Could not load the plugin details.")).not.toBeInTheDocument();
+  });
+
+  it("ignores a README response that lands after leaving the details view", async () => {
+    let resolveFetch!: (value: unknown) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+      ),
+    );
+    renderMarket();
+    fireEvent.click(screen.getByText("Dictionary"));
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    resolveFetch({ ok: true, text: () => Promise.resolve("# late") });
+    await waitFor(() => expect(screen.getByRole("searchbox")).toBeInTheDocument());
+    expect(screen.queryByText("late")).not.toBeInTheDocument();
+  });
+
+  it("shows an error message when the README cannot be fetched", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    renderMarket();
+    fireEvent.click(screen.getByText("Dictionary"));
+    expect(await screen.findByText("Could not load the plugin details.")).toBeInTheDocument();
+  });
+});

--- a/src/components/plugins/PluginMarketplace.tsx
+++ b/src/components/plugins/PluginMarketplace.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { usePluginsOptional } from "@/contexts/PluginsContext";
+import { filterRegistry, REGISTRY_CATEGORIES, type RegistryEntry } from "@/lib/plugins/marketplace";
+import { PluginDetail } from "./PluginDetail";
+import { PluginMarketplaceRow } from "./PluginMarketplaceRow";
+
+const inputClass =
+  "px-2 py-1 text-xs rounded border border-[var(--color-border)] bg-transparent text-[var(--color-text-primary)]";
+
+/**
+ * The marketplace section of Manage Plugins: search + category filter over
+ * the not-yet-installed registry entries, with a per-plugin details view
+ * (the plugin's registry README) a click away.
+ */
+export function PluginMarketplace() {
+  const { t } = useTranslation("plugins");
+  const plugins = usePluginsOptional();
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState("");
+  const [selected, setSelected] = useState<RegistryEntry | null>(null);
+
+  if (!plugins) return null;
+
+  const installedIds = new Set(plugins.installed.map((p) => p.id));
+  const available = filterRegistry(
+    plugins.registry.filter((e) => !installedIds.has(e.id)),
+    query,
+    category,
+  );
+
+  const handleInstall = (entry: RegistryEntry) => {
+    setSelected(null);
+    void plugins.installFromRegistry(entry);
+  };
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-[var(--color-text-secondary)] mt-5 mb-1">
+        {t("availableHeading")}
+      </h3>
+      {selected ? (
+        <PluginDetail entry={selected} onBack={() => setSelected(null)} onInstall={handleInstall} />
+      ) : (
+        <>
+          <div className="flex items-center gap-2 mb-1">
+            <input
+              type="search"
+              className={`${inputClass} flex-1 min-w-0`}
+              placeholder={t("searchPlaceholder")}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label={t("searchPlaceholder")}
+            />
+            <select
+              className={inputClass}
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              aria-label={t("categoryLabel")}
+            >
+              <option value="">{t("categoryAll")}</option>
+              {REGISTRY_CATEGORIES.map((c) => (
+                <option key={c} value={c}>
+                  {t(`categories.${c}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+          {available.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-secondary)] py-2">{t("noAvailable")}</p>
+          ) : (
+            available.map((entry) => (
+              <PluginMarketplaceRow
+                key={entry.id}
+                entry={entry}
+                onSelect={setSelected}
+                onInstall={handleInstall}
+              />
+            ))
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/plugins/PluginMarketplaceRow.tsx
+++ b/src/components/plugins/PluginMarketplaceRow.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from "react-i18next";
+import type { RegistryEntry } from "@/lib/plugins/marketplace";
+import { PluginPermissionsLine } from "./PluginPermissionsLine";
+
+const rowClass =
+  "flex items-start gap-3 py-3 border-b border-[var(--color-border)] last:border-b-0";
+const btnClass =
+  "px-2 py-1 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface-secondary)]";
+
+/**
+ * One marketplace listing: name, badges, description, and trust line, with
+ * the whole text area clickable to open the details view.
+ */
+export function PluginMarketplaceRow({
+  entry,
+  onSelect,
+  onInstall,
+}: {
+  entry: RegistryEntry;
+  onSelect: (entry: RegistryEntry) => void;
+  onInstall: (entry: RegistryEntry) => void;
+}) {
+  const { t } = useTranslation("plugins");
+  return (
+    <div className={rowClass}>
+      <button
+        type="button"
+        className="flex-1 min-w-0 text-left cursor-pointer bg-transparent border-0 p-0"
+        onClick={() => onSelect(entry)}
+      >
+        <div className="text-sm text-[var(--color-text-primary)]">
+          {entry.name} <span className="text-[var(--color-text-secondary)]">v{entry.version}</span>
+          {entry.official && (
+            <span className="ml-2 px-1.5 py-0.5 text-[10px] uppercase rounded bg-[var(--color-surface-secondary)] text-[var(--color-text-secondary)]">
+              {t("officialBadge")}
+            </span>
+          )}
+        </div>
+        {entry.description && (
+          <div className="text-xs text-[var(--color-text-secondary)] truncate">
+            {entry.description}
+          </div>
+        )}
+        <PluginPermissionsLine permissions={entry.permissions} sandbox={entry.sandbox} />
+      </button>
+      <button type="button" className={btnClass} onClick={() => onInstall(entry)}>
+        {t("install")}
+      </button>
+    </div>
+  );
+}

--- a/src/components/plugins/PluginsModal.tsx
+++ b/src/components/plugins/PluginsModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { ModalCloseIcon } from "@/components/icons/ModalCloseIcon";
 import { usePluginsOptional } from "@/contexts/PluginsContext";
 import { useRegistryEntries } from "@/hooks/usePluginRegistry";
+import { PluginMarketplace } from "./PluginMarketplace";
 import { PluginMountSlot } from "./PluginMountSlot";
 import { PluginPermissionsLine } from "./PluginPermissionsLine";
 
@@ -39,8 +40,6 @@ export function PluginsModal({ onClose }: { onClose: () => void }) {
   if (!plugins) return null;
 
   const updatesById = new Map(plugins.updates.map((u) => [u.entry.id, u.entry]));
-  const installedIds = new Set(plugins.installed.map((p) => p.id));
-  const available = plugins.registry.filter((e) => !installedIds.has(e.id));
 
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: Escape is handled globally above.
@@ -121,36 +120,7 @@ export function PluginsModal({ onClose }: { onClose: () => void }) {
             })
           )}
 
-          <h3 className="text-sm font-semibold text-[var(--color-text-secondary)] mt-5 mb-1">
-            {t("availableHeading")}
-          </h3>
-          {available.length === 0 ? (
-            <p className="text-sm text-[var(--color-text-secondary)] py-2">{t("noAvailable")}</p>
-          ) : (
-            available.map((e) => (
-              <div key={e.id} className={rowClass}>
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm text-[var(--color-text-primary)]">
-                    {e.name}{" "}
-                    <span className="text-[var(--color-text-secondary)]">v{e.version}</span>
-                  </div>
-                  {e.description && (
-                    <div className="text-xs text-[var(--color-text-secondary)] truncate">
-                      {e.description}
-                    </div>
-                  )}
-                  <PluginPermissionsLine permissions={e.permissions} sandbox={e.sandbox} />
-                </div>
-                <button
-                  type="button"
-                  className={btnClass}
-                  onClick={() => void plugins.installFromRegistry(e)}
-                >
-                  {t("install")}
-                </button>
-              </div>
-            ))
-          )}
+          <PluginMarketplace />
         </div>
       </div>
     </div>

--- a/src/lib/plugins/marketplace.test.ts
+++ b/src/lib/plugins/marketplace.test.ts
@@ -1,7 +1,14 @@
 import { invoke } from "@tauri-apps/api/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PLUGIN_API_VERSION } from "./apiVersion";
-import { fetchRegistry, findUpdates, installFromRegistry, type RegistryEntry } from "./marketplace";
+import {
+  fetchRegistry,
+  filterRegistry,
+  findUpdates,
+  installFromRegistry,
+  type RegistryEntry,
+  registryReadmeUrl,
+} from "./marketplace";
 
 // Fixed package bytes for install tests, with their real SHA-256 (hex of
 // the four bytes 1,2,3,4). Zip parsing happens in Rust, so the frontend
@@ -95,5 +102,40 @@ describe("installFromRegistry", () => {
 
     await expect(installFromRegistry(entry())).rejects.toThrow(/checksum mismatch/);
     expect(vi.mocked(invoke)).not.toHaveBeenCalled();
+  });
+});
+
+describe("filterRegistry", () => {
+  const entries = [
+    entry({ id: "a.theme", name: "Nord Theme", category: "themes" }),
+    entry({
+      id: "b.dict",
+      name: "Dictionary",
+      category: "language",
+      keywords: ["farsi", "spellcheck"],
+    }),
+  ];
+
+  it("returns everything for an empty query and no category", () => {
+    expect(filterRegistry(entries, "", "")).toHaveLength(2);
+  });
+
+  it("matches name, id, and keywords case-insensitively", () => {
+    expect(filterRegistry(entries, "NORD", "").map((e) => e.id)).toEqual(["a.theme"]);
+    expect(filterRegistry(entries, "b.dict", "").map((e) => e.id)).toEqual(["b.dict"]);
+    expect(filterRegistry(entries, "FARSI", "").map((e) => e.id)).toEqual(["b.dict"]);
+  });
+
+  it("restricts to a category, combined with the query", () => {
+    expect(filterRegistry(entries, "", "language").map((e) => e.id)).toEqual(["b.dict"]);
+    expect(filterRegistry(entries, "nord", "language")).toHaveLength(0);
+  });
+});
+
+describe("registryReadmeUrl", () => {
+  it("points at the plugin's registry folder README", () => {
+    expect(registryReadmeUrl("com.x.demo")).toBe(
+      "https://raw.githubusercontent.com/glyph-md/plugins/main/plugins/com.x.demo/README.md",
+    );
   });
 });

--- a/src/lib/plugins/marketplace.ts
+++ b/src/lib/plugins/marketplace.ts
@@ -1,11 +1,51 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { InstalledPlugin } from "./types";
 
-// The marketplace is a single static JSON file maintained in the glyph-md org.
-// The app reads it to discover plugins and detect new versions; plugin code
-// itself lives in each plugin's own repo (referenced by `packageUrl`).
-// ponytail: hardcoded URL; make it a setting if users ever want a custom registry.
+// The marketplace index is generated from per-plugin registrations in the
+// glyph-md/plugins repo. The app reads it to discover plugins and detect new
+// versions; plugin code itself lives in each plugin's own repo (referenced by
+// `packageUrl`), and each plugin's README (its details page) sits next to its
+// registration.
+// ponytail: hardcoded URLs; make them a setting if users ever want a custom registry.
 export const REGISTRY_URL = "https://raw.githubusercontent.com/glyph-md/plugins/main/index.json";
+
+/** URL of a plugin's registry README, shown in the marketplace details view. */
+export function registryReadmeUrl(id: string): string {
+  return `https://raw.githubusercontent.com/glyph-md/plugins/main/plugins/${id}/README.md`;
+}
+
+/** The marketplace categories, in display order. Mirrors the registry schema enum. */
+export const REGISTRY_CATEGORIES = [
+  "themes",
+  "markdown",
+  "exporters",
+  "tools",
+  "integrations",
+  "language",
+  "ai",
+] as const;
+
+export type RegistryCategory = (typeof REGISTRY_CATEGORIES)[number];
+
+/**
+ * Case-insensitive marketplace filter: a category (or "" for all) plus a free
+ * text query matched against name, description, id, and keywords.
+ */
+export function filterRegistry(
+  entries: readonly RegistryEntry[],
+  query: string,
+  category: string,
+): RegistryEntry[] {
+  const needle = query.trim().toLowerCase();
+  return entries.filter((e) => {
+    if (category && e.category !== category) return false;
+    if (!needle) return true;
+    const haystack = [e.name, e.description ?? "", e.id, ...(e.keywords ?? [])]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(needle);
+  });
+}
 
 /** One marketplace entry. Carries everything the app needs to install + version-check. */
 export interface RegistryEntry {
@@ -30,6 +70,12 @@ export interface RegistryEntry {
   sha256: string;
   /** Run isolated in a worker; see the manifest `sandbox` flag. */
   sandbox?: boolean;
+  /** Marketplace section, one of {@link REGISTRY_CATEGORIES}. */
+  category?: string;
+  /** Extra search terms matched by the marketplace search. */
+  keywords?: string[];
+  /** Maintained in the marketplace repo; shown with an Official badge. */
+  official?: boolean;
 }
 
 /** Hex SHA-256 of raw bytes, via WebCrypto (available in the webview and Node). */

--- a/src/locales/de/plugins.json
+++ b/src/locales/de/plugins.json
@@ -15,5 +15,21 @@
   "consentPermissions": "Es fordert an:",
   "permissionsLabel": "Berechtigungen",
   "permissionsNone": "Keine",
-  "sandboxBadge": "Sandbox"
+  "sandboxBadge": "Sandbox",
+  "searchPlaceholder": "Plugins durchsuchen…",
+  "categoryLabel": "Kategorie",
+  "categoryAll": "Alle",
+  "categories": {
+    "themes": "Themes",
+    "markdown": "Markdown",
+    "exporters": "Export",
+    "tools": "Werkzeuge",
+    "integrations": "Integrationen",
+    "language": "Sprache",
+    "ai": "KI"
+  },
+  "officialBadge": "Offiziell",
+  "back": "Zurück",
+  "detailsLoading": "Wird geladen…",
+  "detailsError": "Die Plugin-Details konnten nicht geladen werden."
 }

--- a/src/locales/en/plugins.json
+++ b/src/locales/en/plugins.json
@@ -15,5 +15,21 @@
   "consentPermissions": "It requests:",
   "permissionsLabel": "Permissions",
   "permissionsNone": "None",
-  "sandboxBadge": "Sandboxed"
+  "sandboxBadge": "Sandboxed",
+  "searchPlaceholder": "Search plugins…",
+  "categoryLabel": "Category",
+  "categoryAll": "All",
+  "categories": {
+    "themes": "Themes",
+    "markdown": "Markdown",
+    "exporters": "Exporters",
+    "tools": "Tools",
+    "integrations": "Integrations",
+    "language": "Language",
+    "ai": "AI"
+  },
+  "officialBadge": "Official",
+  "back": "Back",
+  "detailsLoading": "Loading…",
+  "detailsError": "Could not load the plugin details."
 }

--- a/src/locales/es/plugins.json
+++ b/src/locales/es/plugins.json
@@ -15,5 +15,21 @@
   "consentPermissions": "Solicita:",
   "permissionsLabel": "Permisos",
   "permissionsNone": "Ninguno",
-  "sandboxBadge": "Aislado"
+  "sandboxBadge": "Aislado",
+  "searchPlaceholder": "Buscar complementos…",
+  "categoryLabel": "Categoría",
+  "categoryAll": "Todos",
+  "categories": {
+    "themes": "Temas",
+    "markdown": "Markdown",
+    "exporters": "Exportación",
+    "tools": "Herramientas",
+    "integrations": "Integraciones",
+    "language": "Idioma",
+    "ai": "IA"
+  },
+  "officialBadge": "Oficial",
+  "back": "Atrás",
+  "detailsLoading": "Cargando…",
+  "detailsError": "No se pudieron cargar los detalles del complemento."
 }

--- a/src/locales/fa/plugins.json
+++ b/src/locales/fa/plugins.json
@@ -15,5 +15,21 @@
   "consentPermissions": "درخواست می‌کند:",
   "permissionsLabel": "دسترسی‌ها",
   "permissionsNone": "ندارد",
-  "sandboxBadge": "ایزوله"
+  "sandboxBadge": "ایزوله",
+  "searchPlaceholder": "جستجوی افزونه‌ها…",
+  "categoryLabel": "دسته‌بندی",
+  "categoryAll": "همه",
+  "categories": {
+    "themes": "پوسته‌ها",
+    "markdown": "مارک‌داون",
+    "exporters": "خروجی‌گیری",
+    "tools": "ابزارها",
+    "integrations": "یکپارچه‌سازی‌ها",
+    "language": "زبان",
+    "ai": "هوش مصنوعی"
+  },
+  "officialBadge": "رسمی",
+  "back": "بازگشت",
+  "detailsLoading": "در حال بارگذاری…",
+  "detailsError": "جزئیات افزونه بارگذاری نشد."
 }

--- a/src/locales/zh/plugins.json
+++ b/src/locales/zh/plugins.json
@@ -15,5 +15,21 @@
   "consentPermissions": "它请求：",
   "permissionsLabel": "权限",
   "permissionsNone": "无",
-  "sandboxBadge": "沙盒"
+  "sandboxBadge": "沙盒",
+  "searchPlaceholder": "搜索插件…",
+  "categoryLabel": "分类",
+  "categoryAll": "全部",
+  "categories": {
+    "themes": "主题",
+    "markdown": "Markdown",
+    "exporters": "导出",
+    "tools": "工具",
+    "integrations": "集成",
+    "language": "语言",
+    "ai": "AI"
+  },
+  "officialBadge": "官方",
+  "back": "返回",
+  "detailsLoading": "加载中…",
+  "detailsError": "无法加载插件详情。"
 }


### PR DESCRIPTION
## Summary

Second half of #408 (registry v2). The registry side already shipped in glyph-md/plugins: one folder per plugin (`plugins/<id>/plugin.json` + `README.md`), schema-validated registrations, and a generated `index.json` + catalog with a bot commit on merge, so submission PRs never conflict. This PR is the app side: the Manage Plugins marketplace section becomes a small browser, modeled on Obsidian's community plugins view.

## Changes

- `RegistryEntry` gains optional `category`, `keywords`, and `official` (older indexes keep working); `REGISTRY_CATEGORIES`, a pure `filterRegistry` (case-insensitive over name/description/id/keywords + category), and `registryReadmeUrl`
- `PluginMarketplace`: search box + category filter over not-yet-installed entries, with empty state
- `PluginMarketplaceRow`: listing row with the Official badge, description, trust line, Install button, and a clickable body opening the details view
- `PluginDetail`: per-plugin details rendering the plugin's registry README (links open externally via the opener plugin, load/error states, stale responses ignored after leaving the view), with badges, permissions, and Install
- `PluginsModal` shrinks: the marketplace section is the new component
- i18n: search/category/official/back/details keys in all five locales (parity test enforced)
- README plugins bullet mentions in-app browsing

## Testing

- 11 marketplace-browser tests (search incl. keywords, category filter, official badge, installed exclusion, install from row and detail, README render + external links + opener failure swallowed, fetch error state, stale-response guards, no-provider render)
- `filterRegistry`/`registryReadmeUrl` unit tests; full suite 2489+ green; typecheck + Biome clean; all four new/touched files at 100% statement and branch coverage locally

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not attached; the marketplace section of Manage Plugins gains a search input, a category dropdown, Official badges, and a per-plugin details page.

Closes #408
