### PR TITLE
test(rust): add targeted mutation testing with a clean baseline

### DIFF
--- a/.github/workflows/ci-mutation.yml
+++ b/.github/workflows/ci-mutation.yml
@@ -8,6 +8,9 @@ on:
     # red X on someone's PR.
     - cron: "0 4 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   mutants:
     name: cargo-mutants
@@ -24,13 +27,26 @@ jobs:
       - name: Install cargo-mutants
         uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
         with:
-          tool: cargo-mutants
+          tool: cargo-mutants,nextest
       - name: Run targeted mutation tests
         working-directory: src-tauri
         # Scope comes from src-tauri/.cargo/mutants.toml (grants + file/create
-        # commands). Fails the job when any mutant is missed, keeping the
-        # documented baseline non-decreasing (docs/engineering-invariants.md).
-        run: cargo mutants -j 2 --no-shuffle
+        # commands). Gate on the report, not the exit code: the clean baseline
+        # includes a mutant killed by timeout (an infinite-loop mutation), which
+        # makes cargo-mutants exit 3, and exit 3 also masks misses when both
+        # occur in one run. Missed mutants are the only failure condition,
+        # keeping the documented baseline non-decreasing
+        # (docs/engineering-invariants.md).
+        run: |
+          cargo mutants -j 2 --no-shuffle --test-tool=nextest && ec=0 || ec=$?
+          if [ -s mutants.out/missed.txt ]; then
+            echo "Missed mutants:"
+            cat mutants.out/missed.txt
+            exit 2
+          fi
+          if [ "$ec" -ne 0 ] && [ "$ec" -ne 3 ]; then
+            exit "$ec"
+          fi
       - name: Upload mutation report
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/ci-mutation.yml
+++ b/.github/workflows/ci-mutation.yml
@@ -1,0 +1,40 @@
+name: Mutation
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 04:00 UTC. Non-blocking: this workflow is not in the
+    # required-checks ruleset; a missed mutant is a review finding, not a
+    # red X on someone's PR.
+    - cron: "0 4 * * 1"
+
+jobs:
+  mutants:
+    name: cargo-mutants
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: ./.github/actions/rust-setup
+      - name: Install Linux dependencies
+        timeout-minutes: 8
+        uses: ./.github/actions/linux-deps
+        with:
+          cache-key: apt-webkit-ubuntu-latest-${{ runner.arch }}-v1
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
+        with:
+          tool: cargo-mutants
+      - name: Run targeted mutation tests
+        working-directory: src-tauri
+        # Scope comes from src-tauri/.cargo/mutants.toml (grants + file/create
+        # commands). Fails the job when any mutant is missed, keeping the
+        # documented baseline non-decreasing (docs/engineering-invariants.md).
+        run: cargo mutants -j 2 --no-shuffle
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: mutants-report
+          path: src-tauri/mutants.out/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ src-tauri/gen/schemas/android-schema.json
 src-tauri/gen/schemas/iOS-schema.json
 src-tauri/gen/schemas/mobile-schema.json
 src-tauri/gen/schemas/acl-manifests.json
+
+# cargo-mutants output (ci-mutation.yml uploads it as an artifact)
+src-tauri/mutants.out*/

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -69,4 +69,12 @@ For stateful or security-sensitive changes, tests and PR evidence must cover the
 
 - Every escaped data-loss or security defect adds a regression test and, if needed, a new invariant here.
 - Review this catalog at each minor-release kickoff and after every security or data-loss incident.
