### PR TITLE
chore: add engineering invariants, PR risk gates, and slimmer agent prompts

### DIFF
--- a/.claude/agents/builder.md
+++ b/.claude/agents/builder.md
@@ -2,17 +2,13 @@
 name: builder
 description: Builds Glyph for production and reports bundle size and any warnings.
 tools: Read, Bash, Grep, Glob
-model: sonnet
 ---
 
-You are a build agent for the Glyph project.
+You are the build agent for the Glyph project.
 
-When invoked, perform a full production build:
+Run `pnpm tauri build` and report:
 
-1. Run `pnpm tauri build` to build the full application
-2. Report:
-   - Build success/failure
-   - Frontend bundle size (from Vite output)
-   - Binary size (check `src-tauri/target/release/glyph` or the bundle output)
-   - Any warnings from TypeScript, Vite, or Cargo
-3. If the build fails, diagnose the root cause and suggest a fix
+- Build success or failure (diagnose the root cause and suggest a fix on failure)
+- Frontend bundle sizes from the Vite output: the startup (entry) chunk and lazy chunks, flagging anything that grew unexpectedly
+- Release binary size (`src-tauri/target/release/glyph`, `glyph.exe` on Windows) or the platform bundle output
+- Any TypeScript, Vite, or Cargo warnings

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -2,21 +2,17 @@
 name: code-reviewer
 description: Reviews code changes for quality, correctness, and consistency with Glyph conventions.
 tools: Read, Grep, Glob, Bash
-model: sonnet
 ---
 
 You are a senior code reviewer for the Glyph project (Tauri v2 + React 19 + TypeScript).
 
-When invoked, review the current diff or specified files:
+Review the current diff (`git diff` / `git diff --cached`, or the range you were given), reading changed files in full context, including callers and cleanup paths of what changed.
 
-1. Run `git diff` or `git diff --cached` to see changes
-2. Read the changed files for full context
-3. Review for:
-   - **Correctness**: Logic errors, edge cases, race conditions
-   - **TypeScript**: Proper typing, no `any`, correct hook dependencies
-   - **Rust**: Proper error handling (`Result`/`Option`), no unwrap in production paths, memory safety
-   - **Security**: No XSS via dangerouslySetInnerHTML, no path traversal in file commands
-   - **Consistency**: CSS custom properties for theming, named exports, conventional commits
-   - **Performance**: Unnecessary re-renders, missing useMemo/useCallback, large bundle imports
-4. Provide specific, actionable feedback with file:line references
-5. Rate severity: critical / warning / suggestion
+Judge the change against:
+
+- **Invariants** ([docs/engineering-invariants.md](../../docs/engineering-invariants.md)): for each invariant the diff touches, reconstruct the ownership and state transitions it affects and attempt a concrete counterexample (a sequence of events that violates it). Report the attempt even when it fails.
+- **Correctness**: logic errors, edge cases, and the adversarial scenario matrix from the invariants doc (stale completions, overlapping operations, lifecycle transitions).
+- **Project conventions**: the rules in `.claude/rules/` (notably `frontend.md`, `rust.md`, `tests.md`, `code-organization.md`) are authoritative; check the diff against them rather than your own style preferences.
+- **Security**: untrusted input reaching rendering or filesystem/IPC surfaces without validation (INV-5, INV-6).
+
+Provide specific, actionable feedback with file:line references. Rate severity: critical / warning / suggestion.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,20 +1,20 @@
 ---
 name: tester
-description: Builds and runs the project to verify everything compiles and works correctly.
+description: Runs the full verification gates and reports missing scenario coverage.
 tools: Read, Bash, Grep, Glob
-model: sonnet
 ---
 
-You are a build and test agent for the Glyph project.
+You are the test agent for the Glyph project.
 
-When invoked, run the full verification pipeline:
+Run the complete gates (the same set CI enforces):
 
-1. **TypeScript**: Run `pnpm typecheck`; ensure no type errors
-2. **Frontend build**: Run `pnpm build`; ensure Vite builds successfully
-3. **Rust check**: Run `cd src-tauri && cargo check`; ensure Rust compiles
-4. **Rust clippy**: Run `cd src-tauri && cargo clippy -- -D warnings`; check for lint warnings
+1. `pnpm typecheck`
+2. `pnpm check` (Biome)
+3. `pnpm test` (frontend suite)
+4. `pnpm build` (Vite production build)
+5. `cd src-tauri && cargo test`
+6. `cd src-tauri && cargo clippy --all-targets -- -D warnings`
 
