### PR TITLE
fix(packaging): unblock PPA builds and verify the installed binary

### DIFF
--- a/.github/workflows/release-smoke-test.yml
+++ b/.github/workflows/release-smoke-test.yml
@@ -34,6 +34,7 @@ jobs:
       run: ${{ steps.resolve.outputs.run }}
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
+      mature: ${{ steps.resolve.outputs.mature }}
     steps:
       - name: Resolve target release
         id: resolve
@@ -47,9 +48,16 @@ jobs:
           TAG="${TAG:-$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)}"
           PUBLISHED=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json publishedAt --jq .publishedAt)
 
+          AGE=$(( $(date +%s) - $(date -d "$PUBLISHED" +%s) ))
+
+          # Two days is long enough for every channel we publish to ourselves to
+          # have built and indexed, so a channel still serving an older version
+          # by then is broken, not slow. Below that, pending stays informational.
+          MATURE=false
+          [ "$AGE" -ge 172800 ] && MATURE=true
+
           RUN=true
           if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-            AGE=$(( $(date +%s) - $(date -d "$PUBLISHED" +%s) ))
             if [ "$AGE" -lt 172800 ] || [ "$AGE" -ge 259200 ]; then
               RUN=false
               echo "::notice::Skipping: latest release $TAG is outside the 2-3 day window"
@@ -71,6 +79,7 @@ jobs:
             echo "run=$RUN"
             echo "tag=$TAG"
             echo "version=${TAG#v}"
+            echo "mature=$MATURE"
           } >> "$GITHUB_OUTPUT"
 
   homebrew-cask:
@@ -99,7 +108,10 @@ jobs:
           brew install --cask glyph-md/tap/glyph
           INSTALLED=$(defaults read /Applications/Glyph.app/Contents/Info CFBundleShortVersionString)
           [ "$INSTALLED" = "$VERSION" ]
-          test -x /Applications/Glyph.app/Contents/MacOS/glyph || test -x "/Applications/Glyph.app/Contents/MacOS/Glyph"
+
+          BIN=/Applications/Glyph.app/Contents/MacOS/glyph
+          [ -x "$BIN" ] || BIN=/Applications/Glyph.app/Contents/MacOS/Glyph
+          [ "$("$BIN" --version)" = "glyph $VERSION" ]
           echo "status=verified" >> "$GITHUB_OUTPUT"
 
   homebrew-formula:
@@ -127,6 +139,7 @@ jobs:
 
           brew install glyph-md/tap/glyph
           sudo apt-get update && sudo apt-get install -y xvfb libwebkit2gtk-4.1-0 libgtk-3-0
+          [ "$("$(brew --prefix)/bin/glyph" --version)" = "glyph $VERSION" ]
 
           set +e
           WEBKIT_DISABLE_COMPOSITING_MODE=1 xvfb-run -a timeout 15 "$(brew --prefix)/bin/glyph"
@@ -162,6 +175,7 @@ jobs:
           sudo apt-get install -y glyph xvfb
           INSTALLED=$(dpkg-query -W -f='${Version}' glyph)
           [ "$INSTALLED" = "$VERSION" ]
+          [ "$(glyph --version)" = "glyph $VERSION" ]
 
           set +e
           WEBKIT_DISABLE_COMPOSITING_MODE=1 xvfb-run -a timeout 15 glyph
@@ -202,6 +216,8 @@ jobs:
           sudo apt-get install -y glyph xvfb
           INSTALLED=$(dpkg-query -W -f='${Version}' glyph)
           case "$INSTALLED" in "$VERSION"-*) ;; *) echo "installed $INSTALLED"; exit 1 ;; esac
+          # Catches a package that installs cleanly but ships no binary.
+          [ "$(glyph --version)" = "glyph $VERSION" ]
 
           set +e
           WEBKIT_DISABLE_COMPOSITING_MODE=1 xvfb-run -a timeout 15 glyph
@@ -240,6 +256,8 @@ jobs:
           sudo apt-get install -y glyph xvfb
           INSTALLED=$(dpkg-query -W -f='${Version}' glyph)
           case "$INSTALLED" in "$VERSION"-*) ;; *) echo "installed $INSTALLED"; exit 1 ;; esac
+          # Catches a package that installs cleanly but ships no binary.
+          [ "$(glyph --version)" = "glyph $VERSION" ]
 
           set +e
           WEBKIT_DISABLE_COMPOSITING_MODE=1 xvfb-run -a timeout 15 glyph
@@ -271,6 +289,7 @@ jobs:
           sudo snap install glyph
           INSTALLED=$(snap list glyph | awk 'NR==2 {print $2}')
           [ "$INSTALLED" = "$VERSION" ]
+          [ "$(snap run glyph --version)" = "glyph $VERSION" ]
           sudo apt-get update && sudo apt-get install -y xvfb
 
           set +e
