### PR TITLE
chore(ci): extract the Linux webkit deps install into a composite action

### DIFF
--- a/.github/actions/linux-deps/action.yml
+++ b/.github/actions/linux-deps/action.yml
@@ -1,0 +1,27 @@
+name: Install Linux dependencies
+description: Cache and install the webkit apt packages Tauri needs on Linux runners
+inputs:
+  cache-key:
+    description: Key for the apt .deb cache
+    required: true
+  extra-packages:
+    description: Extra apt packages appended to the base webkit list
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Cache apt packages
+      uses: actions/cache@v5
+      with:
+        path: ~/apt-cache/*.deb
+        key: ${{ inputs.cache-key }}
+    - name: Install apt packages
+      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        mkdir -p ~/apt-cache/partial
+        sudo apt-get update
+        sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
+          -o Binary::apt::APT::Keep-Downloaded-Packages=true \
+          install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf ${{ inputs.extra-packages }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -48,23 +48,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ github.event_name == 'pull_request' && matrix.targets_pr || matrix.targets_full }}
-      - name: Cache apt packages
-        if: startsWith(matrix.platform, 'ubuntu')
-        uses: actions/cache@v5
-        with:
-          path: ~/apt-cache/*.deb
-          key: apt-webkit-${{ matrix.platform }}-v1
       - name: Install Linux dependencies
         if: startsWith(matrix.platform, 'ubuntu')
         timeout-minutes: 8
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          mkdir -p ~/apt-cache/partial
-          sudo apt-get update
-          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
-            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
-            install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils xvfb
+        uses: ./.github/actions/linux-deps
+        with:
+          cache-key: apt-webkit-${{ matrix.platform }}-v1
+          extra-packages: xdg-utils xvfb
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -58,21 +58,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: ~/apt-cache/*.deb
-          key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
       - name: Install Linux dependencies
         timeout-minutes: 8
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          mkdir -p ~/apt-cache/partial
-          sudo apt-get update
-          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
-            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
-            install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        uses: ./.github/actions/linux-deps
+        with:
+          cache-key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install cargo-nextest
@@ -114,21 +104,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: ~/apt-cache/*.deb
-          key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
       - name: Install Linux dependencies
         timeout-minutes: 8
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          mkdir -p ~/apt-cache/partial
-          sudo apt-get update
-          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
-            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
-            install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        uses: ./.github/actions/linux-deps
+        with:
+          cache-key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
       - name: Add Clippy problem matcher
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Run Clippy

--- a/.github/workflows/dependabot-tauri-npm-sync.yml
+++ b/.github/workflows/dependabot-tauri-npm-sync.yml
@@ -51,25 +51,11 @@ jobs:
           node-version-file: ".nvmrc"
           cache: pnpm
 
-      - name: Cache apt packages
-        uses: actions/cache@v5
-        with:
-          path: ~/apt-cache/*.deb
-          key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
       - name: Install Linux Tauri build deps
         timeout-minutes: 8
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          mkdir -p ~/apt-cache/partial
-          sudo apt-get update
-          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
-            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
-            install -y \
-            libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf
+        uses: ./.github/actions/linux-deps
+        with:
+          cache-key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,23 +35,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
-      - name: Cache apt packages
-        if: startsWith(matrix.platform, 'ubuntu')
-        uses: actions/cache@v5
-        with:
-          path: ~/apt-cache/*.deb
-          key: apt-webkit-${{ matrix.platform }}-v1
       - name: Install Linux dependencies
         if: startsWith(matrix.platform, 'ubuntu')
         timeout-minutes: 8
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          mkdir -p ~/apt-cache/partial
-          sudo apt-get update
-          sudo apt-get -o Dir::Cache::archives="$HOME/apt-cache" \
-            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
-            install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+        uses: ./.github/actions/linux-deps
+        with:
+          cache-key: apt-webkit-${{ matrix.platform }}-v1
+          extra-packages: xdg-utils
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri


### PR DESCRIPTION
## Summary

Extracts the apt cache + webkit dependency install block, previously copy-pasted across five job sites, into a local composite action (`.github/actions/linux-deps`). Pure refactor: package lists, cache keys, platform guards, and the 8-minute timeout are preserved exactly per site.

## Changes

- New composite action `.github/actions/linux-deps/action.yml` with inputs `cache-key` (required) and `extra-packages`
- `ci-tests.yml` (test-rust, clippy): use the action with `apt-webkit-ubuntu-latest-${{ runner.arch }}-v1`, base packages
- `ci-build.yml`: use the action with `apt-webkit-${{ matrix.platform }}-v1` and `extra-packages: xdg-utils xvfb`
- `release.yml`: use the action with `apt-webkit-${{ matrix.platform }}-v1` and `extra-packages: xdg-utils`
- `dependabot-tauri-npm-sync.yml`: use the action with the base package set
- `timeout-minutes: 8` moved to the caller `uses:` step (composite inner steps cannot set timeouts; the step-level timeout is enforced against the whole composite step)

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux

CI-only change; the Linux jobs on this PR exercise the new action directly. YAML validated locally. Job names are unchanged, so the pinned required-check contexts are unaffected.

Note: the Dependabot sync workflow checks out `inputs.branch`, so Dependabot branches cut before this merges will not contain the action until rebased; branches cut afterwards are unaffected.
