### PR TITLE
fix(plugins): make plugin error toasts readable

### DIFF
--- a/src/components/plugins/PluginToasts.test.tsx
+++ b/src/components/plugins/PluginToasts.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PluginToasts } from "./PluginToasts";
+
+describe("PluginToasts", () => {
+  it("renders nothing when there is nothing to show", () => {
+    const { container } = render(<PluginToasts toasts={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stacks every toast as a live status region", () => {
+    render(
+      <PluginToasts
+        toasts={[
+          { id: 1, message: "first" },
+          { id: 2, message: "second" },
+        ]}
+      />,
+    );
+    const toasts = screen.getAllByRole("status");
+    expect(toasts.map((el) => el.textContent)).toEqual(["first", "second"]);
+  });
+
+  it("separates a failure from an informational toast by more than colour", () => {
+    render(
+      <PluginToasts
+        toasts={[
+          { id: 1, message: "installed" },
+          { id: 2, message: "broke", tone: "error" },
+        ]}
+      />,
+    );
+    const [info, error] = screen.getAllByRole("status");
+    expect(error.className).toContain("--color-error");
+    expect(info.className).not.toContain("--color-error");
+  });
+
+  // The stack sits above the modal backdrop so failures raised from the plugins
+  // modal stay readable; it must not eat the clicks meant for the modal.
+  it("does not intercept pointer events", () => {
+    const { container } = render(<PluginToasts toasts={[{ id: 1, message: "hi" }]} />);
+    expect(container.firstElementChild?.className).toContain("pointer-events-none");
+  });
+});

--- a/src/components/plugins/PluginToasts.tsx
+++ b/src/components/plugins/PluginToasts.tsx
@@ -1,7 +1,18 @@
 export interface PluginToast {
   id: number;
   message: string;
+  /** Failures render in the error palette; anything else uses the neutral surface. */
+  tone?: "error";
 }
+
+const BASE_CLASS =
+  "max-w-[min(28rem,90vw)] px-4 py-2 rounded-lg border text-sm shadow-lg select-none break-words";
+
+const TONE_CLASS = {
+  neutral:
+    "border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-primary)]",
+  error: "border-[var(--color-error)] bg-[var(--color-error-bg)] text-[var(--color-error)]",
+} as const;
 
 /**
  * Transient notifications raised by plugins via `ctx.notify`. Stacked
@@ -10,13 +21,16 @@ export interface PluginToast {
 export function PluginToasts({ toasts }: { toasts: readonly PluginToast[] }) {
   if (toasts.length === 0) return null;
   return (
-    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2">
+    // z-[200] clears the modal backdrop (z-index 100 in settings.css): installs are
+    // driven from PluginsModal, and under its scrim the toast reads as a black smear.
+    // Sitting above the modal means it must not swallow the clicks meant for it.
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-[200] flex flex-col items-center gap-2 pointer-events-none">
       {toasts.map((toast) => (
         <div
           key={toast.id}
           role="status"
           aria-live="polite"
-          className="px-4 py-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] text-sm text-[var(--color-text-primary)] shadow-lg select-none"
+          className={`${BASE_CLASS} ${TONE_CLASS[toast.tone ?? "neutral"]}`}
         >
           {toast.message}
         </div>

--- a/src/contexts/PluginsProvider.tsx
+++ b/src/contexts/PluginsProvider.tsx
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { PluginStyles } from "@/components/plugins/PluginStyles";
 import { type PluginToast, PluginToasts } from "@/components/plugins/PluginToasts";
 import { PluginsContext } from "@/contexts/PluginsContext";
@@ -27,6 +28,7 @@ const TOAST_DURATION_MS = 4000;
  * management modal drives.
  */
 export function PluginsProvider({ children }: { children: ReactNode }) {
+  const { t } = useTranslation("plugins");
   const { hydrateGrants, hasFullTrust, getGrant, restoreGrant, ensureConsent, revokeGrant } =
     usePluginConsent();
   const [toasts, setToasts] = useState<PluginToast[]>([]);
@@ -37,9 +39,9 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
   const [registry, setRegistry] = useState<RegistryEntry[]>([]);
   const toastId = useRef(0);
 
-  const pushToast = useCallback((message: string) => {
+  const pushToast = useCallback((message: string, tone?: "error") => {
     const id = ++toastId.current;
-    setToasts((prev) => [...prev, { id, message }]);
+    setToasts((prev) => [...prev, { id, message, tone }]);
     window.setTimeout(() => {
       setToasts((prev) => prev.filter((t) => t.id !== id));
     }, TOAST_DURATION_MS);
@@ -131,17 +133,18 @@ export function PluginsProvider({ children }: { children: ReactNode }) {
         prev.includes(plugin.id) ? prev.filter((d) => d !== plugin.id) : prev,
       );
       setLoaded(host.listLoaded());
-      pushToast(`Installed plugin: ${plugin.name} v${plugin.version}`);
+      pushToast(t("toast.installed", { name: plugin.name, version: plugin.version }));
     },
-    [host, pushToast, persistDisabled],
+    [host, pushToast, persistDisabled, t],
   );
 
   const reportFailure = useCallback(
     (err: unknown) => {
       console.error("Plugin operation failed:", err);
-      pushToast(`Plugin error: ${err instanceof Error ? err.message : String(err)}`);
+      const message = err instanceof Error ? err.message : String(err);
+      pushToast(t("toast.error", { message }), "error");
     },
-    [pushToast],
+    [pushToast, t],
   );
 
   const uninstall = useCallback(

--- a/src/locales/de/plugins.json
+++ b/src/locales/de/plugins.json
@@ -37,5 +37,9 @@
   "officialBadge": "Offiziell",
   "back": "Zurück",
   "detailsLoading": "Wird geladen…",
-  "detailsError": "Die Plugin-Details konnten nicht geladen werden."
+  "detailsError": "Die Plugin-Details konnten nicht geladen werden.",
+  "toast": {
+    "installed": "Plugin installiert: {{name}} v{{version}}",
+    "error": "Plugin-Fehler: {{message}}"
+  }
 }

--- a/src/locales/en/plugins.json
+++ b/src/locales/en/plugins.json
@@ -37,5 +37,9 @@
   "officialBadge": "Official",
   "back": "Back",
   "detailsLoading": "Loading…",
-  "detailsError": "Could not load the plugin details."
+  "detailsError": "Could not load the plugin details.",
+  "toast": {
+    "installed": "Installed plugin: {{name}} v{{version}}",
+    "error": "Plugin error: {{message}}"
+  }
 }

--- a/src/locales/es/plugins.json
+++ b/src/locales/es/plugins.json
@@ -37,5 +37,9 @@
   "officialBadge": "Oficial",
   "back": "Atrás",
   "detailsLoading": "Cargando…",
-  "detailsError": "No se pudieron cargar los detalles del complemento."
+  "detailsError": "No se pudieron cargar los detalles del complemento.",
+  "toast": {
+    "installed": "Complemento instalado: {{name}} v{{version}}",
+    "error": "Error del complemento: {{message}}"
+  }
 }

--- a/src/locales/fa/plugins.json
+++ b/src/locales/fa/plugins.json
@@ -37,5 +37,9 @@
   "officialBadge": "رسمی",
   "back": "بازگشت",
   "detailsLoading": "در حال بارگذاری…",
-  "detailsError": "جزئیات افزونه بارگذاری نشد."
+  "detailsError": "جزئیات افزونه بارگذاری نشد.",
+  "toast": {
+    "installed": "افزونه نصب شد: {{name}} نسخه {{version}}",
+    "error": "خطای افزونه: {{message}}"
+  }
 }

--- a/src/locales/zh/plugins.json
+++ b/src/locales/zh/plugins.json
@@ -37,5 +37,9 @@
   "officialBadge": "官方",
   "back": "返回",
   "detailsLoading": "加载中…",
-  "detailsError": "无法加载插件详情。"
+  "detailsError": "无法加载插件详情。",
+  "toast": {
+    "installed": "已安装插件：{{name}} v{{version}}",
+    "error": "插件错误：{{message}}"
+  }
 }

--- a/src/styles/ai-chat.css
+++ b/src/styles/ai-chat.css
@@ -275,10 +275,10 @@
 }
 
 .ai-error {
-  color: #e53e3e;
+  color: var(--color-error);
   font-size: 12px;
   padding: 10px;
-  background: rgba(229, 62, 62, 0.08);
+  background: var(--color-error-bg);
   border-radius: var(--glyph-radius-sm);
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -40,6 +40,8 @@
   --color-alert-important: #8250df;
   --color-alert-warning: #9a6700;
   --color-alert-caution: #cf222e;
+  --color-error: #d70015;
+  --color-error-bg: rgba(215, 0, 21, 0.08);
 }
 
 /* Scoped to :root so a non-theme "dark" class on a subtree can't flip its native controls. */
