### PR TITLE
feat(image-viewer): zoom with hotkeys and Ctrl/Cmd+scroll

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -298,7 +298,7 @@ Relative paths resolve against this file's folder, so SVGs and other images comm
 
 Click any image to open it in the lightbox: zoom in/out, fit or actual size, drag to pan around a zoomed-in image, and use the arrow keys to move between them. Press `Esc` or click the backdrop to close.
 
-The workspace also ships standalone image files in several formats. Open `diagram.png`, `diagram.jpg`, `diagram.gif`, or `diagram.svg` from the file tree: each opens in the image viewer, where the same controls (zoom in/out, fit, actual size, scroll or drag to pan) apply. SVGs render crisply at any zoom.
+The workspace also ships standalone image files in several formats. Open `diagram.png`, `diagram.jpg`, `diagram.gif`, or `diagram.svg` from the file tree: each opens in the image viewer, where the same controls (zoom in/out, fit, actual size, scroll or drag to pan) apply, plus `Cmd/Ctrl+=/-/0` or `Cmd/Ctrl`+scroll to zoom. SVGs render crisply at any zoom.
 
 ### Inline SVG
 

--- a/src/components/markdown/ImageViewer.test.tsx
+++ b/src/components/markdown/ImageViewer.test.tsx
@@ -1,7 +1,13 @@
 import { invoke } from "@tauri-apps/api/core";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, type Mock } from "vitest";
+import { useZoomApi } from "@/contexts/ZoomContext";
+import { ZoomProvider } from "@/contexts/ZoomProvider";
 import { ImageViewer } from "./ImageViewer";
