### PR TITLE
fix(plugins): give sandboxed plugins ctx.spellcheck

### DIFF
--- a/src/lib/plugins/host.ts
+++ b/src/lib/plugins/host.ts
@@ -222,6 +222,7 @@ export function createPluginHost(
             },
             registerExporter: tracked(exporters.register, bag),
             registerSiteTheme: tracked(siteThemes.register, bag),
+            registerDictionary: tracked(registerDictionarySource, bag),
             notify,
             registerTranslations,
             settingsSet(key, value) {

--- a/src/lib/plugins/sandbox/bootstrap.test.ts
+++ b/src/lib/plugins/sandbox/bootstrap.test.ts
@@ -96,6 +96,112 @@ describe("worker bootstrap", () => {
     await w.send({ type: "run-command", id: "ghost" });
   });
 
+  // The entry file of the published com.glyph.dictionary-fa package, verbatim.
+  // Before the sandbox context gained ctx.spellcheck this threw during
+  // activate, which the host reports as a failed install.
+  it("activates the real Persian dictionary plugin and loads it on demand", async () => {
+    const w = bootWorker();
+    const plugin = `export default {
+      activate(ctx) {
+        ctx.spellcheck.registerDictionary({
+          language: "fa",
+          label: "فارسی (Persian)",
+          load: async () => ({
+            aff: await ctx.assets.readText("assets/fa.aff"),
+            dic: await ctx.assets.readText("assets/fa.dic"),
+          }),
+        });
+      },
+    };`;
+    await w.send(init(plugin));
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("activated"));
+    expect(w.typesPosted()).not.toContain("error");
+    expect(w.posted).toContainEqual({
+      type: "register-dictionary",
+      language: "fa",
+      label: "فارسی (Persian)",
+      scripts: undefined,
+    });
+    // Registering reads nothing; the 2.5MB of assets are touched only on demand.
+    expect(w.typesPosted()).not.toContain("asset-read");
+
+    void w.send({ type: "load-dictionary", callId: 1, language: "fa" });
+    // The plugin awaits its two reads in sequence, so each has to be answered
+    // before the next is even requested.
+    const answered = new Set<number>();
+    for (const path of ["assets/fa.aff", "assets/fa.dic"]) {
+      await vi.waitFor(() =>
+        expect(
+          w.posted.some(
+            (m) => m.type === "asset-read" && m.path === path && !answered.has(m.callId),
+          ),
+        ).toBe(true),
+      );
+      const read = w.posted.find((m) => m.type === "asset-read" && m.path === path) as Extract<
+        WorkerMessage,
+        { type: "asset-read" }
+      >;
+      answered.add(read.callId);
+      await w.send({
+        type: "host-result",
+        callId: read.callId,
+        ok: true,
+        value: Array.from(new TextEncoder().encode(`data-${read.callId}`)),
+      });
+    }
+    await vi.waitFor(() =>
+      expect(w.posted).toContainEqual({
+        type: "dictionary-result",
+        callId: 1,
+        ok: true,
+        sources: { aff: "data-1", dic: "data-2" },
+      }),
+    );
+  });
+
+  it("reports a dictionary load failure instead of leaving the host waiting", async () => {
+    const w = bootWorker();
+    const plugin = `export default {
+      activate(ctx) {
+        ctx.spellcheck.registerDictionary({
+          language: "xx",
+          label: "Broken",
+          scripts: ["Latn"],
+          load: async () => { throw new Error("asset missing"); },
+        });
+      },
+    }`;
+    await w.send(init(plugin));
+    await vi.waitFor(() => expect(w.typesPosted()).toContain("activated"));
+    expect(w.posted).toContainEqual({
+      type: "register-dictionary",
+      language: "xx",
+      label: "Broken",
+      scripts: ["Latn"],
+    });
+
+    await w.send({ type: "load-dictionary", callId: 7, language: "xx" });
+    await vi.waitFor(() =>
+      expect(w.posted).toContainEqual({
+        type: "dictionary-result",
+        callId: 7,
+        ok: false,
+        error: "Error: asset missing",
+      }),
+    );
+
+    // A language with nothing registered fails the call rather than going quiet.
+    await w.send({ type: "load-dictionary", callId: 8, language: "ghost" });
+    await vi.waitFor(() =>
+      expect(w.posted).toContainEqual({
+        type: "dictionary-result",
+        callId: 8,
+        ok: false,
+        error: "Error: no dictionary registered for ghost",
+      }),
+    );
+  });
+
   it("builds exports and reports build failures", async () => {
     const w = bootWorker();
     const plugin = `export default {

--- a/src/lib/plugins/sandbox/bootstrap.ts
+++ b/src/lib/plugins/sandbox/bootstrap.ts
@@ -19,6 +19,7 @@ let callSeq = 0;
 const pendingHost = new Map(); // callId -> {resolve, reject}
 const commands = new Map();    // id -> run
 const exporters = new Map();   // id -> build
+const dictionaries = new Map(); // language -> load
 let settings = {};
 
 function hostCall(message) {
@@ -108,6 +109,20 @@ function buildContext(init) {
         return new TextDecoder().decode(new Uint8Array(bytes));
       },
     },
+    spellcheck: {
+      // Only the picker metadata crosses now; load() stays in the worker and
+      // runs on demand, so a dictionary the user never selects is never read.
+      registerDictionary(dictionary) {
+        dictionaries.set(dictionary.language, dictionary.load);
+        postMessage({
+          type: "register-dictionary",
+          language: dictionary.language,
+          label: dictionary.label,
+          scripts: dictionary.scripts ? Array.from(dictionary.scripts) : undefined,
+        });
+        return () => dictionaries.delete(dictionary.language);
+      },
+    },
     settings: {
       get(key) {
         return settings[key];
@@ -155,6 +170,25 @@ onmessage = async (event) => {
         });
       } catch (err) {
         postMessage({ type: "export-result", callId: msg.callId, ok: false, error: String(err) });
+      }
+    } else if (msg.type === "load-dictionary") {
+      const load = dictionaries.get(msg.language);
+      try {
+        if (!load) throw new Error("no dictionary registered for " + msg.language);
+        const sources = await load();
+        postMessage({
+          type: "dictionary-result",
+          callId: msg.callId,
+          ok: true,
+          sources: { aff: String(sources.aff), dic: String(sources.dic) },
+        });
+      } catch (err) {
+        postMessage({
+          type: "dictionary-result",
+          callId: msg.callId,
+          ok: false,
+          error: String(err),
+        });
       }
     } else if (msg.type === "host-result") {
       const pending = pendingHost.get(msg.callId);

--- a/src/lib/plugins/sandbox/protocol.ts
+++ b/src/lib/plugins/sandbox/protocol.ts
@@ -14,6 +14,8 @@ export type HostMessage =
     }
   | { type: "run-command"; id: string }
   | { type: "build-export"; callId: number; id: string; bodyHtml: string }
+  /** Run a registered dictionary's `load()`; nothing is read until a language is selected. */
+  | { type: "load-dictionary"; callId: number; language: string }
   /** Reply to any worker-initiated call (workspace-read/list, asset-read). */
   | { type: "host-result"; callId: number; ok: boolean; value?: unknown; error?: string };
 
@@ -38,6 +40,14 @@ export type WorkerMessage =
       callId: number;
       ok: boolean;
       output?: string | number[];
+      error?: string;
+    }
+  | { type: "register-dictionary"; language: string; label: string; scripts?: string[] }
+  | {
+      type: "dictionary-result";
+      callId: number;
+      ok: boolean;
+      sources?: { aff: string; dic: string };
       error?: string;
     }
   | { type: "workspace-read"; callId: number; path: string }

--- a/src/lib/plugins/sandbox/sandbox.test.ts
+++ b/src/lib/plugins/sandbox/sandbox.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { DictionaryContribution } from "@/lib/spellcheck/dictionarySources";
 import { FakeWorker } from "@/test/fakeWorker";
 import { PLUGIN_API_VERSION } from "../apiVersion";
 import type { ExporterContribution, InstalledPlugin } from "../types";
@@ -22,6 +23,7 @@ function apiStub(): SandboxHostApi {
     addStyles: vi.fn(),
     registerExporter: vi.fn(),
     registerSiteTheme: vi.fn(),
+    registerDictionary: vi.fn(),
     notify: vi.fn(),
     registerTranslations: vi.fn(),
     settingsSet: vi.fn(),
@@ -173,6 +175,54 @@ describe("startSandbox", () => {
 
     // Unknown callId is ignored rather than crashing the bridge.
     worker.emit({ type: "export-result", callId: 99, ok: true, output: "x" });
+  });
+
+  it("round-trips a dictionary load through the worker", async () => {
+    const { worker, api } = await startActivated();
+    worker.emit({
+      type: "register-dictionary",
+      language: "fa",
+      label: "Persian",
+      scripts: ["Arab"],
+    });
+    const [dictionary] = vi.mocked(api.registerDictionary).mock.calls[0] as [
+      DictionaryContribution,
+    ];
+    expect(dictionary).toMatchObject({ language: "fa", label: "Persian", scripts: ["Arab"] });
+
+    // Registering must not read anything: load() only runs once asked.
+    expect(worker.posted.some((m) => m.type === "load-dictionary")).toBe(false);
+
+    const loading = dictionary.load();
+    const request = worker.posted.find((m) => m.type === "load-dictionary");
+    expect(request).toMatchObject({ language: "fa" });
+
+    worker.emit({
+      type: "dictionary-result",
+      callId: (request as { callId: number }).callId,
+      ok: true,
+      sources: { aff: "SET UTF-8", dic: "1\nسلام" },
+    });
+    await expect(loading).resolves.toEqual({ aff: "SET UTF-8", dic: "1\nسلام" });
+  });
+
+  it("rejects a failed dictionary load and ignores an unknown callId", async () => {
+    const { worker, api } = await startActivated();
+    worker.emit({ type: "register-dictionary", language: "fa", label: "Persian" });
+    const [dictionary] = vi.mocked(api.registerDictionary).mock.calls[0] as [
+      DictionaryContribution,
+    ];
+
+    const first = dictionary.load();
+    worker.emit({ type: "dictionary-result", callId: 1, ok: false, error: "asset missing" });
+    await expect(first).rejects.toThrow("asset missing");
+
+    // An ok result with no sources rejects rather than resolving undefined.
+    const second = dictionary.load();
+    worker.emit({ type: "dictionary-result", callId: 2, ok: true });
+    await expect(second).rejects.toThrow("dictionary load failed");
+
+    worker.emit({ type: "dictionary-result", callId: 99, ok: true, sources: { aff: "", dic: "" } });
   });
 
   it("answers workspace-read and workspace-list with host-result", async () => {

--- a/src/lib/plugins/sandbox/sandbox.ts
+++ b/src/lib/plugins/sandbox/sandbox.ts
@@ -1,3 +1,4 @@
+import type { DictionaryContribution } from "@/lib/spellcheck/dictionarySources";
 import { PLUGIN_API_VERSION } from "../apiVersion";
 import type { Disposer } from "../disposer";
 import type { ExporterContribution, InstalledPlugin, SiteThemeContribution } from "../types";
@@ -21,6 +22,7 @@ export interface SandboxHostApi {
   addStyles(css: string): void;
   registerExporter(exporter: ExporterContribution): void;
   registerSiteTheme(theme: SiteThemeContribution): void;
+  registerDictionary(dictionary: DictionaryContribution): void;
   notify(message: string): void;
   registerTranslations(locale: string, namespace: string, resources: Record<string, unknown>): void;
   settingsSet(key: string, value: unknown): void;
@@ -58,6 +60,11 @@ export function startSandbox(
   const pendingExports = new Map<
     number,
     { resolve: (v: string | Uint8Array) => void; reject: (e: Error) => void }
+  >();
+  let dictionarySeq = 0;
+  const pendingDictionaries = new Map<
+    number,
+    { resolve: (v: { aff: string; dic: string }) => void; reject: (e: Error) => void }
   >();
 
   return new Promise<Disposer>((resolve, reject) => {
@@ -127,6 +134,27 @@ export function startSandbox(
           } else {
             pending.reject(new Error(data.error ?? "export failed"));
           }
+          break;
+        }
+        case "register-dictionary":
+          api.registerDictionary({
+            language: data.language,
+            label: data.label,
+            scripts: data.scripts,
+            load: () =>
+              new Promise((res, rej) => {
+                const callId = ++dictionarySeq;
+                pendingDictionaries.set(callId, { resolve: res, reject: rej });
+                worker.postMessage({ type: "load-dictionary", callId, language: data.language });
+              }),
+          });
+          break;
+        case "dictionary-result": {
+          const pending = pendingDictionaries.get(data.callId);
+          if (!pending) break;
+          pendingDictionaries.delete(data.callId);
+          if (data.ok && data.sources) pending.resolve(data.sources);
+          else pending.reject(new Error(data.error ?? "dictionary load failed"));
           break;
         }
         case "workspace-read":


### PR DESCRIPTION
## Summary

Installing the Persian dictionary (`com.glyph.dictionary-fa`) from the marketplace failed. The package downloads and installs fine; **activation** is what throws, reproduced in-process against the real sandbox worker source:

```
TypeError: Cannot read properties of undefined (reading 'registerDictionary')
```

The sandbox worker context in `bootstrap.ts` never had `ctx.spellcheck`, so a sandboxed dictionary plugin died in `activate()`. `sandbox.ts` turns a pre-`activated` error into a rejected `host.load`, which `installFromRegistry` catches and surfaces as a failed install, which is why this looked like a download problem.

Since #521 made sandboxing the default, this is every dictionary plugin that does not explicitly opt out of the sandbox.

## Changes

- Add `spellcheck.registerDictionary` to the sandbox context, bridged the way exporters already are: `register-dictionary` carries only `language`, `label` and `scripts` to the host, and the host's `load()` posts `load-dictionary` back into the worker, which runs the plugin's own `load` and answers with `dictionary-result`.
- Wire `registerDictionary` into `SandboxHostApi` and point it at the same `registerDictionarySource` registry the full-trust context uses, tracked by the plugin's `DisposerBag` so unload removes it.

`load()` stays in the worker and runs on demand, so a dictionary the user never selects never reads its assets. The Persian package's 2.5MB of Hunspell data only crosses the boundary once the language is picked in Settings → Editor → Spell Check.

## Not fixed here

`com.glyph.hello-status` fails the same way on `ctx.ui.addStatusBarItem`, which cannot be bridged as cheaply: `mount(el, registerCleanup)` needs a live DOM node, and the worker has none. That needs either a small remote-DOM shim or republishing the plugin as full-trust, and is deliberately left out of this PR.

The underlying shape is worth noting: sandboxed plugins receive a `ctx` typed as the full `GlyphPluginContext` while only a subset exists at runtime, so this class of failure is a `TypeError` at activation rather than a type error at build time. `markdown.*`, `ui.addSidebarPanel` and `ui.addSettingsPanel` are still in that gap.

## Risk classification

- [x] Asynchronous ordering / races
- [x] Untrusted rendering (Markdown, plugins, links)

### Invariants at stake and evidence

**INV-5 (all external input is untrusted).** The new path does not widen what a sandboxed plugin can reach. Assets still come through the existing `asset-read` call, which the host answers via `createAssetsApi(plugin.id)`, so a plugin can still only read its own manifest-declared files. What crosses the boundary is plugin-authored strings that were already crossing as `notify`/`register-command` payloads, and the host coerces both dictionary sources with `String()` before they leave the worker.

**INV-3 (stale results never win) / async ordering.** `dictionarySeq` mints monotonic call ids and each reply settles exactly its own entry, mirroring the export bridge; an unknown `callId` is ignored rather than crashing the bridge. A load that fails, or an `ok` reply carrying no sources, rejects rather than resolving `undefined`, so a broken dictionary surfaces instead of leaving the speller waiting forever. Both are covered by tests.

**INV-4 (owners flush before they die).** The registration is routed through the plugin's `DisposerBag`, so unload/disable/update removes the dictionary from the shared registry exactly like every other contribution.

## Testing

`pnpm typecheck && pnpm check && pnpm test` (2883 passing) on top of current `main`.

New coverage:

- `bootstrap.test.ts` drives **the published plugin's entry file verbatim**: it activates without error, posts `register-dictionary`, reads nothing until asked, and answers a `load-dictionary` with the decoded sources. This is the regression lock, so the same break cannot land silently again.
- `bootstrap.test.ts` also covers a `load()` that throws and a `load-dictionary` for a language with nothing registered.
- `sandbox.test.ts` covers the host side: the round trip, the failure path, an `ok` reply with no sources, and an unknown `callId`.

Not yet exercised by hand in a running app; the end-to-end check is installing the Persian dictionary from the marketplace and selecting it in Settings → Editor → Spell Check.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Follow-up

If `glyph-md/plugins` `docs/api-reference.md` marks which `ctx.*` APIs are available under the sandbox, it needs the `spellcheck` row updated to match.
