### PR TITLE
feat(app): offer to set Glyph as the default markdown handler

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -56,6 +56,12 @@ ignore:
   # unit test cannot survive. The testable halves (CLI export state and the
   # stdout/stderr routing) live in commands/export.rs with direct tests.
   - "src-tauri/src/commands/export_runtime.rs"
+  # set_default_markdown_app is pure OS handler-registration glue: each arm
+  # shells out to a real process (xdg-mime on Linux, `start ms-settings:` on
+  # Windows) or returns static guidance (macOS). There's no logic to exercise
+  # without spawning real processes and mutating the host's default-app
+  # registration, so it can't run under test.
+  - "src-tauri/src/commands/default_app.rs"
   # Multi-window runtime wiring (focus/spawn/emit_to real windows + the
   # set_window_workspace / request_open command shims): every line drives the
   # live window manager and can't be reached from MockRuntime. The routing

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
 pub mod create;
+pub mod default_app;
 pub mod directory;
 pub mod export;
 pub mod export_runtime;

--- a/src-tauri/src/commands/default_app.rs
+++ b/src-tauri/src/commands/default_app.rs
@@ -1,0 +1,54 @@
+use std::process::Command;
+
+/// Set, or guide the user to set, Glyph as the default application for Markdown
+/// files. Silently registering a default handler is restricted on modern
+/// desktops, so the behaviour is per-platform and the returned tag tells the UI
+/// what happened:
+/// - `"registered"`     the association was set for us (Linux, via `xdg-mime`)
+/// - `"openedSettings"` the OS Default Apps page was opened so the user can
+///                      pick Glyph (Windows blocks silent handler changes)
+/// - `"guidance"`       no programmatic path; the UI shows manual steps (macOS)
+#[tauri::command]
+pub fn set_default_markdown_app() -> Result<String, String> {
+    // Exactly one arm survives cfg on any given target, so each is the tail
+    // expression of the function (no `return` needed).
+    #[cfg(target_os = "linux")]
+    {
+        // The installed bundle ships a desktop entry named after the bundle id.
+        const DESKTOP: &str = "com.hamidfzm.glyph.desktop";
+        // Cover the common MIME spellings file managers use for Markdown.
+        for mime in ["text/markdown", "text/x-markdown"] {
+            let status = Command::new("xdg-mime")
+                .args(["default", DESKTOP, mime])
+                .status()
+                .map_err(|e| format!("xdg-mime is unavailable: {e}"))?;
+            if !status.success() {
+                return Err(format!("xdg-mime exited with {status}"));
+            }
+        }
+        Ok("registered".into())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // Windows 10+ forbids silently changing the default handler; open the
+        // Default Apps settings page so the user can assign Glyph to Markdown.
+        Command::new("cmd")
+            .args(["/C", "start", "", "ms-settings:defaultapps"])
+            .status()
+            .map_err(|e| format!("failed to open Default Apps settings: {e}"))?;
+        Ok("openedSettings".into())
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // Changing the handler needs private LaunchServices calls, so the UI
+        // shows Get Info -> Open With guidance instead.
+        Ok("guidance".into())
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        Ok("guidance".into())
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -302,6 +302,7 @@ pub fn run() {
             commands::file::print_document,
             commands::export::get_cli_export,
             commands::export_runtime::finish_cli_export,
+            commands::default_app::set_default_markdown_app,
             commands::directory::get_initial_folder,
             commands::directory::read_directory,
             commands::directory::list_markdown_files,

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { useAutoSave } from "@/hooks/useAutoSave";
 import { useCliExport } from "@/hooks/useCliExport";
 import { useCommandPaletteController } from "@/hooks/useCommandPaletteController";
 import { useContextMenu } from "@/hooks/useContextMenu";
+import { useDefaultAppPrompt } from "@/hooks/useDefaultAppPrompt";
 import { useDocumentUndoRedo } from "@/hooks/useDocumentUndoRedo";
 import { useErrorReporting } from "@/hooks/useErrorReporting";
 import { useExport } from "@/hooks/useExport";
@@ -30,6 +31,7 @@ import { openDocumentation, openReleaseNotes, openReportIssue } from "@/lib/help
 import { isImageFile } from "@/lib/imageExtensions";
 import { nextEditorMode } from "@/lib/settings";
 import { AIChatPanel } from "./ai/AIChatPanel";
+import { DefaultAppBanner } from "./layout/DefaultAppBanner";
 import { EmptyState } from "./layout/EmptyState";
 import { ExportProgress } from "./layout/ExportProgress";
 import { Sidebar } from "./layout/Sidebar";
@@ -71,6 +73,9 @@ export function AppShell() {
   // Once-per-session check for a newer GitHub release; the banner shows only
   // when the user has the feature on and an update is actually available.
   const updateCheck = useUpdateCheck(settings.behavior.checkForUpdates, loaded);
+
+  // One-time first-run nudge to make Glyph the default Markdown app.
+  const defaultAppPrompt = useDefaultAppPrompt();
 
   const {
     tabs: openTabs,
@@ -270,6 +275,13 @@ export function AppShell() {
   return (
     <div className="flex flex-col h-full bg-[var(--color-surface)]">
       <UpdateBanner update={updateCheck.update} onDismiss={updateCheck.dismiss} />
+      {defaultAppPrompt.show && (
+        <DefaultAppBanner
+          onSetDefault={defaultAppPrompt.setDefault}
+          onNotNow={defaultAppPrompt.notNow}
+          onNever={defaultAppPrompt.never}
+        />
+      )}
       <WorkspaceNoticeBanner
         notice={tabs.workspaceNotice}
         onDismiss={tabs.dismissWorkspaceNotice}

--- a/src/components/layout/DefaultAppBanner.tsx
+++ b/src/components/layout/DefaultAppBanner.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from "react-i18next";
+import { BannerCloseIcon } from "@/components/icons/BannerCloseIcon";
+
+interface DefaultAppBannerProps {
+  onSetDefault: () => void;
+  onNotNow: () => void;
+  onNever: () => void;
+}
+
+/**
+ * First-run nudge to make Glyph the default Markdown app. "Set as default"
+ * triggers the platform registration; "Not now" and the close button dismiss
+ * for now; "Never" stops it from returning. Mirrors {@link UpdateBanner}.
+ */
+export function DefaultAppBanner({ onSetDefault, onNotNow, onNever }: DefaultAppBannerProps) {
+  const { t } = useTranslation("common");
+
+  return (
+    <div
+      data-print-hide="true"
+      className="flex items-center gap-3 px-4 py-2 border-b border-[var(--color-border)] border-s-4 border-s-[var(--color-accent)] bg-[var(--color-banner-bg)] text-sm text-[var(--color-text-primary)] select-none shrink-0"
+    >
+      <span>{t("defaultAppBanner.message")}</span>
+      <button
+        type="button"
+        className="ms-auto cursor-pointer rounded-md bg-[var(--color-accent)] px-2.5 py-1 text-xs font-semibold text-white hover:bg-[var(--color-accent-hover)]"
+        onClick={onSetDefault}
+      >
+        {t("defaultAppBanner.setDefault")}
+      </button>
+      <button
+        type="button"
+        className="cursor-pointer text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+        onClick={onNotNow}
+      >
+        {t("defaultAppBanner.notNow")}
+      </button>
+      <button
+        type="button"
+        className="cursor-pointer text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+        onClick={onNever}
+      >
+        {t("defaultAppBanner.never")}
+      </button>
+      <button
+        type="button"
+        className="cursor-pointer text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+        onClick={onNotNow}
+        aria-label={t("defaultAppBanner.dismiss")}
+      >
+        <BannerCloseIcon />
+      </button>
+    </div>
+  );
+}

--- a/src/components/modals/settings/BehaviorTab.tsx
+++ b/src/components/modals/settings/BehaviorTab.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useSettings } from "@/hooks/useSettings";
+import { DefaultAppSection } from "./DefaultAppSection";
 import { Toggle } from "./Toggle";
 import { UpdatesSection } from "./UpdatesSection";
 
@@ -47,6 +48,8 @@ export function BehaviorTab() {
           />
         </div>
       </div>
+
+      <DefaultAppSection />
 
       <UpdatesSection />
 

--- a/src/components/modals/settings/DefaultAppSection.test.tsx
+++ b/src/components/modals/settings/DefaultAppSection.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DefaultAppSection } from "./DefaultAppSection";
+
+const { setDefaultMock } = vi.hoisted(() => ({ setDefaultMock: vi.fn() }));
+vi.mock("@/lib/defaultApp", () => ({ setDefaultMarkdownApp: setDefaultMock }));
+
+describe("DefaultAppSection", () => {
+  beforeEach(() => {
+    setDefaultMock.mockReset();
+  });
+
+  it("invokes the command and shows the outcome message on click", async () => {
+    setDefaultMock.mockResolvedValue("openedSettings");
+    render(<DefaultAppSection />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Set Glyph as default" }));
+
+    expect(setDefaultMock).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(
+        screen.getByText("Opened Default Apps settings. Choose Glyph for Markdown files."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows guidance when the platform has no programmatic path", async () => {
+    setDefaultMock.mockResolvedValue("guidance");
+    render(<DefaultAppSection />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Set Glyph as default" }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/right-click a Markdown file/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/components/modals/settings/DefaultAppSection.tsx
+++ b/src/components/modals/settings/DefaultAppSection.tsx
@@ -1,0 +1,44 @@
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { type DefaultAppOutcome, setDefaultMarkdownApp } from "@/lib/defaultApp";
+
+// The canonical place to (re)register Glyph as the default Markdown app, with a
+// per-platform result line (silent success on Linux, an opened settings page on
+// Windows, or manual guidance on macOS).
+export function DefaultAppSection() {
+  const { t } = useTranslation("settings");
+  const [outcome, setOutcome] = useState<DefaultAppOutcome | "busy" | null>(null);
+
+  const handleSet = useCallback(async () => {
+    setOutcome("busy");
+    setOutcome(await setDefaultMarkdownApp());
+  }, []);
+
+  return (
+    <div className="settings-section">
+      <div className="settings-section-title">{t("defaultApp.title")}</div>
+      <div className="settings-row">
+        <div>
+          <span className="settings-label">{t("defaultApp.label")}</span>
+          <div className="settings-description">{t("defaultApp.description")}</div>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="settings-reset-btn"
+        style={{ marginTop: 8 }}
+        onClick={handleSet}
+        disabled={outcome === "busy"}
+      >
+        {outcome === "busy" ? t("defaultApp.working") : t("defaultApp.button")}
+      </button>
+
+      {outcome && outcome !== "busy" && (
+        <div className="settings-description" style={{ marginTop: 8 }}>
+          {t(`defaultApp.outcome.${outcome}`)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useDefaultAppPrompt.test.tsx
+++ b/src/hooks/useDefaultAppPrompt.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDefaultAppPrompt } from "./useDefaultAppPrompt";
+
+const { useSettingsMock } = vi.hoisted(() => ({ useSettingsMock: vi.fn() }));
+vi.mock("@/hooks/useSettings", () => ({ useSettings: useSettingsMock }));
+
+const { isPrimaryWindowMock } = vi.hoisted(() => ({ isPrimaryWindowMock: vi.fn() }));
+vi.mock("@/lib/windowContext", () => ({ isPrimaryWindow: isPrimaryWindowMock }));
+
+const { setDefaultMock } = vi.hoisted(() => ({
+  setDefaultMock: vi.fn(() => Promise.resolve("openedSettings")),
+}));
+vi.mock("@/lib/defaultApp", () => ({ setDefaultMarkdownApp: setDefaultMock }));
+
+function setup(prompt: string, loaded = true, primary = true) {
+  const updateSettings = vi.fn();
+  useSettingsMock.mockReturnValue({
+    settings: { behavior: { defaultAppPrompt: prompt } },
+    updateSettings,
+    loaded,
+  });
+  isPrimaryWindowMock.mockReturnValue(primary);
+  const { result } = renderHook(() => useDefaultAppPrompt());
+  return { result, updateSettings };
+}
+
+describe("useDefaultAppPrompt", () => {
+  beforeEach(() => {
+    setDefaultMock.mockClear();
+  });
+
+  it("shows only when unanswered, loaded, and in the primary window", () => {
+    expect(setup("unanswered").result.current.show).toBe(true);
+    expect(setup("set").result.current.show).toBe(false);
+    expect(setup("notNow").result.current.show).toBe(false);
+    expect(setup("never").result.current.show).toBe(false);
+    expect(setup("unanswered", false).result.current.show).toBe(false);
+    expect(setup("unanswered", true, false).result.current.show).toBe(false);
+  });
+
+  it("records the answer and triggers registration on 'set default'", () => {
+    const { result, updateSettings } = setup("unanswered");
+    act(() => result.current.setDefault());
+    expect(updateSettings).toHaveBeenCalledWith("behavior.defaultAppPrompt", "set");
+    expect(setDefaultMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("records 'not now' and 'never' without registering", () => {
+    const notNow = setup("unanswered");
+    act(() => notNow.result.current.notNow());
+    expect(notNow.updateSettings).toHaveBeenCalledWith("behavior.defaultAppPrompt", "notNow");
+
+    const never = setup("unanswered");
+    act(() => never.result.current.never());
+    expect(never.updateSettings).toHaveBeenCalledWith("behavior.defaultAppPrompt", "never");
+
+    expect(setDefaultMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDefaultAppPrompt.ts
+++ b/src/hooks/useDefaultAppPrompt.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+import { useSettings } from "@/hooks/useSettings";
+import { setDefaultMarkdownApp } from "@/lib/defaultApp";
+import { isPrimaryWindow } from "@/lib/windowContext";
+
+/**
+ * Drives the one-time "make Glyph your default Markdown app?" banner. It shows
+ * once, only in the primary window and only while the stored answer is
+ * "unanswered", so any choice stops it from appearing again. The Settings action
+ * stays available regardless.
+ */
+export function useDefaultAppPrompt() {
+  const { settings, updateSettings, loaded } = useSettings();
+
+  const show = loaded && isPrimaryWindow() && settings.behavior.defaultAppPrompt === "unanswered";
+
+  const setDefault = useCallback(() => {
+    updateSettings("behavior.defaultAppPrompt", "set");
+    void setDefaultMarkdownApp();
+  }, [updateSettings]);
+
+  const notNow = useCallback(
+    () => updateSettings("behavior.defaultAppPrompt", "notNow"),
+    [updateSettings],
+  );
+
+  const never = useCallback(
+    () => updateSettings("behavior.defaultAppPrompt", "never"),
+    [updateSettings],
+  );
+
+  return { show, setDefault, notNow, never };
+}

--- a/src/lib/defaultApp.test.ts
+++ b/src/lib/defaultApp.test.ts
@@ -1,0 +1,22 @@
+import { invoke } from "@tauri-apps/api/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setDefaultMarkdownApp } from "./defaultApp";
+
+describe("setDefaultMarkdownApp", () => {
+  afterEach(() => {
+    vi.mocked(invoke).mockReset();
+  });
+
+  it("returns the backend outcome tag", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce("openedSettings");
+    expect(await setDefaultMarkdownApp()).toBe("openedSettings");
+    expect(invoke).toHaveBeenCalledWith("set_default_markdown_app");
+  });
+
+  it("resolves to 'error' and never throws when the command fails", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(invoke).mockRejectedValueOnce(new Error("boom"));
+    expect(await setDefaultMarkdownApp()).toBe("error");
+    errSpy.mockRestore();
+  });
+});

--- a/src/lib/defaultApp.ts
+++ b/src/lib/defaultApp.ts
@@ -1,0 +1,17 @@
+import { invoke } from "@tauri-apps/api/core";
+
+// What the backend did when asked to make Glyph the default Markdown app.
+// "registered" = set for us; "openedSettings" = OS Default Apps page opened;
+// "guidance" = no programmatic path, show manual steps; "error" = it failed.
+export type DefaultAppOutcome = "registered" | "openedSettings" | "guidance" | "error";
+
+/** Ask the backend to set (or guide the user to set) Glyph as the default
+ *  Markdown handler. Never rejects; a failure resolves to "error". */
+export async function setDefaultMarkdownApp(): Promise<DefaultAppOutcome> {
+  try {
+    return (await invoke<string>("set_default_markdown_app")) as DefaultAppOutcome;
+  } catch (err) {
+    console.error("Failed to set the default Markdown app:", err);
+    return "error";
+  }
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -99,7 +99,13 @@ export interface BehaviorSettings {
   // tabs). Used to restore which tab is selected on launch.
   activeTabPath: string;
   defaultEditorMode: EditorMode;
+  // Answer to the first-run "make Glyph your default Markdown app?" prompt.
+  // The prompt auto-shows only while "unanswered", so any other value stops it
+  // from nagging; the Settings action stays available regardless.
+  defaultAppPrompt: DefaultAppPrompt;
 }
+
+export type DefaultAppPrompt = "unanswered" | "notNow" | "never" | "set";
 
 export interface AISettings {
   provider: "none" | "claude" | "openai" | "ollama";
@@ -203,6 +209,7 @@ export const DEFAULT_SETTINGS: Settings = {
     openTabs: [],
     activeTabPath: "",
     defaultEditorMode: EDITOR_MODE.view,
+    defaultAppPrompt: "unanswered",
   },
   ai: {
     provider: "none",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -241,5 +241,12 @@
     "circular": "Zirkuläre Einbettung: {{target}}",
     "headingNotFound": "Überschrift nicht gefunden: {{heading}}",
     "error": "Eingebettete Notiz konnte nicht geladen werden: {{target}}"
+  },
+  "defaultAppBanner": {
+    "message": "Glyph als Standard-Markdown-App festlegen?",
+    "setDefault": "Als Standard festlegen",
+    "notNow": "Jetzt nicht",
+    "never": "Nie",
+    "dismiss": "Hinweis zur Standard-App schließen"
   }
 }

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -283,5 +283,18 @@
       "label": "Wikilinks",
       "description": "[[Notiz]]-Links im Arbeitsbereich auflösen"
     }
+  },
+  "defaultApp": {
+    "title": "Standard-App",
+    "label": "Standard-Markdown-App",
+    "description": "Markdown-Dateien standardmäßig in Glyph öffnen.",
+    "button": "Glyph als Standard festlegen",
+    "working": "Wird ausgeführt…",
+    "outcome": {
+      "registered": "Glyph ist jetzt deine Standard-Markdown-App.",
+      "openedSettings": "Einstellungen für Standard-Apps geöffnet. Wähle dort Glyph für Markdown-Dateien.",
+      "guidance": "Klicke im Finder mit der rechten Maustaste auf eine Markdown-Datei, wähle „Informationen“, stelle „Öffnen mit“ auf Glyph und klicke auf „Alle ändern“.",
+      "error": "Standard-App konnte nicht festgelegt werden. Lege sie stattdessen in den Systemeinstellungen fest."
+    }
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -241,5 +241,12 @@
     "circular": "Circular embed: {{target}}",
     "headingNotFound": "Heading not found: {{heading}}",
     "error": "Could not load embed: {{target}}"
+  },
+  "defaultAppBanner": {
+    "message": "Make Glyph your default Markdown app?",
+    "setDefault": "Set as default",
+    "notNow": "Not now",
+    "never": "Never",
+    "dismiss": "Dismiss default-app prompt"
   }
 }

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -283,5 +283,18 @@
       "label": "Wikilinks",
       "description": "Resolve [[note]] links against the workspace"
     }
+  },
+  "defaultApp": {
+    "title": "Default app",
+    "label": "Default Markdown app",
+    "description": "Open Markdown files in Glyph by default.",
+    "button": "Set Glyph as default",
+    "working": "Working…",
+    "outcome": {
+      "registered": "Glyph is now your default Markdown app.",
+      "openedSettings": "Opened Default Apps settings. Choose Glyph for Markdown files.",
+      "guidance": "In Finder, right-click a Markdown file, choose Get Info, set Open With to Glyph, then Change All.",
+      "error": "Couldn't set the default app. Set it from your system settings instead."
+    }
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -241,5 +241,12 @@
   },
   "headingAnchor": {
     "label": "Copiar enlace al encabezado"
+  },
+  "defaultAppBanner": {
+    "message": "¿Hacer de Glyph tu app de Markdown predeterminada?",
+    "setDefault": "Establecer como predeterminada",
+    "notNow": "Ahora no",
+    "never": "Nunca",
+    "dismiss": "Descartar aviso de app predeterminada"
   }
 }

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -283,5 +283,18 @@
       "label": "Wikienlaces",
       "description": "Resolver enlaces [[nota]] en el espacio de trabajo"
     }
+  },
+  "defaultApp": {
+    "title": "App predeterminada",
+    "label": "App de Markdown predeterminada",
+    "description": "Abrir archivos Markdown en Glyph de forma predeterminada.",
+    "button": "Establecer Glyph como predeterminada",
+    "working": "Procesando…",
+    "outcome": {
+      "registered": "Glyph ahora es tu app de Markdown predeterminada.",
+      "openedSettings": "Se abrió la configuración de Apps predeterminadas. Elige Glyph para los archivos Markdown.",
+      "guidance": "En el Finder, haz clic derecho en un archivo Markdown, elige Obtener información, ajusta Abrir con a Glyph y pulsa Cambiar todo.",
+      "error": "No se pudo establecer la app predeterminada. Configúrala desde los ajustes del sistema."
+    }
   }
 }

--- a/src/locales/fa/common.json
+++ b/src/locales/fa/common.json
@@ -241,5 +241,12 @@
     "circular": "ارجاع حلقه‌ای: {{target}}",
     "headingNotFound": "عنوان پیدا نشد: {{heading}}",
     "error": "بارگذاری محتوای جاسازی‌شده ممکن نشد: {{target}}"
+  },
+  "defaultAppBanner": {
+    "message": "Glyph برنامه پیش‌فرض Markdown شما شود؟",
+    "setDefault": "تنظیم به‌عنوان پیش‌فرض",
+    "notNow": "اکنون نه",
+    "never": "هرگز",
+    "dismiss": "بستن پیام برنامه پیش‌فرض"
   }
 }

--- a/src/locales/fa/settings.json
+++ b/src/locales/fa/settings.json
@@ -283,5 +283,18 @@
       "label": "ویکی‌لینک",
       "description": "حل پیوندهای [[یادداشت]] در فضای کاری"
     }
+  },
+  "defaultApp": {
+    "title": "برنامه پیش‌فرض",
+    "label": "برنامه پیش‌فرض Markdown",
+    "description": "پرونده‌های Markdown به‌طور پیش‌فرض در Glyph باز شوند.",
+    "button": "تنظیم Glyph به‌عنوان پیش‌فرض",
+    "working": "در حال انجام…",
+    "outcome": {
+      "registered": "Glyph اکنون برنامه پیش‌فرض Markdown شماست.",
+      "openedSettings": "تنظیمات برنامه‌های پیش‌فرض باز شد. Glyph را برای پرونده‌های Markdown انتخاب کنید.",
+      "guidance": "در Finder روی یک پرونده Markdown راست‌کلیک کنید، Get Info را انتخاب کنید، Open With را روی Glyph بگذارید و سپس Change All را بزنید.",
+      "error": "تنظیم برنامه پیش‌فرض ممکن نبود. آن را از تنظیمات سیستم انجام دهید."
+    }
   }
 }

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -241,5 +241,12 @@
   },
   "headingAnchor": {
     "label": "复制标题链接"
+  },
+  "defaultAppBanner": {
+    "message": "将 Glyph 设为你的默认 Markdown 应用？",
+    "setDefault": "设为默认",
+    "notNow": "以后再说",
+    "never": "不再提示",
+    "dismiss": "关闭默认应用提示"
   }
 }

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -283,5 +283,18 @@
       "label": "双链笔记",
       "description": "在工作区内解析 [[笔记]] 链接"
     }
+  },
+  "defaultApp": {
+    "title": "默认应用",
+    "label": "默认 Markdown 应用",
+    "description": "默认使用 Glyph 打开 Markdown 文件。",
+    "button": "将 Glyph 设为默认",
+    "working": "处理中…",
+    "outcome": {
+      "registered": "Glyph 现在是你的默认 Markdown 应用。",
+      "openedSettings": "已打开“默认应用”设置。请为 Markdown 文件选择 Glyph。",
+      "guidance": "在访达中右键点击 Markdown 文件，选择“显示简介”，将“打开方式”设为 Glyph，然后点击“全部更改”。",
+      "error": "无法设置默认应用。请从系统设置中进行设置。"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Glyph declares `fileAssociations` for `.md`/`.markdown`/etc., but there was no in-app way to actually become the OS default handler, so markdown files fall back to whatever else claims them (e.g. VS Code). This adds an explicit "set Glyph as default" flow: a one-time first-run nudge and a Settings action.

## Changes

- **`set_default_markdown_app` command** (`src-tauri/src/commands/default_app.rs`): per-platform, returning a tag the UI maps to a message.
  - **Linux**: registers silently via `xdg-mime default com.hamidfzm.glyph.desktop text/markdown` → `"registered"`.
  - **Windows**: opens the Default Apps settings page (`ms-settings:defaultapps`) since Win10+ blocks silent handler changes → `"openedSettings"`.
  - **macOS**: returns `"guidance"`; the UI shows the manual Get Info → Open With steps.
- **First-run banner** (`DefaultAppBanner` + `useDefaultAppPrompt`): "Set as default / Not now / Never", shown once in the primary window while `behavior.defaultAppPrompt === "unanswered"`, then remembered so it never nags again.
- **Settings → Behavior row** (`DefaultAppSection`): a button plus a per-platform result line.
- Strings added to all five locales (`settings.defaultApp`, `common.defaultAppBanner`).

## Scope notes

- Meets all four acceptance criteria (first-run prompt, settings status + button, registration on supported platforms, Win deep-link).
- **Deferred** (not in the acceptance criteria): a live "Glyph is / isn't the default" status readout (needs per-OS registry / LaunchServices / xdg queries) and the optional menu entry. Called out for a follow-up.
- The OS-registration step itself can't be exercised in jsdom; the wiring and outcome mapping are unit-tested, but the actual association needs a manual pass on an **installed** build (dev builds don't register file associations).

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- New tests: the invoke wrapper (incl. error path), the prompt hook (show-gating + answer/registration), and the settings section (invoke + outcome message).
- Full gate green: `pnpm typecheck && pnpm check && pnpm test` (2484 tests), `cargo clippy -D warnings` (359 Rust tests).

Closes #191