### PR TITLE
fix(csp): allow 'unsafe-eval' in script-src so D2 diagrams render on WebKit

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -90,6 +90,13 @@ feature:
   plugin marketplace over HTTPS).
 - `script-src data: blob: 'wasm-unsafe-eval'` is required by the Mermaid and
   D2 WASM renderers.
+- `script-src 'unsafe-eval'` is required by D2 alone: its blob-URL worker
+  loads the ELK layout engine via `new Function(...)`, and WebKit (WebKitGTK
+  on Linux, WKWebView on macOS) enforces the page CSP inside blob workers, so
+  without it every D2 render fails there. CSP offers no way to grant eval to
+  one worker only. The practical loss is small: `script-src` already allows
+  `data:` and `blob:` scripts, so an attacker who can inject markup can
+  already run arbitrary script without `eval`.
 - `style-src 'unsafe-inline'` is required by markdown theming and syntax
   highlighting (`dangerousDisableAssetCspModification` keeps Tauri from
   rewriting it).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -714,7 +714,9 @@ mod tests {
     }
 
     // Each (directive, source) pair backs a shipped surface: WASM for
-    // Mermaid/D2, blob/data scripts for the plugin worker sandbox, remote
+    // Mermaid/D2, blob/data scripts for the plugin worker sandbox, eval for
+    // the D2 blob worker's `new Function` ELK loader (WebKit enforces the page
+    // CSP inside blob workers, so without it D2 never renders there), remote
     // schemes for document-embedded images/media, https for AI providers and
     // the marketplace, inline styles for theme injection.
     #[test]
@@ -726,6 +728,7 @@ mod tests {
             let csp = sec[key].as_str().unwrap();
             for (directive, source) in [
                 ("script-src", "'wasm-unsafe-eval'"),
+                ("script-src", "'unsafe-eval'"),
                 ("script-src", "blob:"),
                 ("script-src", "data:"),
                 ("img-src", "https:"),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,8 +21,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost https: http:; img-src 'self' asset: http://asset.localhost https://asset.localhost https: http: data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost https: http:; script-src 'self' data: blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
-      "devCsp": "default-src 'self' http://localhost:1420; connect-src 'self' ipc: http://ipc.localhost ws://localhost:1420 http://localhost:1420 https: http:; img-src 'self' asset: http://asset.localhost https://asset.localhost https: http: data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost https: http:; script-src 'self' data: blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost https: http:; img-src 'self' asset: http://asset.localhost https://asset.localhost https: http: data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost https: http:; script-src 'self' data: blob: 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
+      "devCsp": "default-src 'self' http://localhost:1420; connect-src 'self' ipc: http://ipc.localhost ws://localhost:1420 http://localhost:1420 https: http:; img-src 'self' asset: http://asset.localhost https://asset.localhost https: http: data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost https: http:; script-src 'self' data: blob: 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
       "dangerousDisableAssetCspModification": ["style-src"],
       "assetProtocol": {
         "enable": true,


### PR DESCRIPTION
## Summary

D2 diagrams failed to render on Linux (observed on the v0.17.1 flatpak under WebKitGTK) with "Failed to render diagram", while Mermaid worked. Root cause: the `@terrastruct/d2` engine runs in a blob-URL worker whose init unconditionally loads its ELK layout engine via `new Function(...)`. WebKit enforces the page CSP inside blob workers, and our `script-src` only allowed `'wasm-unsafe-eval'`, so the worker died with "Refused to evaluate a string as JavaScript because 'unsafe-eval' ... is not an allowed source of script" on every render. Chromium-based WebView2 (Windows) does not enforce the page CSP in blob workers the same way, which is why only WebKit platforms (Linux WebKitGTK, and by the same mechanism macOS WKWebView) were affected. Nothing is missing from the deb/flatpak packaging; the WASM is inlined in the JS bundle.

Reproduced and verified against WebKitGTK 2.50.4 (the same engine the flatpak uses) by loading the d2 browser bundle in a WebKitGTK view over HTTP: with the shipped CSP it fails with the exact error above; with `'unsafe-eval'` added it renders (SVG produced).

Security note (also added to `docs/security/threat-model.md`): CSP has no way to grant eval to a single worker, so this is page-wide. The practical loss is small because `script-src` already admits `data:` and `blob:` scripts, so markup injection already implied arbitrary script execution; DOMPurify sanitization of rendered content is unchanged.

## Changes

- `src-tauri/tauri.conf.json`: add `'unsafe-eval'` to `script-src` in both `csp` and `devCsp`
- `src-tauri/src/lib.rs`: pin the new source in the `csp_keeps_every_surface_the_app_depends_on` guard test so a future CSP tightening cannot silently re-break D2
- `docs/security/threat-model.md`: document the new carve-out and its justification

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux (app itself not run; engine-level WebKitGTK verification below)

Verified on WebKitGTK 2.50.4 (WSLg Ubuntu 22.04): a minimal page importing the d2 browser bundle under the app's exact `script-src` reproduces the failure, and renders successfully with this change. Gates run: `pnpm typecheck`, `pnpm check`, `pnpm test` (2711 passed), `cargo test --lib csp` and `cargo clippy --all-targets -- -D warnings`.

## Screenshots

Not applicable (config change).
