### PR TITLE
feat(palette): add icons to command palette rows and the graph reset control

### DIFF
--- a/src/components/graph/GraphView.tsx
+++ b/src/components/graph/GraphView.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { FitIcon } from "@/components/icons/FitIcon";
 import { useZoomApi, type ZoomHandlers } from "@/contexts/ZoomContext";
 import { useElementSize } from "@/hooks/useElementSize";
 import { useGraphCamera } from "@/hooks/useGraphCamera";
@@ -280,9 +281,10 @@ export function GraphView({ workspaceFiles, wikilinkRefs, onOpenFile }: GraphVie
         type="button"
         onClick={refit}
         disabled={autoFit}
-        className="absolute top-3 end-3 px-2.5 py-1 text-xs rounded-md border border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-[var(--color-text-secondary)] enabled:hover:text-[var(--color-text-primary)] disabled:opacity-40"
+        className="absolute top-3 end-3 inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-md border border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-[var(--color-text-secondary)] enabled:hover:text-[var(--color-text-primary)] disabled:opacity-40"
         title={t("graph.reset")}
       >
+        <FitIcon className="w-3.5 h-3.5" />
         {t("graph.resetView")}
       </button>
       {hovered && (

--- a/src/components/modals/CommandPalette.test.tsx
+++ b/src/components/modals/CommandPalette.test.tsx
@@ -226,6 +226,19 @@ describe("CommandPalette", () => {
     expect(screen.getByText("/workspace/note.md")).toBeInTheDocument();
   });
 
+  it("renders the leading icon when provided, and an empty slot when not", () => {
+    const { container } = renderPalette({
+      commands: [
+        cmd({ id: "with", title: "With Icon", icon: () => <svg aria-label="icon" role="img" /> }),
+        cmd({ id: "without", title: "Without Icon" }),
+      ],
+    });
+    expect(screen.getByRole("img", { name: "icon" })).toBeInTheDocument();
+    // Both rows keep the slot, so titles stay aligned when only some have icons.
+    expect(container.querySelectorAll(".command-palette-icon")).toHaveLength(2);
+    expect(screen.getByText("Without Icon")).toBeInTheDocument();
+  });
+
   it("focuses the input when opened", () => {
     renderPalette({});
     expect(document.activeElement).toBe(screen.getByLabelText("Command palette query"));

--- a/src/components/modals/CommandPaletteItem.tsx
+++ b/src/components/modals/CommandPaletteItem.tsx
@@ -8,14 +8,15 @@ interface CommandPaletteItemProps {
   onHover: () => void;
 }
 
-// A single result row in the command palette: title (with fuzzy-match
-// highlights), optional subtitle, and optional shortcut hint.
+// A single result row in the command palette: optional leading icon, title
+// (with fuzzy-match highlights), optional subtitle, and optional shortcut hint.
 export function CommandPaletteItem({
   row,
   selected,
   onActivate,
   onHover,
 }: CommandPaletteItemProps) {
+  const Icon = row.command.icon;
   return (
     <button
       type="button"
@@ -28,6 +29,8 @@ export function CommandPaletteItem({
       // are pointer-actionable but never the keyboard's focus target.
       tabIndex={-1}
     >
+      {/* Slot renders even without an icon so titles line up across rows. */}
+      <span className="command-palette-icon">{Icon && <Icon />}</span>
       <span className="command-palette-title">
         {renderHighlight(row.command.title, row.matches)}
       </span>

--- a/src/hooks/useAppCommands.test.ts
+++ b/src/hooks/useAppCommands.test.ts
@@ -328,6 +328,16 @@ describe("useAppCommands", () => {
     expect(actions.runPluginExporter).toHaveBeenCalledWith(slides);
   });
 
+  it("gives navigation and view commands a palette icon", () => {
+    const actions = makeActions();
+    const { result } = renderHook(() =>
+      useAppCommands({ workspaceOpen: false, workspaceFiles: [], tocEntries: [], actions }),
+    );
+    for (const id of ["cmd:openFile", "cmd:openGraph", "cmd:zoomIn", "cmd:exportPdf"]) {
+      expect(result.current.find((c) => c.id === id)?.icon).toBeTypeOf("function");
+    }
+  });
+
   it("includes a Manage Plugins command", () => {
     const actions = makeActions();
     const { result } = renderHook(() =>

--- a/src/hooks/useAppCommands.ts
+++ b/src/hooks/useAppCommands.ts
@@ -1,5 +1,21 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { ActualSizeIcon } from "@/components/icons/ActualSizeIcon";
+import { EditModeIcon } from "@/components/icons/EditModeIcon";
+import { ExternalLinkIcon } from "@/components/icons/ExternalLinkIcon";
+import { FileTextIcon } from "@/components/icons/FileTextIcon";
+import { FitIcon } from "@/components/icons/FitIcon";
+import { FolderIcon } from "@/components/icons/FolderIcon";
+import { FolderOpenIcon } from "@/components/icons/FolderOpenIcon";
+import { GraphIcon } from "@/components/icons/GraphIcon";
+import { NewFolderIcon } from "@/components/icons/NewFolderIcon";
+import { NewNoteIcon } from "@/components/icons/NewNoteIcon";
+import { OpenIcon } from "@/components/icons/OpenIcon";
+import { OutlineIcon } from "@/components/icons/OutlineIcon";
+import { SparkleIcon } from "@/components/icons/SparkleIcon";
+import { TabCloseIcon } from "@/components/icons/TabCloseIcon";
+import { ZoomInIcon } from "@/components/icons/ZoomInIcon";
+import { ZoomOutIcon } from "@/components/icons/ZoomOutIcon";
 import { usePluginsOptional } from "@/contexts/PluginsContext";
 import type { MenuEventHandlers } from "@/hooks/useMenuEvents";
 import type { TocEntry } from "@/hooks/useTableOfContents";
@@ -91,6 +107,7 @@ export function useAppCommands({
         id: "cmd:newDocument",
         title: t("newDocument"),
         section: "Commands",
+        icon: NewNoteIcon,
         shortcut: "Cmd/Ctrl+N",
         run: actions.newDocument,
       },
@@ -98,6 +115,7 @@ export function useAppCommands({
         id: "cmd:openFile",
         title: t("openFile"),
         section: "Commands",
+        icon: OpenIcon,
         shortcut: "Cmd/Ctrl+O",
         run: actions.openFile,
       },
@@ -105,6 +123,7 @@ export function useAppCommands({
         id: "cmd:openFolder",
         title: t("openFolder"),
         section: "Commands",
+        icon: FolderOpenIcon,
         shortcut: "Cmd/Ctrl+Shift+O",
         run: actions.openFolder,
       },
@@ -112,12 +131,14 @@ export function useAppCommands({
         id: "cmd:newWorkspace",
         title: t("newWorkspace"),
         section: "Commands",
+        icon: NewFolderIcon,
         run: actions.newWorkspace,
       },
       {
         id: "cmd:closeTab",
         title: t("closeTab"),
         section: "Commands",
+        icon: TabCloseIcon,
         shortcut: "Cmd/Ctrl+W",
         run: actions.closeTab,
       },
@@ -125,6 +146,7 @@ export function useAppCommands({
         id: "cmd:toggleFilesSidebar",
         title: t("toggleFilesSidebar"),
         section: "Commands",
+        icon: FolderIcon,
         shortcut: "Cmd/Ctrl+B",
         run: actions.toggleFilesSidebar,
       },
@@ -132,10 +154,17 @@ export function useAppCommands({
         id: "cmd:toggleOutlineSidebar",
         title: t("toggleOutlineSidebar"),
         section: "Commands",
+        icon: OutlineIcon,
         shortcut: "Cmd/Ctrl+\\",
         run: actions.toggleOutlineSidebar,
       },
-      { id: "cmd:resetView", title: t("resetView"), section: "Commands", run: actions.resetView },
+      {
+        id: "cmd:resetView",
+        title: t("resetView"),
+        section: "Commands",
+        icon: FitIcon,
+        run: actions.resetView,
+      },
       {
         id: "cmd:openSettings",
         title: t("openSettings"),
@@ -166,6 +195,7 @@ export function useAppCommands({
         id: "cmd:toggleEdit",
         title: t("toggleEdit"),
         section: "Commands",
+        icon: EditModeIcon,
         shortcut: "Cmd/Ctrl+E",
         run: actions.toggleEdit,
       },
@@ -173,6 +203,7 @@ export function useAppCommands({
         id: "cmd:openGraph",
         title: t("openGraph"),
         section: "Commands",
+        icon: GraphIcon,
         shortcut: "Cmd/Ctrl+G",
         run: actions.openGraph,
       },
@@ -187,21 +218,30 @@ export function useAppCommands({
         id: "cmd:exportHtml",
         title: t("exportHtml"),
         section: "Commands",
+        icon: FileTextIcon,
         run: actions.exportHtml,
       },
       {
         id: "cmd:exportDocx",
         title: t("exportDocx"),
         section: "Commands",
+        icon: FileTextIcon,
         run: actions.exportDocx,
       },
       {
         id: "cmd:exportEpub",
         title: t("exportEpub"),
         section: "Commands",
+        icon: FileTextIcon,
         run: actions.exportEpub,
       },
-      { id: "cmd:exportPdf", title: t("exportPdf"), section: "Commands", run: actions.exportPdf },
+      {
+        id: "cmd:exportPdf",
+        title: t("exportPdf"),
+        section: "Commands",
+        icon: FileTextIcon,
+        run: actions.exportPdf,
+      },
     );
 
     // Workspace-wide export; pointless (and menu-disabled) without a folder.
@@ -211,6 +251,7 @@ export function useAppCommands({
           id: "cmd:exportWebsite",
           title: t("exportWebsite"),
           section: "Commands",
+          icon: ExternalLinkIcon,
           run: actions.exportWebsite,
         },
         {
@@ -227,6 +268,7 @@ export function useAppCommands({
         id: "cmd:zoomIn",
         title: t("zoomIn"),
         section: "Commands",
+        icon: ZoomInIcon,
         shortcut: "Cmd/Ctrl+=",
         run: actions.zoomIn,
       },
@@ -234,6 +276,7 @@ export function useAppCommands({
         id: "cmd:zoomOut",
         title: t("zoomOut"),
         section: "Commands",
+        icon: ZoomOutIcon,
         shortcut: "Cmd/Ctrl+-",
         run: actions.zoomOut,
       },
@@ -241,6 +284,7 @@ export function useAppCommands({
         id: "cmd:zoomReset",
         title: t("zoomReset"),
         section: "Commands",
+        icon: ActualSizeIcon,
         shortcut: "Cmd/Ctrl+0",
         run: actions.zoomReset,
       },
@@ -248,6 +292,7 @@ export function useAppCommands({
         id: "cmd:aiChat",
         title: t("aiChat"),
         section: "Commands",
+        icon: SparkleIcon,
         shortcut: "Cmd/Ctrl+Shift+A",
         run: actions.aiChat,
       },
@@ -279,6 +324,7 @@ export function useAppCommands({
         id: `plugin-export:${exporter.id}`,
         title: t("exportAs", { label: exporter.label }),
         section: "Commands",
+        icon: FileTextIcon,
         run: () => actions.runPluginExporter(exporter),
       });
     }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -6,6 +6,7 @@
 // the fuzzy matcher in `./fuzzyMatch`. Empty queries pass through in source
 // order (modulo per-section priority).
 
+import type { ComponentType } from "react";
 import { fuzzyMatch } from "./fuzzyMatch";
 
 export type CommandSection = "Files" | "Headings" | "Commands";
@@ -17,6 +18,8 @@ export interface Command {
   /** Optional secondary line (file path, parent heading, accelerator). */
   subtitle?: string;
   section: CommandSection;
+  /** Optional leading icon component from `src/components/icons/`. */
+  icon?: ComponentType<{ className?: string }>;
   /** Optional keyboard shortcut hint shown on the right edge of the row. */
   shortcut?: string;
   run: () => void;

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -104,6 +104,19 @@
   background: color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
+.command-palette-icon {
+  flex: 0 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Icons stroke with currentColor, so this is the whole theme story. */
+  color: var(--color-text-tertiary);
+}
+
+.command-palette-item[data-selected="true"] .command-palette-icon {
+  color: var(--color-text-secondary);
+}
+
 .command-palette-title {
   flex: 1 1 auto;
   min-width: 0;


### PR DESCRIPTION
## Summary

Command palette rows now render an optional leading icon, and the graph view's reset control is icon-labelled. Closes #525.

## Changes

- `Command` gains an optional `icon` field typed as a component (`ComponentType<{ className?: string }>`), so command builders reference an icon from `src/components/icons/` without constructing elements.
- `CommandPaletteItem` renders a fixed 16px leading slot. The slot renders even when a command has no icon, so titles stay aligned across mixed rows.
- `.command-palette-icon` styles the slot with `var(--color-text-tertiary)` and brightens on the selected row. Icons stroke with `currentColor`, so light and dark both follow the existing theme variables.
- Built-in commands map to the existing icon set: new note, open, folder, tab close, outline, fit, edit, graph, document (exports), external link, zoom in/out, actual size, sparkle. Plugin-contributed exports reuse the document icon.
- The graph view's reset button becomes an icon plus label using the same `FitIcon`.
- No change to the plugin command contribution API, so `PLUGIN_API_VERSION` and the plugin ecosystem are untouched.

Commands with no fitting icon in the current set (Settings, Cloud Sync, Auto Save, Find, Print, Workspace Settings, Read Aloud, Manage Plugins) render the empty slot rather than getting new artwork in this PR.

## Risk classification

- [x] Accessibility
- [ ] No risk areas touched

### Invariants at stake and evidence

Icons are decorative: every icon used here renders `aria-hidden="true"` (directly or via `MenuIconBase`), and the palette row's accessible name still comes from the command title, so keyboard and screen-reader behaviour is unchanged. The graph reset button keeps its visible text label and `title`. Covered by the existing palette keyboard/selection tests plus the new row test in `CommandPalette.test.tsx`.

## Testing

`pnpm typecheck && pnpm check && pnpm test` all green (2958 tests). New coverage:

- `CommandPalette.test.tsx`: a row with an icon renders it, a row without one still renders the slot.
- `useAppCommands.test.ts`: navigation, view, and export commands carry an icon component.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux (unit tests only, app not launched)

## Screenshots

Not included; the change is a leading 16px glyph per palette row and on the graph reset button.
