### PR TITLE
chore: assign new issues to the maintainer by default

### DIFF
--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -27,6 +27,7 @@ Idea: **$ARGUMENTS**
    - Create the issue with an **imperative-mood title** (per CONTRIBUTING.md, e.g. "Add word count to the status bar"):
      ```
      gh issue create --title "<imperative title>" --body "<spec markdown>" \
+       --assignee hamidfzm \
        --label enhancement --label "priority: <low|medium|high>" --label <category>
      ```
      Category labels where they fit: `markdown`, `ui`, `navigation` (check `gh label list` first; omit if none fit).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
 labels: ["bug"]
+assignees: ["hamidfzm"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement (doubles as the implementable spec)
 labels: ["enhancement"]
+assignees: ["hamidfzm"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

New issues opened from either issue form are now auto-assigned to the maintainer, so nothing lands in the tracker unowned.

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/ISSUE_TEMPLATE/feature_request.yml`: add `assignees: ["hamidfzm"]`
- `spec.md` command: pass `--assignee hamidfzm` when creating the spec issue

Blank issues are still enabled (`blank_issues_enabled: true`), and those get no assignee. Say the word if the tracker should be forms-only.

Companion change in the org: glyph-md/.github#1 adds an org-wide default issue-template config so satellite repos redirect their New issue page here.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

YAML-only change, verified by opening the issue-form picker after merge.
