### PR TITLE
test: cover the codecov patch gaps from the settings-flush and index-truncation changes

### DIFF
--- a/src/components/layout/WorkspaceIndexWarning.test.tsx
+++ b/src/components/layout/WorkspaceIndexWarning.test.tsx
@@ -37,6 +37,14 @@ describe("WorkspaceIndexWarning", () => {
     expect(status.getAttribute("title")).toContain("10000");
   });
 
+  it("falls back to a zero limit when the scan status carries none", () => {
+    renderWith({
+      files: { truncated: true, reason: "fileLimit", limit: null },
+      wikilinks: COMPLETE_SCAN,
+    });
+    expect(screen.getByRole("status").getAttribute("title")).toContain("first 0 documents");
+  });
+
   it("falls back to the wikilink scan's depth message", () => {
     renderWith({
       files: COMPLETE_SCAN,

--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -148,6 +148,15 @@ describe("SettingsContext", () => {
     act(() => screen.getByTestId("reset").click());
     expect(screen.getByTestId("font-size").textContent).toBe("16");
   });
+
+  it("the default flushSettings resolves true without a provider", async () => {
+    render(<FlushConsumer />);
+    await act(async () => {
+      screen.getByTestId("flush").click();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("flush-result").textContent).toBe("true");
+  });
 });
 
 describe("SettingsProvider", () => {
@@ -683,6 +692,55 @@ describe("SettingsProvider", () => {
       expect(screen.getByTestId("flush-result").textContent).toBe("true");
       expect(set).not.toHaveBeenCalled();
       expect(save).not.toHaveBeenCalled();
+    });
+
+    it("keeps a newer update pending when it lands during an in-flight write", async () => {
+      let resolveSet: (() => void) | null = null;
+      const set = vi.fn(
+        () =>
+          new Promise<void>((r) => {
+            resolveSet = r;
+          }),
+      );
+      const save = vi.fn(() => Promise.resolve());
+      const get = vi.fn(() => Promise.resolve(null));
+      mockedLoad.mockResolvedValueOnce({ get, set, save } as unknown as Awaited<
+        ReturnType<typeof load>
+      >);
+      await renderFlushConsumer();
+
+      vi.useFakeTimers();
+      act(() => screen.getByTestId("update-font").click());
+      act(() => screen.getByTestId("flush").click());
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(set).toHaveBeenCalledTimes(1);
+
+      // The write for fontSize 21 is still awaiting; a newer update arrives.
+      act(() => screen.getByTestId("update-font-again").click());
+      await act(async () => {
+        resolveSet?.();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The newer value stayed pending, so the next flush writes it.
+      await act(async () => {
+        screen.getByTestId("flush").click();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(set).toHaveBeenCalledTimes(2);
+      expect(set).toHaveBeenLastCalledWith(
+        "settings",
+        expect.objectContaining({
+          appearance: expect.objectContaining({ fontSize: 22 }),
+        }),
+      );
     });
 
     it("writes a pending update on unmount instead of abandoning it", async () => {

--- a/src/hooks/useTabs.test.tsx
+++ b/src/hooks/useTabs.test.tsx
@@ -3686,6 +3686,30 @@ describe("useTabs graph tabs", () => {
     );
   });
 
+  it("falls back to a zero limit in the notice when the scan status carries none", async () => {
+    const onWorkspaceNotice = vi.fn();
+    vi.mocked(invoke).mockImplementation(
+      makeInvoker({
+        list_markdown_files: async () => ({
+          files: [],
+          status: { truncated: true, reason: "fileLimit", limit: null },
+        }),
+      }) as typeof invoke,
+    );
+    const { result } = renderHook(() => useTabs(defaultOptions({ onWorkspaceNotice })));
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+    await act(async () => {
+      await result.current.openFolder("/p/ws");
+    });
+
+    await waitFor(() =>
+      expect(onWorkspaceNotice).toHaveBeenCalledWith(
+        { key: "notice.indexIncompleteFiles", values: { limit: "0" } },
+        { persistent: true },
+      ),
+    );
+  });
+
   it("fires the notice once when both indexes report the same truncation", async () => {
     const truncated = { truncated: true, reason: "fileLimit", limit: 10 };
     const onWorkspaceNotice = vi.fn();


### PR DESCRIPTION
## Summary

Covers the patch-coverage gaps Codecov flagged on #478 and #479. Test-only change, no production code touched.

## Changes

- `SettingsContext.test.tsx`: the default `flushSettings` (no provider mounted) resolves true, covering the context default; a new test drives an update landing while a write is in flight, covering the keep-newer-value-pending branch in `SettingsProvider`
- `WorkspaceIndexWarning.test.tsx`: a truncated scan status with no limit renders the zero fallback in the tooltip
- `useTabs.test.tsx`: the incomplete-index notice interpolates a zero limit when the scan status carries none

## Testing

- Verified against `pnpm test:coverage`: each previously-unhit line and branch side in `SettingsContext.ts`, `SettingsProvider.tsx`, `WorkspaceIndexWarning.tsx`, and `useTabs.ts` now reports hits
- `pnpm typecheck`, `pnpm check`, and the full `pnpm test` suite pass
- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable, test-only change.