@@ -306,7 +325,7 @@ jobs:
           dnf install -y "$NAME" xorg-x11-server-Xvfb
           INSTALLED=$(rpm -q --qf '%{VERSION}' "$NAME")
           [ "$INSTALLED" = "$VERSION" ]
-          command -v glyph
+          [ "$(glyph --version)" = "glyph $VERSION" ]
 
           Xvfb :99 >/dev/null 2>&1 &
           for _ in $(seq 1 20); do [ -S /tmp/.X11-unix/X99 ] && break; sleep 0.5; done
@@ -349,7 +368,7 @@ jobs:
 
           INSTALLED=$(pacman -Q glyph-md-bin | awk '{print $2}')
           [ "${INSTALLED%%-*}" = "$VERSION" ]
-          command -v glyph
+          [ "$(glyph --version)" = "glyph $VERSION" ]
 
           Xvfb :99 >/dev/null 2>&1 &
           for _ in $(seq 1 20); do [ -S /tmp/.X11-unix/X99 ] && break; sleep 0.5; done
@@ -474,18 +493,23 @@ jobs:
       - name: Build channel summary
         env:
           TAG: ${{ needs.resolve.outputs.tag }}
+          MATURE: ${{ needs.resolve.outputs.mature }}
+          # Field 2 is the publishing model: "direct" channels are pushed by our
+          # own release workflow, so once the release has matured a pending one
+          # means publishing broke. "queued" channels wait on third-party review
+          # (Chocolatey moderation, winget-pkgs PRs) and stay informational.
           ROWS: |