+
+function zoomLevel(container: HTMLElement): number {
+  return parseInt(container.querySelector(".image-viewer-zoom-level")?.textContent ?? "", 10);
+}
 
 describe("ImageViewer", () => {
   it("renders a raster image through the asset protocol", () => {
@@ -41,6 +47,19 @@ describe("ImageViewer", () => {
     // The cleanup flag must suppress the setSrc on the unmounted component
     // (no act warning / state-update-after-unmount).
     resolveRead("<svg/>");
+    await Promise.resolve();
+  });
+
+  it("ignores a late SVG read that fails after unmount", async () => {
+    let rejectRead!: (err: Error) => void;
+    (invoke as Mock).mockReturnValueOnce(
+      new Promise<string>((_resolve, reject) => {
+        rejectRead = reject;
+      }),
+    );
+    const { unmount } = render(<ImageViewer filePath="/notes/late-fail.svg" />);
+    unmount();
+    rejectRead(new Error("read failed"));
     await Promise.resolve();
   });
 
@@ -119,6 +138,63 @@ describe("ImageViewer", () => {
     fireEvent.load(img);
     fireEvent(window, new Event("resize"));
     expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("zooms with Ctrl or Cmd + wheel and ignores a plain wheel", () => {
+    const { container } = render(<ImageViewer filePath="/a/b/photo.png" />);
+    const stage = container.querySelector(".image-viewer-stage") as HTMLElement;
+    // happy-dom drops WheelEvent modifiers from its init, so set them directly.
+    const wheel = (modifiers: { ctrlKey?: boolean; metaKey?: boolean }, deltaY: number) =>
+      act(() => {
+        const event = new Event("wheel", { bubbles: true, cancelable: true });
+        Object.defineProperty(event, "ctrlKey", { value: modifiers.ctrlKey ?? false });
+        Object.defineProperty(event, "metaKey", { value: modifiers.metaKey ?? false });
+        Object.defineProperty(event, "deltaY", { value: deltaY });
+        stage.dispatchEvent(event);
+      });
+
+    wheel({}, -100);
+    expect(zoomLevel(container)).toBe(100);
+
+    wheel({ ctrlKey: true }, -100);
+    const afterCtrl = zoomLevel(container);
+    expect(afterCtrl).toBeGreaterThan(100);
+
+    // Cmd+wheel is the macOS equivalent; scrolling down zooms back out.
+    wheel({ metaKey: true }, 100);
+    expect(zoomLevel(container)).toBeLessThan(afterCtrl);
+  });
+
+  it("responds to the Zoom In/Out/Actual-Size commands", () => {
+    const ZoomButtons = () => {
+      const api = useZoomApi();
+      return (
+        <>
+          <button type="button" onClick={() => api?.actions.zoomIn()}>
+            cmd-zoom-in
+          </button>
+          <button type="button" onClick={() => api?.actions.zoomOut()}>
+            cmd-zoom-out
+          </button>
+          <button type="button" onClick={() => api?.actions.zoomReset()}>
+            cmd-actual-size
+          </button>
+        </>
+      );
+    };
+    const { container } = render(
+      <ZoomProvider>
+        <ImageViewer filePath="/a/b/photo.png" />
+        <ZoomButtons />
+      </ZoomProvider>,
+    );
+    act(() => screen.getByText("cmd-zoom-in").click());
+    expect(zoomLevel(container)).toBe(125);
+    act(() => screen.getByText("cmd-zoom-out").click());
+    expect(zoomLevel(container)).toBe(100);
+    act(() => screen.getByText("cmd-zoom-in").click());
+    act(() => screen.getByText("cmd-actual-size").click());
+    expect(zoomLevel(container)).toBe(100);
   });
 
   it("stops refitting on resize once the user has zoomed", () => {

--- a/src/components/markdown/ImageViewer.tsx
+++ b/src/components/markdown/ImageViewer.tsx
@@ -5,6 +5,7 @@ import { ActualSizeIcon } from "@/components/icons/ActualSizeIcon";
 import { FitIcon } from "@/components/icons/FitIcon";
 import { ZoomInIcon } from "@/components/icons/ZoomInIcon";
 import { ZoomOutIcon } from "@/components/icons/ZoomOutIcon";
+import { useZoomApi } from "@/contexts/ZoomContext";
 import { useDragPan } from "@/hooks/useDragPan";
 import { isSvgFile } from "@/lib/imageExtensions";
 import { clampScale, fitScale, ZOOM_STEP } from "@/lib/lightbox";
@@ -15,6 +16,8 @@ import { toAssetUrl } from "./resolveImageSrc";
 interface ImageViewerProps {
   filePath: string;
 }
+
+const WHEEL_ZOOM_SPEED = 0.0015;
 
 // Read-only viewer for an image/SVG file tab. The asset is served through
 // Tauri's asset protocol (never read as text), laid out inside a scrollable
@@ -114,6 +117,36 @@ export function ImageViewer({ filePath }: ImageViewerProps) {
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, [isFit, computeFit]);
+
+  // Route the Zoom In/Out/Actual-Size commands to this viewer while it's the
+  // active surface. Actual Size maps to 100%, matching the toolbar button.
+  const registerZoomTarget = useZoomApi()?.registerTarget;
+  useEffect(() => {
+    if (!registerZoomTarget) return;
+    registerZoomTarget({
+      zoomIn: () => zoomBy(ZOOM_STEP),
+      zoomOut: () => zoomBy(1 / ZOOM_STEP),
+      zoomReset: actualSize,
+    });
+    return () => registerZoomTarget(null);
+  }, [registerZoomTarget, zoomBy, actualSize]);
+
+  // Ctrl/Cmd + wheel zooms; a plain wheel keeps panning a zoomed image. Native
+  // non-passive listener so preventDefault cancels the scroll.
+  useEffect(() => {
+    const stage = stageRef.current;
+    /* v8 ignore start -- defensive: the stage div is always mounted by now */
+    if (!stage) return;
+    /* v8 ignore stop */
+    const handleWheel = (event: WheelEvent) => {
+      if (!event.ctrlKey && !event.metaKey) return;
+      event.preventDefault();
+      setScale((s) => clampScale(s * Math.exp(-event.deltaY * WHEEL_ZOOM_SPEED)));
+      setIsFit(false);
+    };
+    stage.addEventListener("wheel", handleWheel, { passive: false });
+    return () => stage.removeEventListener("wheel", handleWheel);
+  }, []);
 
   // With an intrinsic size we lay the image out at `natural × scale` so zooming
   // past the viewport pans. Without one (an SVG with only a viewBox) there are


### PR DESCRIPTION
## Summary

Wires the standalone image/SVG file viewer into the same zoom commands as the note and graph surfaces. `Cmd/Ctrl` `+`/`-`/`0` and `Cmd/Ctrl`+scroll now zoom an open image, alongside the existing toolbar buttons. A plain wheel still pans a zoomed image.

Stacked on #549 (base branch `feat/temporary-tab-zoom`), which adds the `ZoomProvider` registration this builds on. Review/merge #549 first; this PR's diff is only the image-viewer changes.

## Changes

- `ImageViewer` registers its zoom handlers with `ZoomProvider` while it's the active surface, mapping Zoom In/Out to its scale and Actual Size to 100%.
- Adds a `Ctrl`/`Cmd`+wheel listener on the image stage (non-passive, so it cancels the scroll); a plain wheel is untouched and keeps panning.
- Docs: README and samples note the image zoom shortcuts.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated gates green locally: `pnpm typecheck`, `pnpm check`, `pnpm test` (2763 tests). No Rust changed. Not yet exercised in a running desktop build.

## Screenshots

N/A
