### PR TITLE
fix(cli): keep the CLI folder when StrictMode double-invokes init

### DIFF
--- a/src/hooks/useTabs.test.tsx
+++ b/src/hooks/useTabs.test.tsx
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { pickFiles, pickFolder } from "@/lib/pickers";
 import { COMPLETE_SCAN } from "@/lib/workspaceScan";
@@ -157,6 +158,34 @@ describe("useTabs initialization", () => {
     });
     expect(invoke).toHaveBeenCalledWith("watch_directory", { path: "/p/workspace" });
     expect(invoke).not.toHaveBeenCalledWith("read_file", { path: "/p/cli.md" });
+  });
+
+  it("keeps the CLI folder when StrictMode double-invokes the init effect", async () => {
+    // Regression: get_initial_folder consumes its value, so the second dev-mode
+    // run read None and fell through to session restore, replacing the folder
+    // the CLI had just opened.
+    let folderReads = 0;
+    vi.mocked(invoke).mockImplementation(
+      makeInvoker({
+        get_initial_folder: async () => {
+          folderReads += 1;
+          return folderReads === 1 ? "/p/cli-workspace" : null;
+        },
+      }) as typeof invoke,
+    );
+    const { result } = renderHook(
+      () =>
+        useTabs(
+          defaultOptions({
+            openTabs: [{ kind: "folder" as const, path: "/p/old-session" }],
+          }),
+        ),
+      { wrapper: StrictMode },
+    );
+
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+    expect(result.current.workspace?.root).toBe("/p/cli-workspace");
+    expect(invoke).not.toHaveBeenCalledWith("watch_directory", { path: "/p/old-session" });
   });
 
   it("restores legacy string[] open tabs", async () => {

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -221,6 +221,8 @@ export function useTabs(options: UseTabsOptions) {
   workspaceRef.current = workspace;
   const optionsRef = useRef(options);
   optionsRef.current = options;
+  // Guards the mount-only init effect against StrictMode's double invoke.
+  const didInit = useRef(false);
 
   // The single close coordinator. Defined up here so every destructive
   // lifecycle path (tab close, workspace close/replace, window close) flushes
@@ -1193,6 +1195,12 @@ export function useTabs(options: UseTabsOptions) {
   // Initialize: load CLI arg, restore workspace + tabs, or reopen last file
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only effect
   useEffect(() => {
+    // `get_initial_file` / `get_initial_folder` consume their value, so a second
+    // run reads None and would fall through to session restore, replacing the
+    // folder the CLI just opened. StrictMode double-invokes effects in dev, so
+    // this must run exactly once per mount lifetime.
+    if (didInit.current) return;
+    didInit.current = true;
     (async () => {
       try {
         // A spawned secondary window was created to open one specific path.


### PR DESCRIPTION
## Summary

`glyph <folder>` (and `pnpm tauri dev -- -- <folder>`) opened the **previous session's** workspace instead of the folder passed on the command line. Reproduced every time in `pnpm tauri dev`.

**Root cause:** `get_initial_file` / `get_initial_folder` *consume* their stashed value (`.take()`), so they only answer once. The init effect in `useTabs` is mount-only but had no run-once guard, and `main.tsx` wraps the app in `<StrictMode>`, which double-invokes effects in development:

1. **Mount 1** reads `get_initial_folder()` → the CLI folder → opens it, consuming the stash.
2. **Mount 2** reads `None` → falls through to session restore → `openFolder(previousSessionRoot)`.

One workspace per window means step 2 **replaces** the folder step 1 just opened. Production builds mount once, so packaged Glyph was unaffected — this was dev-only.

**Fix:** guard the init effect with a ref so it runs exactly once per mount lifetime.

## Changes

- `src/hooks/useTabs.ts`: `didInit` ref guarding the mount-only init effect
- `src/hooks/useTabs.test.tsx`: regression test that renders the hook inside a real `StrictMode` wrapper (so the effect genuinely double-invokes), with a one-shot `get_initial_folder` and a persisted session folder, asserting the CLI folder wins and the session root is never watched

Verified the test actually catches the bug: with the guard removed it fails with `expected '/p/old-session' to be '/p/cli-workspace'`, which is exactly the reported symptom.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Repro before/after: `pnpm tauri dev -- -- samples/` (note the **two** `--`; the first goes to pnpm, the second marks app args).

Gates green: `pnpm typecheck`, `pnpm check`, `pnpm test` (full suite), and `useTabs.ts` line coverage 100%.
