### PR TITLE
feat(markdown): render svg <image> icons with http(s) hrefs

### DIFF
--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -29,7 +29,7 @@ Review the current diff (`git diff` + `git diff --cached`, or `git diff origin/m
 
 5. **Right altitude.** Fix the mechanism, not a symptom: a special case layered on shared infrastructure means the fix is too shallow. Prefer gating/configuring the underlying seam once over sprinkling checks at call sites.
 
-6. **Tests assert the surface that exists.** Cover the branches the diff adds (Codecov patch must stay green), but do not write tests for capabilities the code no longer has.
+6. **Tests assert the surface that exists.** Cover the branches the diff adds (Codecov patch must stay green), but do not write tests for capabilities the code no longer has. Asserting the absence of an attribute the component never emits is vacuous (an `xlink:href`-is-null assertion on a component that only ever renders `href` passes with sanitization deleted); assert the observable the guard actually controls.
 
 ## Procedure
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -317,6 +317,13 @@ You can also embed SVG straight into the markdown. It renders inline from a sani
   <text x="190" y="68" text-anchor="middle" font-family="sans-serif" font-size="24" font-weight="700" fill="#ffffff">Inline SVG</text>
 </svg>
 
+Inline SVG can also embed raster or vector icons through `<image>`. A workspace-relative `href` resolves against this file's folder (through the asset protocol), and `http(s)` URLs load directly; every other scheme is dropped by the sanitiser.
+
+<svg viewBox="0 0 160 80" width="160" height="80" role="img" aria-label="Inline SVG with embedded image icons">
+  <image href="./diagram.svg" x="0" y="0" width="72" height="72" preserveAspectRatio="xMidYMid meet" />
+  <image href="https://raw.githubusercontent.com/hamidfzm/glyph/main/src-tauri/icons/128x128.png" x="88" y="8" width="56" height="56" preserveAspectRatio="xMidYMid meet" />
+</svg>
+
 ## Links
 
 - [Glyph on GitHub](https://github.com/hamidfzm/glyph) — External links open in your system browser

--- a/src/components/markdown/ImageComponent.tsx
+++ b/src/components/markdown/ImageComponent.tsx
@@ -1,5 +1,6 @@
-import { type ComponentPropsWithoutRef, useCallback } from "react";
+import { type ComponentPropsWithoutRef, type SVGProps, useCallback } from "react";
 import { MarkdownImage } from "./MarkdownImage";
+import { SvgImage } from "./SvgImage";
 
 // Binds the document's file path into the `img` component ReactMarkdown
 // renders, so relative image paths resolve against the right directory. The
@@ -7,6 +8,13 @@ import { MarkdownImage } from "./MarkdownImage";
 export function useImageComponent(filePath: string | undefined) {
   return useCallback(
     (props: ComponentPropsWithoutRef<"img">) => <MarkdownImage {...props} filePath={filePath} />,
+    [filePath],
+  );
+}
+
+export function useSvgImageComponent(filePath: string | undefined) {
+  return useCallback(
+    (props: SVGProps<SVGImageElement>) => <SvgImage {...props} filePath={filePath} />,
     [filePath],
   );
 }

--- a/src/components/markdown/MarkdownContent.tsx
+++ b/src/components/markdown/MarkdownContent.tsx
@@ -14,7 +14,7 @@ import { resolveWorkspacePath } from "@/lib/relativePath";
 import { CodeBlockComponent } from "./CodeBlockComponent";
 import { EmbedComponent } from "./EmbedComponent";
 import { FrontmatterBlock } from "./FrontmatterBlock";
-import { useImageComponent } from "./ImageComponent";
+import { useImageComponent, useSvgImageComponent } from "./ImageComponent";
 import { LinkComponent, type LinkComponentProps } from "./LinkComponent";
 import { MarkdownHeading } from "./MarkdownHeading";
 import { TaskListItem } from "./TaskListItem";
@@ -83,6 +83,7 @@ export function MarkdownContent({
   );
 
   const ImageComponent = useImageComponent(filePath);
+  const SvgImageComponent = useSvgImageComponent(filePath);
 
   // Resolve a relative link against this document's directory and open it only
   // when it stays inside the opened workspace. Gating on workspaceRoot keeps
@@ -136,6 +137,7 @@ export function MarkdownContent({
           components={{
             a: LinkWithWikilink,
             img: ImageComponent,
+            image: SvgImageComponent,
             pre: CodeBlockComponent,
             li: TaskListLi,
             div: DivComponent,

--- a/src/components/markdown/MarkdownViewer.test.tsx
+++ b/src/components/markdown/MarkdownViewer.test.tsx
@@ -35,25 +35,46 @@ describe("MarkdownViewer raw HTML", () => {
     const image = container.querySelector("svg image");
     expect(image?.getAttribute("href")).toBe("https://icons.example.com/aws/s3.svg");
     expect(image?.getAttribute("width")).toBe("24");
+    expect(image?.getAttribute("node")).toBeNull();
   });
 
-  it("renders svg <image> via the legacy xlink:href spelling", () => {
+  it("normalizes the legacy xlink:href spelling to href", () => {
     const { container } = renderMd('<svg><image xlink:href="https://x.test/i.png"/></svg>');
+    expect(container.querySelector("svg image")?.getAttribute("href")).toBe("https://x.test/i.png");
+  });
+
+  it("resolves workspace-relative svg <image> hrefs through the asset protocol", () => {
+    const { container } = renderMd('<svg><image href="assets/icon.png" width="24"/></svg>', {
+      filePath: "/ws/doc.md",
+    });
     const image = container.querySelector("svg image");
-    expect(
-      image?.getAttribute("xlink:href") ??
-        image?.getAttributeNS("http://www.w3.org/1999/xlink", "href"),
-    ).toBe("https://x.test/i.png");
+    expect(image?.getAttribute("href")).toBe("asset://localhost//ws/assets/icon.png");
   });
 
   it("strips non-http(s) hrefs from svg <image> but keeps the element", () => {
-    const { container } = renderMd(
-      '<svg><image href="javascript:alert(1)" xlink:href="data:text/html,x" width="24"/></svg>',
-    );
+    const { container } = renderMd('<svg><image href="javascript:alert(1)" width="24"/></svg>');
     const image = container.querySelector("svg image");
     expect(image).not.toBeNull();
     expect(image?.getAttribute("href")).toBeNull();
-    expect(image?.getAttribute("xlink:href")).toBeNull();
+  });
+
+  it("strips a data: xlink:href on its own", () => {
+    const { container } = renderMd('<svg><image xlink:href="data:text/html,x"/></svg>');
+    const image = container.querySelector("svg image");
+    expect(image).not.toBeNull();
+    expect(image?.getAttribute("href")).toBeNull();
+  });
+
+  it("drops anchor-only schemes that pass the shared href protocol list", () => {
+    const { container } = renderMd('<svg><image href="mailto:a@b.test"/></svg>', {
+      filePath: "/ws/doc.md",
+    });
+    expect(container.querySelector("svg image")?.getAttribute("href")).toBeNull();
+  });
+
+  it("falls back to xlink:href when href is empty", () => {
+    const { container } = renderMd('<svg><image href="" xlink:href="https://x.test/i.png"/></svg>');
+    expect(container.querySelector("svg image")?.getAttribute("href")).toBe("https://x.test/i.png");
   });
 
   it("keeps <use> and <foreignObject> out of inline SVG", () => {
@@ -62,6 +83,8 @@ describe("MarkdownViewer raw HTML", () => {
     );
     expect(container.querySelector("use")).toBeNull();
     expect(container.querySelector("foreignObject, foreignobject")).toBeNull();
+    // foreignObject is stripped with its children, not unwrapped into the svg.
+    expect(container.querySelector("svg")?.textContent).not.toContain("x");
     expect(container.querySelector("svg image")).not.toBeNull();
   });
 

--- a/src/components/markdown/MarkdownViewer.test.tsx
+++ b/src/components/markdown/MarkdownViewer.test.tsx
@@ -28,6 +28,43 @@ describe("MarkdownViewer raw HTML", () => {
     expect(container.querySelector("summary")?.textContent).toBe("More");
   });
 
+  it("renders svg <image> icons with http(s) hrefs", () => {
+    const { container } = renderMd(
+      '<svg viewBox="0 0 24 24"><image href="https://icons.example.com/aws/s3.svg" width="24" height="24"/></svg>',
+    );
+    const image = container.querySelector("svg image");
+    expect(image?.getAttribute("href")).toBe("https://icons.example.com/aws/s3.svg");
+    expect(image?.getAttribute("width")).toBe("24");
+  });
+
+  it("renders svg <image> via the legacy xlink:href spelling", () => {
+    const { container } = renderMd('<svg><image xlink:href="https://x.test/i.png"/></svg>');
+    const image = container.querySelector("svg image");
+    expect(
+      image?.getAttribute("xlink:href") ??
+        image?.getAttributeNS("http://www.w3.org/1999/xlink", "href"),
+    ).toBe("https://x.test/i.png");
+  });
+
+  it("strips non-http(s) hrefs from svg <image> but keeps the element", () => {
+    const { container } = renderMd(
+      '<svg><image href="javascript:alert(1)" xlink:href="data:text/html,x" width="24"/></svg>',
+    );
+    const image = container.querySelector("svg image");
+    expect(image).not.toBeNull();
+    expect(image?.getAttribute("href")).toBeNull();
+    expect(image?.getAttribute("xlink:href")).toBeNull();
+  });
+
+  it("keeps <use> and <foreignObject> out of inline SVG", () => {
+    const { container } = renderMd(
+      '<svg><use href="https://x.test/s.svg#i"/><foreignObject><b>x</b></foreignObject><image href="https://x.test/i.png"/></svg>',
+    );
+    expect(container.querySelector("use")).toBeNull();
+    expect(container.querySelector("foreignObject, foreignobject")).toBeNull();
+    expect(container.querySelector("svg image")).not.toBeNull();
+  });
+
   it("strips <script> tags from raw HTML", () => {
     const { container } = renderMd("ok <script>alert('xss')</script> done");
     expect(container.querySelector("script")).toBeNull();

--- a/src/components/markdown/SvgImage.tsx
+++ b/src/components/markdown/SvgImage.tsx
@@ -1,0 +1,24 @@
+import type { SVGProps } from "react";
+import { useWorkspaceRoot } from "@/contexts/TabsContext";
+import { resolveImageSrc } from "./resolveImageSrc";
+
+interface SvgImageProps extends SVGProps<SVGImageElement> {
+  filePath: string | undefined;
+  node?: unknown;
+}
+
+// An inline-SVG <image> with its href resolved like a markdown image, so
+// workspace-relative icon paths load through the asset protocol.
+export function SvgImage({ filePath, href, xlinkHref, node: _node, ...rest }: SvgImageProps) {
+  const workspaceRoot = useWorkspaceRoot();
+  // || not ??: some SVG tooling writes href="" beside a valid xlink:href.
+  const candidate = href || xlinkHref;
+  // The sanitizer's shared href protocol list admits anchor schemes (mailto:,
+  // irc:); only http(s) or scheme-less relative paths are images.
+  const nonHttpScheme =
+    typeof candidate === "string" &&
+    /^[a-z][a-z0-9+.-]*:/i.test(candidate) &&
+    !/^https?:/i.test(candidate);
+  const resolved = nonHttpScheme ? undefined : resolveImageSrc(candidate, filePath, workspaceRoot);
+  return <image href={resolved} {...rest} />;
+}

--- a/src/components/markdown/sanitizeSchema.ts
+++ b/src/components/markdown/sanitizeSchema.ts
@@ -150,7 +150,9 @@ export const markdownSanitizeSchema = {
   clobber: [],
   // Disallowed elements are unwrapped by default; foreignObject carries
   // arbitrary HTML children that must not leak into the svg as stray DOM.
-  strip: [...(defaultSchema.strip ?? []), "foreignObject"],
+  // rehype's default strip is the static ["script"], listed inline (like `div`
+  // below) so there's no dead `?? []` fallback branch.
+  strip: ["script", "foreignObject"],
   tagNames: [
     ...(defaultSchema.tagNames ?? []),
     "kbd",

--- a/src/components/markdown/sanitizeSchema.ts
+++ b/src/components/markdown/sanitizeSchema.ts
@@ -3,8 +3,8 @@ import { defaultSchema } from "rehype-sanitize";
 // Inline SVG drawing primitives that are safe to render from markdown. We keep
 // out anything that can smuggle behaviour: <foreignObject> (arbitrary HTML),
 // <script>, <style> (CSS injection), <a>/<use href> (external refs), and
-// <animate>/<set> (attribute injection). <image> is allowed with http(s)-only
-// hrefs, matching the remote-image policy for plain markdown (#460).
+// <animate>/<set> (attribute injection). <image> is allowed; SvgImage drops
+// every scheme except http(s) before resolving relative paths (#460).
 const svgTagNames = [
   "svg",
   "g",
@@ -121,7 +121,7 @@ const svgAttributes: Record<string, string[]> = {
   ],
   symbol: ["viewBox", "preserveAspectRatio", ...svgCommonAttributes],
   clipPath: ["clipPathUnits", ...svgCommonAttributes],
-  image: ["href", "xLinkHref", "preserveAspectRatio", "crossOrigin", ...svgCommonAttributes],
+  image: ["href", "xLinkHref", "preserveAspectRatio", ...svgCommonAttributes],
 };
 
 // Allowlist for raw HTML in markdown. Glyph is a local-file viewer so the
@@ -148,6 +148,9 @@ export const markdownSanitizeSchema = {
   // Glyph is a local viewer with no host-page collisions to worry about.
   clobberPrefix: "",
   clobber: [],
+  // Disallowed elements are unwrapped by default; foreignObject carries
+  // arbitrary HTML children that must not leak into the svg as stray DOM.
+  strip: [...(defaultSchema.strip ?? []), "foreignObject"],
   tagNames: [
     ...(defaultSchema.tagNames ?? []),
     "kbd",

--- a/src/components/markdown/sanitizeSchema.ts
+++ b/src/components/markdown/sanitizeSchema.ts
@@ -1,10 +1,10 @@
 import { defaultSchema } from "rehype-sanitize";
 
 // Inline SVG drawing primitives that are safe to render from markdown. We keep
-// out anything that can smuggle behaviour or external content: <foreignObject>
-// (arbitrary HTML), <script>, <style> (CSS injection), <a>/<use href>/<image
-// href> (external refs), and <animate>/<set> (attribute injection). What's left
-// is static, self-contained geometry.
+// out anything that can smuggle behaviour: <foreignObject> (arbitrary HTML),
+// <script>, <style> (CSS injection), <a>/<use href> (external refs), and
+// <animate>/<set> (attribute injection). <image> is allowed with http(s)-only
+// hrefs, matching the remote-image policy for plain markdown (#460).
 const svgTagNames = [
   "svg",
   "g",
@@ -26,6 +26,7 @@ const svgTagNames = [
   "marker",
   "symbol",
   "clipPath",
+  "image",
 ];
 
 // Geometry + paint attributes shared by the SVG elements above. hast-util-sanitize
@@ -120,6 +121,7 @@ const svgAttributes: Record<string, string[]> = {
   ],
   symbol: ["viewBox", "preserveAspectRatio", ...svgCommonAttributes],
   clipPath: ["clipPathUnits", ...svgCommonAttributes],
+  image: ["href", "xLinkHref", "preserveAspectRatio", "crossOrigin", ...svgCommonAttributes],
 };
 
 // Allowlist for raw HTML in markdown. Glyph is a local-file viewer so the
@@ -133,6 +135,11 @@ const svgAttributes: Record<string, string[]> = {
 // content this needs to be revisited.
 export const markdownSanitizeSchema = {
   ...defaultSchema,
+  // xlink:href needs its own protocol entry or it would bypass URL filtering.
+  protocols: {
+    ...defaultSchema.protocols,
+    xLinkHref: ["http", "https"],
+  },
   // Disable id/name namespacing. The default schema rewrites these by
   // prepending `user-content-`, but remark-gfm v4 already emits footnote
   // ids with that prefix (`user-content-fn-1`). The double-prefix breaks

--- a/src/lib/export/prepareContent.test.ts
+++ b/src/lib/export/prepareContent.test.ts
@@ -304,6 +304,20 @@ describe("prepareContent", () => {
     expect(html).not.toContain("https://example.com/pic.png");
   });
 
+  it("inlines svg <image> hrefs as data URIs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        blob: async () => new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" }),
+      })),
+    );
+    setBody(`<svg><image href="asset://localhost/ws/icon.png"></image></svg>`);
+    const html = await prepareHtml();
+    expect(html).toContain('href="data:image/png;base64,');
+    expect(html).not.toContain("asset://localhost");
+  });
+
   it("leaves the original src when the fetch is not ok", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/lib/export/prepareContent.ts
+++ b/src/lib/export/prepareContent.ts
@@ -144,18 +144,18 @@ function blobToDataUrl(blob: Blob): Promise<string> {
   });
 }
 
-// Inline an <img> as a base64 data URI so the export is portable and offline.
-// Already-inlined (data:) images are left alone; a fetch failure leaves the
-// original src untouched rather than dropping the image.
-async function embedImage(img: HTMLImageElement): Promise<void> {
-  const src = img.getAttribute("src");
-  if (!src || src.startsWith("data:")) return;
+// Inline an image asset as a base64 data URI so the export is portable and
+// offline. Already-inlined (data:) values are left alone; a fetch failure
+// leaves the original untouched rather than dropping the image.
+async function embedAsset(el: Element, attr: "src" | "href"): Promise<void> {
+  const value = el.getAttribute(attr);
+  if (!value || value.startsWith("data:")) return;
   try {
-    const res = await fetch(src);
+    const res = await fetch(value);
     if (!res.ok) return;
-    img.setAttribute("src", await blobToDataUrl(await res.blob()));
+    el.setAttribute(attr, await blobToDataUrl(await res.blob()));
   } catch {
-    // Leave the original src; the reader may still resolve it.
+    // Leave the original; the reader may still resolve it.
   }
 }
 
@@ -207,7 +207,12 @@ export async function prepareContent({
     }
   }
 
-  await Promise.all(Array.from(clone.querySelectorAll("img")).map(embedImage));
+  await Promise.all([
+    ...Array.from(clone.querySelectorAll("img")).map((el) => embedAsset(el, "src")),
+    // SVG <image> icons carry asset: URLs from the live DOM; inline them too
+    // or exported files leak absolute local paths that resolve nowhere.
+    ...Array.from(clone.querySelectorAll("image")).map((el) => embedAsset(el, "href")),
+  ]);
 
   if (includeToc && entries.length > 0) {
     clone.insertBefore(buildTocElement(entries), clone.firstChild);

--- a/src/lib/export/site/rewriteUrls.test.ts
+++ b/src/lib/export/site/rewriteUrls.test.ts
@@ -123,6 +123,13 @@ describe("rehypeSiteUrls images", () => {
     expect(ctx.assets.get("/ws/guide/img/shot.png")).toBe("guide/img/shot.png");
   });
 
+  it("rewrites svg <image> hrefs and records the asset copy", async () => {
+    const ctx = makeCtx("/ws/guide/intro.md", "guide/intro.html");
+    const html = await render('<svg><image href="./img/icon.png"/></svg>', ctx);
+    expect(html).toContain('href="img/icon.png"');
+    expect(ctx.assets.get("/ws/guide/img/icon.png")).toBe("guide/img/icon.png");
+  });
+
   it("sends out-of-workspace images to assets/ and dedupes name collisions", async () => {
     const ctx = makeCtx("/ws/other.md", "other.html");
     ctx.assets.set("/elsewhere/pic.png", "assets/pic.png");

--- a/src/lib/export/site/rewriteUrls.ts
+++ b/src/lib/export/site/rewriteUrls.ts
@@ -93,11 +93,26 @@ function rewriteAnchor(ctx: SiteUrlContext, props: Record<string, unknown>): voi
 }
 
 function rewriteImage(ctx: SiteUrlContext, props: Record<string, unknown>): void {
-  const src = props.src;
-  if (typeof src !== "string" || !isRelativeLocalHref(src)) return;
-  const abs = normalizeRelativePath(ctx.filePath, decodeHref(src));
+  rewriteAssetRef(ctx, props, "src");
+}
+
+// Inline-SVG <image> icons: rewrite both href spellings and register the
+// referenced files so the exporter copies them into the site tree.
+function rewriteSvgImage(ctx: SiteUrlContext, props: Record<string, unknown>): void {
+  rewriteAssetRef(ctx, props, "href");
+  rewriteAssetRef(ctx, props, "xLinkHref");
+}
+
+function rewriteAssetRef(
+  ctx: SiteUrlContext,
+  props: Record<string, unknown>,
+  key: "src" | "href" | "xLinkHref",
+): void {
+  const value = props[key];
+  if (typeof value !== "string" || !isRelativeLocalHref(value)) return;
+  const abs = normalizeRelativePath(ctx.filePath, decodeHref(value));
   const dest = assetDestination(ctx, abs);
-  props.src = encodeHref(relativeHref(ctx.pageRel, dest));
+  props[key] = encodeHref(relativeHref(ctx.pageRel, dest));
 }
 
 // A unified attacher: use as `[rehypeSiteUrls, ctx]` so unified invokes it
@@ -109,6 +124,7 @@ export function rehypeSiteUrls(ctx: SiteUrlContext) {
       if (!props) return;
       if (node.tagName === "a") rewriteAnchor(ctx, props);
       else if (node.tagName === "img") rewriteImage(ctx, props);
+      else if (node.tagName === "image") rewriteSvgImage(ctx, props);
     });
   };
 }


### PR DESCRIPTION
## Summary

Inline SVG diagrams that embed icons (AWS architecture icons, D2 icon links) lost their `<image>` elements to the markdown sanitizer, and workspace-relative icon paths had no way to load. This allows `<image>` end to end: sanitizer, in-app rendering (remote and workspace-relative hrefs), and every export path.

## Changes

- **Sanitizer**: `<image>` joins the inline-SVG allowlist with geometry attributes plus `href`/`xlink:href`; `xLinkHref` gets an explicit `http/https` protocols entry (without one it would bypass URL filtering entirely). `<foreignObject>` is now stripped **with its children** instead of unwrapped, so its HTML can't leak into the svg as stray searchable DOM. `<script>`, `<style>`, `<use>`, and animation elements stay out.
- **Rendering** (`SvgImage`, own file): resolves hrefs exactly like markdown images — http(s) passes through, workspace-relative paths resolve through the asset protocol and are clamped to the workspace. Falls back to `xlink:href` when `href` is empty, normalizes to modern `href`, strips react-markdown's `node` prop, and drops anchor-only schemes (`mailto:`, `irc:`) that survive the shared href protocol list rather than resolving them as file paths.
- **Exports** (per the frontend rule that rendering changes cover every export path):
  - HTML/EPUB/PDF: `prepareContent` inlines svg `<image>` hrefs as data URIs — exported files no longer carry `asset://localhost/<absolute local path>` URLs (which were both broken outside the app and a local-path leak).
  - Website export: the URL rewriter handles `image` elements (both href spellings), registering referenced files so they're copied into the site tree.
- Reviewed via self-review + an eight-angle code-review pass; the vacuous xlink assertion it caught was replaced with real single-attribute strip tests, and the self-review skill gained that rule.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- Tests: https href renders, xlink:href normalizes to href, empty-href fallback, javascript:/data:/mailto: dropped, foreignObject stripped with children, workspace-relative resolution, site-export rewrite + asset registration, prepareContent inlining. Full gate green (2580 tests, typecheck, Biome).

Closes #460