@@ -65,6 +67,8 @@
   --color-alert-important: #bf8cff;
   --color-alert-warning: #d29922;
   --color-alert-caution: #f85149;
+  --color-error: #ff6961;
+  --color-error-bg: rgba(255, 105, 97, 0.14);
 }
 
 html,

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -147,7 +147,7 @@
 
 /* Spell check: red wavy underline under misspelled words. */
 .cm-misspelled {
-  text-decoration: underline wavy var(--color-error, #e5484d);
+  text-decoration: underline wavy var(--color-error);
   text-decoration-skip-ink: none;
   text-underline-offset: 2px;
 }

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -417,7 +417,7 @@
   padding: 8px 10px;
   font-size: 12px;
   color: var(--color-error);
-  background: rgba(229, 62, 62, 0.08);
+  background: var(--color-error-bg);
   border-radius: var(--glyph-radius-sm);
 }
 :is(.settings-sync, .settings-workspace) .settings-actions {


### PR DESCRIPTION
## Summary

Installing the Persian dictionary from the marketplace failed, and the toast that said why was unreadable.

The toast stack sat at `z-50` while the plugins modal backdrop is `z-index: 100`, so the message rendered *underneath* the scrim as a black smear. That is why the underlying failure went unexplained for as long as it did.

This PR fixes the readability only. **The install failure itself is a separate bug and is not fixed here** (see below).

## Changes

- Raise the plugin toast stack above the modal backdrop, and mark it `pointer-events-none`: sitting above a modal otherwise means swallowing the clicks meant for it (a ~28rem band across the bottom of the dialog, for four seconds after every failure).
- Render failures in an error tone instead of the neutral surface.
- Route the two provider-owned toast strings through i18n, in all five locales. English wording is unchanged.
- Define `--color-error` and `--color-error-bg` for both themes. `--color-error` was referenced by three rules in `settings.css` but **never defined anywhere**, so those errors rendered in the inherited text colour. The hardcoded `#e53e3e` / `rgba(229, 62, 62, 0.08)` duplicates in `ai-chat.css` now use the variables.

## The install failure this exposed

Once the toast was legible the real error turned out to have nothing to do with the download. Both published marketplace plugins fail at *activation*, reproduced in-process against the real sandbox worker source:

```
com.glyph.hello-status  → TypeError: ctx.ui.addStatusBarItem is not a function
com.glyph.dictionary-fa → TypeError: Cannot read properties of undefined (reading 'registerDictionary')
```

`sandbox.ts` turns a pre-`activated` error into a rejected `host.load`, which `installFromRegistry` catches and surfaces as a failed install.

The cause is the sandbox context in `bootstrap.ts`, which exposes only `commands.register`, `ui.addStyles`, `exporters.*`, `workspace.*`, `assets.*`, `settings.*`, `notify` and `registerTranslations`. The full-trust context in `host.ts` additionally has `ui.addStatusBarItem`, `ui.addSidebarPanel`, `ui.addSettingsPanel`, `markdown.*` and `spellcheck.registerDictionary`. Neither plugin declares `sandbox`, so since #521 made sandboxing the default both get the reduced context and both break.

That fix lands separately: `spellcheck.registerDictionary` can be proxied across the worker boundary (its `load` returns plain strings), while `ui.addStatusBarItem` cannot, since `mount(el)` needs a live DOM node.

## Risk classification

- [x] Accessibility
- [x] No other risk areas touched

### Invariants at stake and evidence

No invariant from `docs/engineering-invariants.md` is at stake: this is presentation plus five locale files. Toast identity and expiry are untouched (`pushToast` still mints monotonic ids and each timer filters by its own id, so the added `tone` field cannot let one toast's expiry remove another).

**Accessibility**: the toast keeps `role="status"` / `aria-live="polite"`. The error tone carries a border and background rather than relying on colour alone, and `pointer-events-none` means it can no longer intercept clicks meant for the dialog underneath.

## Testing

`pnpm typecheck && pnpm check && pnpm test` (2883 passing) on top of current `main`.

New coverage: a colocated `PluginToasts.test.tsx` for the empty case, stacking, both tones, and the pointer-events guard.

Not yet exercised by hand in a running app.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