-- Mutation-testing baseline for the persistence and authorization modules is documented here once introduced (#441, Phase 4).
+## Mutation testing
+
+Targeted mutation testing guards the authorization and persistence command
+modules: `src-tauri/src/grants.rs`, `src-tauri/src/commands/file.rs`, and
+`src-tauri/src/commands/create.rs`, scoped in `src-tauri/.cargo/mutants.toml`.
+
+- Run locally with `cargo mutants` in `src-tauri/` (install: `cargo install cargo-mutants`). CI runs it weekly and on demand via the Mutation workflow (`ci-mutation.yml`), non-blocking.
+- **Baseline (2026-07-27): 70 mutants tested, 0 missed** (64 caught, 5 unviable, 1 caught by test timeout). The threshold is non-decreasing: a run that reports any missed mutant is a review failure; either kill the mutant with a test or triage it into the config's `exclude_re` with a written justification (current triage: `print_document`, a one-line webview delegation the mock runtime cannot make observably fail).
+- Every surviving high-impact mutant found by a scheduled run gets the same treatment before the next release.

--- a/docs/engineering-invariants.md
+++ b/docs/engineering-invariants.md
@@ -69,6 +69,7 @@ For stateful or security-sensitive changes, tests and PR evidence must cover the
 
 - Every escaped data-loss or security defect adds a regression test and, if needed, a new invariant here.
 - Review this catalog at each minor-release kickoff and after every security or data-loss incident.
+
 ## Mutation testing
 
 Targeted mutation testing guards the authorization and persistence command

--- a/src-tauri/.cargo/mutants.toml
+++ b/src-tauri/.cargo/mutants.toml
@@ -1,0 +1,14 @@
+# Targeted mutation testing for the persistence and authorization modules
+# (#441 Phase 4). Scope is deliberate: these files carry the security and
+# data-safety invariants (docs/engineering-invariants.md), and a full-crate
+# run would take hours for little extra signal.
+examine_globs = [
+    "src/grants.rs",
+    "src/commands/file.rs",
+    "src/commands/create.rs",
+]
+
+# Triaged acceptable miss: print_document is a one-line delegation to the
+# webview's print(); making it observably fail needs a real window, which the
+# mock runtime cannot provide. Low impact: no state, no filesystem access.
+exclude_re = ["print_document"]

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -426,6 +426,40 @@ mod tests {
     }
 
     #[test]
+    fn unique_path_keeps_counting_past_existing_collisions() {
+        let dir = unique_tmp("unique_counter");
+        fs::write(dir.join("Untitled.md"), "x").unwrap();
+        fs::write(dir.join("Untitled 1.md"), "x").unwrap();
+
+        // Two collisions deep: the counter must advance monotonically.
+        let next = unique_path(&dir, "Untitled", Some("md"));
+        assert_eq!(next, dir.join("Untitled 2.md"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn move_into_own_subfolder_is_refused() {
+        let root = unique_tmp("move_into_self");
+        let folder = root.join("folder");
+        let child = folder.join("child");
+        fs::create_dir_all(&child).unwrap();
+
+        let app = app_with_root(&root.to_string_lossy());
+        let result = super::move_path(
+            folder.to_string_lossy().to_string(),
+            child.to_string_lossy().to_string(),
+            root.to_string_lossy().to_string(),
+            app.state::<GrantRegistry>(),
+        );
+        // The guard must answer, not the OS rename failure.
+        assert_eq!(result.unwrap_err(), "Can't move an item into itself");
+        assert!(folder.is_dir());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn rename_with_separators_or_dot_dot_stays_inside_root() {
         let root = unique_tmp("rename_guard");
         let canonical_root = root.canonicalize().unwrap();

--- a/src-tauri/src/grants.rs
+++ b/src-tauri/src/grants.rs
@@ -564,6 +564,29 @@ mod tests {
     }
 
     #[test]
+    fn asset_scope_mirrors_dir_and_file_grants() {
+        use tauri::Manager;
+        let app = tauri::test::mock_app();
+
+        let dir_grant = TempDir::new().unwrap();
+        let nested = dir_grant.path().join("sub");
+        fs::create_dir_all(&nested).unwrap();
+        let inside = nested.join("img.png");
+        fs::write(&inside, "x").unwrap();
+        allow_asset_dir(app.handle(), dir_grant.path());
+        assert!(app.asset_protocol_scope().is_allowed(&inside));
+
+        let file_grant = TempDir::new().unwrap();
+        let file = file_grant.path().join("cover.png");
+        let sibling = file_grant.path().join("other.png");
+        fs::write(&file, "x").unwrap();
+        fs::write(&sibling, "x").unwrap();
+        allow_asset_file(app.handle(), &file);
+        assert!(app.asset_protocol_scope().is_allowed(&file));
+        assert!(!app.asset_protocol_scope().is_allowed(&sibling));
+    }
+
+    #[test]
     fn ensure_readable_returns_the_canonical_path() {
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("a.md");


### PR DESCRIPTION
## Summary

Phase 4 of #441, the final phase: targeted mutation testing for the authorization and persistence modules, with a clean documented baseline and a scheduled non-blocking CI workflow. Closes #441.

## Changes

- `src-tauri/.cargo/mutants.toml`: cargo-mutants scoped to `grants.rs`, `commands/file.rs`, `commands/create.rs`, with one written triage (`print_document`, a one-line webview delegation the mock runtime cannot make observably fail)
- New `Mutation` workflow (`ci-mutation.yml`): weekly plus on-demand, runs under nextest, uploads the report artifact, outside the required-checks ruleset. Gates on `mutants.out/missed.txt` rather than the exit code, since a timeout-killed mutant makes cargo-mutants exit 3 and that code can mask misses (review finding, verified against the tool's actual behavior)
- Baseline documented in `docs/engineering-invariants.md`: **70 mutants, 0 missed** (64 caught, 5 unviable, 1 caught by timeout), with the non-decreasing threshold policy
- Three new Rust tests that killed the six initially missed mutants, each a genuine coverage gap:
  - asset-protocol scope mirroring had no tests at all (both `allow_asset_*` functions could silently become no-ops)
  - `unique_path`'s collision counter was never driven past one collision
  - `move_path`'s into-itself guard was only distinguishable from the OS rename error
- `.gitignore` entry for the local `mutants.out*/` output

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

No runtime behavior changed; the three new tests strengthen INV-5/INV-6 evidence (asset-scope mirroring, workspace containment) and the mutation suite itself becomes the standing enforcement for them.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

Two full local mutation runs (initial 6 missed, final 0 missed), 422 Rust tests pass, `cargo clippy --all-targets -- -D warnings` clean, frontend gates re-run green by the pre-commit hook. Gate logic verified against the actual `mutants.out` report files. First scheduled workflow run will confirm the CI runtime budget.

## Screenshots

Not applicable (tests, CI, and docs).