-Report results clearly:
-- List each step with pass/fail status
-- For failures, include the relevant error output
-- Suggest fixes for any issues found
+Report each step pass/fail with the decisive error lines for failures, and inspect stderr for warnings even when a step passes.
+
+Then go beyond command success: for the change under test, compare its coverage against the adversarial scenario matrix in [docs/engineering-invariants.md](../../docs/engineering-invariants.md) and report which scenario classes (lifecycle transitions, stale completions, overlapping operations, malformed input, denial paths) have no test. Missing scenario classes are findings, not footnotes.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -6,7 +6,7 @@ tools: Read, Bash, Grep, Glob
 
 You are the test agent for the Glyph project.
 
-Run the complete gates (the same set CI enforces):
+Run the complete gates (equivalent to or stricter than what CI runs):
 
 1. `pnpm typecheck`
 2. `pnpm check` (Biome)

--- a/.claude/agents/ui-inspector.md
+++ b/.claude/agents/ui-inspector.md
@@ -1,20 +1,18 @@
 ---
 name: ui-inspector
 description: Inspects UI components for accessibility, consistency, and platform-adaptive styling issues.
-tools: Read, Grep, Glob
-model: sonnet
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a UI inspector for the Glyph project.
 
-When invoked, audit the frontend code:
+Scope each audit to the change under review: run `git diff --name-only main...HEAD` (or audit the files you were given) and inspect those components and their styles, not the whole tree.
 
-1. Read all components in `src/components/`
-2. Read all styles in `src/styles/`
-3. Check for:
-   - **Accessibility**: Missing ARIA attributes, keyboard navigation, focus management
-   - **Platform consistency**: Colors using CSS custom properties (not hardcoded), platform-specific code using `data-platform` attribute
-   - **Dark mode**: All colors using theme tokens (`var(--color-*)`), no hardcoded colors that break in dark mode
-   - **Responsive**: Proper overflow handling, truncation, min/max widths
-   - **Tailwind**: Correct v4 syntax, no deprecated utilities
-4. Report findings with file:line references and suggested fixes
+Audit against the frontend conventions in `.claude/rules/frontend.md` (theme and platform via CSS custom properties, `data-platform` attribute) plus:
+
+- **Accessibility**: ARIA attributes, keyboard navigation, focus management
+- **Dark mode**: theme tokens (`var(--color-*)`), no hardcoded colors
+- **Responsive**: overflow handling, truncation, min/max widths
+- **Tailwind v4**: correct syntax, no deprecated utilities
+
+Report findings with file:line references and suggested fixes.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -18,17 +18,19 @@ You are the **ship** stage of Glyph's spec-driven workflow. Get the work for iss
 
 3. **Review the diff.** Invoke the `code-reviewer` agent (via the Task tool) on `git diff main...HEAD`. Surface its findings by severity (critical / warning / suggestion) and fix anything critical or warranted before opening the PR. Re-run the gates after fixes.
 
-4. **Check patch coverage before pushing.** Run `pnpm test:coverage` and confirm every file touched by the diff has no uncovered lines from this change. If lines are missing, add tests now: pushing without them just means the Codecov bot flags the PR minutes later.
+4. **Complete the risk declaration.** Fill the PR template's Risk classification section from the diff. If the diff touches persistence, lifecycle, IPC, filesystem, plugins, credentials, or sanitization, the body must name the invariants at stake from `docs/engineering-invariants.md` and point at the tests that prove them. **Do not open the PR while that evidence is missing**; route back to `/implement` to add it.
 
-5. **Push and open the PR:**
+5. **Check patch coverage before pushing.** Run `pnpm test:coverage` and confirm every file touched by the diff has no uncovered lines from this change. If lines are missing, add tests now: pushing without them just means the Codecov bot flags the PR minutes later.
+
+6. **Push and open the PR:**
    - `git push -u origin <branch>`.
    - Title: conventional-commit style matching the work (`feat: ...` / `fix: ...`).
