### PR TITLE
fix(flatpak): current release pins, per-release metainfo stamp, deb extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -918,6 +918,10 @@ jobs:
             { print }
           ' flatpak/com.hamidfzm.glyph.yml > /tmp/manifest.yml
 
+          # Stamp the metainfo release entry with this release; the committed
+          # file only carries the entry that was current when it last changed.
+          sed -i "s|<release version=\"[0-9.]*\" date=\"[0-9-]*\">|<release version=\"$VERSION\" date=\"$(date -u +%F)\">|; s|releases/tag/v[0-9.]*|releases/tag/v$VERSION|" flatpak/com.hamidfzm.glyph.metainfo.xml
+
           # Single-source the homepage URL from package.json (falls back to the
           # committed value if the field is absent).
           HOMEPAGE=$(jq -r '.homepage // empty' package.json)

--- a/flatpak/com.hamidfzm.glyph.metainfo.xml
+++ b/flatpak/com.hamidfzm.glyph.metainfo.xml
@@ -69,8 +69,8 @@
   </branding>
 
   <releases>
-    <release version="0.10.0" date="2026-06-11">
-      <url type="details">https://github.com/hamidfzm/glyph/releases/tag/v0.10.0</url>
+    <release version="0.17.1" date="2026-07-18">
+      <url type="details">https://github.com/hamidfzm/glyph/releases/tag/v0.17.1</url>
     </release>
   </releases>
 </component>

--- a/flatpak/com.hamidfzm.glyph.yml
+++ b/flatpak/com.hamidfzm.glyph.yml
@@ -51,13 +51,13 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        url: https://github.com/hamidfzm/glyph/releases/download/v0.10.0/Glyph_0.10.0_amd64.deb
-        sha256: 93e5d40ba44ee78563bc27e717ee954c714bbe6e63337d361a801c6c8cb53e4d
+        url: https://github.com/hamidfzm/glyph/releases/download/v0.17.1/Glyph_0.17.1_amd64.deb
+        sha256: 34a44ff3ff37ccaa1408b7797600daa6bcc05a835fd6b8a324bd8e25570dac7b
       - type: archive
         only-arches:
           - aarch64
-        url: https://github.com/hamidfzm/glyph/releases/download/v0.10.0/Glyph_0.10.0_arm64.deb
-        sha256: 86dbc1e9b0f29e8c20464b7e2aaa33daead86f270d65a3b0f8ebed7f204c8dcb
+        url: https://github.com/hamidfzm/glyph/releases/download/v0.17.1/Glyph_0.17.1_arm64.deb
+        sha256: 71690dd8a5b4a9b38926681acb9b115524af4cebefc29e037674503115835b92
       - type: file
         path: com.hamidfzm.glyph.desktop
       - type: file

--- a/flatpak/com.hamidfzm.glyph.yml
+++ b/flatpak/com.hamidfzm.glyph.yml
@@ -2,9 +2,10 @@
 #
 # This installs the released Debian package into the GNOME runtime rather than
 # recompiling from source, matching the AUR/PPA pattern already used in
-# `.github/workflows/release.yml`. flatpak-builder understands `.deb` archives
-# and unpacks the embedded data tarball, so `usr/...` paths below come straight
-# from the Tauri-generated package.
+# `.github/workflows/release.yml`. flatpak-builder cannot unpack `.deb`
+# archives itself, so the build extracts the embedded data tarball with
+# `ar` + `tar`; the `usr/...` paths below come straight from the
+# Tauri-generated package.
 #
 # The `url` versions and `sha256` checksums below are placeholders. They are
 # filled in per release (the SHA256s are the same ones computed by the
@@ -35,6 +36,8 @@ modules:
   - name: glyph
     buildsystem: simple
     build-commands:
+      - ar -x glyph.deb
+      - tar -xf data.tar.*
       - install -Dm755 usr/bin/glyph /app/bin/glyph
       - install -Dm644 com.hamidfzm.glyph.desktop /app/share/applications/com.hamidfzm.glyph.desktop
       - install -Dm644 com.hamidfzm.glyph.metainfo.xml /app/share/metainfo/com.hamidfzm.glyph.metainfo.xml
@@ -48,16 +51,18 @@ modules:
           install -Dm644 "$src" "${dest%/glyph.png}/com.hamidfzm.glyph.png"
         done
     sources:
-      - type: archive
+      - type: file
         only-arches:
           - x86_64
         url: https://github.com/hamidfzm/glyph/releases/download/v0.17.1/Glyph_0.17.1_amd64.deb
         sha256: 34a44ff3ff37ccaa1408b7797600daa6bcc05a835fd6b8a324bd8e25570dac7b
-      - type: archive
+        dest-filename: glyph.deb
+      - type: file
         only-arches:
           - aarch64
         url: https://github.com/hamidfzm/glyph/releases/download/v0.17.1/Glyph_0.17.1_arm64.deb
         sha256: 71690dd8a5b4a9b38926681acb9b115524af4cebefc29e037674503115835b92
+        dest-filename: glyph.deb
       - type: file
         path: com.hamidfzm.glyph.desktop
       - type: file


### PR DESCRIPTION
## Summary

Follow-up to #467, which was merged while these three fixes were still landing on its branch, so they missed the squash. Without them the committed manifest cannot build: it pins v0.10.0 and relies on flatpak-builder unpacking `.deb` archives, which it does not support.

Verified locally on Linux with `org.flatpak.Builder`: build succeeds, app installs, `flatpak-builder-lint` passes apart from `finish-args-home-filesystem-access` (justified at submission time) and the two appstream mirroring notices that are expected outside Flathub infrastructure.

## Changes

- Pin manifest deb URLs/sha256s and the metainfo release entry to v0.17.1 (current release)
- `publish-flathub` now stamps the metainfo `<release>` entry per release, so it no longer goes stale
- Extract the deb with `ar` + `tar` in build-commands (`type: file` sources); flatpak-builder has no native deb support

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux (WSL2 flatpak build + lint + install)

Refs #117, #290