### PR TITLE
chore(ci): skip installer bundling on ubuntu PR builds

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,9 +26,10 @@ jobs:
             targets_full: "aarch64-apple-darwin,x86_64-apple-darwin"
             targets_pr: "aarch64-apple-darwin"
           - platform: ubuntu-22.04
-            # Bundle analysis needs the real bundle, so no --no-bundle here.
+            # Bundle analysis is the codecov Vite plugin, which runs during
+            # the frontend build; it does not need installer packaging.
             args_full: ""
-            args_pr: ""
+            args_pr: "--no-bundle"
             bundle_analysis: true
           # No include entry for ubuntu-22.04-arm: include is processed
           # AFTER exclude, so an entry here would resurrect the excluded


### PR DESCRIPTION
## Summary

Removes the last ~80s from the PR critical path. Ubuntu PR builds now pass `--no-bundle` like Windows and macOS already do.

## Changes

- `args_pr: --no-bundle` for ubuntu-22.04 in ci-build.yml, with the comment corrected: bundle analysis is the codecov **Vite** plugin (`codecovVitePlugin` in vite.config.ts, gated on `CODECOV_TOKEN`), which runs during the frontend build and never consumed the deb/rpm/AppImage output
- The CSP export smoke test is unaffected: it runs the plain `target/release/glyph` binary, which `--no-bundle` still produces
- Pushes to main keep full bundling on all platforms, so packaging regressions still surface before release

Expected PR wall clock: ~6.6 min to ~5.5-6.0 min (critical path shifts from the Ubuntu build to the Windows build).

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

This PR's own run verifies it: the Ubuntu build job should drop to ~4.8 min, and the codecov Bundle Report comment should still appear.

## Screenshots

N/A