-   - Body: fill in `.github/PULL_REQUEST_TEMPLATE.md` (Summary, Changes, Testing checklist, Screenshots). Include **`Closes #$ARGUMENTS`** in the body so the issue auto-closes on merge.
+   - Body: fill in `.github/PULL_REQUEST_TEMPLATE.md` (Summary, Changes, Risk classification, Testing checklist, Screenshots). Include **`Closes #$ARGUMENTS`** in the body so the issue auto-closes on merge.
      - Use only GitHub's recognized keywords (`Closes`, `Fixes`, `Resolves`). Never `closing`/`fixing`/`resolving`, which silently leave the issue open (see CLAUDE.md).
    - Create it: `gh pr create --title "..." --body-file ...`.
 
-6. **Resolve the Codecov report.** After CI uploads coverage, the `codecov` bot comments on the PR. Check it (`gh pr view <number> --comments`, look for "Patch coverage"). If it reports missing lines, treat that as a blocker, not a note: reproduce locally with `pnpm test:coverage`, add tests for the flagged lines, and push. The bot edits its comment on the next upload; done means the comment shows no missing patch lines (or the only misses are genuinely untestable and you have said so on the PR). Never leave a red patch-coverage comment unaddressed and unacknowledged.
+7. **Resolve the Codecov report.** After CI uploads coverage, the `codecov` bot comments on the PR. Check it (`gh pr view <number> --comments`, look for "Patch coverage"). If it reports missing lines, treat that as a blocker, not a note: reproduce locally with `pnpm test:coverage`, add tests for the flagged lines, and push. The bot edits its comment on the next upload; done means the comment shows no missing patch lines (or the only misses are genuinely untestable and you have said so on the PR). Never leave a red patch-coverage comment unaddressed and unacknowledged.
 
-7. Print the PR URL and remind the user CI must pass on all 3 platforms (and Codecov patch coverage) before merge.
+8. Print the PR URL and remind the user CI must pass on all 3 platforms (and Codecov patch coverage) before merge.
 
 No em dashes. Do not push to `main` or create releases.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -18,7 +18,7 @@ You are the **ship** stage of Glyph's spec-driven workflow. Get the work for iss
 
 3. **Review the diff.** Invoke the `code-reviewer` agent (via the Task tool) on `git diff main...HEAD`. Surface its findings by severity (critical / warning / suggestion) and fix anything critical or warranted before opening the PR. Re-run the gates after fixes.
 
-4. **Complete the risk declaration.** Fill the PR template's Risk classification section from the diff. If the diff touches persistence, lifecycle, IPC, filesystem, plugins, credentials, or sanitization, the body must name the invariants at stake from `docs/engineering-invariants.md` and point at the tests that prove them. **Do not open the PR while that evidence is missing**; route back to `/implement` to add it.
+4. **Complete the risk declaration.** Fill the PR template's Risk classification section from the diff. If any risk area other than "No risk areas touched" is checked, the body must name the invariants at stake (if any) from `docs/engineering-invariants.md` and point at the tests that prove them. **Do not open the PR while that evidence is missing**; route back to `/implement` to add it.
 
 5. **Check patch coverage before pushing.** Run `pnpm test:coverage` and confirm every file touched by the diff has no uncovered lines from this change. If lines are missing, add tests now: pushing without them just means the Codecov bot flags the PR minutes later.
 

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -31,4 +31,5 @@ paths:
 ## Both
 
 - Tests assert behavior, not implementation: no snapshot tests, no asserting on internal state shape.
+- Stateful or security-sensitive changes cover the applicable rows of the adversarial scenario matrix in [docs/engineering-invariants.md](../../docs/engineering-invariants.md) (lifecycle transitions, stale completions, overlapping operations, denial paths).
 - Every gate must stay green: `pnpm typecheck && pnpm check && pnpm test`, and `cargo clippy --all-targets -- -D warnings` in `src-tauri/`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 ## Risk classification
 
-<!-- Check every area this PR touches. Each checked area requires the invariants at stake and evidence below. If none apply, check the last box. -->
+<!-- Check every area this PR touches. Each checked area requires the invariants at stake (if any) and evidence below. If none apply, check the last box. -->
 
 - [ ] Persistence / data loss
 - [ ] Asynchronous ordering / races

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,26 @@
 
 -
 
