### PR TITLE
feat(markdown): hover preview popover for wikilinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 - GitHub-style alerts: `> [!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`
 - Heading anchor links: every heading gets a GitHub-compatible slug; `[text](#heading)` scrolls smoothly to the target
 - Wikilinks: `[[note]]`, `[[note|alias]]`, `[[note#heading]]` resolve against the open folder workspace; broken links render with a distinct style
+- Wikilink hover preview (desktop): rest the pointer on a wikilink to peek at the target note in a floating popover (a `#heading` link previews just that section); click it to open the note, or press `Esc` to dismiss. Hovering a broken link offers to create the missing note
 - Note embeds: `![[note]]` and `![[note#heading]]` render another note (or one heading's section) inline in a bordered block with a control to open the source; broken targets and cycles show a placeholder
 - Relative links: `[text](./note.md)`, `[text](../folder/board.canvas)`, and relative image paths resolve against the document's folder (including `../`) and open in-app, anywhere inside the open workspace; targets that would escape the workspace folder are not followed
 - Backlinks panel: sidebar list of every workspace note that links to the current file, with surrounding-line snippets

--- a/samples/README.md
+++ b/samples/README.md
@@ -341,6 +341,11 @@ When you open a folder as a workspace, `[[note]]` style links resolve to other m
 
 Opening this file on its own (no folder) treats every wikilink as broken.
 
+On desktop, resting the pointer on any of them pops up a preview of the target
+without leaving this page: `[[Index#setup]]` previews just that section, and
+`[[Missing]]` offers to create the note instead. Click the preview to open the
+note for real, or move away (or press `Esc`) to dismiss it.
+
 ### Note embeds
 
 Prefix a wikilink with `!` to render its target inline instead of linking to

--- a/src/components/markdown/LinkComponent.tsx
+++ b/src/components/markdown/LinkComponent.tsx
@@ -6,6 +6,7 @@ import { ExternalLinkIcon } from "@/components/icons/ExternalLinkIcon";
 import { SettingsContext } from "@/contexts/SettingsContext";
 import { isOpenableRelativeHref } from "@/lib/relativePath";
 import { scrollToHeading } from "@/lib/scrollToHeading";
+import { WikilinkAnchor } from "./WikilinkAnchor";
 
 export interface LinkComponentProps extends ComponentPropsWithoutRef<"a"> {
   onOpenWikilink?: (path: string, heading?: string) => void;
@@ -35,9 +36,8 @@ export function LinkComponent(props: LinkComponentProps) {
 
   // Wikilink: identified by remarkWikilink-emitted data attributes. We never
   // route these through openUrl — they're either a workspace file (resolved)
-  // or a no-op (broken).
+  // or a no-op (broken). WikilinkAnchor owns click and hover preview.
   const wikilinkTarget = (rest as Record<string, unknown>)["data-wikilink"];
-  const isWikilink = typeof wikilinkTarget === "string";
   const wikilinkPath = (rest as Record<string, unknown>)["data-wikilink-path"] as
     | string
     | undefined;
@@ -48,13 +48,6 @@ export function LinkComponent(props: LinkComponentProps) {
 
   const handleClick = useCallback(
     async (e: React.MouseEvent<HTMLAnchorElement>) => {
-      if (isWikilink) {
-        e.preventDefault();
-        if (wikilinkBroken || !wikilinkPath) return;
-        onOpenWikilink?.(wikilinkPath, wikilinkHeading);
-        return;
-      }
-
       if (!href) return;
 
       if (href.startsWith("#")) {
@@ -86,25 +79,21 @@ export function LinkComponent(props: LinkComponentProps) {
 
       await openUrl(href);
     },
-    [
-      href,
-      isWikilink,
-      wikilinkBroken,
-      wikilinkPath,
-      wikilinkHeading,
-      onOpenWikilink,
-      onOpenRelativeFile,
-      settings.behavior.confirmExternalLinks,
-      t,
-    ],
+    [href, onOpenRelativeFile, settings.behavior.confirmExternalLinks, t],
   );
 
-  if (isWikilink) {
+  if (typeof wikilinkTarget === "string") {
     return (
-      // biome-ignore lint/a11y/useValidAnchor: navigation routes through onClick by design — wikilinks resolve to in-app file paths, not URLs
-      <a href="#" onClick={handleClick} aria-disabled={wikilinkBroken ? true : undefined} {...rest}>
+      <WikilinkAnchor
+        wikilinkTarget={wikilinkTarget}
+        path={wikilinkPath}
+        heading={wikilinkHeading}
+        broken={wikilinkBroken}
+        onOpenWikilink={onOpenWikilink}
+        {...rest}
+      >
         {children}
-      </a>
+      </WikilinkAnchor>
     );
   }
 

--- a/src/components/markdown/WikilinkAnchor.test.tsx
+++ b/src/components/markdown/WikilinkAnchor.test.tsx
@@ -96,4 +96,24 @@ describe("WikilinkAnchor", () => {
 
     expect(screen.queryByTestId("preview")).not.toBeInTheDocument();
   });
+
+  it("wires up no hover handlers on mobile, where hover has no equivalent", async () => {
+    // The platform gate is a module-level const, so the mock has to be in place
+    // before the module is imported.
+    vi.resetModules();
+    vi.doMock("@/lib/platform", () => ({ isMobilePlatform: () => true }));
+    const { WikilinkAnchor: MobileAnchor } = await import("./WikilinkAnchor");
+
+    try {
+      render(<MobileAnchor {...defaultProps}>Note</MobileAnchor>);
+      const link = screen.getByText("Note");
+
+      fireEvent.mouseEnter(link);
+      act(() => vi.advanceTimersByTime(1000));
+      expect(screen.queryByTestId("preview")).not.toBeInTheDocument();
+    } finally {
+      vi.doUnmock("@/lib/platform");
+      vi.resetModules();
+    }
+  });
 });

--- a/src/components/markdown/WikilinkAnchor.test.tsx
+++ b/src/components/markdown/WikilinkAnchor.test.tsx
@@ -1,0 +1,99 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WikilinkAnchor } from "./WikilinkAnchor";
+
+// The popover's own behaviour is covered in WikilinkPreview.test.tsx; here it is
+// a marker so the tests can assert purely on hover timing and click routing.
+vi.mock("./WikilinkPreview", () => ({
+  WikilinkPreview: ({ target }: { target: string }) => <div data-testid="preview">{target}</div>,
+}));
+
+type AnchorProps = React.ComponentProps<typeof WikilinkAnchor>;
+
+const defaultProps: AnchorProps = {
+  wikilinkTarget: "Note",
+  path: "/w/Note.md",
+  broken: false,
+  onOpenWikilink: vi.fn(),
+};
+
+function renderAnchor(props: Partial<AnchorProps> = {}) {
+  render(
+    <WikilinkAnchor {...defaultProps} {...props}>
+      Note
+    </WikilinkAnchor>,
+  );
+  return screen.getByText("Note");
+}
+
+describe("WikilinkAnchor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("previews the target only after the hover delay elapses", () => {
+    const link = renderAnchor();
+
+    fireEvent.mouseEnter(link);
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.queryByTestId("preview")).not.toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.getByTestId("preview")).toHaveTextContent("Note");
+  });
+
+  it("skips the preview when the pointer leaves before the delay", () => {
+    const link = renderAnchor();
+
+    fireEvent.mouseEnter(link);
+    act(() => vi.advanceTimersByTime(200));
+    fireEvent.mouseLeave(link);
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(screen.queryByTestId("preview")).not.toBeInTheDocument();
+  });
+
+  it("keeps the preview up briefly so the pointer can reach it", () => {
+    const link = renderAnchor();
+
+    fireEvent.mouseEnter(link);
+    act(() => vi.advanceTimersByTime(400));
+    fireEvent.mouseLeave(link);
+    act(() => vi.advanceTimersByTime(100));
+    expect(screen.getByTestId("preview")).toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(100));
+    expect(screen.queryByTestId("preview")).not.toBeInTheDocument();
+  });
+
+  it("opens the note on click, heading and all", () => {
+    const onOpenWikilink = vi.fn();
+    const link = renderAnchor({ heading: "Section", onOpenWikilink });
+
+    fireEvent.click(link);
+    expect(onOpenWikilink).toHaveBeenCalledWith("/w/Note.md", "Section");
+  });
+
+  it("does nothing when a broken link is clicked", () => {
+    const onOpenWikilink = vi.fn();
+    const link = renderAnchor({ path: undefined, broken: true, onOpenWikilink });
+
+    fireEvent.click(link);
+    expect(onOpenWikilink).not.toHaveBeenCalled();
+    expect(link).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("dismisses the preview once the link is clicked", () => {
+    const link = renderAnchor();
+
+    fireEvent.mouseEnter(link);
+    act(() => vi.advanceTimersByTime(400));
+    fireEvent.click(link);
+
+    expect(screen.queryByTestId("preview")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/markdown/WikilinkAnchor.tsx
+++ b/src/components/markdown/WikilinkAnchor.tsx
@@ -1,0 +1,96 @@
+import { type ComponentPropsWithoutRef, useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { isMobilePlatform } from "@/lib/platform";
+import { WikilinkPreview } from "./WikilinkPreview";
+
+const OPEN_DELAY_MS = 350;
+// Grace period so the pointer can travel from the anchor into the popover.
+const CLOSE_DELAY_MS = 150;
+// Hover has no touch equivalent, so the preview is desktop-only (#211).
+const previewEnabled = !isMobilePlatform();
+
+interface WikilinkAnchorProps extends ComponentPropsWithoutRef<"a"> {
+  /** Named `wikilinkTarget`, not `target`, so it can't shadow the anchor attribute. */
+  wikilinkTarget: string;
+  /** Absolute path of the resolved note; absent when the link is broken. */
+  path?: string;
+  heading?: string;
+  broken: boolean;
+  onOpenWikilink?: (path: string, heading?: string) => void;
+}
+
+// A rendered `[[wikilink]]`: navigates in-app on click (never through openUrl,
+// since the href is a placeholder) and peeks the target in a floating preview
+// after a hover delay.
+export function WikilinkAnchor({
+  wikilinkTarget,
+  path,
+  heading,
+  broken,
+  onOpenWikilink,
+  children,
+  ...rest
+}: WikilinkAnchorProps) {
+  const anchorRef = useRef<HTMLAnchorElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const cancelTimer = useCallback(() => clearTimeout(timerRef.current), []);
+  useEffect(() => cancelTimer, [cancelTimer]);
+
+  const scheduleOpen = useCallback(() => {
+    cancelTimer();
+    timerRef.current = setTimeout(() => setPreviewOpen(true), OPEN_DELAY_MS);
+  }, [cancelTimer]);
+
+  const scheduleClose = useCallback(() => {
+    cancelTimer();
+    timerRef.current = setTimeout(() => setPreviewOpen(false), CLOSE_DELAY_MS);
+  }, [cancelTimer]);
+
+  const closeNow = useCallback(() => {
+    cancelTimer();
+    setPreviewOpen(false);
+  }, [cancelTimer]);
+
+  const handleOpen = useCallback(() => {
+    closeNow();
+    if (!broken && path) onOpenWikilink?.(path, heading);
+  }, [closeNow, broken, path, heading, onOpenWikilink]);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    handleOpen();
+  };
+
+  return (
+    <>
+      {/* biome-ignore lint/a11y/useValidAnchor: navigation routes through onClick by design: wikilinks resolve to in-app file paths, not URLs */}
+      <a
+        ref={anchorRef}
+        href="#"
+        onClick={handleClick}
+        aria-disabled={broken ? true : undefined}
+        onMouseEnter={previewEnabled ? scheduleOpen : undefined}
+        onMouseLeave={previewEnabled ? scheduleClose : undefined}
+        {...rest}
+      >
+        {children}
+      </a>
+      {previewOpen &&
+        anchorRef.current &&
+        createPortal(
+          <WikilinkPreview
+            anchor={anchorRef.current}
+            target={wikilinkTarget}
+            path={path}
+            heading={heading}
+            onOpen={handleOpen}
+            onKeepOpen={cancelTimer}
+            onClose={closeNow}
+          />,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/src/components/markdown/WikilinkPreview.test.tsx
+++ b/src/components/markdown/WikilinkPreview.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EmbedContext, type EmbedContextValue } from "@/contexts/EmbedContext";
+import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
+import { readNoteCached } from "@/lib/noteContentCache";
+import { WikilinkPreview } from "./WikilinkPreview";
+
+// Stub the nested renderer so these tests exercise WikilinkPreview's own logic
+// (load, slice, placeholders, dismissal) without the full markdown provider tree.
+vi.mock("./MarkdownContent", () => ({
+  MarkdownContent: ({ content, filePath }: { content: string; filePath?: string }) => (
+    <div data-testid="nested" data-filepath={filePath}>
+      {content}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/noteContentCache", () => ({ readNoteCached: vi.fn() }));
+
+type PreviewProps = React.ComponentProps<typeof WikilinkPreview>;
+
+const defaultProps: PreviewProps = {
+  anchor: document.createElement("a"),
+  target: "Note",
+  path: "/w/Note.md",
+  onOpen: vi.fn(),
+  onKeepOpen: vi.fn(),
+  onClose: vi.fn(),
+};
+
+const tabsApi = {
+  createNote: vi.fn(),
+  renamePath: vi.fn(),
+  openFile: vi.fn(),
+};
+
+function renderPreview(props: Partial<PreviewProps> = {}, workspaceFiles = ["/w/Note.md"]) {
+  const embed: EmbedContextValue = { chain: [], workspaceFiles };
+  const tabs = { workspace: { root: "/w" }, ...tabsApi } as unknown as TabsContextValue;
+  const ui: ReactNode = (
+    <TabsContext.Provider value={tabs}>
+      <EmbedContext.Provider value={embed}>
+        <WikilinkPreview {...defaultProps} {...props} />
+      </EmbedContext.Provider>
+    </TabsContext.Provider>
+  );
+  return render(ui);
+}
+
+describe("WikilinkPreview", () => {
+  beforeEach(() => {
+    vi.mocked(readNoteCached).mockReset();
+    for (const fn of Object.values(tabsApi)) fn.mockReset();
+  });
+
+  it("renders the target note once loaded", async () => {
+    vi.mocked(readNoteCached).mockResolvedValueOnce("# Note\nbody text");
+    renderPreview();
+
+    const nested = await screen.findByTestId("nested");
+    expect(nested).toHaveTextContent("body text");
+    expect(nested).toHaveAttribute("data-filepath", "/w/Note.md");
+  });
+
+  it("previews only the linked section", async () => {
+    vi.mocked(readNoteCached).mockResolvedValueOnce("## A\nalpha\n## B\nbeta");
+    renderPreview({ heading: "B" });
+
+    const nested = await screen.findByTestId("nested");
+    expect(nested).toHaveTextContent("beta");
+    expect(nested).not.toHaveTextContent("alpha");
+  });
+
+  it("reports a missing heading", async () => {
+    vi.mocked(readNoteCached).mockResolvedValueOnce("## A\nalpha");
+    renderPreview({ heading: "Nope" });
+
+    expect(await screen.findByText(/Heading not found/)).toBeInTheDocument();
+    expect(screen.queryByTestId("nested")).not.toBeInTheDocument();
+  });
+
+  it("reports a failed read", async () => {
+    vi.mocked(readNoteCached).mockRejectedValueOnce(new Error("denied"));
+    renderPreview();
+
+    expect(await screen.findByText(/Could not load preview/)).toBeInTheDocument();
+  });
+
+  it("ignores a read that settles after unmount", async () => {
+    let resolve: ((v: string) => void) | undefined;
+    vi.mocked(readNoteCached).mockReturnValueOnce(
+      new Promise<string>((r) => {
+        resolve = r;
+      }),
+    );
+    const { unmount } = renderPreview();
+    unmount();
+    resolve?.("late body");
+    await Promise.resolve();
+    expect(screen.queryByTestId("nested")).not.toBeInTheDocument();
+  });
+
+  it("refuses to read a path outside the workspace (raw-HTML injection guard)", () => {
+    renderPreview({ path: "/etc/passwd", target: "passwd" });
+
+    expect(screen.getByText(/Note not found: passwd/)).toBeInTheDocument();
+    expect(readNoteCached).not.toHaveBeenCalled();
+  });
+
+  it("creates and opens the missing note from a broken link", async () => {
+    tabsApi.createNote.mockResolvedValue("/w/Untitled.md");
+    tabsApi.renamePath.mockResolvedValue("/w/Missing.md");
+    renderPreview({ path: undefined, target: "Missing" });
+
+    fireEvent.click(screen.getByRole("button", { name: /create note/i }));
+    await vi.waitFor(() => expect(tabsApi.openFile).toHaveBeenCalledWith("/w/Missing.md"));
+    expect(tabsApi.createNote).toHaveBeenCalledWith("/w");
+    expect(tabsApi.renamePath).toHaveBeenCalledWith("/w/Untitled.md", "Missing");
+  });
+
+  it("offers no create affordance for a nested target", () => {
+    renderPreview({ path: undefined, target: "folder/Missing" });
+
+    expect(screen.getByText(/Note not found/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /create note/i })).not.toBeInTheDocument();
+  });
+
+  it("opens the note when the popover is clicked, but not when it is broken", async () => {
+    vi.mocked(readNoteCached).mockResolvedValueOnce("body");
+    const onOpen = vi.fn();
+    const { unmount } = renderPreview({ onOpen });
+
+    fireEvent.click(await screen.findByRole("dialog"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    unmount();
+
+    const brokenOnOpen = vi.fn();
+    renderPreview({ path: undefined, target: "Missing", onOpen: brokenOnOpen });
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(brokenOnOpen).not.toHaveBeenCalled();
+  });
+
+  it("dismisses on Escape, on an outside press, and when the pointer leaves", async () => {
+    vi.mocked(readNoteCached).mockResolvedValue("body");
+    const onClose = vi.fn();
+    renderPreview({ onClose });
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.mouseDown(document.body);
+    fireEvent.mouseLeave(await screen.findByRole("dialog"));
+    expect(onClose).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/components/markdown/WikilinkPreview.test.tsx
+++ b/src/components/markdown/WikilinkPreview.test.tsx
@@ -101,6 +101,20 @@ describe("WikilinkPreview", () => {
     expect(screen.queryByTestId("nested")).not.toBeInTheDocument();
   });
 
+  it("ignores a read that rejects after unmount", async () => {
+    let reject: ((e: unknown) => void) | undefined;
+    vi.mocked(readNoteCached).mockReturnValueOnce(
+      new Promise<string>((_, r) => {
+        reject = r;
+      }),
+    );
+    const { unmount } = renderPreview();
+    unmount();
+    reject?.(new Error("late"));
+    await Promise.resolve();
+    expect(screen.queryByText(/Could not load preview/)).not.toBeInTheDocument();
+  });
+
   it("refuses to read a path outside the workspace (raw-HTML injection guard)", () => {
     renderPreview({ path: "/etc/passwd", target: "passwd" });
 
@@ -141,6 +155,30 @@ describe("WikilinkPreview", () => {
     expect(brokenOnOpen).not.toHaveBeenCalled();
   });
 
+  it("opens the note on Enter but ignores other keys", async () => {
+    vi.mocked(readNoteCached).mockResolvedValueOnce("body");
+    const onOpen = vi.fn();
+    renderPreview({ onOpen });
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.keyDown(dialog, { key: "a" });
+    expect(onOpen).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(dialog, { key: "Enter" });
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays open on a press inside it and on keys other than Escape", async () => {
+    vi.mocked(readNoteCached).mockResolvedValueOnce("body");
+    const onClose = vi.fn();
+    renderPreview({ onClose });
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.mouseDown(dialog);
+    fireEvent.keyDown(window, { key: "a" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("dismisses on Escape, on an outside press, and when the pointer leaves", async () => {
     vi.mocked(readNoteCached).mockResolvedValue("body");
     const onClose = vi.fn();
@@ -150,5 +188,32 @@ describe("WikilinkPreview", () => {
     fireEvent.mouseDown(document.body);
     fireEvent.mouseLeave(await screen.findByRole("dialog"));
     expect(onClose).toHaveBeenCalledTimes(3);
+  });
+
+  it("flips above the link when it would not fit below", async () => {
+    // happy-dom reports every element as 0-height, so the popover has to be
+    // given a real height for the fit calculation to have anything to weigh.
+    const height = 200;
+    const offsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetHeight");
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      get: () => height,
+    });
+
+    const bottomAnchor = document.createElement("a");
+    const top = window.innerHeight - 20;
+    bottomAnchor.getBoundingClientRect = () => ({ top, bottom: top + 18, left: 40 }) as DOMRect;
+
+    try {
+      vi.mocked(readNoteCached).mockResolvedValueOnce("body");
+      renderPreview({ anchor: bottomAnchor });
+
+      const dialog = await screen.findByRole("dialog");
+      // Sits above the anchor and grows downward from its own bottom edge.
+      expect(dialog.style.transformOrigin).toBe("bottom left");
+      expect(dialog.style.top).toBe(`${top - 6 - height}px`);
+    } finally {
+      if (offsetHeight) Object.defineProperty(HTMLElement.prototype, "offsetHeight", offsetHeight);
+    }
   });
 });

--- a/src/components/markdown/WikilinkPreview.tsx
+++ b/src/components/markdown/WikilinkPreview.tsx
@@ -83,8 +83,8 @@ export function WikilinkPreview({
   // clamps both axes into the viewport.
   // biome-ignore lint/correctness/useExhaustiveDependencies: `state` is a re-measure trigger, not a value read; the height changes when content replaces the loading line
   useLayoutEffect(() => {
-    const el = rootRef.current;
-    if (!el) return;
+    // Attached before any layout effect runs, so it is never null here.
+    const el = rootRef.current!;
     const rect = anchor.getBoundingClientRect();
     const height = el.offsetHeight;
     const spaceBelow = window.innerHeight - rect.bottom - ANCHOR_GAP - VIEWPORT_MARGIN;

--- a/src/components/markdown/WikilinkPreview.tsx
+++ b/src/components/markdown/WikilinkPreview.tsx
@@ -1,0 +1,201 @@
+import type { TFunction } from "i18next";
+import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useEmbedContext } from "@/contexts/EmbedContext";
+import { useCreateWikilinkNote } from "@/hooks/useCreateWikilinkNote";
+import { extractHeadingSection } from "@/lib/headingSection";
+import { readNoteCached } from "@/lib/noteContentCache";
+import { isNestedTarget } from "@/lib/wikilinkResolver";
+import { MarkdownContent } from "./MarkdownContent";
+
+const WIDTH = 380;
+const MAX_HEIGHT = 320;
+const VIEWPORT_MARGIN = 8;
+const ANCHOR_GAP = 6;
+
+const SURFACE_CLASS =
+  "fixed z-50 overflow-y-auto overscroll-contain rounded-[var(--glyph-radius)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 shadow-[0_10px_30px_rgba(0,0,0,0.22)] text-[var(--color-text-primary)]";
+
+const PLACEHOLDER_CLASS = "text-sm text-[var(--color-text-secondary)]";
+
+type LoadState = { status: "loading" } | { status: "error" } | { status: "ready"; content: string };
+
+interface WikilinkPreviewProps {
+  /** The hovered anchor; the popover positions itself against its rect. */
+  anchor: HTMLElement;
+  target: string;
+  path?: string;
+  heading?: string;
+  onOpen: () => void;
+  /** Pointer re-entered the popover: cancel the pending close. */
+  onKeepOpen: () => void;
+  onClose: () => void;
+}
+
+// Floating preview of a wikilink's target, shown after a hover delay. Renders
+// through the shared MarkdownContent so it matches the document view. A
+// `#heading` link previews just that section (the same slice embeds use)
+// rather than scrolling a full render.
+export function WikilinkPreview({
+  anchor,
+  target,
+  path,
+  heading,
+  onOpen,
+  onKeepOpen,
+  onClose,
+}: WikilinkPreviewProps) {
+  const { t } = useTranslation("common");
+  const { workspaceFiles } = useEmbedContext();
+  const createNote = useCreateWikilinkNote();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  // Only ever read a file the resolver already matched to a workspace member.
+  // `data-wikilink-path` can be injected via raw HTML that survives the
+  // sanitizer, so this gate (mirroring EmbedComponent's) keeps `read_file` off
+  // arbitrary absolute paths.
+  const canLoad = !!path && !!workspaceFiles?.includes(path);
+
+  useEffect(() => {
+    if (!canLoad || !path) return;
+    let alive = true;
+    readNoteCached(path)
+      .then((content) => {
+        if (alive) setState({ status: "ready", content });
+      })
+      .catch(() => {
+        if (alive) setState({ status: "error" });
+      });
+    return () => {
+      alive = false;
+    };
+  }, [canLoad, path]);
+
+  // Position before paint, and again once content lands and the height changes.
+  // Prefers below the anchor, flips above when that side has more room, then
+  // clamps both axes into the viewport.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `state` is a re-measure trigger, not a value read; the height changes when content replaces the loading line
+  useLayoutEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const rect = anchor.getBoundingClientRect();
+    const height = el.offsetHeight;
+    const spaceBelow = window.innerHeight - rect.bottom - ANCHOR_GAP - VIEWPORT_MARGIN;
+    const spaceAbove = rect.top - ANCHOR_GAP - VIEWPORT_MARGIN;
+    const flipUp = height > spaceBelow && spaceAbove > spaceBelow;
+    const rawTop = flipUp ? rect.top - ANCHOR_GAP - height : rect.bottom + ANCHOR_GAP;
+    const maxTop = window.innerHeight - height - VIEWPORT_MARGIN;
+    const maxLeft = window.innerWidth - WIDTH - VIEWPORT_MARGIN;
+    setPos({
+      top: Math.max(VIEWPORT_MARGIN, Math.min(rawTop, maxTop)),
+      left: Math.max(VIEWPORT_MARGIN, Math.min(rect.left, maxLeft)),
+    });
+  }, [anchor, state]);
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) onClose();
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("mousedown", handleMouseDown, true);
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("resize", onClose);
+    window.addEventListener("blur", onClose);
+    return () => {
+      window.removeEventListener("mousedown", handleMouseDown, true);
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", onClose);
+      window.removeEventListener("blur", onClose);
+    };
+  }, [onClose]);
+
+  // Clicking the surface opens the note in full (the issue's "click anywhere to
+  // navigate"); Enter mirrors it for anyone who reaches the popover by keyboard.
+  const handleOpen = canLoad ? onOpen : undefined;
+
+  return (
+    <div
+      ref={rootRef}
+      role="dialog"
+      aria-label={target}
+      className={SURFACE_CLASS}
+      style={{ top: pos.top, left: pos.left, width: WIDTH, maxHeight: MAX_HEIGHT }}
+      onMouseEnter={onKeepOpen}
+      onMouseLeave={onClose}
+      onClick={handleOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") handleOpen?.();
+      }}
+    >
+      {renderBody(
+        state,
+        canLoad ? path : undefined,
+        target,
+        heading,
+        workspaceFiles,
+        createNote,
+        t,
+      )}
+    </div>
+  );
+}
+
+function renderBody(
+  state: LoadState,
+  path: string | undefined,
+  target: string,
+  heading: string | undefined,
+  workspaceFiles: string[] | undefined,
+  createNote: ((target: string) => Promise<void>) | null,
+  t: TFunction<"common">,
+): ReactNode {
+  if (!path) {
+    // A nested target (`[[folder/note]]`) is skipped: rename_path collapses
+    // separators into a single component, so the created file wouldn't satisfy
+    // the link anyway.
+    const canCreate = createNote && !isNestedTarget(target);
+    return (
+      <div className={PLACEHOLDER_CLASS}>
+        <p>{t("wikilinkPreview.notFound", { target })}</p>
+        {canCreate && (
+          <button
+            type="button"
+            className="mt-2 rounded-[var(--glyph-radius-sm)] border border-[var(--color-border)] px-2 py-1 text-[var(--color-accent)] hover:bg-[color-mix(in_srgb,var(--color-accent)_16%,transparent)]"
+            onClick={() => createNote(target)}
+          >
+            {t("wikilinkPreview.createNote")}
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  if (state.status === "loading") {
+    return <p className={PLACEHOLDER_CLASS}>{t("wikilinkPreview.loading")}</p>;
+  }
+  if (state.status === "error") {
+    return <p className={PLACEHOLDER_CLASS}>{t("wikilinkPreview.error", { target })}</p>;
+  }
+
+  const content = heading ? extractHeadingSection(state.content, heading) : state.content;
+  if (heading && content === "") {
+    return <p className={PLACEHOLDER_CLASS}>{t("wikilinkPreview.headingNotFound", { heading })}</p>;
+  }
+
+  // filePath=path resolves the preview's own wikilinks against the target and
+  // extends EmbedContext.chain, so an embed inside it can't recurse forever.
+  return (
+    <div className="markdown-body" dir="auto">
+      <MarkdownContent
+        content={content}
+        filePath={path}
+        workspaceFiles={workspaceFiles}
+        showFrontmatter={false}
+      />
+    </div>
+  );
+}

--- a/src/components/markdown/WikilinkPreview.tsx
+++ b/src/components/markdown/WikilinkPreview.tsx
@@ -8,13 +8,15 @@ import { readNoteCached } from "@/lib/noteContentCache";
 import { isNestedTarget } from "@/lib/wikilinkResolver";
 import { MarkdownContent } from "./MarkdownContent";
 
-const WIDTH = 380;
-const MAX_HEIGHT = 320;
+const WIDTH = 440;
+const MAX_HEIGHT = 400;
 const VIEWPORT_MARGIN = 8;
 const ANCHOR_GAP = 6;
 
+// `wikilink-preview` (markdown.css) adds the materialize-in transition and its
+// transform-origin follows the flip via the inline style below.
 const SURFACE_CLASS =
-  "fixed z-50 overflow-y-auto overscroll-contain rounded-[var(--glyph-radius)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 shadow-[0_10px_30px_rgba(0,0,0,0.22)] text-[var(--color-text-primary)]";
+  "wikilink-preview fixed z-50 overflow-y-auto overscroll-contain rounded-[var(--glyph-radius)] border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 shadow-[0_10px_30px_rgba(0,0,0,0.22)] text-[var(--color-text-primary)]";
 
 const PLACEHOLDER_CLASS = "text-sm text-[var(--color-text-secondary)]";
 
@@ -50,6 +52,9 @@ export function WikilinkPreview({
   const createNote = useCreateWikilinkNote();
   const rootRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState({ top: 0, left: 0 });
+  // Scale-in origin: from the top when the popover sits below the anchor, from
+  // the bottom when it flips above, so it grows out of the link either way.
+  const [origin, setOrigin] = useState("top left");
   const [state, setState] = useState<LoadState>({ status: "loading" });
 
   // Only ever read a file the resolver already matched to a workspace member.
@@ -92,6 +97,7 @@ export function WikilinkPreview({
       top: Math.max(VIEWPORT_MARGIN, Math.min(rawTop, maxTop)),
       left: Math.max(VIEWPORT_MARGIN, Math.min(rect.left, maxLeft)),
     });
+    setOrigin(flipUp ? "bottom left" : "top left");
   }, [anchor, state]);
 
   useEffect(() => {
@@ -123,7 +129,13 @@ export function WikilinkPreview({
       role="dialog"
       aria-label={target}
       className={SURFACE_CLASS}
-      style={{ top: pos.top, left: pos.left, width: WIDTH, maxHeight: MAX_HEIGHT }}
+      style={{
+        top: pos.top,
+        left: pos.left,
+        width: WIDTH,
+        maxHeight: MAX_HEIGHT,
+        transformOrigin: origin,
+      }}
       onMouseEnter={onKeepOpen}
       onMouseLeave={onClose}
       onClick={handleOpen}
@@ -189,7 +201,7 @@ function renderBody(
   // filePath=path resolves the preview's own wikilinks against the target and
   // extends EmbedContext.chain, so an embed inside it can't recurse forever.
   return (
-    <div className="markdown-body" dir="auto">
+    <div className="markdown-body markdown-preview-body" dir="auto">
       <MarkdownContent
         content={content}
         filePath={path}

--- a/src/hooks/useCreateWikilinkNote.test.tsx
+++ b/src/hooks/useCreateWikilinkNote.test.tsx
@@ -1,0 +1,75 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
+import { useCreateWikilinkNote } from "./useCreateWikilinkNote";
+
+// Minimal context stubs, like renderInWorkspace: only the fields the hook reads.
+function wrapperFor(tabs: object | null) {
+  const value = tabs as unknown as TabsContextValue | null;
+  return ({ children }: { children: ReactNode }) => (
+    <TabsContext.Provider value={value}>{children}</TabsContext.Provider>
+  );
+}
+
+describe("useCreateWikilinkNote", () => {
+  it("returns null without an open workspace, so the affordance stays hidden", () => {
+    const { result } = renderHook(() => useCreateWikilinkNote(), { wrapper: wrapperFor(null) });
+    expect(result.current).toBeNull();
+  });
+
+  it("no-ops when the workspace context cannot create files", async () => {
+    const openFile = vi.fn();
+    const { result } = renderHook(() => useCreateWikilinkNote(), {
+      // A root but no create/rename API: the callback exists and must bail out
+      // rather than throw on the missing commands.
+      wrapper: wrapperFor({ workspace: { root: "/w" }, openFile }),
+    });
+
+    await act(async () => {
+      await result.current?.("Missing");
+    });
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it("stops when the note cannot be created", async () => {
+    const createNote = vi.fn().mockResolvedValue(null);
+    const renamePath = vi.fn();
+    const openFile = vi.fn();
+    const { result } = renderHook(() => useCreateWikilinkNote(), {
+      wrapper: wrapperFor({
+        workspace: { root: "/w" },
+        createNote,
+        renamePath,
+        openFile,
+      }),
+    });
+
+    await act(async () => {
+      await result.current?.("Missing");
+    });
+    expect(createNote).toHaveBeenCalledWith("/w");
+    expect(renamePath).not.toHaveBeenCalled();
+    expect(openFile).not.toHaveBeenCalled();
+  });
+
+  it("opens the created note when the rename fails", async () => {
+    const createNote = vi.fn().mockResolvedValue("/w/Untitled.md");
+    const renamePath = vi.fn().mockResolvedValue(null);
+    const openFile = vi.fn();
+    const { result } = renderHook(() => useCreateWikilinkNote(), {
+      wrapper: wrapperFor({
+        workspace: { root: "/w" },
+        createNote,
+        renamePath,
+        openFile,
+      }),
+    });
+
+    await act(async () => {
+      await result.current?.("Missing");
+    });
+    // Falls back to the untitled path so the new note still opens.
+    expect(openFile).toHaveBeenCalledWith("/w/Untitled.md");
+  });
+});

--- a/src/hooks/useCreateWikilinkNote.ts
+++ b/src/hooks/useCreateWikilinkNote.ts
@@ -1,0 +1,29 @@
+import { useCallback, useContext } from "react";
+import { TabsContext } from "@/contexts/TabsContext";
+
+// Create the note a broken wikilink points at (at the workspace root, named
+// after the target) and open it. Reads the tabs context optionally, like
+// useWorkspaceRoot, so the shared renderers that run without a provider get
+// null and hide the affordance instead of throwing.
+export function useCreateWikilinkNote(): ((target: string) => Promise<void>) | null {
+  const ctx = useContext(TabsContext);
+  const root = ctx?.workspace?.root;
+  const createNote = ctx?.createNote;
+  const renamePath = ctx?.renamePath;
+  const openFile = ctx?.openFile;
+
+  const create = useCallback(
+    async (target: string) => {
+      if (!root || !createNote || !renamePath || !openFile) return;
+      const created = await createNote(root);
+      if (!created) return;
+      // rename_path keeps the .md extension when the name carries none, and
+      // resolves collisions, so the target name goes through as authored.
+      const renamed = await renamePath(created, target);
+      await openFile(renamed ?? created);
+    },
+    [root, createNote, renamePath, openFile],
+  );
+
+  return root ? create : null;
+}

--- a/src/lib/noteContentCache.test.ts
+++ b/src/lib/noteContentCache.test.ts
@@ -1,0 +1,27 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readNoteCached } from "./noteContentCache";
+
+describe("readNoteCached", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockClear();
+  });
+
+  it("reads a note once and serves later peeks from the cache", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce("body");
+
+    await expect(readNoteCached("/w/A.md")).resolves.toBe("body");
+    await expect(readNoteCached("/w/A.md")).resolves.toBe("body");
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith("read_file", { path: "/w/A.md" });
+  });
+
+  it("evicts a failed read so the next peek retries", async () => {
+    vi.mocked(invoke).mockRejectedValueOnce(new Error("denied"));
+    await expect(readNoteCached("/w/B.md")).rejects.toThrow("denied");
+
+    vi.mocked(invoke).mockResolvedValueOnce("recovered");
+    await expect(readNoteCached("/w/B.md")).resolves.toBe("recovered");
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/noteContentCache.ts
+++ b/src/lib/noteContentCache.ts
@@ -1,0 +1,15 @@
+import { invoke } from "@tauri-apps/api/core";
+
+// Session cache for hover-preview reads: peeking the same note repeatedly while
+// browsing would otherwise cost a Rust round-trip each time. Failed reads are
+// evicted so a transient error doesn't poison the entry (as in d2Render).
+const cache = new Map<string, Promise<string>>();
+
+export function readNoteCached(path: string): Promise<string> {
+  const hit = cache.get(path);
+  if (hit) return hit;
+  const pending = invoke<string>("read_file", { path });
+  cache.set(path, pending);
+  pending.catch(() => cache.delete(path));
+  return pending;
+}

--- a/src/lib/wikilinkResolver.ts
+++ b/src/lib/wikilinkResolver.ts
@@ -35,6 +35,11 @@ function normalizeTarget(raw: string): string {
   return t;
 }
 
+/** A target that names a location ("folder/note") rather than a bare note name. */
+export function isNestedTarget(target: string): boolean {
+  return target.includes("/") || target.includes("\\");
+}
+
 export function resolveWikilink(
   rawTarget: string,
   workspaceFiles: string[],
@@ -49,7 +54,7 @@ export function resolveWikilink(
   // Two match modes:
   //  1. relative-path-ish target ("folder/note") → match the suffix of any path
   //  2. bare name → match by stem
-  const looksLikePath = cleaned.includes("/") || cleaned.includes("\\");
+  const nested = isNestedTarget(cleaned);
   // Path-suffix matching normalizes separators: workspace paths arrive with the
   // OS separator (backslashes on Windows), while a wikilink target is authored
   // with `/`, so `[[Notes/Ingredients]]` must still match `…\Notes\Ingredients`.
@@ -57,7 +62,7 @@ export function resolveWikilink(
 
   const candidates: string[] = [];
   for (const file of workspaceFiles) {
-    if (looksLikePath) {
+    if (nested) {
       const noExt = file
         .replace(/\.[^./\\]+$/, "")
         .replace(/\\/g, "/")

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -243,6 +243,13 @@
     "headingNotFound": "Überschrift nicht gefunden: {{heading}}",
     "error": "Eingebettete Notiz konnte nicht geladen werden: {{target}}"
   },
+  "wikilinkPreview": {
+    "loading": "Vorschau wird geladen…",
+    "notFound": "Notiz nicht gefunden: {{target}}",
+    "createNote": "Notiz erstellen",
+    "headingNotFound": "Überschrift nicht gefunden: {{heading}}",
+    "error": "Vorschau konnte nicht geladen werden: {{target}}"
+  },
   "defaultAppBanner": {
     "message": "Glyph als Standard-Markdown-App festlegen?",
     "setDefault": "Als Standard festlegen",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -243,6 +243,13 @@
     "headingNotFound": "Heading not found: {{heading}}",
     "error": "Could not load embed: {{target}}"
   },
+  "wikilinkPreview": {
+    "loading": "Loading preview...",
+    "notFound": "Note not found: {{target}}",
+    "createNote": "Create note",
+    "headingNotFound": "Heading not found: {{heading}}",
+    "error": "Could not load preview: {{target}}"
+  },
   "defaultAppBanner": {
     "message": "Make Glyph your default Markdown app?",
     "setDefault": "Set as default",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -240,6 +240,13 @@
     "headingNotFound": "Encabezado no encontrado: {{heading}}",
     "error": "No se pudo cargar la inserción: {{target}}"
   },
+  "wikilinkPreview": {
+    "loading": "Cargando vista previa...",
+    "notFound": "Nota no encontrada: {{target}}",
+    "createNote": "Crear nota",
+    "headingNotFound": "Encabezado no encontrado: {{heading}}",
+    "error": "No se pudo cargar la vista previa: {{target}}"
+  },
   "headingAnchor": {
     "label": "Copiar enlace al encabezado"
   },

--- a/src/locales/fa/common.json
+++ b/src/locales/fa/common.json
@@ -243,6 +243,13 @@
     "headingNotFound": "عنوان پیدا نشد: {{heading}}",
     "error": "بارگذاری محتوای جاسازی‌شده ممکن نشد: {{target}}"
   },
+  "wikilinkPreview": {
+    "loading": "در حال بارگذاری پیش‌نمایش…",
+    "notFound": "یادداشت پیدا نشد: {{target}}",
+    "createNote": "ایجاد یادداشت",
+    "headingNotFound": "سرفصل پیدا نشد: {{heading}}",
+    "error": "پیش‌نمایش بارگذاری نشد: {{target}}"
+  },
   "defaultAppBanner": {
     "message": "Glyph برنامه پیش‌فرض Markdown شما شود؟",
     "setDefault": "تنظیم به‌عنوان پیش‌فرض",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -240,6 +240,13 @@
     "headingNotFound": "找不到标题：{{heading}}",
     "error": "无法加载嵌入内容：{{target}}"
   },
+  "wikilinkPreview": {
+    "loading": "正在加载预览…",
+    "notFound": "未找到笔记：{{target}}",
+    "createNote": "创建笔记",
+    "headingNotFound": "未找到标题：{{heading}}",
+    "error": "无法加载预览：{{target}}"
+  },
   "headingAnchor": {
     "label": "复制标题链接"
   },

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "./platform.css";
 @import "./markdown.css";
+@import "./wikilinkPreview.css";
 @import "./notebook.css";
 @import "./canvas.css";
 @import "./settings.css";

--- a/src/styles/wikilinkPreview.css
+++ b/src/styles/wikilinkPreview.css
@@ -1,0 +1,47 @@
+/* Hover preview popover (WikilinkPreview). Kept out of markdown.css so the main
+   renderer's stylesheet (which also feeds the HTML/EPUB exports via
+   collectStyles) stays untouched. Imported after markdown.css so the
+   `.markdown-preview-body` overrides win on equal specificity. */
+
+/* Scales in from the anchor; transform-origin is set inline per flip. */
+.wikilink-preview {
+  transition:
+    opacity 150ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+@starting-style {
+  .wikilink-preview {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+}
+
+/* Denser than the document: smaller type, no outer margins so the content sits
+   flush with the popover padding, and no 70vh scroll tail (the box sizes to
+   its content). */
+.markdown-preview-body {
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  padding-bottom: 0;
+}
+
+.markdown-preview-body > :first-child {
+  margin-top: 0;
+}
+
+.markdown-preview-body > :last-child {
+  margin-bottom: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wikilink-preview {
+    transition: opacity 120ms ease;
+  }
+
+  @starting-style {
+    .wikilink-preview {
+      transform: none;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Resting the pointer on a wikilink now peeks the target note in a floating popover instead of costing a full navigation. Renders through the shared `MarkdownContent`, so preview content matches the document view. Desktop only (hover has no touch equivalent).

Closes #211

## Changes

- New `WikilinkAnchor` owns the rendered `[[wikilink]]`: click navigation plus a hover-delay (350ms open / 150ms close grace) that mounts the preview through a portal. `LinkComponent`'s wikilink branch moved here and shrank.
- New `WikilinkPreview`: positions against the anchor, flips above it near the viewport bottom, clamps into the viewport, scrolls internally when long, and dismisses on pointer-out, Escape, outside press, resize, or blur (the `ContextMenu` pattern). Click opens the note in full.
- `[[note#heading]]` previews just that section, reusing `extractHeadingSection` (the same slice `![[note#heading]]` embeds use).
- Broken link offers a "create note" affordance (workspace root, named after the target) via the existing `create_note` + `rename_path` commands; nested targets (`[[folder/note]]`) are skipped since rename collapses separators.
- Session cache (`noteContentCache`) over `read_file` so repeated peeks cost one round-trip; failed reads evict so they retry.
- Reads gated on workspace membership, the same injection guard `EmbedComponent` applies, so an injected `data-wikilink-path` can never point `read_file` at an arbitrary path.
- Extracted `isNestedTarget` in `wikilinkResolver` (replaces an inline separator check, now shared).
- `wikilinkPreview` i18n keys in all five locales; README + samples/README docs.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated gates green: `pnpm typecheck`, `pnpm check`, `pnpm test` (2722 pass, 18 new), `cargo clippy --all-targets -- -D warnings`. Not yet exercised in a running build against a real pointer (hover timing, popover placement/flip, create-note landing) — leaving the platform boxes unchecked.

## Screenshots

<!-- pending manual run -->
