### PR TITLE
fix(mobile): make the app usable on phones and tablets

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 
 ### Platform
 - macOS, Windows, and Linux; native menu bar with remappable shortcuts and update notifications
+- iOS and Android (experimental): open and read single files, with a touch layout for phones and tablets; folder workspaces are desktop-only for now
 - Plugins (experimental): extend rendering, palette, status bar, dictionaries, and themes; sandboxed by default with consent-gated permissions and checksum-verified marketplace installs (see the [plugin docs](https://glyph-md.github.io/plugins/))
 - Local-first with opt-in crash reporting (off by default; see [Privacy & Error Reporting](#privacy--error-reporting))
 
@@ -279,7 +280,7 @@ Glyph is built around speed, native feel, and offline-first usage. The tables be
 | Native window styling | ✅ (vibrancy/Mica) | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
 | Native bundle (non-Electron) | ✅ Tauri (~3 MB core) | ❌ | ✅ Qt | ❌ | ❌ | ❌ | ❌ |
 | macOS / Windows / Linux | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Mobile (iOS / Android) | planned | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Mobile (iOS / Android) | ⚠️ experimental (viewing) | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | File associations + CLI | ✅ | ⚠️ | ✅ | ⚠️ | ⚠️ | ❌ | ✅ |
 | Open source | ✅ MIT | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Free | ✅ | ✅ | $14.99 | ✅ | ✅ | ✅ | ✅ |

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -306,9 +306,9 @@ export function AppShell() {
   const showContent = activeTab?.kind === "graph" || showDocument;
 
   return (
-    // Safe-area insets pad the whole shell so whatever sits at each edge — a
-    // banner or the tab bar at the top, the status bar at the bottom — clears
-    // the status bar / cutout / home indicator. The bottom bar adds its own
+    // Safe-area insets pad the whole shell so whatever sits at each edge (a
+    // banner or the tab bar at the top, the status bar at the bottom) clears
+    // the status bar, cutout, and home indicator. The bottom bar adds its own
     // gesture-nav floor on top of this (see .status-bar).
     <div
       className="flex flex-col h-full bg-[var(--color-surface)]"

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -14,6 +14,7 @@ import { useErrorReportingPrompt } from "@/hooks/useErrorReportingPrompt";
 import { useExport } from "@/hooks/useExport";
 import { useExportSite } from "@/hooks/useExportSite";
 import { useFontZoom } from "@/hooks/useFontZoom";
+import { useCanSplit } from "@/hooks/useMediaQuery";
 import { useMenuEvents } from "@/hooks/useMenuEvents";
 import { useNativeKeybindings } from "@/hooks/useNativeKeybindings";
 import { useNativeMenuLabels } from "@/hooks/useNativeMenuLabels";
@@ -38,6 +39,7 @@ import { EmptyState } from "./layout/EmptyState";
 import { ErrorReportingBanner } from "./layout/ErrorReportingBanner";
 import { ExportProgress } from "./layout/ExportProgress";
 import { Sidebar } from "./layout/Sidebar";
+import { SidebarDrawerBackdrop } from "./layout/SidebarDrawerBackdrop";
 import { StatusBar } from "./layout/StatusBar";
 import { TabBar } from "./layout/TabBar";
 import { UpdateBanner } from "./layout/UpdateBanner";
@@ -177,12 +179,15 @@ export function AppShell() {
     if (activeTabId) closeTab(activeTabId);
   }, [activeTabId, closeTab]);
 
+  // Narrow (phone) viewports drop split from the cycle, so the toggle goes
+  // view → edit → view.
+  const canSplit = useCanSplit();
   const handleToggleEdit = useCallback(() => {
     if (!activeTabId) return;
     // nextEditorMode treats an undefined mode as view, so no fallback branch
     // is needed at the call site.
-    setTabMode(activeTabId, nextEditorMode(activeFile?.mode));
-  }, [activeTabId, activeFile?.mode, setTabMode]);
+    setTabMode(activeTabId, nextEditorMode(activeFile?.mode, canSplit));
+  }, [activeTabId, activeFile?.mode, setTabMode, canSplit]);
 
   const handleSave = useCallback(() => {
     if (activeTabId) saveDocument(activeTabId);
@@ -301,7 +306,18 @@ export function AppShell() {
   const showContent = activeTab?.kind === "graph" || showDocument;
 
   return (
-    <div className="flex flex-col h-full bg-[var(--color-surface)]">
+    // Safe-area insets pad the whole shell so whatever sits at each edge — a
+    // banner or the tab bar at the top, the status bar at the bottom — clears
+    // the status bar / cutout / home indicator. The bottom bar adds its own
+    // gesture-nav floor on top of this (see .status-bar).
+    <div
+      className="flex flex-col h-full bg-[var(--color-surface)]"
+      style={{
+        paddingTop: "var(--glyph-safe-top)",
+        paddingLeft: "var(--glyph-safe-left)",
+        paddingRight: "var(--glyph-safe-right)",
+      }}
+    >
       <UpdateBanner update={updateCheck.update} onDismiss={updateCheck.dismiss} />
       {defaultAppPrompt.show && (
         <DefaultAppBanner
@@ -321,7 +337,8 @@ export function AppShell() {
         onDismiss={tabs.dismissWorkspaceNotice}
       />
       <TabBar onToggleAIChat={aiController.configured ? aiController.togglePanel : null} />
-      <div className="flex flex-1 min-h-0">
+      <div className="relative flex flex-1 min-h-0">
+        <SidebarDrawerBackdrop />
         <Sidebar side="left" />
         {showContent ? (
           <TabContent searchOpen={searchOpen} onSearchClose={() => setSearchOpen(false)} />

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -1,10 +1,11 @@
 import { useCallback } from "react";
 import { useTabsContext } from "@/contexts/TabsContext";
+import { useCanSplit } from "@/hooks/useMediaQuery";
 import { useTaskList } from "@/hooks/useTaskList";
 import { isCanvasFile } from "@/lib/canvasExtensions";
 import { isImageFile } from "@/lib/imageExtensions";
 import { isNotebookFile } from "@/lib/notebookExtensions";
-import { EDITOR_MODE } from "@/lib/settings";
+import { EDITOR_MODE, effectiveEditorMode } from "@/lib/settings";
 import { CanvasEditor, CanvasViewer } from "./canvas/lazyCanvas";
 import { MarkdownEditor, SplitView } from "./editor/lazyEditor";
 import { GraphView } from "./graph/lazyGraph";
@@ -41,6 +42,9 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
   );
 
   const { handleToggle: handleTaskToggle } = useTaskList({ activeTabId, toggleTask });
+  // Split needs two panes' width; on a narrow (phone) viewport a split tab
+  // renders as the single-pane view instead. See effectiveEditorMode.
+  const canSplit = useCanSplit();
 
   const handleEditorChange = useCallback(
     (newContent: string) => {
@@ -78,6 +82,7 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
   // `activeTab` is narrowed to a file tab here (graph returned above), so its
   // file is always present.
   const file = activeTab.file;
+  const mode = effectiveEditorMode(file.mode, canSplit);
 
   // Image/SVG tabs carry no text content (they're never read as text); they
   // render straight from the asset protocol in the read-only image viewer.
@@ -97,9 +102,9 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
   // would let autosave write malformed content back and corrupt the file.
   if (isNotebookFile(file.path)) {
     const NotebookComponent =
-      file.mode === EDITOR_MODE.view
+      mode === EDITOR_MODE.view
         ? NotebookViewer
-        : file.mode === EDITOR_MODE.split
+        : mode === EDITOR_MODE.split
           ? NotebookSplit
           : NotebookSource;
     return (
@@ -146,7 +151,7 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
     );
   }
 
-  if (file.mode === EDITOR_MODE.edit) {
+  if (mode === EDITOR_MODE.edit) {
     return (
       <div className="flex-1 overflow-hidden">
         <MarkdownEditor
@@ -158,7 +163,7 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
     );
   }
 
-  if (file.mode === EDITOR_MODE.split) {
+  if (mode === EDITOR_MODE.split) {
     return (
       <div className="flex-1 overflow-hidden">
         <SplitView

--- a/src/components/layout/OutlineSection.tsx
+++ b/src/components/layout/OutlineSection.tsx
@@ -18,7 +18,7 @@ export function OutlineSection({ entries, activeId }: { entries: TocEntry[]; act
           <button
             type="button"
             onClick={() => scrollTo(entry.id)}
-            className={`w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors ${
+            className={`outline-item w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors ${
               activeId === entry.id
                 ? "bg-[var(--color-accent)] text-white font-medium"
                 : "text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)]"

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -61,6 +61,8 @@ interface RenderOpts {
   tocEntries?: TocEntry[];
   filesVisible?: boolean;
   outlineVisible?: boolean;
+  compact?: boolean;
+  closeCompactPanels?: () => void;
   sidebarLayout?: SidebarLayout;
   swapSidebarSides?: boolean;
   toggleFiles?: () => void;
@@ -128,6 +130,8 @@ function buildSidebarContext(opts: RenderOpts): SidebarLayoutContextValue {
   return {
     filesVisible: opts.filesVisible ?? true,
     outlineVisible: opts.outlineVisible ?? true,
+    compact: opts.compact ?? false,
+    closeCompactPanels: opts.closeCompactPanels ?? vi.fn(),
     toggleFiles: opts.toggleFiles ?? vi.fn(),
     toggleOutline: opts.toggleOutline ?? vi.fn(),
     resetLayout: vi.fn(),

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -479,3 +479,61 @@ describe("Sidebar", () => {
     expect(movePath).not.toHaveBeenCalled();
   });
 });
+
+describe("Sidebar as a compact drawer", () => {
+  it("overlays the document instead of taking a column", () => {
+    const { container } = renderSidebar({ compact: true });
+    const panel = container.querySelector("[data-sidebar]");
+    expect(panel?.className).toContain("absolute");
+  });
+
+  it("sits in the layout flow on a desktop-width viewport", () => {
+    const { container } = renderSidebar({ compact: false });
+    const panel = container.querySelector("[data-sidebar]");
+    expect(panel?.className).toContain("relative");
+    expect(panel?.className).not.toContain("absolute");
+  });
+
+  // The drawer anchors to the edge it belongs to, so a swapped layout slides in
+  // from the right instead of the left.
+  it("anchors to the side it is rendered on", () => {
+    const left = renderSidebar({ compact: true });
+    expect(left.container.querySelector("[data-sidebar]")?.className).toContain("start-0");
+    left.unmount();
+
+    const right = renderSidebar({ compact: true, swapSidebarSides: true, side: "right" });
+    expect(right.container.querySelector("[data-sidebar]")?.className).toContain("end-0");
+  });
+
+  // Opening a file has to dismiss the drawer, or the freshly opened document
+  // stays hidden behind it.
+  it("closes itself when a file is opened from the tree", () => {
+    const openFile = vi.fn();
+    const closeCompactPanels = vi.fn();
+    renderSidebar({
+      workspace: makeWorkspace(),
+      compact: true,
+      closeCompactPanels,
+      tabs: { openFile },
+    });
+
+    fireEvent.click(screen.getByText("readme.md"));
+    expect(openFile).toHaveBeenCalled();
+    expect(closeCompactPanels).toHaveBeenCalled();
+  });
+
+  it("stays open when a file is opened on a desktop-width viewport", () => {
+    const openFile = vi.fn();
+    const closeCompactPanels = vi.fn();
+    renderSidebar({
+      workspace: makeWorkspace(),
+      compact: false,
+      closeCompactPanels,
+      tabs: { openFile },
+    });
+
+    fireEvent.click(screen.getByText("readme.md"));
+    expect(openFile).toHaveBeenCalled();
+    expect(closeCompactPanels).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -82,7 +82,7 @@ export function Sidebar({ side }: SidebarProps) {
   const activeId = useActiveHeading(tocEntries);
 
   // On a phone the sidebar is a drawer over the document, so opening a file
-  // dismisses it — otherwise the freshly opened doc stays hidden behind it.
+  // dismisses it, otherwise the freshly opened doc stays hidden behind it.
   const onOpenFile = useCallback(
     (path: string) => {
       onOpenFileRaw(path);

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -41,7 +41,7 @@ export function Sidebar({ side }: SidebarProps) {
     tocEntries,
     backlinks,
     toggleExpand: onToggleExpand,
-    openFile: onOpenFile,
+    openFile: onOpenFileRaw,
     closeWorkspace,
     createNote,
     createCanvas,
@@ -71,6 +71,8 @@ export function Sidebar({ side }: SidebarProps) {
     filesSidebarWidth,
     outlineSidebarWidth,
     backlinksHeight,
+    compact,
+    closeCompactPanels,
     setFilesSidebarWidth,
     setOutlineSidebarWidth,
     setBacklinksHeight,
@@ -78,6 +80,16 @@ export function Sidebar({ side }: SidebarProps) {
     toggleOutline: onToggleOutline,
   } = useSidebarLayoutContext();
   const activeId = useActiveHeading(tocEntries);
+
+  // On a phone the sidebar is a drawer over the document, so opening a file
+  // dismisses it — otherwise the freshly opened doc stays hidden behind it.
+  const onOpenFile = useCallback(
+    (path: string) => {
+      onOpenFileRaw(path);
+      if (compact) closeCompactPanels();
+    },
+    [onOpenFileRaw, compact, closeCompactPanels],
+  );
 
   // Vertical divider between the file tree and the backlinks block. The idle
   // height is DOM-measured so a drag starts from the rendered height even when

--- a/src/components/layout/SidebarDrawerBackdrop.test.tsx
+++ b/src/components/layout/SidebarDrawerBackdrop.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  SidebarLayoutContext,
+  type SidebarLayoutContextValue,
+} from "@/contexts/SidebarLayoutContext";
+import { SidebarDrawerBackdrop } from "./SidebarDrawerBackdrop";
+
+function renderBackdrop(overrides: Partial<SidebarLayoutContextValue> = {}) {
+  const value: SidebarLayoutContextValue = {
+    filesVisible: false,
+    outlineVisible: false,
+    compact: true,
+    closeCompactPanels: vi.fn(),
+    toggleFiles: vi.fn(),
+    toggleOutline: vi.fn(),
+    resetLayout: vi.fn(),
+    sidebarLayout: "split",
+    swapSidebarSides: false,
+    filesSidebarWidth: 200,
+    outlineSidebarWidth: 260,
+    backlinksHeight: null,
+    setFilesSidebarWidth: vi.fn(),
+    setOutlineSidebarWidth: vi.fn(),
+    setBacklinksHeight: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(
+    <SidebarLayoutContext.Provider value={value}>
+      <SidebarDrawerBackdrop />
+    </SidebarLayoutContext.Provider>,
+  );
+  return { ...utils, value };
+}
+
+const backdrop = () => screen.queryByRole("button", { name: "Close" });
+
+describe("SidebarDrawerBackdrop", () => {
+  it("renders nothing when no drawer is open", () => {
+    renderBackdrop();
+    expect(backdrop()).not.toBeInTheDocument();
+  });
+
+  it("renders nothing on a desktop-width viewport, even with panels visible", () => {
+    renderBackdrop({ compact: false, filesVisible: true, outlineVisible: true });
+    expect(backdrop()).not.toBeInTheDocument();
+  });
+
+  it("covers the document while the files drawer is open", () => {
+    renderBackdrop({ filesVisible: true });
+    expect(backdrop()).toBeInTheDocument();
+  });
+
+  it("covers the document while the outline drawer is open", () => {
+    renderBackdrop({ outlineVisible: true });
+    expect(backdrop()).toBeInTheDocument();
+  });
+
+  it("dismisses the open drawer when tapped", () => {
+    const closeCompactPanels = vi.fn();
+    renderBackdrop({ outlineVisible: true, closeCompactPanels });
+    fireEvent.click(backdrop()!);
+    expect(closeCompactPanels).toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/SidebarDrawerBackdrop.tsx
+++ b/src/components/layout/SidebarDrawerBackdrop.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from "react-i18next";
+import { useSidebarLayoutContext } from "@/contexts/SidebarLayoutContext";
+
+// Dimmed backdrop behind the compact (phone) sidebar drawers. Tapping it
+// dismisses the open drawer — the "tap outside to close" that makes the panel
+// read as a drawer. Only rendered on compact when a drawer is actually open,
+// so it never covers the desktop beside-layout. Sits below the panel (z-20)
+// and above the document.
+export function SidebarDrawerBackdrop() {
+  const { t } = useTranslation("common");
+  const { compact, filesVisible, outlineVisible, closeCompactPanels } = useSidebarLayoutContext();
+  if (!compact || (!filesVisible && !outlineVisible)) return null;
+  return (
+    <button
+      type="button"
+      aria-label={t("sidebar.closeDrawer")}
+      className="absolute inset-0 z-10 bg-black/40"
+      onClick={closeCompactPanels}
+    />
+  );
+}

--- a/src/components/layout/SidebarDrawerBackdrop.tsx
+++ b/src/components/layout/SidebarDrawerBackdrop.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 import { useSidebarLayoutContext } from "@/contexts/SidebarLayoutContext";
 
 // Dimmed backdrop behind the compact (phone) sidebar drawers. Tapping it
-// dismisses the open drawer — the "tap outside to close" that makes the panel
+// dismisses the open drawer, the "tap outside to close" that makes the panel
 // read as a drawer. Only rendered on compact when a drawer is actually open,
 // so it never covers the desktop beside-layout. Sits below the panel (z-20)
 // and above the document.

--- a/src/components/layout/SidebarPanel.tsx
+++ b/src/components/layout/SidebarPanel.tsx
@@ -33,8 +33,8 @@ export function SidebarPanel({
     onReset: () => onWidthCommit(SIDEBAR_WIDTH_DEFAULT),
   });
   const borderClass = side === "left" ? "border-e" : "border-s";
-  // Compact (phone): the panel is a drawer overlaying the document — absolutely
-  // positioned against its edge, capped so it never covers the whole screen —
+  // Compact (phone): the panel is a drawer overlaying the document, absolutely
+  // positioned against its edge and capped so it never covers the whole screen,
   // rather than a flex column that squeezes the content into a sliver.
   const layoutClass = compact
     ? `absolute inset-y-0 ${side === "left" ? "start-0" : "end-0"} z-20 max-w-[85%] shadow-xl`

--- a/src/components/layout/SidebarPanel.tsx
+++ b/src/components/layout/SidebarPanel.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { useSidebarLayoutContext } from "@/contexts/SidebarLayoutContext";
 import { usePanelResize } from "@/hooks/usePanelResize";
 import { SIDEBAR_WIDTH_DEFAULT, SIDEBAR_WIDTH_MAX, SIDEBAR_WIDTH_MIN } from "@/lib/settings";
 import { ResizeHandle } from "./ResizeHandle";
@@ -19,6 +20,7 @@ export function SidebarPanel({
   children: React.ReactNode;
 }) {
   const { t } = useTranslation("common");
+  const { compact } = useSidebarLayoutContext();
   const { size, handleProps } = usePanelResize({
     size: width,
     min: SIDEBAR_WIDTH_MIN,
@@ -31,11 +33,17 @@ export function SidebarPanel({
     onReset: () => onWidthCommit(SIDEBAR_WIDTH_DEFAULT),
   });
   const borderClass = side === "left" ? "border-e" : "border-s";
+  // Compact (phone): the panel is a drawer overlaying the document — absolutely
+  // positioned against its edge, capped so it never covers the whole screen —
+  // rather than a flex column that squeezes the content into a sliver.
+  const layoutClass = compact
+    ? `absolute inset-y-0 ${side === "left" ? "start-0" : "end-0"} z-20 max-w-[85%] shadow-xl`
+    : "relative shrink-0";
   return (
     <nav
       data-print-hide="true"
       data-sidebar={side}
-      className={`relative shrink-0 flex ${borderClass} border-[var(--color-border)] select-none`}
+      className={`${layoutClass} flex ${borderClass} border-[var(--color-border)] select-none`}
       style={{ width: size, background: "var(--glyph-sidebar-bg)" }}
     >
       <div className="flex-1 min-w-0 flex flex-col overflow-y-auto pt-3">{children}</div>

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -36,7 +36,7 @@ export function StatusBar({ onOpenSync }: StatusBarProps) {
     >
       {filePath && (
         // Hidden on mobile (see platform.css): the path there is an opaque
-        // `content://…` picker URI — long and meaningless — and it crowds the
+        // `content://…` picker URI, long and meaningless, and it crowds the
         // word count / reading time off a narrow bar.
         <span className="status-bar-path truncate max-w-[50%]" title={filePath}>
           {filePath}

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -32,10 +32,13 @@ export function StatusBar({ onOpenSync }: StatusBarProps) {
   return (
     <div
       data-print-hide="true"
-      className="flex items-center gap-4 px-4 min-h-7 pb-[var(--glyph-safe-bottom)] border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-xs text-[var(--color-text-secondary)] select-none shrink-0"
+      className="status-bar flex items-center gap-4 px-4 min-h-7 border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-xs text-[var(--color-text-secondary)] select-none shrink-0"
     >
       {filePath && (
-        <span className="truncate max-w-[50%]" title={filePath}>
+        // Hidden on mobile (see platform.css): the path there is an opaque
+        // `content://…` picker URI — long and meaningless — and it crowds the
+        // word count / reading time off a narrow bar.
+        <span className="status-bar-path truncate max-w-[50%]" title={filePath}>
           {filePath}
         </span>
       )}

--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SidebarLayoutContext,
   type SidebarLayoutContextValue,
@@ -10,7 +10,9 @@ import { activeFileOf, type FileTab, type GraphTab, type Tab } from "@/hooks/use
 import { COMPLETE_INDEX_STATUS } from "@/lib/workspaceScan";
 import { TabBar } from "./TabBar";
 
-const sidebarContext: SidebarLayoutContextValue = {
+const buildSidebarContext = (
+  overrides: Partial<SidebarLayoutContextValue> = {},
+): SidebarLayoutContextValue => ({
   filesVisible: true,
   outlineVisible: true,
   compact: false,
@@ -26,7 +28,8 @@ const sidebarContext: SidebarLayoutContextValue = {
   setFilesSidebarWidth: vi.fn(),
   setOutlineSidebarWidth: vi.fn(),
   setBacklinksHeight: vi.fn(),
-};
+  ...overrides,
+});
 
 const makeFileTab = (i: number): FileTab => ({
   id: `tab-${i}`,
@@ -60,6 +63,9 @@ interface RenderOpts {
   closeTab?: (id: string) => Promise<void>;
   setTabMode?: TabsContextValue["setTabMode"];
   moveTab?: (id: string, toIndex: number) => void;
+  tocEntries?: TabsContextValue["tocEntries"];
+  openFileDialog?: TabsContextValue["openFileDialog"];
+  sidebar?: Partial<SidebarLayoutContextValue>;
 }
 
 function buildContext(opts: RenderOpts): TabsContextValue {
@@ -101,36 +107,44 @@ function buildContext(opts: RenderOpts): TabsContextValue {
     flushForClose: vi.fn(),
     toggleTask: vi.fn(),
     saveScrollPosition: vi.fn(),
-    openFileDialog: vi.fn(),
+    openFileDialog: opts.openFileDialog ?? vi.fn(),
     undoEdit: vi.fn(),
     redoEdit: vi.fn(),
     displayContent: null,
-    tocEntries: [],
+    tocEntries: opts.tocEntries ?? [],
     backlinks: [],
     workspaceNotice: null,
     dismissWorkspaceNotice: vi.fn(),
   };
 }
 
-function Wrapper({ value, children }: { value: TabsContextValue; children: ReactNode }) {
+function Wrapper({
+  value,
+  sidebar,
+  children,
+}: {
+  value: TabsContextValue;
+  sidebar: SidebarLayoutContextValue;
+  children: ReactNode;
+}) {
   return (
     <TabsContext.Provider value={value}>
-      <SidebarLayoutContext.Provider value={sidebarContext}>
-        {children}
-      </SidebarLayoutContext.Provider>
+      <SidebarLayoutContext.Provider value={sidebar}>{children}</SidebarLayoutContext.Provider>
     </TabsContext.Provider>
   );
 }
 
 function renderTabBar(opts: RenderOpts = {}, onToggleAIChat: (() => void) | null = null) {
   const value = buildContext(opts);
+  const sidebar = buildSidebarContext(opts.sidebar);
   return {
     ...render(
-      <Wrapper value={value}>
+      <Wrapper value={value} sidebar={sidebar}>
         <TabBar onToggleAIChat={onToggleAIChat} />
       </Wrapper>,
     ),
     value,
+    sidebar,
   };
 }
 
@@ -406,5 +420,94 @@ describe("TabBar", () => {
     for (const button of container.querySelectorAll("button")) {
       expect(button.querySelector("button")).toBeNull();
     }
+  });
+});
+
+describe("TabBar on mobile", () => {
+  const heading = [{ id: "h1", text: "Heading", level: 1 }];
+
+  beforeEach(async () => {
+    const { platform } = await import("@tauri-apps/plugin-os");
+    vi.mocked(platform).mockReturnValue("android");
+  });
+
+  afterEach(async () => {
+    const { platform } = await import("@tauri-apps/plugin-os");
+    vi.mocked(platform).mockReturnValue("macos");
+  });
+
+  // Mobile has no native menu or keyboard shortcut, so the tab bar is the only
+  // way to open another file once a tab is showing.
+  it("offers Open File and runs the picker", () => {
+    const openFileDialog = vi.fn();
+    renderTabBar({ tabs: makeTabs(1), activeTabId: "tab-0", openFileDialog });
+    fireEvent.click(screen.getByRole("button", { name: "Open File" }));
+    expect(openFileDialog).toHaveBeenCalled();
+  });
+
+  it("keeps Open File off the desktop tab bar", async () => {
+    const { platform } = await import("@tauri-apps/plugin-os");
+    vi.mocked(platform).mockReturnValue("macos");
+    renderTabBar({ tabs: makeTabs(1), activeTabId: "tab-0" });
+    expect(screen.queryByRole("button", { name: "Open File" })).not.toBeInTheDocument();
+  });
+
+  it("toggles the outline drawer from the tab bar", () => {
+    const toggleOutline = vi.fn();
+    renderTabBar({
+      tabs: makeTabs(1),
+      activeTabId: "tab-0",
+      tocEntries: heading,
+      sidebar: { outlineVisible: false, toggleOutline },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Show outline sidebar" }));
+    expect(toggleOutline).toHaveBeenCalled();
+  });
+
+  it("labels the outline button as hide while the drawer is open", () => {
+    renderTabBar({
+      tabs: makeTabs(1),
+      activeTabId: "tab-0",
+      tocEntries: heading,
+      sidebar: { outlineVisible: true },
+    });
+    expect(screen.getByRole("button", { name: "Hide outline sidebar" })).toBeInTheDocument();
+  });
+
+  it("hides the outline button for a document with no headings", () => {
+    renderTabBar({ tabs: makeTabs(1), activeTabId: "tab-0", tocEntries: [] });
+    expect(screen.queryByRole("button", { name: /outline sidebar/ })).not.toBeInTheDocument();
+  });
+});
+
+describe("TabBar on a viewport too small to split", () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    window.matchMedia = vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("hides the Split button", () => {
+    renderTabBar({ tabs: makeTabs(1), activeTabId: "tab-0" });
+    expect(screen.queryByLabelText("Split mode")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("View mode")).toBeInTheDocument();
+    expect(screen.getByLabelText("Edit mode")).toBeInTheDocument();
+  });
+
+  // A tab persisted as split from a desktop session renders as the read-only
+  // view here, so View is the button that reads as active.
+  it("marks View active for a tab stored as split", () => {
+    const splitTab = makeFileTab(0);
+    splitTab.file.mode = "split";
+    renderTabBar({ tabs: [splitTab], activeTabId: "tab-0" });
+    expect(screen.getByLabelText("View mode")).toHaveAttribute("data-active", "true");
   });
 });

--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -1,10 +1,32 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
+import {
+  SidebarLayoutContext,
+  type SidebarLayoutContextValue,
+} from "@/contexts/SidebarLayoutContext";
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import { activeFileOf, type FileTab, type GraphTab, type Tab } from "@/hooks/useTabs";
 import { COMPLETE_INDEX_STATUS } from "@/lib/workspaceScan";
 import { TabBar } from "./TabBar";
+
+const sidebarContext: SidebarLayoutContextValue = {
+  filesVisible: true,
+  outlineVisible: true,
+  compact: false,
+  closeCompactPanels: vi.fn(),
+  toggleFiles: vi.fn(),
+  toggleOutline: vi.fn(),
+  resetLayout: vi.fn(),
+  sidebarLayout: "split",
+  swapSidebarSides: false,
+  filesSidebarWidth: 200,
+  outlineSidebarWidth: 260,
+  backlinksHeight: null,
+  setFilesSidebarWidth: vi.fn(),
+  setOutlineSidebarWidth: vi.fn(),
+  setBacklinksHeight: vi.fn(),
+};
 
 const makeFileTab = (i: number): FileTab => ({
   id: `tab-${i}`,
@@ -91,7 +113,13 @@ function buildContext(opts: RenderOpts): TabsContextValue {
 }
 
 function Wrapper({ value, children }: { value: TabsContextValue; children: ReactNode }) {
-  return <TabsContext.Provider value={value}>{children}</TabsContext.Provider>;
+  return (
+    <TabsContext.Provider value={value}>
+      <SidebarLayoutContext.Provider value={sidebarContext}>
+        {children}
+      </SidebarLayoutContext.Provider>
+    </TabsContext.Provider>
+  );
 }
 
 function renderTabBar(opts: RenderOpts = {}, onToggleAIChat: (() => void) | null = null) {

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -2,18 +2,24 @@ import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { EditModeIcon } from "@/components/icons/EditModeIcon";
 import { GraphIcon } from "@/components/icons/GraphIcon";
+import { OpenIcon } from "@/components/icons/OpenIcon";
+import { OutlineIcon } from "@/components/icons/OutlineIcon";
 import { SparkleIcon } from "@/components/icons/SparkleIcon";
 import { SplitModeIcon } from "@/components/icons/SplitModeIcon";
 import { TabCloseIcon } from "@/components/icons/TabCloseIcon";
 import { ViewModeIcon } from "@/components/icons/ViewModeIcon";
+import { useSidebarLayoutContext } from "@/contexts/SidebarLayoutContext";
 import { useTabsContext } from "@/contexts/TabsContext";
+import { useCanSplit } from "@/hooks/useMediaQuery";
+import { usePlatform } from "@/hooks/usePlatform";
 import { useTabDragReorder } from "@/hooks/useTabDragReorder";
 import { activeFileOf, type Tab, tabPathOf } from "@/hooks/useTabs";
 import { isCanvasFile } from "@/lib/canvasExtensions";
 import { isImageFile } from "@/lib/imageExtensions";
 import { isLooseFilePath } from "@/lib/looseFile";
 import { displayName } from "@/lib/paths";
-import { EDITOR_MODE } from "@/lib/settings";
+import { isMobile } from "@/lib/platform";
+import { EDITOR_MODE, effectiveEditorMode } from "@/lib/settings";
 
 function tabLabel(tab: Tab, t: TFunction<"common">): string {
   if (tab.kind === "graph") {
@@ -40,8 +46,15 @@ export function TabBar({ onToggleAIChat }: TabBarProps) {
     closeTab: onClose,
     setTabMode: onModeChange,
     moveTab: onMove,
+    openFileDialog,
+    tocEntries,
   } = useTabsContext();
+  const { outlineVisible, toggleOutline } = useSidebarLayoutContext();
   const { indicator, handlersFor } = useTabDragReorder(onMove);
+  const canSplit = useCanSplit();
+  // Mobile has no native menu or keyboard shortcut, so the tab bar carries the
+  // in-app controls: opening a file and toggling the outline drawer.
+  const mobile = isMobile(usePlatform());
   if (tabs.length === 0) return null;
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
@@ -49,9 +62,12 @@ export function TabBar({ onToggleAIChat }: TabBarProps) {
   // Images have a single read-only view, so the whole view/edit/split toggle is
   // hidden for them (as opposed to canvas, which keeps view + edit).
   const showModeToggle = activeTab !== null && activeFile !== null && !isImageFile(activeFile.path);
-  // Canvas has no source-beside-preview split: the board itself is the editor,
-  // so split would duplicate edit mode. Only markdown gets the third button.
-  const showSplit = activeFile !== null && !isCanvasFile(activeFile.path);
+  // Split is offered only for markdown (canvas is its own editor) and only when
+  // the viewport is wide enough for two panes — phones get view + edit only.
+  const showSplit = activeFile !== null && !isCanvasFile(activeFile.path) && canSplit;
+  // The rendered mode: a tab stored as split shows as view on a narrow screen,
+  // so the view button, not the (hidden) split button, reads as active.
+  const shownMode = activeFile ? effectiveEditorMode(activeFile.mode, canSplit) : undefined;
 
   return (
     <div className="tab-bar-container" data-print-hide="true">
@@ -106,12 +122,37 @@ export function TabBar({ onToggleAIChat }: TabBarProps) {
           );
         })}
       </div>
+      {mobile && (
+        <div className="mode-toggle">
+          {activeFile !== null && tocEntries.length > 0 && (
+            <button
+              type="button"
+              className="mode-toggle-btn"
+              data-active={outlineVisible || undefined}
+              onClick={toggleOutline}
+              aria-label={outlineVisible ? t("sidebar.hideOutline") : t("sidebar.showOutline")}
+              title={outlineVisible ? t("sidebar.hideOutline") : t("sidebar.showOutline")}
+            >
+              <OutlineIcon active={outlineVisible} />
+            </button>
+          )}
+          <button
+            type="button"
+            className="mode-toggle-btn"
+            onClick={openFileDialog}
+            aria-label={t("emptyState.openFile")}
+            title={t("emptyState.openFile")}
+          >
+            <OpenIcon />
+          </button>
+        </div>
+      )}
       {showModeToggle && (
         <div className="mode-toggle">
           <button
             type="button"
             className="mode-toggle-btn"
-            data-active={activeFile.mode === EDITOR_MODE.view || undefined}
+            data-active={shownMode === EDITOR_MODE.view || undefined}
             onClick={() => onModeChange(activeTab.id, EDITOR_MODE.view)}
             aria-label={t("tabBar.viewMode")}
             title={t("tabBar.view")}
@@ -121,7 +162,7 @@ export function TabBar({ onToggleAIChat }: TabBarProps) {
           <button
             type="button"
             className="mode-toggle-btn"
-            data-active={activeFile.mode === EDITOR_MODE.edit || undefined}
+            data-active={shownMode === EDITOR_MODE.edit || undefined}
             onClick={() => onModeChange(activeTab.id, EDITOR_MODE.edit)}
             aria-label={t("tabBar.editMode")}
             title={t("tabBar.edit")}

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -63,7 +63,7 @@ export function TabBar({ onToggleAIChat }: TabBarProps) {
   // hidden for them (as opposed to canvas, which keeps view + edit).
   const showModeToggle = activeTab !== null && activeFile !== null && !isImageFile(activeFile.path);
   // Split is offered only for markdown (canvas is its own editor) and only when
-  // the viewport is wide enough for two panes — phones get view + edit only.
+  // the viewport is wide enough for two panes; phones get view + edit only.
   const showSplit = activeFile !== null && !isCanvasFile(activeFile.path) && canSplit;
   // The rendered mode: a tab stored as split shows as view on a narrow screen,
   // so the view button, not the (hidden) split button, reads as active.

--- a/src/hooks/useMediaQuery.test.ts
+++ b/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TABLET_QUERY, useCanSplit, useMediaQuery } from "./useMediaQuery";
+
+const originalMatchMedia = window.matchMedia;
+
+// Minimal MediaQueryList stub that records its change listeners so a test can
+// flip `matches` and fire them, the way a real resize/rotation would.
+function stubMatchMedia(matches: boolean) {
+  const listeners = new Set<() => void>();
+  const mql = {
+    matches,
+    addEventListener: vi.fn((_: string, fn: () => void) => {
+      listeners.add(fn);
+    }),
+    removeEventListener: vi.fn((_: string, fn: () => void) => {
+      listeners.delete(fn);
+    }),
+  };
+  const matchMedia = vi.fn(() => mql);
+  window.matchMedia = matchMedia as unknown as typeof window.matchMedia;
+  return {
+    matchMedia,
+    mql,
+    fire(next: boolean) {
+      mql.matches = next;
+      for (const fn of listeners) fn();
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
+describe("useMediaQuery", () => {
+  it("reports whether the query currently matches", () => {
+    stubMatchMedia(true);
+    const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+    expect(result.current).toBe(true);
+  });
+
+  it("re-renders when the query starts matching", () => {
+    const media = stubMatchMedia(false);
+    const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      media.fire(true);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("drops its listener on unmount", () => {
+    const media = stubMatchMedia(false);
+    const { unmount } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+    expect(media.listenerCount()).toBe(1);
+
+    unmount();
+    expect(media.listenerCount()).toBe(0);
+  });
+
+  it("returns false when matchMedia is unavailable", () => {
+    // jsdom without matchMedia, and the same path a non-browser render takes.
+    (window as { matchMedia?: typeof window.matchMedia }).matchMedia = undefined;
+    const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+    expect(result.current).toBe(false);
+  });
+});
+
+describe("useCanSplit", () => {
+  it("asks for the tablet query", () => {
+    const media = stubMatchMedia(true);
+    const { result } = renderHook(() => useCanSplit());
+    expect(media.matchMedia).toHaveBeenCalledWith(TABLET_QUERY);
+    expect(result.current).toBe(true);
+  });
+
+  it("is false on a viewport too small to split", () => {
+    stubMatchMedia(false);
+    const { result } = renderHook(() => useCanSplit());
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -3,7 +3,7 @@ import { useSyncExternalStore } from "react";
 /**
  * Subscribe to a CSS media query and re-render when it flips. Used for
  * viewport-width responsiveness (phone vs tablet/desktop): the app otherwise
- * only knows the OS family, not the screen size. SSR/test-safe — returns
+ * only knows the OS family, not the screen size. SSR/test-safe: returns
  * `false` when `matchMedia` is unavailable.
  */
 export function useMediaQuery(query: string): boolean {

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Subscribe to a CSS media query and re-render when it flips. Used for
+ * viewport-width responsiveness (phone vs tablet/desktop): the app otherwise
+ * only knows the OS family, not the screen size. SSR/test-safe — returns
+ * `false` when `matchMedia` is unavailable.
+ */
+export function useMediaQuery(query: string): boolean {
+  return useSyncExternalStore(
+    (onChange) => {
+      if (typeof window === "undefined" || !window.matchMedia) return () => {};
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    },
+    () =>
+      typeof window !== "undefined" && window.matchMedia ? window.matchMedia(query).matches : false,
+    () => false,
+  );
+}
+
+// Split view (editor beside preview) and beside-the-content sidebars need a
+// tablet-sized window. Both dimensions are checked so a phone in landscape
+// (wide but short) still counts as compact, keeping the split off and the
+// sidebars as drawers.
+export const TABLET_QUERY = "(min-width: 768px) and (min-height: 600px)";
+
+/** True when the viewport is large enough for the split view / beside sidebars. */
+export function useCanSplit(): boolean {
+  return useMediaQuery(TABLET_QUERY);
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -3,8 +3,8 @@ import { useSyncExternalStore } from "react";
 /**
  * Subscribe to a CSS media query and re-render when it flips. Used for
  * viewport-width responsiveness (phone vs tablet/desktop): the app otherwise
- * only knows the OS family, not the screen size. SSR/test-safe: returns
- * `false` when `matchMedia` is unavailable.
+ * only knows the OS family, not the screen size. Returns `false` where
+ * `matchMedia` is unavailable, so a non-browser render never throws.
  */
 export function useMediaQuery(query: string): boolean {
   return useSyncExternalStore(
@@ -16,7 +16,6 @@ export function useMediaQuery(query: string): boolean {
     },
     () =>
       typeof window !== "undefined" && window.matchMedia ? window.matchMedia(query).matches : false,
-    () => false,
   );
 }
 

--- a/src/hooks/useSidebarLayout.test.ts
+++ b/src/hooks/useSidebarLayout.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useSidebarLayout } from "./useSidebarLayout";
 
 describe("useSidebarLayout", () => {
@@ -98,5 +98,71 @@ describe("useSidebarLayout", () => {
     expect(updateSettings).toHaveBeenCalledWith("layout.outlineSidebarWidth", 224);
     expect(updateSettings).toHaveBeenCalledWith("layout.aiPanelWidth", 340);
     expect(updateSettings).toHaveBeenCalledWith("layout.backlinksHeight", null);
+  });
+});
+
+describe("useSidebarLayout on a compact viewport", () => {
+  const originalMatchMedia = window.matchMedia;
+
+  // Compact is "the tablet query does not match", so the panels behave as
+  // drawers: closed by default and toggled without touching the settings.
+  beforeEach(() => {
+    window.matchMedia = vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  const renderCompact = (updateSettings = vi.fn()) =>
+    renderHook(() =>
+      useSidebarLayout({
+        filesVisibleSetting: true,
+        outlineVisibleSetting: true,
+        updateSettings,
+      }),
+    );
+
+  it("starts with both drawers closed even when the settings say visible", () => {
+    const { result } = renderCompact();
+    expect(result.current.compact).toBe(true);
+    expect(result.current.filesVisible).toBe(false);
+    expect(result.current.outlineVisible).toBe(false);
+  });
+
+  it("toggles the drawers without writing the desktop visibility settings", () => {
+    const updateSettings = vi.fn();
+    const { result } = renderCompact(updateSettings);
+
+    act(() => {
+      result.current.toggleFiles();
+    });
+    expect(result.current.filesVisible).toBe(true);
+
+    act(() => {
+      result.current.toggleOutline();
+    });
+    expect(result.current.outlineVisible).toBe(true);
+
+    expect(updateSettings).not.toHaveBeenCalledWith("layout.filesSidebarVisible", true);
+    expect(updateSettings).not.toHaveBeenCalledWith("layout.outlineSidebarVisible", true);
+  });
+
+  it("closeCompactPanels dismisses both drawers", () => {
+    const { result } = renderCompact();
+    act(() => {
+      result.current.toggleFiles();
+      result.current.toggleOutline();
+    });
+
+    act(() => {
+      result.current.closeCompactPanels();
+    });
+    expect(result.current.filesVisible).toBe(false);
+    expect(result.current.outlineVisible).toBe(false);
   });
 });

--- a/src/hooks/useSidebarLayout.ts
+++ b/src/hooks/useSidebarLayout.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { useCanSplit } from "@/hooks/useMediaQuery";
 import { AI_PANEL_WIDTH_DEFAULT, type Settings, SIDEBAR_WIDTH_DEFAULT } from "@/lib/settings";
 
 interface UseSidebarLayoutOptions {
@@ -17,6 +18,13 @@ export function useSidebarLayout({
 }: UseSidebarLayoutOptions) {
   const [filesVisible, setFilesVisible] = useState(filesVisibleSetting);
   const [outlineVisible, setOutlineVisible] = useState(outlineVisibleSetting);
+  // On a narrow (phone) viewport the sidebars are drawers overlaying the
+  // document, so they default closed and toggle local state instead of the
+  // persisted desktop visibility — resizing back to a wide window restores
+  // whatever the user had there.
+  const compact = !useCanSplit();
+  const [compactFilesOpen, setCompactFilesOpen] = useState(false);
+  const [compactOutlineOpen, setCompactOutlineOpen] = useState(false);
 
   useEffect(() => {
     setFilesVisible(filesVisibleSetting);
@@ -30,16 +38,30 @@ export function useSidebarLayout({
   // side effect there updates SettingsProvider mid-render and can cascade
   // into an update-depth loop.
   const toggleFiles = useCallback(() => {
+    if (compact) {
+      setCompactFilesOpen((v) => !v);
+      return;
+    }
     const next = !filesVisible;
     setFilesVisible(next);
     updateSettings("layout.filesSidebarVisible", next);
-  }, [filesVisible, updateSettings]);
+  }, [compact, filesVisible, updateSettings]);
 
   const toggleOutline = useCallback(() => {
+    if (compact) {
+      setCompactOutlineOpen((v) => !v);
+      return;
+    }
     const next = !outlineVisible;
     setOutlineVisible(next);
     updateSettings("layout.outlineSidebarVisible", next);
-  }, [outlineVisible, updateSettings]);
+  }, [compact, outlineVisible, updateSettings]);
+
+  // Dismiss the compact drawers (backdrop tap, or after opening a file).
+  const closeCompactPanels = useCallback(() => {
+    setCompactFilesOpen(false);
+    setCompactOutlineOpen(false);
+  }, []);
 
   const setFilesSidebarWidth = useCallback(
     (width: number) => updateSettings("layout.filesSidebarWidth", width),
@@ -68,8 +90,12 @@ export function useSidebarLayout({
   }, [updateSettings]);
 
   return {
-    filesVisible,
-    outlineVisible,
+    filesVisible: compact ? compactFilesOpen : filesVisible,
+    outlineVisible: compact ? compactOutlineOpen : outlineVisible,
+    // Phone drawers overlay the document instead of pushing it; consumers use
+    // this to switch the panel to an overlay and show a dismiss backdrop.
+    compact,
+    closeCompactPanels,
     toggleFiles,
     toggleOutline,
     setFilesSidebarWidth,

--- a/src/hooks/useSidebarLayout.ts
+++ b/src/hooks/useSidebarLayout.ts
@@ -20,7 +20,7 @@ export function useSidebarLayout({
   const [outlineVisible, setOutlineVisible] = useState(outlineVisibleSetting);
   // On a narrow (phone) viewport the sidebars are drawers overlaying the
   // document, so they default closed and toggle local state instead of the
-  // persisted desktop visibility — resizing back to a wide window restores
+  // persisted desktop visibility, so resizing back to a wide window restores
   // whatever the user had there.
   const compact = !useCanSplit();
   const [compactFilesOpen, setCompactFilesOpen] = useState(false);

--- a/src/hooks/useTabs.test.tsx
+++ b/src/hooks/useTabs.test.tsx
@@ -4083,6 +4083,31 @@ describe("mobile file opening", () => {
     expect(commands).not.toContain("watch_file");
   });
 
+  it("opens an extensionless Android content URI instead of refusing it", async () => {
+    // Android's document picker returns opaque `content://` URIs with no file
+    // extension, so the extension-based support gate can't classify them; the
+    // picker's type filter already restricted the choice, so they must open.
+    const { platform } = await import("@tauri-apps/plugin-os");
+    vi.mocked(platform).mockReturnValue("android");
+    const { readTextFile } = await import("@tauri-apps/plugin-fs");
+    vi.mocked(readTextFile).mockResolvedValue("# picked");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useTabs(defaultOptions()));
+    await waitFor(() => expect(result.current.initializing).toBe(false));
+
+    await act(async () => {
+      await result.current.openFile(
+        "content://com.android.providers.media.documents/document/document%3A1000000036",
+      );
+    });
+
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.activeFile?.content).toBe("# picked");
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("unsupported"));
+    warnSpy.mockRestore();
+  });
+
   it("opens picked images without Rust-side metadata", async () => {
     const { platform } = await import("@tauri-apps/plugin-os");
     vi.mocked(platform).mockReturnValue("android");

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -371,7 +371,13 @@ export function useTabs(options: UseTabsOptions) {
       // (`.ipynb`) are allowed — they take the dedicated NotebookViewer path.
       // Images/SVGs are allowed too — they render in the read-only image
       // viewer, never as text. See memory/reject-unsupported-file-types.md.
-      if (!isSupportedFile(path) && !isImageFile(path)) {
+      // Android's document picker returns opaque `content://` URIs with no file
+      // extension, so the extension-based check below can't classify them. The
+      // picker's own type filters already restricted selection to supported
+      // files, so trust them here. (iOS returns `file://` URLs that keep the
+      // extension and take the normal path.)
+      const isAndroidContentUri = path.startsWith("content://");
+      if (!isAndroidContentUri && !isSupportedFile(path) && !isImageFile(path)) {
         console.warn(`Refusing to open unsupported file: ${path}`);
         return;
       }

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -5,6 +5,7 @@ import {
   CONTENT_WIDTH_MAP,
   DEFAULT_SETTINGS,
   EDITOR_MODE,
+  effectiveEditorMode,
   FONT_FAMILY_MAP,
   LINE_HEIGHT_MAP,
   MODEL_SUGGESTIONS,
@@ -135,5 +136,24 @@ describe("nextEditorMode", () => {
 
   it("treats an undefined current mode as view (cycles to edit)", () => {
     expect(nextEditorMode(undefined)).toBe(EDITOR_MODE.edit);
+  });
+
+  it("skips split on a narrow viewport (view → edit → view)", () => {
+    expect(nextEditorMode(EDITOR_MODE.view, false)).toBe(EDITOR_MODE.edit);
+    expect(nextEditorMode(EDITOR_MODE.edit, false)).toBe(EDITOR_MODE.view);
+    // A tab already stored as split advances to edit, not back into split.
+    expect(nextEditorMode(EDITOR_MODE.split, false)).toBe(EDITOR_MODE.edit);
+  });
+});
+
+describe("effectiveEditorMode", () => {
+  it("collapses split to view when the viewport is too narrow to split", () => {
+    expect(effectiveEditorMode(EDITOR_MODE.split, false)).toBe(EDITOR_MODE.view);
+  });
+
+  it("leaves the stored mode untouched when split fits or the mode isn't split", () => {
+    expect(effectiveEditorMode(EDITOR_MODE.split, true)).toBe(EDITOR_MODE.split);
+    expect(effectiveEditorMode(EDITOR_MODE.edit, false)).toBe(EDITOR_MODE.edit);
+    expect(effectiveEditorMode(EDITOR_MODE.view, false)).toBe(EDITOR_MODE.view);
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -68,11 +68,24 @@ const EDITOR_MODE_CYCLE: readonly EditorMode[] = [
 /**
  * The next mode when cycling the editor toggle (wraps view → edit → split →
  * view). An undefined/unknown current mode is treated as `view`, so the cycle
- * starts at `edit`.
+ * starts at `edit`. On a narrow viewport `canSplit` is false, so the cycle
+ * skips split (view → edit → view).
  */
-export function nextEditorMode(current: EditorMode | undefined): EditorMode {
-  const idx = current ? EDITOR_MODE_CYCLE.indexOf(current) : 0;
-  return EDITOR_MODE_CYCLE[(idx + 1) % EDITOR_MODE_CYCLE.length];
+export function nextEditorMode(current: EditorMode | undefined, canSplit = true): EditorMode {
+  const cycle = canSplit ? EDITOR_MODE_CYCLE : [EDITOR_MODE.view, EDITOR_MODE.edit];
+  const idx = current ? cycle.indexOf(current) : 0;
+  // indexOf is -1 when the stored mode is split but split is no longer in the
+  // cycle; treat that as position 0 so the next tap lands on edit.
+  return cycle[((idx < 0 ? 0 : idx) + 1) % cycle.length];
+}
+
+/**
+ * The mode to actually render. Split needs two panes' worth of width, so on a
+ * narrow viewport (`canSplit` false) a tab stored as split falls back to the
+ * read-only view. The stored mode is left untouched, so widening restores it.
+ */
+export function effectiveEditorMode(mode: EditorMode, canSplit: boolean): EditorMode {
+  return mode === EDITOR_MODE.split && !canSplit ? EDITOR_MODE.view : mode;
 }
 
 export interface PersistedTab {

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -25,6 +25,7 @@
     "hideOutline": "Gliederungs-Seitenleiste ausblenden",
     "showFiles": "Dateien-Seitenleiste anzeigen",
     "showOutline": "Gliederungs-Seitenleiste anzeigen",
+    "closeDrawer": "Schließen",
     "newNote": "Neue Notiz",
     "newFolder": "Neuer Ordner",
     "collapseAll": "Alle einklappen",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -25,6 +25,7 @@
     "hideOutline": "Hide outline sidebar",
     "showFiles": "Show files sidebar",
     "showOutline": "Show outline sidebar",
+    "closeDrawer": "Close",
     "newNote": "New note",
     "newFolder": "New folder",
     "collapseAll": "Collapse all",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -25,6 +25,7 @@
     "hideOutline": "Ocultar barra de esquema",
     "showFiles": "Mostrar barra de archivos",
     "showOutline": "Mostrar barra de esquema",
+    "closeDrawer": "Cerrar",
     "newNote": "Nueva nota",
     "newFolder": "Nueva carpeta",
     "collapseAll": "Contraer todo",

--- a/src/locales/fa/common.json
+++ b/src/locales/fa/common.json
@@ -25,6 +25,7 @@
     "hideOutline": "پنهان کردن نوار رئوس مطالب",
     "showFiles": "نمایش نوار فایل‌ها",
     "showOutline": "نمایش نوار رئوس مطالب",
+    "closeDrawer": "بستن",
     "newNote": "یادداشت جدید",
     "newFolder": "پوشه جدید",
     "collapseAll": "جمع کردن همه",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -25,6 +25,7 @@
     "hideOutline": "隐藏大纲侧边栏",
     "showFiles": "显示文件侧边栏",
     "showOutline": "显示大纲侧边栏",
+    "closeDrawer": "关闭",
     "newNote": "新建笔记",
     "newFolder": "新建文件夹",
     "collapseAll": "全部折叠",

--- a/src/styles/platform.css
+++ b/src/styles/platform.css
@@ -12,7 +12,7 @@
 }
 
 /* Mobile draws edge-to-edge (viewport-fit=cover), so the shell pads itself past
-   the notch, home indicator, and — in landscape — the side cutout/status bar. */
+   the notch, home indicator, and (in landscape) the side cutout/status bar. */
 [data-platform="ios"],
 [data-platform="android"] {
   --glyph-safe-top: env(safe-area-inset-top);

--- a/src/styles/platform.css
+++ b/src/styles/platform.css
@@ -7,14 +7,18 @@
   --glyph-sidebar-bg: var(--color-surface-secondary);
   --glyph-safe-top: 0px;
   --glyph-safe-bottom: 0px;
+  --glyph-safe-left: 0px;
+  --glyph-safe-right: 0px;
 }
 
-/* Mobile draws edge-to-edge (viewport-fit=cover), so the shell's top and
-   bottom bars pad themselves past the notch and home indicator. */
+/* Mobile draws edge-to-edge (viewport-fit=cover), so the shell pads itself past
+   the notch, home indicator, and — in landscape — the side cutout/status bar. */
 [data-platform="ios"],
 [data-platform="android"] {
   --glyph-safe-top: env(safe-area-inset-top);
   --glyph-safe-bottom: env(safe-area-inset-bottom);
+  --glyph-safe-left: env(safe-area-inset-left);
+  --glyph-safe-right: env(safe-area-inset-right);
 }
 
 [data-platform="macos"] {
@@ -43,4 +47,45 @@
   --glyph-radius: 6px;
   --glyph-radius-sm: 4px;
   --glyph-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+/* Comfortable tap targets on touch platforms (phone + tablet): the toolbar
+   mode buttons and outline rows are sized for a mouse on desktop, too small
+   for a fingertip here. Scoped to mobile data-platform so desktop is untouched. */
+[data-platform="android"] .mode-toggle-btn,
+[data-platform="ios"] .mode-toggle-btn {
+  width: 40px;
+  height: 40px;
+}
+
+[data-platform="android"] .outline-item,
+[data-platform="ios"] .outline-item {
+  padding-block: 10px;
+  font-size: 0.9375rem;
+}
+
+/* Bottom status bar clears the home indicator / gesture bar. env() reports 0
+   for the gesture area on Android, so a floor keeps the text off the pill. */
+.status-bar {
+  padding-bottom: var(--glyph-safe-bottom);
+}
+
+[data-platform="android"] .status-bar,
+[data-platform="ios"] .status-bar {
+  flex-wrap: wrap;
+  padding-bottom: max(var(--glyph-safe-bottom), 0.75rem);
+}
+
+/* The mobile picker path is an opaque content:// URI; drop it so the word
+   count / reading time fit the narrow bar. */
+[data-platform="android"] .status-bar-path,
+[data-platform="ios"] .status-bar-path {
+  display: none;
+}
+
+/* On mobile the outline drawer is opened from the tab-bar button, so hide the
+   thin desktop edge strip (a poor touch target). */
+[data-platform="android"] [data-sidebar-edge],
+[data-platform="ios"] [data-sidebar-edge] {
+  display: none;
 }

--- a/src/styles/tabs.css
+++ b/src/styles/tabs.css
@@ -1,6 +1,5 @@
 .tab-bar-container {
   display: flex;
-  padding-top: var(--glyph-safe-top);
   border-bottom: 1px solid var(--color-border);
   background: var(--color-surface-secondary);
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

The Android build runs but was unusable: opening a file silently did nothing, and the desktop layout squeezed the document into a sliver behind full-width sidebars. This fixes the open path and adds the app's first viewport breakpoint so the phone and tablet layouts stop borrowing desktop geometry.

Verified end to end on an Android emulator (Pixel 7, API 34, x86_64), portrait and landscape. Every change is gated behind `compact` / `isMobile` / `[data-platform]`, so desktop layout and behaviour are unchanged.

## Changes

- **Opening a file works on Android.** `openFile` gated on an extension check, but the document picker returns opaque `content://` URIs that carry no extension, so every pick was refused with a console warning and no UI feedback. iOS returns `file://` URLs that keep the extension, which is why this only ever showed on Android.
- **Split view is phone-aware.** New `useMediaQuery` hook plus a tablet breakpoint (min 768x600, so a landscape phone still counts as compact). The split button is hidden, the mode cycle skips split, and a tab stored as split renders as the single view. The stored mode is untouched, so widening restores it.
- **Sidebars become drawers on phones.** They overlay the document instead of pushing it, default closed, dismiss on backdrop tap or file select, and are opened from a tab-bar toggle rather than the thin desktop edge strip. Compact visibility is local state, so the persisted desktop visibility is never clobbered.
- **Safe areas.** Horizontal insets (landscape cutout) were never wired; the top inset moved from the tab bar to the shell root so banners at the top edge are inset too. The status bar clears the gesture nav via a `max(env(), 0.75rem)` floor, since `env(safe-area-inset-bottom)` reports 0 there.
- **Touch targets and fit.** Outline rows and toolbar buttons sized for a fingertip, an Open File button in the tab bar (mobile has no native menu or shortcut), and the status bar drops the opaque `content://` path so the word count and reading time fit.
- **README.** The comparison table listed mobile as `planned`; it now records experimental viewing support and that folder workspaces stay desktop-only.

## Risk classification

- [x] Filesystem / IPC surface
- [x] Untrusted rendering (Markdown, plugins, links)
- [x] Accessibility
- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Bundle size / startup

### Invariants at stake and evidence

**Untrusted rendering.** The `openFile` gate exists so a random `.txt` / `.html` is never fed to the markdown renderer, which is a code-injection vector. This PR bypasses that gate for `content://` paths, because the URI carries no extension to classify. The replacement guarantee is the picker's own type filter: `pickFiles` passes the same markdown, notebook, and D2 extension list to the OS document picker, so the user cannot hand back an unsupported type through that path. Worth a reviewer's eye, since it trades a local check for a platform one. Scope is limited to `content://` (Android picker output); desktop and iOS still take the extension check unchanged. Covered by `useTabs.test.tsx` "opens an extensionless Android content URI instead of refusing it", which also asserts the refusal warning is not emitted.

**Filesystem / IPC surface.** No new commands or permissions. Mobile reads continue through the fs plugin's `readTextFile`, and the watch call stays skipped for picker URIs (they have no canonical path to watch).

**Accessibility.** Touch targets on mobile move from 22px to 40px for toolbar buttons and roughly 22px to 40px for outline rows. The drawer backdrop is a real `button` with an `aria-label`, and the outline toggle's label and title switch between show and hide with its state.

New behaviour is covered by unit tests: `settings.test.ts` for `nextEditorMode` skipping split and `effectiveEditorMode` collapsing split to view, and `useTabs.test.tsx` for the content URI open path.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Manual verification was on Android (emulator, Pixel 7, API 34, portrait and landscape): opening a file renders it, split is absent on the phone in both orientations, the outline opens as an overlay drawer and dismisses on backdrop tap, and the top and bottom bars clear the status bar and gesture pill.

Desktop was not re-verified by hand. The full gate is green (`pnpm typecheck`, `pnpm check`, 2862 tests, and `cargo clippy` on an unchanged Rust tree), and every mobile behaviour is behind a compact or platform gate, so the desktop render paths are the same code as before.

### Not included

- Folder workspaces on mobile. Android returns SAF tree URIs, and `read_directory` and the workspace walker are `std::fs` based, so this needs native directory enumeration and a mobile `pick_folder`. Tracked separately.
- Tab titles for files picked from the picker's "Recent" list still show the provider's opaque document id. Files browsed through storage resolve correctly, because those URIs carry the name. Reading the display name for the opaque case needs a native `ContentResolver` lookup.
