### PR TITLE
fix(release): create the GitHub release before the build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,72 @@ permissions:
   discussions: write
 
 jobs:
+  # Create the release once before the build matrix; parallel tauri-action
+  # jobs racing to create it fail with "already_exists".
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && exit 0
+          cat > /tmp/release-body.md <<'BODY'
+          ## Install
+
+          ### macOS
+          ```bash
+          brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask glyph
+          ```
+          Or download `Glyph_*_universal.dmg` below.
+
+          ### Windows
+          ```powershell
+          # winget
+          winget install hamidfzm.Glyph
+
+          # Chocolatey
+          choco install glyph
+
+          # Scoop
+          scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
+          scoop install glyph
+          ```
+          Or download `Glyph_*_x64_en-US.msi` below.
+
+          ### Linux
+          ```bash
+          # Snap Store
+          sudo snap install glyph
+
+          # Arch (AUR)
+          yay -S glyph-md-bin
+
+          # Homebrew (Linuxbrew)
+          brew tap glyph-md/tap && brew install glyph
+
+          # Debian/Ubuntu (PPA)
+          sudo add-apt-repository ppa:hamidfzm/glyph
+          sudo apt update
+          sudo apt install glyph
+
+          # Debian (apt repo)
+          curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+          sudo apt update && sudo apt install glyph
+
+          # Fedora/RHEL (dnf)
+          sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
+          sudo dnf install glyph
+          ```
+          Or download the `.deb` / `.rpm` / `.AppImage` below.
+          BODY
+          gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --title "Glyph $GITHUB_REF_NAME" \
+            --notes-file /tmp/release-body.md
+
   build:
+    needs: create-release
     strategy:
       fail-fast: false
       matrix:
@@ -55,58 +120,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: "Glyph ${{ github.ref_name }}"
-          releaseBody: |
-            ## Install
-
-            ### macOS
-            ```bash
-            brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask glyph
-            ```
-            Or download `Glyph_*_universal.dmg` below.
-
-            ### Windows
-            ```powershell
-            # winget
-            winget install hamidfzm.Glyph
-
-            # Chocolatey
-            choco install glyph
-
-            # Scoop
-            scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
-            scoop install glyph
-            ```
-            Or download `Glyph_*_x64_en-US.msi` below.
-
-            ### Linux
-            ```bash
-            # Snap Store
-            sudo snap install glyph
-
-            # Arch (AUR)
-            yay -S glyph-md-bin
-
-            # Homebrew (Linuxbrew)
-            brew tap glyph-md/tap && brew install glyph
-
-            # Debian/Ubuntu (PPA)
-            sudo add-apt-repository ppa:hamidfzm/glyph
-            sudo apt update
-            sudo apt install glyph
-
-            # Debian (apt repo)
-            curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-            echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
-            sudo apt update && sudo apt install glyph
-
-            # Fedora/RHEL (dnf)
-            sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
-            sudo dnf install glyph
-            ```
-            Or download the `.deb` / `.rpm` / `.AppImage` below.
-          releaseDraft: false
-          prerelease: false
           args: ${{ matrix.args }}
 
   update-release-notes:


### PR DESCRIPTION
## Summary

The v0.17.0 release run failed because the four parallel `tauri-action` build jobs each create the GitHub release when it does not exist. Two jobs raced, and the `ubuntu-22.04-arm` job failed with `Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}`, which skipped every publish job. This PR creates the release once, in a dedicated job, before the build matrix fans out, so build jobs only look the release up by tag and upload their assets.

## Changes

- Add a `create-release` job that creates the release with `gh release create` and the same install-instructions body (idempotent, skips if the tag's release already exists, so tag re-runs pass), and gate the `build` matrix on it with `needs`.
- Move `releaseName` and `releaseBody` from the `tauri-action` step into `create-release` (they only apply at creation time, which no longer happens in the build jobs), and drop `releaseDraft`/`prerelease` which match the action defaults. Release body behavior is unchanged: install instructions at creation, changelog prepended by `update-release-notes` after the build.

## Testing

- YAML validated locally.
- Verified tauri-action v0 source: with `releaseDraft` defaulting to false it looks up the release via `getReleaseByTag` and uploads assets without creating.
- The failed v0.17.0 jobs were re-run against the already-existing release, exercising the same look-up-and-upload path this PR makes the default; the rerun went fully green (all builds and publish jobs).

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A (CI workflow change)