### PR TITLE
fix(settings): gate the app tree on settings load so startup writes cannot wipe settings.json

### DIFF
--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -36,10 +36,11 @@ Review the current diff (`git diff` + `git diff --cached`, or `git diff origin/m
 1. Collect the diff.
 2. Walk each changed hunk against the rules above; list findings as `file:line — rule — fix`.
 3. Check the diff against the governing conventions, not just the code-quality rules: every `.claude/rules/*.md` whose scope covers a changed path, plus the global ones (no em dashes and no AI attribution in commits/PR bodies, branch naming, PR template). Verify, don't assume; grep the actual commit messages and PR body.
-4. Run `/code-review` (medium) on the same diff and fold its confirmed findings into the fix list. Self-review alone is the author grading their own homework; the independent pass catches what familiarity hides.
-5. Apply every fix. Skip only what would change intended behavior, and say so.
-6. Re-run the gates: `pnpm typecheck && pnpm check && pnpm test`, and `cargo clippy --all-targets -- -D warnings` if Rust changed.
-7. Report: what was cut or rewritten, net line delta.
+4. When the change ships as a PR, re-read CONTRIBUTING.md's Pull Requests section before `gh pr create` and verify against the posted result, not the draft: PR title in conventional commit style (`fix(settings): ...`, not a bare imperative sentence; squash merge makes the title the `main` commit), `Closes #N` present, and the template's Testing checkboxes claiming only what actually ran (automated gates are not "Tested on <platform>"; leave the box unchecked and say what ran).
+5. Run `/code-review` (medium) on the same diff and fold its confirmed findings into the fix list. Self-review alone is the author grading their own homework; the independent pass catches what familiarity hides.
+6. Apply every fix. Skip only what would change intended behavior, and say so.
+7. Re-run the gates: `pnpm typecheck && pnpm check && pnpm test`, and `cargo clippy --all-targets -- -D warnings` if Rust changed.
+8. Report: what was cut or rewritten, net line delta.
 
 ## Self-improvement
 

--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -12,17 +12,29 @@ const realMatchMedia = window.matchMedia;
 
 // Builds a fake store whose `get` resolves the given saved value, registered as
 // the next `load()` result. Returns the `set` and `save` spies so tests can
-// assert persisted writes.
-function mockStore(saved: unknown, { setRejects = false } = {}) {
+// assert persisted writes. With `deferLoad`, `load()` stays pending until the
+// returned `resolveLoad` is called.
+function mockStore(saved: unknown, { setRejects = false, deferLoad = false } = {}) {
   const set = vi.fn(() =>
     setRejects ? Promise.reject(new Error("disk full")) : Promise.resolve(),
   );
   const save = vi.fn(() => Promise.resolve());
   const get = vi.fn(() => Promise.resolve(saved));
-  mockedLoad.mockResolvedValueOnce({ get, set, save } as unknown as Awaited<
-    ReturnType<typeof load>
-  >);
-  return { get, set, save };
+  const store = { get, set, save } as unknown as Awaited<ReturnType<typeof load>>;
+  // Captured when the provider calls load(), so resolveLoad must stay a stable
+  // wrapper that reads the latest resolver.
+  let resolve: ((store: Awaited<ReturnType<typeof load>>) => void) | undefined;
+  if (deferLoad) {
+    mockedLoad.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolve = r;
+        }),
+    );
+  } else {
+    mockedLoad.mockResolvedValueOnce(store);
+  }
+  return { get, set, save, resolveLoad: () => resolve?.(store) };
 }
 
 // Generic consumer that fires a sequence of updateSettings(path, value) calls,
@@ -330,6 +342,30 @@ describe("SettingsProvider", () => {
       expect(screen.getByTestId("theme").textContent).toBe("system");
       expect(document.documentElement.style.getPropertyValue("--glyph-font-size")).toBe("16px");
       errSpy.mockRestore();
+    });
+
+    it("does not render children until the store has loaded (#490)", async () => {
+      const { resolveLoad } = mockStore({ appearance: { fontSize: 22 } }, { deferLoad: true });
+
+      render(
+        <SettingsProvider>
+          <TestConsumer />
+        </SettingsProvider>,
+      );
+
+      // While the load is pending no consumer is mounted, so nothing can read
+      // DEFAULT_SETTINGS and persist it over the user's stored settings.
+      expect(screen.queryByTestId("loaded")).toBeNull();
+
+      await act(async () => {
+        resolveLoad();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loaded").textContent).toBe("true");
+      });
+      // Children mount straight into the merged settings, never the defaults.
+      expect(screen.getByTestId("font-size").textContent).toBe("22");
     });
 
     it("does not apply settings when unmounted before the load resolves", async () => {

--- a/src/contexts/SettingsProvider.tsx
+++ b/src/contexts/SettingsProvider.tsx
@@ -245,9 +245,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     }
   }, [saveToStore]);
 
+  // Gate children on loaded: a mount-time settings write would persist
+  // DEFAULT_SETTINGS over the stored settings (#490); reveal waits for load anyway.
   return (
     <SettingsContext value={{ settings, updateSettings, resetSettings, flushSettings, loaded }}>
-      {children}
+      {loaded ? children : null}
     </SettingsContext>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the intermittent full reset of user settings. On launch, `SettingsProvider` loads `settings.json` asynchronously while the rest of the app mounts immediately. When the tab-persist effect in `useTabs` fired before the store load resolved (likely, since the load also waits on OS keychain reads), `updateSettings` patched `DEFAULT_SETTINGS` and the debounced save wrote a full defaults snapshot over the user's `settings.json`. The same race made open tabs silently fail to restore on launches where it was lost.

`SettingsProvider` now renders its children only once the store has loaded, so no consumer can read or persist settings before the stored values exist. There is no visible cost: the window is created hidden and `useWindowReveal` already waits for `loaded` plus one painted frame before showing it, so startup looks identical.

Closes #490

## Changes

- `SettingsProvider` renders `children` only when `loaded` is true, closing the wipe path for every consumer at one seam
- Regression test covering the gate: children stay unmounted while `load()` is pending and mount straight into the merged stored settings, never the defaults
- `mockStore` test helper gains a `deferLoad` option so tests can hold the store load open

## Testing

- `pnpm typecheck`, `pnpm check`, `pnpm test` (2703 tests, 265 files) all green; `cargo clippy --all-targets -- -D warnings` green
- [ ] Tested on macOS
- [ ] Tested on Windows (automated gates ran on Windows; no manual app run yet)
- [ ] Tested on Linux

## Screenshots

Not applicable.