-            homebrew-cask ${{ needs.homebrew-cask.result }} ${{ needs.homebrew-cask.outputs.status }}
-            homebrew-formula ${{ needs.homebrew-formula.result }} ${{ needs.homebrew-formula.outputs.status }}
-            apt ${{ needs.apt.result }} ${{ needs.apt.outputs.status }}
-            ppa-jammy ${{ needs.ppa-jammy.result }} ${{ needs.ppa-jammy.outputs.status }}
-            ppa-noble ${{ needs.ppa-noble.result }} ${{ needs.ppa-noble.outputs.status }}
-            snap ${{ needs.snap.result }} ${{ needs.snap.outputs.status }}
-            dnf ${{ needs.dnf.result }} ${{ needs.dnf.outputs.status }}
-            aur ${{ needs.aur.result }} ${{ needs.aur.outputs.status }}
-            scoop ${{ needs.scoop.result }} ${{ needs.scoop.outputs.status }}
-            chocolatey ${{ needs.chocolatey.result }} ${{ needs.chocolatey.outputs.status }}
-            winget ${{ needs.winget.result }} ${{ needs.winget.outputs.status }}
+            homebrew-cask direct ${{ needs.homebrew-cask.result }} ${{ needs.homebrew-cask.outputs.status }}
+            homebrew-formula direct ${{ needs.homebrew-formula.result }} ${{ needs.homebrew-formula.outputs.status }}
+            apt direct ${{ needs.apt.result }} ${{ needs.apt.outputs.status }}
+            ppa-jammy direct ${{ needs.ppa-jammy.result }} ${{ needs.ppa-jammy.outputs.status }}
+            ppa-noble direct ${{ needs.ppa-noble.result }} ${{ needs.ppa-noble.outputs.status }}
+            snap direct ${{ needs.snap.result }} ${{ needs.snap.outputs.status }}
+            dnf direct ${{ needs.dnf.result }} ${{ needs.dnf.outputs.status }}
+            aur direct ${{ needs.aur.result }} ${{ needs.aur.outputs.status }}
+            scoop direct ${{ needs.scoop.result }} ${{ needs.scoop.outputs.status }}
+            chocolatey queued ${{ needs.chocolatey.result }} ${{ needs.chocolatey.outputs.status }}
+            winget queued ${{ needs.winget.result }} ${{ needs.winget.outputs.status }}
         run: |
           {
             echo "## Release Smoke Test: $TAG"
@@ -495,9 +519,12 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           FAILED=0
-          while read -r CHANNEL RESULT STATUS; do
+          while read -r CHANNEL MODEL RESULT STATUS; do
             [ -z "$CHANNEL" ] && continue
-            if [ "$RESULT" = "success" ] && [ -n "$STATUS" ]; then
+            if [ "$STATUS" = "pending" ] && [ "$MODEL" = "direct" ] && [ "$MATURE" = "true" ]; then
+              ROW="pending (never published)"
+              FAILED=1
+            elif [ "$RESULT" = "success" ] && [ -n "$STATUS" ]; then
               ROW="$STATUS"
             elif [ "$RESULT" = "success" ]; then
               ROW="verified"

--- a/ppa/debian/control
+++ b/ppa/debian/control
@@ -2,7 +2,11 @@ Source: glyph
 Section: text
 Priority: optional
 Maintainer: hamidfzm <hamidfzm@users.noreply.github.com>
-Build-Depends: debhelper-compat (= 13)
+# The binary is prebuilt, but dh_shlibdeps still has to resolve every library
+# it links against to fill ${shlibs:Depends}, and it can only do that for
+# libraries installed in the build chroot. libwebkit2gtk-4.1-0 pulls in
+# javascriptcoregtk, soup3, gtk3, glib, cairo and gdk-pixbuf transitively.
+Build-Depends: debhelper-compat (= 13), libwebkit2gtk-4.1-0, libgtk-3-0
 Standards-Version: 4.6.0
 Homepage: {{HOMEPAGE}}
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -174,6 +174,17 @@ pub fn make_app_builder() -> tauri::Builder<tauri::Wry> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Answered before Tauri (and therefore GTK/WebKit) starts, so packaging
+    // smoke tests can verify an installed binary headlessly. `tauri-plugin-cli`
+    // parses args from inside `setup`, which is far too late for that.
+    if std::env::args()
+        .skip(1)
+        .any(|a| a == "--version" || a == "-V")
+    {
+        println!("glyph {}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+
     let builder = make_app_builder()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())


### PR DESCRIPTION
## Summary

The PPA has failed to build every upload since 0.17.1 (jammy and noble, four builds), so `ppa:hamidfzm/glyph` still serves 0.17.0. This restores PPA builds and closes the two gaps that let the breakage go unnoticed for two releases.

Root cause, from [the jammy 0.17.1 build log](https://launchpad.net/~hamidfzm/+archive/ubuntu/glyph/+build/33414733):

```
dpkg-shlibdeps: error: cannot find library libgtk-3.so.0 needed by debian/glyph/usr/bin/glyph
dh_shlibdeps: error: dpkg-shlibdeps ... returned exit code 2
make[1]: *** [debian/rules:11: override_dh_shlibdeps] Error 25
```

`ppa/debian/install` (added in 5f90f43) made the package actually ship `usr/bin/glyph`. From then on `dh_shlibdeps` had a real ELF binary to scan, and it can only resolve a library it finds installed in the build chroot. `Build-Depends` was `debhelper-compat (= 13)` and nothing else. `--ignore-missing-info` only tolerates missing shlibs *metadata*, not a missing library.

Before that commit the package installed no files at all, which is why it built: there was no binary to scan. The 0.17.0 PPA deb currently in the pool is 1972 bytes and contains no executable.

## Changes

- `ppa/debian/control`: add `libwebkit2gtk-4.1-0` and `libgtk-3-0` to `Build-Depends`. They pull javascriptcoregtk, soup3, gtk3, glib, cairo and gdk-pixbuf transitively, which covers every library the binary links. Both are in jammy and noble universe, and PPA chroots have universe enabled.
- `src-tauri/src/lib.rs`: answer `--version` / `-V` at the top of `run()`, before Tauri and therefore before GTK/WebKit start, so an installed binary can be verified with no display server. `tauri-plugin-cli` parses args from inside `setup`, far too late for that.
- `.github/workflows/release-smoke-test.yml`:
  - Every channel that installs a binary now runs `glyph --version` and compares it to the release version. This catches a package that installs cleanly but ships nothing executable, which is exactly what the PPA has been publishing.
  - `pending` no longer passes forever. Channels we publish ourselves fail the summary if they are still pending once the release is two days old (the same window the scheduled run already uses). Chocolatey and winget wait on third-party review, so they stay informational.

## Risk classification

- [x] No risk areas touched

Packaging and CI only. The single app-code change is an early return in `run()` for `--version`, before any state, window, or plugin exists.

### Invariants at stake and evidence

None. `--version` returns before the Tauri builder is constructed, so no managed state, window, or plugin lifecycle is reachable from that path.

## Testing

- `pnpm typecheck && pnpm test`, `cargo test --lib`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all green via the pre-commit gate.
- Summary-table logic exercised locally against a synthetic row set for both mature and immature releases: a `direct` channel stuck on pending fails only when mature, `queued` channels never do, and an empty `status` from a failed job still parses into the right column.
- The `--version` assertions go live with the next release. Manually dispatching the smoke test against 0.17.2 or older will report failure on those lines, since those binaries predate the flag.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Notes, out of scope

`ppa/debian/control` declares `Architecture: amd64 arm64`, but the release workflow only extracts `Glyph_${VERSION}_amd64.deb` into the source package. If arm64 is ever enabled on the PPA it would ship an amd64 binary in an arm64 package. Launchpad has never built arm64 for this PPA, so it has not bitten yet. Worth a separate issue.
