### PR TITLE
ci(release): push the version bump and tag over a deploy key

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json src-tauri/Cargo.toml src-tauri/Cargo.lock
           if git diff --cached --quiet; then
             echo "Version already at ${{ inputs.version }}, skipping commit"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,8 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+
+      # main's ruleset only lets deploy keys push; humans and PATs go through PRs.
+      - name: Set up release deploy key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.RELEASE_DEPLOY_KEY }}" > ~/.ssh/release_key
+          chmod 600 ~/.ssh/release_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          git remote set-url --push origin "git@github.com:${{ github.repository }}.git"
+          echo "GIT_SSH_COMMAND=ssh -i ~/.ssh/release_key -o IdentitiesOnly=yes" >> "$GITHUB_ENV"
 
       - name: Validate version format
         run: |


### PR DESCRIPTION
## Summary

The main-branch ruleset no longer has an admin bypass, so the Create Release workflow can't push the version bump (or would fail once the deploy-key bypass is the only one). This switches its pushes (bump commit and tag) to SSH with a dedicated deploy key, the only actor allowed to bypass the ruleset. `TAP_GITHUB_TOKEN` is no longer used by this workflow; deploy-key pushes still trigger the tag's release workflow.

## Changes

- `create-release.yml`: checkout with the default token, add a step that installs the `RELEASE_DEPLOY_KEY` secret and points origin's push URL at SSH

## Setup required before merging

1. Generate a keypair and register the public half as a write deploy key
2. Store the private half as the `RELEASE_DEPLOY_KEY` Actions secret
3. Add `DeployKey` as the ruleset's only bypass actor

(Exact commands in the session that opened this PR.)

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Verified by the next release run; the workflow has no other test surface.

## Screenshots

N/A