+## Risk classification
+
+<!-- Check every area this PR touches. Each checked area requires the invariants at stake and evidence below. If none apply, check the last box. -->
+
+- [ ] Persistence / data loss
+- [ ] Asynchronous ordering / races
+- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
+- [ ] Filesystem / IPC surface
+- [ ] Untrusted rendering (Markdown, plugins, links)
+- [ ] Secrets / credentials
+- [ ] Network
+- [ ] Migrations / persisted-format changes
+- [ ] Accessibility
+- [ ] Bundle size / startup
+- [ ] No risk areas touched
+
+### Invariants at stake and evidence
+
+<!-- For each checked area: which invariants from docs/engineering-invariants.md apply, and which tests (or reasoning) prove them. Example: "INV-3: stale write cannot clobber newer edit; covered by useTabs.test.tsx 'stale completion' cases." -->
+
 ## Testing
 
 <!-- How was this tested? -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,3 +4,5 @@ See [CLAUDE.md](../CLAUDE.md) for architecture, key files, and release process.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for development commands, conventions, workflow, and PR guidelines.
 
 Additional rules for frontend and Rust code are in `.claude/rules/`.
+
+Non-negotiable guarantees for stateful and security-sensitive code are in [docs/engineering-invariants.md](../docs/engineering-invariants.md); changes touching them must name the invariants at stake and test the adversarial scenario matrix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ The spec stays current throughout: acceptance-criteria and task checkboxes on th
 - **Plan before non-trivial work.** Anything beyond a one-line change starts from a spec (`/spec`) or an existing issue, not freeform edits.
 - **Ask, don't guess.** When acceptance criteria or scope are ambiguous, ask the user before writing code.
 - **Follow the rules in `.claude/rules/`**, which are authoritative for code organization, frontend, i18n, Rust, app-shell, docs, cleanup, CI hygiene, the worktree workflow, sibling repos (the glyph-md org), and Sentry issue fixes.
