### PR TITLE
test(rust): extend the negative security matrix and run Windows unit tests in CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -88,6 +88,19 @@ jobs:
           # PyPI uploader: the GPG-verified binary intermittently fails.
           use_pypi: true
 
+  # Windows-gated guards (the junction escape test in grants.rs) never compile
+  # on the ubuntu coverage job above; this keeps them exercised in CI. Not in
+  # the required-checks ruleset.
+  test-rust-windows:
+    name: Rust Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: ./.github/actions/rust-setup
+      - name: Run Rust unit tests
+        working-directory: src-tauri
+        run: cargo test --lib
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -426,6 +426,34 @@ mod tests {
     }
 
     #[test]
+    fn rename_with_separators_or_dot_dot_stays_inside_root() {
+        let root = unique_tmp("rename_guard");
+        fs::create_dir_all(&root).unwrap();
+        let canonical_root = root.canonicalize().unwrap();
+
+        // sanitize_name strips separators but keeps dots; whatever survives
+        // must land inside the workspace, never above it.
+        for (i, evil) in ["../escape", "..\\escape", ".."].iter().enumerate() {
+            let file = root.join(format!("victim{i}.md"));
+            fs::write(&file, "x").unwrap();
+            let result = rename_path(
+                file.to_string_lossy().to_string(),
+                evil.to_string(),
+                root.to_string_lossy().to_string(),
+            );
+            if let Ok(new_path) = result {
+                let landed = Path::new(&new_path).canonicalize().unwrap();
+                assert!(
+                    landed.starts_with(&canonical_root),
+                    "rename to {evil:?} escaped the root: {new_path}"
+                );
+            }
+        }
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn rename_preserves_extension_when_omitted() {
         let dir = unique_tmp("rename_ext");
         let root = dir.to_string_lossy().to_string();

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -435,18 +435,19 @@ mod tests {
         for (i, evil) in ["../escape", "..\\escape", ".."].iter().enumerate() {
             let file = root.join(format!("victim{i}.md"));
             fs::write(&file, "x").unwrap();
-            let result = rename_path(
+            // Every sanitized name is a valid single component, so the rename
+            // must succeed; requiring it keeps the containment assert reachable.
+            let new_path = rename_path(
                 file.to_string_lossy().to_string(),
                 evil.to_string(),
                 root.to_string_lossy().to_string(),
+            )
+            .expect("sanitized rename should succeed");
+            let landed = Path::new(&new_path).canonicalize().unwrap();
+            assert!(
+                landed.starts_with(&canonical_root),
+                "rename to {evil:?} escaped the root: {new_path}"
             );
-            if let Ok(new_path) = result {
-                let landed = Path::new(&new_path).canonicalize().unwrap();
-                assert!(
-                    landed.starts_with(&canonical_root),
-                    "rename to {evil:?} escaped the root: {new_path}"
-                );
-            }
         }
 
         let _ = fs::remove_dir_all(&root);

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -428,7 +428,6 @@ mod tests {
     #[test]
     fn rename_with_separators_or_dot_dot_stays_inside_root() {
         let root = unique_tmp("rename_guard");
-        fs::create_dir_all(&root).unwrap();
         let canonical_root = root.canonicalize().unwrap();
 
         // sanitize_name strips separators but keeps dots; whatever survives

--- a/src-tauri/src/grants.rs
+++ b/src-tauri/src/grants.rs
@@ -335,6 +335,85 @@ mod tests {
     }
 
     #[test]
+    fn revocation_denies_every_ensure_path() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("a.md");
+        fs::write(&file, "x").unwrap();
+
+        let grants = GrantRegistry::default();
+        grants.grant_workspace(tmp.path()).unwrap();
+        grants.revoke_workspace(tmp.path());
+
+        // A stale grant must not survive on any validation path.
+        assert!(grants.ensure_readable(&as_str(&file)).is_err());
+        assert!(grants.ensure_writable(&as_str(&file)).is_err());
+        assert!(grants.ensure_watchable(&as_str(&file)).is_err());
+        assert!(grants.ensure_workspace(&as_str(tmp.path())).is_err());
+    }
+
+    #[test]
+    fn export_grants_never_satisfy_workspace_or_watch() {
+        let tmp = TempDir::new().unwrap();
+        let out = tmp.path().join("site");
+        fs::create_dir_all(&out).unwrap();
+        let target = tmp.path().join("doc.pdf");
+
+        let grants = GrantRegistry::default();
+        grants.grant_export_dir(&out).unwrap();
+        grants.grant_export_file(&target).unwrap();
+
+        // Write-only grants must not open the read-side surfaces.
+        assert!(grants.ensure_workspace(&as_str(&out)).is_err());
+        assert!(grants.ensure_watchable(&as_str(&out)).is_err());
+        assert!(grants.ensure_watchable(&as_str(&target)).is_err());
+    }
+
+    #[test]
+    fn export_dir_missing_tail_with_dot_dot_is_denied() {
+        let tmp = TempDir::new().unwrap();
+        let out = tmp.path().join("site");
+
+        let grants = GrantRegistry::default();
+        grants.grant_export_dir(&out).unwrap();
+
+        // The destination may not exist yet; a crafted tail cannot climb out.
+        let sneaky = out.join("nope").join("..").join("..").join("evil.html");
+        assert!(grants.ensure_writable(&as_str(&sneaky)).is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn junction_inside_a_workspace_cannot_escape_it() {
+        let outer = TempDir::new().unwrap();
+        let root = outer.path().join("ws");
+        let secret_dir = outer.path().join("secret");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&secret_dir).unwrap();
+        fs::write(secret_dir.join("secret.md"), "classified").unwrap();
+
+        // Junctions are the Windows escape vector symlinks are on unix, and
+        // unlike symlinks they need no privilege to create.
+        let link = root.join("innocent");
+        let status = std::process::Command::new("cmd")
+            .arg("/C")
+            .arg("mklink")
+            .arg("/J")
+            .arg(&link)
+            .arg(&secret_dir)
+            .status()
+            .expect("cmd should run");
+        assert!(status.success(), "mklink /J failed");
+
+        let grants = GrantRegistry::default();
+        grants.grant_workspace(&root).unwrap();
+
+        assert!(grants
+            .ensure_readable(&as_str(&link.join("secret.md")))
+            .is_err());
+        assert!(grants.ensure_readable(&as_str(&link)).is_err());
+    }
+
+    #[test]
     fn revoke_tolerates_missing_paths_and_a_poisoned_lock() {
         let tmp = TempDir::new().unwrap();
         let grants = GrantRegistry::default();

--- a/src-tauri/src/grants.rs
+++ b/src-tauri/src/grants.rs
@@ -329,22 +329,8 @@ mod tests {
         grants.grant_workspace(tmp.path()).unwrap();
         assert!(grants.ensure_readable(&as_str(&file)).is_ok());
 
-        grants.revoke_workspace(tmp.path());
-        assert!(grants.ensure_readable(&as_str(&file)).is_err());
-        assert!(grants.ensure_workspace(&as_str(tmp.path())).is_err());
-    }
-
-    #[test]
-    fn revocation_denies_every_ensure_path() {
-        let tmp = TempDir::new().unwrap();
-        let file = tmp.path().join("a.md");
-        fs::write(&file, "x").unwrap();
-
-        let grants = GrantRegistry::default();
-        grants.grant_workspace(tmp.path()).unwrap();
-        grants.revoke_workspace(tmp.path());
-
         // A stale grant must not survive on any validation path.
+        grants.revoke_workspace(tmp.path());
         assert!(grants.ensure_readable(&as_str(&file)).is_err());
         assert!(grants.ensure_writable(&as_str(&file)).is_err());
         assert!(grants.ensure_watchable(&as_str(&file)).is_err());
@@ -394,15 +380,17 @@ mod tests {
         // Junctions are the Windows escape vector symlinks are on unix, and
         // unlike symlinks they need no privilege to create.
         let link = root.join("innocent");
-        let status = std::process::Command::new("cmd")
+        // .output() captures the child's console chatter that .status() would
+        // leak past libtest's output capture.
+        let output = std::process::Command::new("cmd")
             .arg("/C")
             .arg("mklink")
             .arg("/J")
             .arg(&link)
             .arg(&secret_dir)
-            .status()
+            .output()
             .expect("cmd should run");
-        assert!(status.success(), "mklink /J failed");
+        assert!(output.status.success(), "mklink /J failed");
 
         let grants = GrantRegistry::default();
         grants.grant_workspace(&root).unwrap();
@@ -411,6 +399,9 @@ mod tests {
             .ensure_readable(&as_str(&link.join("secret.md")))
             .is_err());
         assert!(grants.ensure_readable(&as_str(&link)).is_err());
+        assert!(grants
+            .ensure_writable(&as_str(&link.join("planted.md")))
+            .is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 3 of #441: extend the Rust negative security matrix across the grant registry and filesystem commands. Tests plus one CI job, no runtime code.

## Changes

- Grant registry tests: revocation now proven to deny on every validation path (read, write, watch, workspace); export grants proven write-only against the read-side surfaces; dot-dot tails denied under a not-yet-existing export destination (reaches the export-dir branch the existing workspace traversal test never touches)
- Windows junction escape test: the junction counterpart to the existing unix symlink test, creating a real junction from inside a granted workspace to an outside folder and asserting canonicalization denies both the read and write side through it
- Rename containment test: separator and dot-dot names ("../escape", "..\\escape", "..") are proven to land inside the workspace root, never above it
- New non-required `Rust Windows` CI job running `cargo test --lib` on windows-latest, so the Windows-gated guards actually compile and run in CI (review finding: they previously only ran on developer machines)

Existing per-command denial tests in the file, directory, and create command surfaces were surveyed first; only genuinely missing matrix rows were added.

Part of #441 (Phase 4, mutation testing, is the last remaining phase).

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

No runtime code changed. The new tests are the INV-5/INV-6 evidence: every added case was mutation-verified during review (guards were deliberately broken and each test failed as intended).

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

419 Rust unit tests pass locally on Windows including the junction test, `cargo clippy --all-targets -- -D warnings` clean, frontend gates re-run green by the pre-commit hook. The new CI job exercises the Windows-gated tests on every PR.

## Screenshots

Not applicable (tests and CI only).
