### PR TITLE
fix(settings): flush pending settings writes during window and app shutdown

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -61,6 +61,7 @@ function withProviders(overrides: Partial<SettingsContextValue> = {}) {
     settings: DEFAULT_SETTINGS,
     updateSettings: vi.fn(),
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
     ...overrides,
   };

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { useTabsContext } from "@/contexts/TabsContext";
 import { useAIController } from "@/hooks/useAIController";
 import { useAutoSave } from "@/hooks/useAutoSave";
 import { useCliExport } from "@/hooks/useCliExport";
+import { useCloseFlush } from "@/hooks/useCloseFlush";
 import { useCommandPaletteController } from "@/hooks/useCommandPaletteController";
 import { useContextMenu } from "@/hooks/useContextMenu";
 import { useDefaultAppPrompt } from "@/hooks/useDefaultAppPrompt";
@@ -122,9 +123,9 @@ export function AppShell() {
   );
   useAutoSave({ documents: dirtyDocuments, save: saveDocument });
 
-  // Intercept native window close / app exit: flush every dirty tab (and
-  // confirm on failure) before the window is allowed to close.
-  useWindowClose(flushForClose);
+  // Intercept native window close / app exit: flush pending settings and every
+  // dirty tab (confirming on failure) before the window is allowed to close.
+  useWindowClose(useCloseFlush(flushForClose));
 
   const aiController = useAIController(
     settings.ai,

--- a/src/components/ai/AIChatPanel.test.tsx
+++ b/src/components/ai/AIChatPanel.test.tsx
@@ -36,7 +36,13 @@ describe("AIChatPanel", () => {
     const updateSettings = vi.fn();
     render(
       <SettingsContext.Provider
-        value={{ settings: DEFAULT_SETTINGS, updateSettings, resetSettings: noop, loaded: true }}
+        value={{
+          settings: DEFAULT_SETTINGS,
+          updateSettings,
+          resetSettings: noop,
+          flushSettings: async () => true,
+          loaded: true,
+        }}
       >
         <AIChatPanel {...defaultProps} />
       </SettingsContext.Provider>,
@@ -58,7 +64,13 @@ describe("AIChatPanel", () => {
       const updateSettings = vi.fn();
       render(
         <SettingsContext.Provider
-          value={{ settings: DEFAULT_SETTINGS, updateSettings, resetSettings: noop, loaded: true }}
+          value={{
+            settings: DEFAULT_SETTINGS,
+            updateSettings,
+            resetSettings: noop,
+            flushSettings: async () => true,
+            loaded: true,
+          }}
         >
           <AIChatPanel {...defaultProps} />
         </SettingsContext.Provider>,
@@ -81,7 +93,13 @@ describe("AIChatPanel", () => {
     const updateSettings = vi.fn();
     render(
       <SettingsContext.Provider
-        value={{ settings: DEFAULT_SETTINGS, updateSettings, resetSettings: noop, loaded: true }}
+        value={{
+          settings: DEFAULT_SETTINGS,
+          updateSettings,
+          resetSettings: noop,
+          flushSettings: async () => true,
+          loaded: true,
+        }}
       >
         <AIChatPanel {...defaultProps} />
       </SettingsContext.Provider>,

--- a/src/components/editor/MarkdownEditor.test.tsx
+++ b/src/components/editor/MarkdownEditor.test.tsx
@@ -23,6 +23,7 @@ function wrapper(settings: Settings) {
     settings,
     updateSettings: vi.fn(),
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
   };
   return ({ children }: { children: ReactNode }) => (
@@ -52,7 +53,13 @@ describe("MarkdownEditor spell-check wiring", () => {
   it("reconfigures spell check in place when the setting toggles on", () => {
     const tree = (settings: Settings) => (
       <SettingsContext.Provider
-        value={{ settings, updateSettings: vi.fn(), resetSettings: vi.fn(), loaded: true }}
+        value={{
+          settings,
+          updateSettings: vi.fn(),
+          resetSettings: vi.fn(),
+          flushSettings: async () => true,
+          loaded: true,
+        }}
       >
         <MarkdownEditor content="helo world" onChange={() => {}} />
       </SettingsContext.Provider>

--- a/src/components/editor/MarkdownEditor.test.tsx
+++ b/src/components/editor/MarkdownEditor.test.tsx
@@ -76,7 +76,13 @@ describe("MarkdownEditor spell-check wiring", () => {
   it("reconfigures when the enabled language set changes", () => {
     const tree = (settings: Settings) => (
       <SettingsContext.Provider
-        value={{ settings, updateSettings: vi.fn(), resetSettings: vi.fn(), loaded: true }}
+        value={{
+          settings,
+          updateSettings: vi.fn(),
+          resetSettings: vi.fn(),
+          flushSettings: async () => true,
+          loaded: true,
+        }}
       >
         <MarkdownEditor content="helo world" onChange={() => {}} />
       </SettingsContext.Provider>

--- a/src/components/markdown/LinkComponent.test.tsx
+++ b/src/components/markdown/LinkComponent.test.tsx
@@ -15,6 +15,7 @@ function renderLink(props: Partial<LinkComponentProps>, settings: Settings = DEF
         settings,
         updateSettings: vi.fn(),
         resetSettings: vi.fn(),
+        flushSettings: async () => true,
         loaded: true,
       }}
     >

--- a/src/components/modals/settings/AITab.test.tsx
+++ b/src/components/modals/settings/AITab.test.tsx
@@ -29,6 +29,7 @@ function setup(settings: Settings = DEFAULT_SETTINGS) {
     settings,
     updateSettings,
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
   };
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/components/modals/settings/AppearanceTab.test.tsx
+++ b/src/components/modals/settings/AppearanceTab.test.tsx
@@ -11,6 +11,7 @@ function setup(settings: Settings = DEFAULT_SETTINGS) {
     settings,
     updateSettings,
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
   };
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/components/modals/settings/BehaviorTab.test.tsx
+++ b/src/components/modals/settings/BehaviorTab.test.tsx
@@ -11,6 +11,7 @@ function setup(settings: Settings = DEFAULT_SETTINGS) {
     settings,
     updateSettings,
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
   };
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/components/modals/settings/EditorTab.test.tsx
+++ b/src/components/modals/settings/EditorTab.test.tsx
@@ -15,6 +15,7 @@ function setup(settings: Settings = DEFAULT_SETTINGS) {
     settings,
     updateSettings,
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
   };
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/components/modals/settings/HotkeysTab.test.tsx
+++ b/src/components/modals/settings/HotkeysTab.test.tsx
@@ -15,6 +15,7 @@ function setup(overrides: Record<string, string> = {}) {
     settings,
     updateSettings,
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
   };
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/components/modals/settings/LanguageSetting.test.tsx
+++ b/src/components/modals/settings/LanguageSetting.test.tsx
@@ -11,6 +11,7 @@ function setup(settings: Settings = DEFAULT_SETTINGS) {
     settings,
     updateSettings,
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
   };
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/components/modals/settings/LayoutTab.test.tsx
+++ b/src/components/modals/settings/LayoutTab.test.tsx
@@ -11,6 +11,7 @@ function setup() {
     settings: DEFAULT_SETTINGS,
     updateSettings,
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
   };
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/components/modals/settings/PrintTab.test.tsx
+++ b/src/components/modals/settings/PrintTab.test.tsx
@@ -11,6 +11,7 @@ function setup() {
     settings: DEFAULT_SETTINGS,
     updateSettings,
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
   };
   const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/components/modals/settings/SettingsModal.test.tsx
+++ b/src/components/modals/settings/SettingsModal.test.tsx
@@ -10,6 +10,7 @@ function withSettings(overrides: Partial<SettingsContextValue> = {}) {
     settings: DEFAULT_SETTINGS,
     updateSettings: vi.fn(),
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
     ...overrides,
   };

--- a/src/components/modals/settings/UpdatesSection.test.tsx
+++ b/src/components/modals/settings/UpdatesSection.test.tsx
@@ -20,6 +20,7 @@ function renderWith(overrides: Partial<SettingsContextValue> = {}) {
     settings: DEFAULT_SETTINGS,
     updateSettings,
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
     ...overrides,
   };

--- a/src/components/modals/settings/lazySettings.test.tsx
+++ b/src/components/modals/settings/lazySettings.test.tsx
@@ -12,6 +12,7 @@ describe("lazySettings", { timeout: CHUNK_LOAD_TIMEOUT_MS }, () => {
       settings: DEFAULT_SETTINGS,
       updateSettings: vi.fn(),
       resetSettings: vi.fn(),
+      flushSettings: async () => true,
       loaded: true,
     };
     const wrapper = ({ children }: { children: ReactNode }) => (

--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { load } from "@tauri-apps/plugin-store";
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
 import { SettingsContext } from "./SettingsContext";
@@ -11,15 +11,18 @@ const mockedLoad = vi.mocked(load);
 const realMatchMedia = window.matchMedia;
 
 // Builds a fake store whose `get` resolves the given saved value, registered as
-// the next `load()` result. Returns the `set` spy so tests can assert persisted
-// writes.
+// the next `load()` result. Returns the `set` and `save` spies so tests can
+// assert persisted writes.
 function mockStore(saved: unknown, { setRejects = false } = {}) {
   const set = vi.fn(() =>
     setRejects ? Promise.reject(new Error("disk full")) : Promise.resolve(),
   );
+  const save = vi.fn(() => Promise.resolve());
   const get = vi.fn(() => Promise.resolve(saved));
-  mockedLoad.mockResolvedValueOnce({ get, set } as unknown as Awaited<ReturnType<typeof load>>);
-  return { get, set };
+  mockedLoad.mockResolvedValueOnce({ get, set, save } as unknown as Awaited<
+    ReturnType<typeof load>
+  >);
+  return { get, set, save };
 }
 
 // Generic consumer that fires a sequence of updateSettings(path, value) calls,
@@ -40,6 +43,40 @@ function UpdateConsumer({ updates }: { updates: Array<[string, unknown]> }) {
           update
         </button>
       ))}
+    </div>
+  );
+}
+
+// Drives updateSettings + flushSettings so tests can exercise the pending-write
+// queue: two font-size updates, a flush whose boolean result is rendered.
+function FlushConsumer() {
+  const { updateSettings, flushSettings, loaded } = useContext(SettingsContext);
+  const [flushResult, setFlushResult] = useState("");
+  return (
+    <div>
+      <span data-testid="loaded">{String(loaded)}</span>
+      <span data-testid="flush-result">{flushResult}</span>
+      <button
+        type="button"
+        data-testid="update-font"
+        onClick={() => updateSettings("appearance.fontSize", 21)}
+      >
+        first update
+      </button>
+      <button
+        type="button"
+        data-testid="update-font-again"
+        onClick={() => updateSettings("appearance.fontSize", 22)}
+      >
+        second update
+      </button>
+      <button
+        type="button"
+        data-testid="flush"
+        onClick={async () => setFlushResult(String(await flushSettings()))}
+      >
+        flush
+      </button>
     </div>
   );
 }
@@ -537,6 +574,137 @@ describe("SettingsProvider", () => {
       });
 
       expect(set).toHaveBeenCalledWith("settings", DEFAULT_SETTINGS);
+    });
+  });
+
+  describe("flushSettings", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function renderFlushConsumer() {
+      const view = render(
+        <SettingsProvider>
+          <FlushConsumer />
+        </SettingsProvider>,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId("loaded").textContent).toBe("true");
+      });
+      return view;
+    }
+
+    it("persists an update still inside the debounce window", async () => {
+      const { set, save } = mockStore(null);
+      await renderFlushConsumer();
+
+      vi.useFakeTimers();
+      act(() => screen.getByTestId("update-font").click());
+      expect(set).not.toHaveBeenCalled();
+
+      await act(async () => {
+        screen.getByTestId("flush").click();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenCalledWith(
+        "settings",
+        expect.objectContaining({
+          appearance: expect.objectContaining({ fontSize: 21 }),
+        }),
+      );
+      expect(save).toHaveBeenCalled();
+      expect(screen.getByTestId("flush-result").textContent).toBe("true");
+
+      // The debounce timer was cleared, so nothing writes a second time.
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+        await Promise.resolve();
+      });
+      expect(set).toHaveBeenCalledTimes(1);
+    });
+
+    it("coalesces rapid updates into one write of the latest value", async () => {
+      const { set } = mockStore(null);
+      await renderFlushConsumer();
+
+      vi.useFakeTimers();
+      act(() => screen.getByTestId("update-font").click());
+      act(() => screen.getByTestId("update-font-again").click());
+
+      await act(async () => {
+        screen.getByTestId("flush").click();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenCalledWith(
+        "settings",
+        expect.objectContaining({
+          appearance: expect.objectContaining({ fontSize: 22 }),
+        }),
+      );
+    });
+
+    it("reports a failed write", async () => {
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockStore(null, { setRejects: true });
+      await renderFlushConsumer();
+
+      vi.useFakeTimers();
+      act(() => screen.getByTestId("update-font").click());
+
+      await act(async () => {
+        screen.getByTestId("flush").click();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(screen.getByTestId("flush-result").textContent).toBe("false");
+      expect(errSpy).toHaveBeenCalledWith("Failed to save settings:", expect.any(Error));
+      errSpy.mockRestore();
+    });
+
+    it("is a no-op without a pending update", async () => {
+      const { set, save } = mockStore(null);
+      await renderFlushConsumer();
+
+      await act(async () => {
+        screen.getByTestId("flush").click();
+        await Promise.resolve();
+      });
+
+      expect(screen.getByTestId("flush-result").textContent).toBe("true");
+      expect(set).not.toHaveBeenCalled();
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    it("writes a pending update on unmount instead of abandoning it", async () => {
+      const { set } = mockStore(null);
+      const { unmount } = await renderFlushConsumer();
+
+      vi.useFakeTimers();
+      act(() => screen.getByTestId("update-font").click());
+      expect(set).not.toHaveBeenCalled();
+
+      await act(async () => {
+        unmount();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(set).toHaveBeenCalledWith(
+        "settings",
+        expect.objectContaining({
+          appearance: expect.objectContaining({ fontSize: 21 }),
+        }),
+      );
     });
   });
 

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -10,6 +10,7 @@ export interface SettingsContextValue {
   settings: Settings;
   updateSettings: (path: string, value: unknown) => void;
   resetSettings: () => void;
+  flushSettings: () => Promise<boolean>;
   loaded: boolean;
 }
 
@@ -17,5 +18,6 @@ export const SettingsContext = createContext<SettingsContextValue>({
   settings: DEFAULT_SETTINGS,
   updateSettings: () => {},
   resetSettings: () => {},
+  flushSettings: async () => true,
   loaded: false,
 });

--- a/src/contexts/SettingsProvider.tsx
+++ b/src/contexts/SettingsProvider.tsx
@@ -94,6 +94,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [loaded, setLoaded] = useState(false);
   const storeRef = useRef<Store | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef<Settings | null>(null);
 
   // Load settings from store on mount
   useEffect(() => {
@@ -147,18 +148,59 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     return () => mq.removeEventListener("change", handler);
   }, [settings.appearance.theme]);
 
-  // Save settings to store (debounced). Secrets never reach the store: every
-  // write persists a stripped copy, so settings.json cannot contain API keys.
-  const saveToStore = useCallback((newSettings: Settings) => {
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = setTimeout(async () => {
-      try {
-        await storeRef.current?.set(STORE_KEY, stripSecrets(newSettings));
-      } catch (err) {
-        console.error("Failed to save settings:", err);
-      }
-    }, SAVE_DEBOUNCE);
+  // Write the latest pending settings to the store and disk. Secrets never
+  // reach the store: every write persists a stripped copy, so settings.json
+  // cannot contain API keys. On failure the pending value is kept so a later
+  // flush can retry.
+  const writePending = useCallback(async () => {
+    const store = storeRef.current;
+    const pending = pendingRef.current;
+    if (!store || !pending) return true;
+    try {
+      await store.set(STORE_KEY, stripSecrets(pending));
+      // save() awaits the disk write; autoSave's own debounce could still be
+      // pending when the process exits.
+      await store.save();
+      // A newer update may have arrived while awaiting; keep it pending.
+      if (pendingRef.current === pending) pendingRef.current = null;
+      return true;
+    } catch (err) {
+      console.error("Failed to save settings:", err);
+      return false;
+    }
   }, []);
+
+  // Save settings to store (debounced).
+  const saveToStore = useCallback(
+    (newSettings: Settings) => {
+      pendingRef.current = newSettings;
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => {
+        saveTimerRef.current = null;
+        void writePending();
+      }, SAVE_DEBOUNCE);
+    },
+    [writePending],
+  );
+
+  // Persist any update still inside the debounce window; called before the
+  // window is allowed to close so a just-changed setting is not lost.
+  const flushSettings = useCallback(async () => {
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    return writePending();
+  }, [writePending]);
+
+  // Unmount (tests, hot reload) clears the timer without abandoning the
+  // pending update.
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      void writePending();
+    };
+  }, [writePending]);
 
   const updateSettings = useCallback(
     (path: string, value: unknown) => {
@@ -197,7 +239,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   }, [saveToStore]);
 
   return (
-    <SettingsContext value={{ settings, updateSettings, resetSettings, loaded }}>
+    <SettingsContext value={{ settings, updateSettings, resetSettings, flushSettings, loaded }}>
       {children}
     </SettingsContext>
   );

--- a/src/contexts/SettingsProvider.tsx
+++ b/src/contexts/SettingsProvider.tsx
@@ -95,6 +95,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const storeRef = useRef<Store | null>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingRef = useRef<Settings | null>(null);
+  const writeChainRef = useRef<Promise<boolean>>(Promise.resolve(true));
 
   // Load settings from store on mount
   useEffect(() => {
@@ -151,23 +152,29 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   // Write the latest pending settings to the store and disk. Secrets never
   // reach the store: every write persists a stripped copy, so settings.json
   // cannot contain API keys. On failure the pending value is kept so a later
-  // flush can retry.
-  const writePending = useCallback(async () => {
-    const store = storeRef.current;
-    const pending = pendingRef.current;
-    if (!store || !pending) return true;
-    try {
-      await store.set(STORE_KEY, stripSecrets(pending));
-      // save() awaits the disk write; autoSave's own debounce could still be
-      // pending when the process exits.
-      await store.save();
-      // A newer update may have arrived while awaiting; keep it pending.
-      if (pendingRef.current === pending) pendingRef.current = null;
-      return true;
-    } catch (err) {
-      console.error("Failed to save settings:", err);
-      return false;
-    }
+  // flush can retry. Writes are serialized through writeChainRef so a flush
+  // cannot overlap an in-flight debounced write and land the older value last.
+  const writePending = useCallback(() => {
+    const write = async () => {
+      const store = storeRef.current;
+      const pending = pendingRef.current;
+      if (!store || !pending) return true;
+      try {
+        await store.set(STORE_KEY, stripSecrets(pending));
+        // save() awaits the disk write; the store plugin's own autosave
+        // debounce could still be pending when the process exits.
+        await store.save();
+        // A newer update may have arrived while awaiting; keep it pending.
+        if (pendingRef.current === pending) pendingRef.current = null;
+        return true;
+      } catch (err) {
+        console.error("Failed to save settings:", err);
+        return false;
+      }
+    };
+    const next = writeChainRef.current.then(write);
+    writeChainRef.current = next;
+    return next;
   }, []);
 
   // Save settings to store (debounced).

--- a/src/hooks/useCloseFlush.test.tsx
+++ b/src/hooks/useCloseFlush.test.tsx
@@ -1,0 +1,55 @@
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SettingsContext } from "@/contexts/SettingsContext";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
+import { useCloseFlush } from "./useCloseFlush";
+
+function settingsWrapper(flushSettings: () => Promise<boolean>) {
+  return ({ children }: { children: ReactNode }) => (
+    <SettingsContext
+      value={{
+        settings: DEFAULT_SETTINGS,
+        updateSettings: () => {},
+        resetSettings: () => {},
+        flushSettings,
+        loaded: true,
+      }}
+    >
+      {children}
+    </SettingsContext>
+  );
+}
+
+describe("useCloseFlush", () => {
+  it("flushes settings before documents and returns the document result", async () => {
+    const order: string[] = [];
+    const flushSettings = vi.fn(async () => {
+      order.push("settings");
+      return true;
+    });
+    const flushDocuments = vi.fn(async () => {
+      order.push("documents");
+      return false;
+    });
+
+    const { result } = renderHook(() => useCloseFlush(flushDocuments), {
+      wrapper: settingsWrapper(flushSettings),
+    });
+
+    await expect(result.current()).resolves.toBe(false);
+    expect(order).toEqual(["settings", "documents"]);
+  });
+
+  it("does not block the close when the settings flush fails", async () => {
+    const flushSettings = vi.fn(async () => false);
+    const flushDocuments = vi.fn(async () => true);
+
+    const { result } = renderHook(() => useCloseFlush(flushDocuments), {
+      wrapper: settingsWrapper(flushSettings),
+    });
+
+    await expect(result.current()).resolves.toBe(true);
+    expect(flushDocuments).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCloseFlush.ts
+++ b/src/hooks/useCloseFlush.ts
@@ -1,0 +1,15 @@
+import { useCallback } from "react";
+import { useSettings } from "@/hooks/useSettings";
+
+/**
+ * Compose the flushes run when a native window close is intercepted: pending
+ * settings first (a failed settings write never blocks the close), then dirty
+ * documents, whose result decides whether the window may close.
+ */
+export function useCloseFlush(flushDocuments: () => Promise<boolean>) {
+  const { flushSettings } = useSettings();
+  return useCallback(async () => {
+    await flushSettings();
+    return flushDocuments();
+  }, [flushSettings, flushDocuments]);
+}

--- a/src/hooks/useNativeKeybindings.test.tsx
+++ b/src/hooks/useNativeKeybindings.test.tsx
@@ -11,6 +11,7 @@ function ctx(over: Partial<SettingsContextValue> = {}): SettingsContextValue {
     settings: DEFAULT_SETTINGS,
     updateSettings: vi.fn(),
     resetSettings: vi.fn(),
+    flushSettings: async () => true,
     loaded: true,
     ...over,
   };

--- a/src/hooks/useSettings.test.tsx
+++ b/src/hooks/useSettings.test.tsx
@@ -18,6 +18,7 @@ describe("useSettings", () => {
       settings: { ...DEFAULT_SETTINGS },
       updateSettings: () => {},
       resetSettings: () => {},
+      flushSettings: async () => true,
       loaded: true,
     };
     const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -52,6 +52,7 @@ vi.mock("@tauri-apps/plugin-store", () => ({
     Promise.resolve({
       get: vi.fn(() => Promise.resolve(null)),
       set: vi.fn(() => Promise.resolve()),
+      save: vi.fn(() => Promise.resolve()),
     }),
   ),
 }));


### PR DESCRIPTION
## Summary

Settings writes are debounced by 500 ms with no flush on window close or provider unmount, so a setting changed just before quitting the app could never reach settings.json. This adds a pending-write queue with an explicit flush that runs before the native window close proceeds.

Closes #439

## Changes

- `SettingsProvider` tracks the latest unwritten settings in a pending queue; writes are serialized so a flush cannot overlap an in-flight debounced write and land the older value last, and the flush awaits the actual store write to disk (`store.save()`) and reports failure
- New `flushSettings()` on `SettingsContext` (no-op resolving true when nothing is pending; a failed write is retried by the next flush)
- New `useCloseFlush` hook composes the settings flush with the existing dirty-document flush; a failed settings write never blocks the close, the document flush result still decides it
- `AppShell` passes the composed flush to `useWindowClose`
- Provider unmount clears the debounce timer and writes the pending update instead of abandoning it
- Tests cover exit inside the debounce window, coalescing of rapid updates, failed writes, no-op flush, unmount, and the flush ordering in `useCloseFlush`

## Testing

- `pnpm typecheck`, `pnpm check`, and the full `pnpm test` suite (2641 tests) pass
- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable, no UI change.
