### PR TITLE
docs(packaging): advertise Flathub install and smoke-test the channel

### DIFF
--- a/.github/workflows/release-smoke-test.yml
+++ b/.github/workflows/release-smoke-test.yml
@@ -278,6 +278,37 @@ jobs:
           [ "$CODE" -eq 124 ] || { echo "launch check failed (exit $CODE)"; exit 1; }
           echo "status=verified" >> "$GITHUB_OUTPUT"
 
+  flathub:
+    needs: resolve
+    if: needs.resolve.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      status: ${{ steps.check.outputs.status }}
+    steps:
+      - name: Install from Flathub and verify
+        id: check
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y flatpak xvfb
+          sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          AVAILABLE=$(flatpak remote-info flathub com.hamidfzm.glyph 2>/dev/null | awk '$1 == "Version:" {print $2}')
+          if [ "$AVAILABLE" != "$VERSION" ]; then
+            echo "status=pending" >> "$GITHUB_OUTPUT"
+            echo "Flathub serves ${AVAILABLE:-nothing}, not $VERSION yet." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          sudo flatpak install -y --noninteractive flathub com.hamidfzm.glyph
+
+          set +e
+          WEBKIT_DISABLE_COMPOSITING_MODE=1 xvfb-run -a timeout 15 flatpak run com.hamidfzm.glyph
+          CODE=$?
+          set -e
+          [ "$CODE" -eq 124 ] || { echo "launch check failed (exit $CODE)"; exit 1; }
+          echo "status=verified" >> "$GITHUB_OUTPUT"
+
   dnf:
     needs: resolve
     if: needs.resolve.outputs.run == 'true'
@@ -460,6 +491,7 @@ jobs:
       - ppa-jammy
       - ppa-noble
       - snap
+      - flathub
       - dnf
       - aur
       - scoop
@@ -479,6 +511,7 @@ jobs:
             ppa-jammy ${{ needs.ppa-jammy.result }} ${{ needs.ppa-jammy.outputs.status }}
             ppa-noble ${{ needs.ppa-noble.result }} ${{ needs.ppa-noble.outputs.status }}
             snap ${{ needs.snap.result }} ${{ needs.snap.outputs.status }}
+            flathub ${{ needs.flathub.result }} ${{ needs.flathub.outputs.status }}
             dnf ${{ needs.dnf.result }} ${{ needs.dnf.outputs.status }}
             aur ${{ needs.aur.result }} ${{ needs.aur.outputs.status }}
             scoop ${{ needs.scoop.result }} ${{ needs.scoop.outputs.status }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
 
           ### Linux
           ```bash
+          # Flathub (Flatpak)
+          flatpak install flathub com.hamidfzm.glyph
+
           # Snap Store
           sudo snap install glyph
 
@@ -156,6 +159,9 @@ jobs:
 
           ### Linux
           ```bash
+          # Flathub (Flatpak)
+          flatpak install flathub com.hamidfzm.glyph
+
           # Snap Store
           sudo snap install glyph
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
 scoop install glyph
 ```
 
+### Linux (Flathub)
+
+```bash
+flatpak install flathub com.hamidfzm.glyph
+flatpak run com.hamidfzm.glyph
+```
+
 ### Linux (Snap)
 
 ```bash


### PR DESCRIPTION
## Summary

Second half of the Flathub rollout, split from #467. That PR lands the inert packaging (manifest, metadata, validate job, token-gated publish job); this one flips the user-facing switch. **Keep as draft until the app is live on Flathub**, otherwise the README and release notes would point at a package that does not exist yet.

Based on `feat/flathub` so the diff stays scoped; GitHub retargets it to `main` automatically when #467 merges.

## Changes

- README: `### Linux (Flathub)` install section
- `release.yml`: Flathub install lines in both Linux release-notes blocks
- `release-smoke-test.yml`: new `flathub` channel job (version check against the Flathub remote, install, headless launch under xvfb, `pending`/`verified` status) wired into the summary table, modeled on the existing `snap` job

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

YAML for both workflows parses; the smoke-test job reports `pending` until Flathub serves the released version, so merging it before the first Flathub build only adds a harmless pending row.

Refs #117, #290