### PR TITLE
fix(packaging): ship PPA payload, fix Linuxbrew formula deps, add Scoop shim and shortcut

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -583,7 +583,7 @@ jobs:
           mkdir -p /tmp/glyph-${VERSION}/debian
           HOMEPAGE=$(jq -r .homepage package.json)
           sed "s|{{HOMEPAGE}}|$HOMEPAGE|g" ppa/debian/control > /tmp/glyph-${VERSION}/debian/control
-          cp ppa/debian/rules /tmp/glyph-${VERSION}/debian/
+          cp ppa/debian/rules ppa/debian/install /tmp/glyph-${VERSION}/debian/
 
           # Generate debian/copyright from repo LICENSE file
           {

--- a/homebrew/glyph-formula.rb.template
+++ b/homebrew/glyph-formula.rb.template
@@ -16,8 +16,6 @@ class Glyph < Formula
   end
 
   depends_on :linux
-  depends_on "webkit2gtk"
-  depends_on "gtk+3"
 
   def install
     # Extract binary from deb
@@ -25,6 +23,15 @@ class Glyph < Formula
     system "tar", "xf", "data.tar.gz"
     bin.install Dir["usr/bin/*"]
     share.install Dir["usr/share/*"]
+  end
+
+  def caveats
+    <<~EOS
+      Glyph links against the system WebKitGTK and GTK 3 libraries, which
+      Homebrew does not provide. Install them with your distro's package
+      manager, e.g. on Debian/Ubuntu:
+        sudo apt install libwebkit2gtk-4.1-0 libgtk-3-0
+    EOS
   end
 
   test do

--- a/ppa/debian/install
+++ b/ppa/debian/install
@@ -1,0 +1,2 @@
+usr/bin/glyph usr/bin
+usr/share/* usr/share

--- a/scoop/glyph.json.template
+++ b/scoop/glyph.json.template
@@ -9,6 +9,14 @@
             "hash": "{{SHA256}}"
         }
     },
+    "extract_dir": "PFiles\\Glyph",
+    "bin": "glyph.exe",
+    "shortcuts": [
+        [
+            "glyph.exe",
+            "Glyph"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/hamidfzm/glyph"
     },


### PR DESCRIPTION
## Summary

Fixes the three packaging bugs found by the first Release Smoke Test run ([run 29658379325](https://github.com/hamidfzm/glyph/actions/runs/29658379325), workflow from #497): the PPA package shipped no files, the Linuxbrew formula was uninstallable, and the Scoop install produced no shim or Start Menu entry.

## Changes

- **PPA**: add `ppa/debian/install` so `dh` packages the extracted deb payload (`usr/bin/glyph`, `usr/share/*`), and copy it into the source package in `release.yml`. Until now the source package built a deb containing only metadata.
- **Linuxbrew**: drop `depends_on "webkit2gtk"` (not a Homebrew formula name, made `brew install` fail) and `depends_on "gtk+3"` from `homebrew/glyph-formula.rb.template`. The binary links against the system `libwebkit2gtk-4.1` which Homebrew's `webkitgtk` would not satisfy anyway, so a `caveats` block now tells users to install `libwebkit2gtk-4.1-0` and `libgtk-3-0` via their distro. The same fix is pushed to the rendered `Formula/glyph.rb` in `glyph-md/homebrew-tap` (a57e19e).
- **Scoop**: add `extract_dir` (`PFiles\Glyph`, the MSI's admin-image layout, verified against the v0.17.0 MSI directory table), `bin: glyph.exe`, and a `shortcuts` entry to `scoop/glyph.json.template`. Same fix pushed to `bucket/glyph.json` in `glyph-md/scoop-bucket` (60b4ead).
- **Smoke test workflow** (on `feat/release-smoke-test`, commit 00caac5): the `homebrew-formula` job now apt-installs `libwebkit2gtk-4.1-0 libgtk-3-0` before the launch check, matching what the new caveats instruct users to do.

## Testing

Re-ran the Release Smoke Test against v0.17.0 after pushing the tap and bucket fixes ([run 29659027900](https://github.com/hamidfzm/glyph/actions/runs/29659027900)):

- [x] `homebrew-formula` green (was: `No available formula with the name "webkit2gtk"`)
- [x] `scoop` green (was: `no glyph shim`)
- [ ] `ppa` (jammy, noble) still red: the fix only takes effect on the next source-package upload. Either re-upload 0.17.0 with a bumped revision (`0.17.0-1~jammy2` / `~noble2`) via the `publish-ppa` steps, or wait for the next release.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux

## Screenshots

N/A (packaging only)