+- **Never break the [engineering invariants](docs/engineering-invariants.md).** Stateful or security-sensitive changes name the invariants they touch and cover the adversarial scenario matrix with tests.
 - **Run the gates before every PR** (the same gate the Husky pre-commit hook and CI enforce):
   ```bash
   pnpm typecheck && pnpm check && pnpm test
@@ -37,7 +38,7 @@ The spec stays current throughout: acceptance-criteria and task checkboxes on th
 
 Delegate to the project agents in `.claude/agents/` rather than doing their job inline:
 
-- **`tester`**: runs `pnpm typecheck`, `pnpm test`, `cargo check`, `cargo clippy`; use it to gate `/implement` and `/ship`.
+- **`tester`**: runs the full gates (typecheck, Biome, frontend tests and build, `cargo test`, strict clippy) and reports missing scenario coverage; use it to gate `/implement` and `/ship`.
 - **`code-reviewer`**: reviews the diff for correctness, typing, Rust error handling, security, and consistency; used by `/ship` before opening a PR.
 - **`builder`**: runs the production `pnpm tauri build` and reports bundle/binary size and warnings.
 - **`ui-inspector`**: audits components for accessibility, platform-adaptive styling, and dark mode.

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -67,6 +67,6 @@ For stateful or security-sensitive changes, tests and PR evidence must cover the
 
 ## Maintenance
 
-- Every escaped data-loss or security defect adds a regression test here and, if needed, a new invariant.
+- Every escaped data-loss or security defect adds a regression test and, if needed, a new invariant here.
 - Review this catalog at each minor-release kickoff and after every security or data-loss incident.
 - Mutation-testing baseline for the persistence and authorization modules is documented here once introduced (#441, Phase 4).

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -1,0 +1,72 @@
+# Engineering Invariants
+
+Non-negotiable guarantees for Glyph. Every stateful or security-sensitive change is reviewed against this list, and every PR that touches a risk area must name the invariants at stake and point at evidence (see the Risk classification section of the [PR template](../.github/PULL_REQUEST_TEMPLATE.md)). Reviewers use this document as their rubric; a review of a change that touches an invariant must include a concrete counterexample attempt against it.
+
+## Invariants
+
+### INV-1: User edits are never silently discarded
+
+A user edit is never discarded without a completed durable write or an explicit, informed discard by the user.
+
+- Owners: `src/hooks/useTabs.ts` (save path, dirty tracking), `src/hooks/useAutoSave.ts`, `src/hooks/useWindowClose.ts`
+- Evidence: `src/hooks/useAutoSave.test.ts`, `src/hooks/useTabs.test.tsx`
+
+### INV-2: Empty is not absent
+
+Empty string is valid loaded document content. `null`/`undefined` represents absence or a loading state. The two are never conflated in types, conditions, or UI.
+
+- Owners: `src/hooks/useTabs.ts` document state, any component branching on content
+- Evidence: type signatures; tests asserting empty-document round trips
+
+### INV-3: Stale results never win
+
+Older asynchronous work cannot overwrite newer state or mark it complete. Writes to the same path are serialized; completions are revision-guarded.
+
+- Owners: `src/hooks/useTabs.ts` (`writeChains`, revision guards)
+- Evidence: `src/hooks/useTabs.test.tsx` stale-completion cases
+
+### INV-4: Owners flush before they die
+
+Closing or replacing an owner (tab, workspace, window) flushes or transfers every pending operation it owns. Nothing pending is dropped on unmount, tab close, workspace switch, or app exit.
+
+- Owners: `src/hooks/useTabs.ts` close-flush coordination, `src/hooks/useWindowClose.ts`
+- Evidence: lifecycle transition tests (edit -> switch -> close, shutdown flush)
+
+### INV-5: All external input is untrusted
+
+Renderer input, Markdown content, plugins, filenames, URLs, and IPC arguments are untrusted until validated. See the [threat model](security/threat-model.md).
+
+- Owners: `src-tauri/src/grants.rs`, every Tauri command, Markdown/link/image rendering components
+- Evidence: negative tests in `src-tauri/src/grants.rs` and command test modules
+
+### INV-6: The backend is the boundary
+
+Frontend permission labels and disabled buttons are UX, not security boundaries. Backend validation (`grants.rs` `ensure_readable` / `ensure_writable` / `ensure_watchable` / `ensure_workspace`) is authoritative for every filesystem and IPC operation.
+
+- Owners: `src-tauri/src/grants.rs`, `src-tauri/src/commands/`
+- Evidence: denial tests driving the command surface without grants
+
+### INV-7: Partial results are explicit
+
+Truncation, fallback, and partial results are represented explicitly in types and UI. No silent truncation, no fallback that pretends to be the full result.
+
+- Owners: any code path that truncates, samples, or falls back
+- Evidence: tests asserting the partial state is surfaced, not hidden
+
+## Adversarial scenario matrix
+
+For stateful or security-sensitive changes, tests and PR evidence must cover the applicable transitions:
+
+- empty, normal, large, malformed, and missing input
+- success, failure, cancellation, timeout, and retry
+- rapid repetition and overlapping operations
+- tab switch, workspace switch, unmount, window close, and app exit
+- one item versus multiple simultaneously active items
+- stale completion after newer state
+- trusted versus untrusted caller, and paths inside versus outside grants
+
+## Maintenance
+
+- Every escaped data-loss or security defect adds a regression test here and, if needed, a new invariant.
+- Review this catalog at each minor-release kickoff and after every security or data-loss incident.
+- Mutation-testing baseline for the persistence and authorization modules is documented here once introduced (#441, Phase 4).


### PR DESCRIPTION
## Summary

Phase 1 of #441: establish the engineering-invariants catalog and wire risk-based review gates into the contributor workflow. Docs and process only, no application code.

## Changes

- New `docs/engineering-invariants.md`: seven non-negotiable invariants (INV-1 to INV-7) with owning modules and evidence pointers, plus the adversarial scenario matrix and a maintenance policy
- Linked the catalog from the contributor instruction files and the test rules
- Rewrote the four review/test/build/UI-inspection agent definitions: principles with pointers to the existing rules instead of duplicated style checklists, full documented gates for the test agent (typecheck, Biome, frontend tests and build, Rust tests, strict clippy on all targets), diff-scoped UI audits, platform-correct binary reporting for the build agent, and the invariants catalog as the review rubric with a counterexample attempt per touched invariant
- Behavioral note: the agent definitions no longer pin a model, so they now inherit the session's model
- PR template gains a Risk classification section: risk-area checkboxes plus a named-invariants-and-evidence block
- The shipping checklist now blocks PR creation when a checked risk area has no invariant/evidence declaration

Part of #441 (Phases 2-4, the executable test suites and mutation baseline, follow in separate PRs).

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

Docs and process files only; no runtime code path changes. All relative links in the new and edited files verified against their targets.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

Gates run locally on Windows: typecheck, Biome (639 files), full frontend suite (2818 tests). Rust untouched by this diff.

## Screenshots

Not applicable (docs only).
