### PR TITLE
fix(ci): stop swallowing AUR keyscan errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,7 +482,12 @@ jobs:
           mkdir -p ~/.ssh
           echo "$AUR_SSH_KEY" > ~/.ssh/aur
           chmod 600 ~/.ssh/aur
-          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+          # Retry: a transient AUR outage silently failed this step before.
+          for i in 1 2 3; do
+            ssh-keyscan -T 10 aur.archlinux.org >> ~/.ssh/known_hosts && break
+            [ "$i" = 3 ] && exit 1
+            sleep 10
+          done
           cat >> ~/.ssh/config << EOF
           Host aur.archlinux.org
             IdentityFile ~/.ssh/aur

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,12 +482,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "$AUR_SSH_KEY" > ~/.ssh/aur
           chmod 600 ~/.ssh/aur
-          # Retry: a transient AUR outage silently failed this step before.
-          for i in 1 2 3; do
-            ssh-keyscan -T 10 aur.archlinux.org >> ~/.ssh/known_hosts && break
-            [ "$i" = 3 ] && exit 1
-            sleep 10
-          done
+          ssh-keyscan -T 10 aur.archlinux.org >> ~/.ssh/known_hosts
           cat >> ~/.ssh/config << EOF
           Host aur.archlinux.org
             IdentityFile ~/.ssh/aur


### PR DESCRIPTION
## Summary

The v0.17.1 `publish-aur` job failed with exit code 1 and zero output: `ssh-keyscan aur.archlinux.org` hit a transient outage, its error went to `/dev/null`, and `set -e` killed the step silently. This drops the stderr suppression and adds a 10s timeout so an AUR outage fails fast with a visible error. No retry logic; a failed publish-aur is simply re-run manually (`gh run rerun <id> --failed`), which is idempotent and does not affect other channels.

## Changes

- `.github/workflows/release.yml` (`publish-aur`): `ssh-keyscan -T 10` with stderr visible, replacing the silenced call.

## Testing

- actionlint clean.
- Failure mode reproduced from the v0.17.1 run logs (14s of silence then exit 1); the successful re-run of the same job confirms the step works unchanged once keyscan succeeds.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux

## Screenshots

N/A