### PR TITLE
ci: extract repeated workflow steps into composite actions

### DIFF
--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -1,0 +1,12 @@
+name: Get version
+description: Output the release version, the tag name without the leading v
+outputs:
+  version:
+    description: Tag name without the leading v
+    value: ${{ steps.version.outputs.version }}
+runs:
+  using: composite
+  steps:
+    - id: version
+      shell: bash
+      run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -1,0 +1,10 @@
+name: Set up pnpm
+description: Set up pnpm and Node from .nvmrc with the pnpm store cache
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v5
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: '.nvmrc'
+        cache: pnpm

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -1,0 +1,19 @@
+name: Set up Rust
+description: Install stable Rust and restore the src-tauri cargo cache
+inputs:
+  targets:
+    description: Comma-separated extra compilation targets
+    default: ""
+  components:
+    description: Comma-separated extra toolchain components
+    default: ""
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ inputs.targets }}
+        components: ${{ inputs.components }}
+    - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: src-tauri

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,11 +40,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
+      - uses: ./.github/actions/pnpm-setup
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -88,18 +84,10 @@ jobs:
       NDK_VERSION: 29.0.14206865
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/pnpm-setup
+      - uses: ./.github/actions/rust-setup
         with:
           targets: aarch64-linux-android
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,11 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
+      - uses: ./.github/actions/pnpm-setup
       - run: pnpm install --frozen-lockfile
       - name: Biome lint
         run: npx @biomejs/biome lint --error-on-warnings --reporter=github src/
@@ -25,11 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
+      - uses: ./.github/actions/pnpm-setup
       - run: pnpm install --frozen-lockfile
       - name: Add TypeScript problem matcher
         run: echo "::add-matcher::.github/matchers/tsc.json"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -9,11 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
+      - uses: ./.github/actions/pnpm-setup
       - run: pnpm install --frozen-lockfile
       - name: Run tests with coverage
         run: pnpm test:coverage
@@ -51,13 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/rust-setup
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
       - name: Install Linux dependencies
         timeout-minutes: 8
         uses: ./.github/actions/linux-deps
@@ -97,13 +89,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/rust-setup
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
       - name: Install Linux dependencies
         timeout-minutes: 8
         uses: ./.github/actions/linux-deps

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,12 +34,7 @@ jobs:
             exit 1
           fi
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
+      - uses: ./.github/actions/rust-setup
 
       - name: Bump version in package.json
         run: |

--- a/.github/workflows/dependabot-tauri-npm-sync.yml
+++ b/.github/workflows/dependabot-tauri-npm-sync.yml
@@ -45,11 +45,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-          cache: pnpm
+      - uses: ./.github/actions/pnpm-setup
 
       - name: Install Linux Tauri build deps
         timeout-minutes: 8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
+      - uses: ./.github/actions/pnpm-setup
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -193,7 +189,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-version
       - name: Download DMG and compute sha256
         id: sha
         env:
@@ -281,8 +277,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get version
         id: version
-        shell: bash
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-version
       - name: Download MSI and compute sha256
         id: sha
         shell: pwsh
@@ -358,7 +353,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-version
       - name: Download MSI and compute sha256
         id: sha
         env:
@@ -449,7 +444,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-version
       - name: Download debs and compute sha256
         id: sha
         env:
@@ -526,7 +521,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y devscripts debhelper dput
       - name: Get version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-version
       - name: Download debs and extract binaries
         env:
           GH_TOKEN: ${{ github.token }}
@@ -612,7 +607,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y dpkg-dev gpg
       - name: Get version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-version
       - name: Download deb packages
         env:
           GH_TOKEN: ${{ github.token }}
@@ -773,7 +768,7 @@ jobs:
       - name: Get version
         if: steps.gate.outputs.enabled == 'true'
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/get-version
       - name: Download RPM packages
         if: steps.gate.outputs.enabled == 'true'
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,11 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: pnpm
+      - uses: ./.github/actions/pnpm-setup
       - run: pnpm install --frozen-lockfile
       # TODO: Revert to `pnpm audit --prod` when pnpm fixes bulk endpoint support
       # Workaround: https://github.com/pnpm/pnpm/issues/11265


### PR DESCRIPTION
## Summary

Extracts step sequences repeated across `.github/workflows/*.yml` into composite actions under `.github/actions/`, following the existing `linux-deps` pattern. Pure refactor: every extraction is a drop-in replacement for a contiguous, identical step sequence, with no step reordering and no changes to job names, workflow names, or release logic. Required check contexts are unaffected.

## Changes

- New `.github/actions/pnpm-setup`: the `pnpm/action-setup` + `actions/setup-node` (.nvmrc, pnpm cache) pair, used in ci-checks (2 jobs), ci-tests, ci-build (2 jobs), release, security, and dependabot-tauri-npm-sync. The `pnpm install --frozen-lockfile` line stays in place in each job, since ci-build and release run it at a later position and moving it would reorder steps.
- New `.github/actions/rust-setup`: the `dtolnay/rust-toolchain@stable` + `Swatinem/rust-cache` (src-tauri) pair with optional `targets`/`components` inputs, used only where the two steps are adjacent: ci-tests (test-rust, clippy), ci-build (android), create-release. The ci-build and release build jobs keep the pair inline because `linux-deps` sits between the two steps there.
- New `.github/actions/get-version`: the `version=${GITHUB_REF_NAME#v}` step with a `version` output, used by the publish-homebrew, publish-chocolatey, publish-scoop, publish-aur, publish-ppa, publish-debian, and publish-dnf jobs in release.yml. Callers keep `id: version`, so all `steps.version.outputs.version` references are untouched. publish-winget keeps its inline copy because that job has no checkout, and local actions require one.

Not extracted: the `gh release download` + `shasum` blocks differ per job (patterns, output names, bash vs pwsh), so deduplicating them would mean splitting and parameterizing steps rather than a pure lift.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux

YAML-only change validated with js-yaml on every workflow and action file; full pre-commit gate (Biome, typecheck, vitest, cargo test, clippy) passed. CI on this PR exercises the pnpm-setup and rust-setup actions directly; get-version runs on the next tagged release.

## Screenshots

N/A
