### PR TITLE
fix(export): pin the site nav and outline below the sticky header

### DIFF
--- a/src/lib/export/site/themes.test.ts
+++ b/src/lib/export/site/themes.test.ts
@@ -12,6 +12,15 @@ describe("builtin site themes", () => {
     expect(github.css).toContain("var(--color-accent, #0969da)");
   });
 
+  it("pins the nav and outline below the sticky header", () => {
+    const github = resolveSiteTheme("github");
+    // The base layout sticks the columns at 1rem; the theme's opaque header
+    // would cover their top rows without a matching offset.
+    expect(github.css).toContain(
+      ".glyph-site-nav, .glyph-site-outline { top: 4rem; max-height: calc(100vh - 5rem); }",
+    );
+  });
+
   it("keeps the pre-theme look available as plain", () => {
     expect(resolveSiteTheme("plain").css).toBe("");
   });

--- a/src/lib/export/site/themes.ts
+++ b/src/lib/export/site/themes.ts
@@ -24,7 +24,6 @@ body { padding: 0 0 4rem; }
 }
 .glyph-site-header a:hover { color: var(--color-accent, #0969da); }
 .glyph-site { padding: 0 1.5rem; }
-/* The header is sticky and opaque; pin the columns below it, not under it. */
 .glyph-site-nav, .glyph-site-outline { top: 4rem; max-height: calc(100vh - 5rem); }
 #glyph-theme-toggle { top: 0.55rem; right: 1rem; width: 2rem; height: 2rem; box-shadow: none; z-index: 200; }
 .glyph-site-nav { font-size: 0.875rem; padding-right: 0.5rem; }

--- a/src/lib/export/site/themes.ts
+++ b/src/lib/export/site/themes.ts
@@ -24,6 +24,8 @@ body { padding: 0 0 4rem; }
 }
 .glyph-site-header a:hover { color: var(--color-accent, #0969da); }
 .glyph-site { padding: 0 1.5rem; }
+/* The header is sticky and opaque; pin the columns below it, not under it. */
+.glyph-site-nav, .glyph-site-outline { top: 4rem; max-height: calc(100vh - 5rem); }
 #glyph-theme-toggle { top: 0.55rem; right: 1rem; width: 2rem; height: 2rem; box-shadow: none; z-index: 200; }
 .glyph-site-nav { font-size: 0.875rem; padding-right: 0.5rem; }
 .glyph-site-nav ul { padding-left: 0.5rem; }


### PR DESCRIPTION
## Summary

On websites exported with the default "github" theme, the file nav and the "On this page" outline scrolled partially underneath the sticky site header: the header is sticky at the viewport top with an opaque background and `z-index: 100`, while the base layout pins both columns at `top: 1rem`, so their first rows disappeared behind the header bar as soon as the page scrolled.

The theme now offsets both sticky columns to clear the header (`top: 4rem`, with a matching `max-height`), so the nav and outline stay fully visible while only the content column scrolls. The plain theme is unaffected (it has no sticky header).

Closes #473

## Changes

- `src/lib/export/site/themes.ts`: the github theme pins `.glyph-site-nav` and `.glyph-site-outline` at `top: 4rem` with `max-height: calc(100vh - 5rem)`
- `src/lib/export/site/themes.test.ts`: regression test for the offset

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

Reproduced against a real Windows export: the exported style.css pins both columns at 1rem while the sticky header is ~50px tall, hiding their top rows on scroll. The 4rem offset clears the measured header height. Regression test added; export suite green (115 tests), plus typecheck and Biome.

## Screenshots

Before: the top rows of both columns slide under the header when scrolling (see #473).
