### PR TITLE
ci: lint test targets with clippy --all-targets

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -101,4 +101,4 @@ jobs:
         run: echo "::add-matcher::.github/matchers/rust.json"
       - name: Run Clippy
         working-directory: src-tauri
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
## Summary

The Clippy CI job ran `cargo clippy -- -D warnings` without `--all-targets`, so test and bench targets escaped linting. The documented gate (CONTRIBUTING.md and the pre-commit hook) uses `--all-targets`, so CI was weaker than the local gate.

## Changes

- Add `--all-targets` to the Clippy step in `.github/workflows/ci-tests.yml` so CI lints the same targets as the local gate.

## Testing

- Ran `cargo clippy --all-targets -- -D warnings` locally in `src-tauri`: clean, no new warnings in test targets.
- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A (CI-only change)