### PR TITLE
ci(smoke-test): add direct-download artifact jobs and clear brew annotations

### DIFF
--- a/.github/workflows/release-smoke-test.yml
+++ b/.github/workflows/release-smoke-test.yml
@@ -95,6 +95,9 @@ jobs:
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
         run: |
+          # The runner image ships aws/tap, which we never use; leaving it
+          # tapped makes every brew command warn that it is untrusted.
+          brew untap aws/tap || true
           brew tap glyph-md/tap
           brew trust glyph-md/tap || true
 
@@ -128,16 +131,22 @@ jobs:
           VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          # Ubuntu 24.04 blocks unprivileged user namespaces, so Homebrew's
+          # bubblewrap probe fails and it falls back to no sandboxing. Best
+          # effort: the knob is AppArmor-specific and only silences a warning.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
           brew tap glyph-md/tap
 
-          AVAILABLE=$(brew info --json=v2 glyph-md/tap/glyph | jq -r '.formulae[0].versions.stable')
+          # The tap ships both a formula and a cask named glyph; without
+          # --formula brew warns about the ambiguity on every invocation.
+          AVAILABLE=$(brew info --formula --json=v2 glyph-md/tap/glyph | jq -r '.formulae[0].versions.stable')
           if [ "$AVAILABLE" != "$VERSION" ]; then
             echo "status=pending" >> "$GITHUB_OUTPUT"
             echo "Formula serves $AVAILABLE, not $VERSION yet." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          brew install glyph-md/tap/glyph
+          brew install --formula glyph-md/tap/glyph
           sudo apt-get update && sudo apt-get install -y xvfb libwebkit2gtk-4.1-0 libgtk-3-0
           [ "$("$(brew --prefix)/bin/glyph" --version)" = "glyph $VERSION" ]
 
@@ -472,6 +481,94 @@ jobs:
           test -x "$PROGRAMFILES/Glyph/Glyph.exe"
           echo "status=verified" >> "$GITHUB_OUTPUT"
 
+  # Direct-download artifacts. Unlike the package channels these are served by
+  # the release itself, so there is nothing to wait for: the artifact is there
+  # and works, or the release is broken. They never report pending.
+  dmg:
+    needs: resolve
+    if: needs.resolve.outputs.run == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - name: Mount the DMG and verify
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DMG="Glyph_${VERSION}_universal.dmg"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "$DMG"
+
+          MOUNT=$(mktemp -d)
+          hdiutil attach "$DMG" -nobrowse -readonly -mountpoint "$MOUNT"
+          trap 'hdiutil detach "$MOUNT" -quiet || true' EXIT
+
+          APP="$MOUNT/Glyph.app"
+          [ "$(defaults read "$APP/Contents/Info" CFBundleShortVersionString)" = "$VERSION" ]
+
+          BIN="$APP/Contents/MacOS/glyph"
+          [ -x "$BIN" ] || BIN="$APP/Contents/MacOS/Glyph"
+          [ "$("$BIN" --version)" = "glyph $VERSION" ]
+
+  appimage:
+    needs: resolve
+    if: needs.resolve.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Extract the AppImage and verify
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          APPIMAGE="Glyph_${VERSION}_amd64.AppImage"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "$APPIMAGE"
+          chmod +x "$APPIMAGE"
+
+          # Runners have no FUSE, so extract rather than mount.
+          "./$APPIMAGE" --appimage-extract >/dev/null
+          sudo apt-get update && sudo apt-get install -y xvfb libwebkit2gtk-4.1-0 libgtk-3-0
+          [ "$(squashfs-root/AppRun --version)" = "glyph $VERSION" ]
+
+          set +e
+          WEBKIT_DISABLE_COMPOSITING_MODE=1 xvfb-run -a timeout 15 squashfs-root/AppRun
+          CODE=$?
+          set -e
+          [ "$CODE" -eq 124 ] || { echo "launch check failed (exit $CODE)"; exit 1; }
+
+  # The MSI is what Chocolatey, Scoop, and winget repackage, so it is covered
+  # by those jobs; the NSIS setup.exe is only ever installed directly.
+  nsis:
+    needs: resolve
+    if: needs.resolve.outputs.run == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Silent-install the NSIS setup and verify
+        shell: pwsh
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $setup = "Glyph_$($env:VERSION)_x64-setup.exe"
+          gh release download $env:TAG --repo $env:GITHUB_REPOSITORY --pattern $setup
+
+          $proc = Start-Process -FilePath ".\$setup" -ArgumentList "/S" -Wait -PassThru
+          if ($proc.ExitCode -ne 0) { Write-Error "installer exited $($proc.ExitCode)"; exit 1 }
+
+          # Tauri's NSIS installer defaults to a per-user install; a
+          # per-machine build lands under Program Files instead.
+          $exe = "$env:LOCALAPPDATA\Programs\Glyph\Glyph.exe"
+          if (-not (Test-Path $exe)) { $exe = "$env:ProgramFiles\Glyph\Glyph.exe" }
+          if (-not (Test-Path $exe)) { Write-Error "Glyph.exe not found after install"; exit 1 }
+
+          # Glyph.exe is a GUI subsystem binary with no console to print to, so
+          # the embedded file version is the assertion available here.
+          $installed = (Get-Item $exe).VersionInfo.FileVersion
+          if ($installed -notlike "$($env:VERSION)*") { Write-Error "installed $installed"; exit 1 }
+
   summary:
     needs:
       - resolve
@@ -486,6 +583,9 @@ jobs:
       - scoop
       - chocolatey
       - winget
+      - dmg
+      - appimage
+      - nsis
     if: ${{ !cancelled() && needs.resolve.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -510,6 +610,9 @@ jobs:
             scoop direct ${{ needs.scoop.result }} ${{ needs.scoop.outputs.status }}
             chocolatey queued ${{ needs.chocolatey.result }} ${{ needs.chocolatey.outputs.status }}
             winget queued ${{ needs.winget.result }} ${{ needs.winget.outputs.status }}
+            dmg direct ${{ needs.dmg.result }}
+            appimage direct ${{ needs.appimage.result }}
+            nsis direct ${{ needs.nsis.result }}
         run: |
           {
             echo "## Release Smoke Test: $TAG"


### PR DESCRIPTION
## Summary

The release notes tell users to download the DMG, AppImage, and Windows installer directly, but those artifacts had zero automated coverage. The package channels repackage the MSI and the `.deb`/`.rpm`; nothing ever mounted the DMG, extracted the AppImage, or ran the NSIS setup.

This adds three jobs to `release-smoke-test.yml` that fetch each artifact from the target release, install or extract it, and assert the binary reports the release version. It also clears the five warnings the workflow leaves in the Actions annotations panel (see run [29993713363](https://github.com/hamidfzm/glyph/actions/runs/29993713363)).

Unlike the package channels, these artifacts are served by the release itself, so there is nothing to wait for and they have no pending state: the artifact works or the release is broken.

## Changes

- `dmg` job: downloads `Glyph_<version>_universal.dmg`, mounts it with `hdiutil`, checks `CFBundleShortVersionString`, and runs the app binary with `--version`
- `appimage` job: downloads `Glyph_<version>_amd64.AppImage`, uses `--appimage-extract` (runners have no FUSE), asserts the version, then launches under xvfb with the same 15s timeout check the other Linux jobs use
- `nsis` job: silent-installs `Glyph_<version>_x64-setup.exe` with `/S`, locates `Glyph.exe` in either the per-user or per-machine install root, and asserts its embedded file version. The MSI is already exercised by the Chocolatey, Scoop, and winget jobs; the NSIS setup was the only Windows artifact nothing installed.
- All three wired into the summary job as `direct` channels
- `brew untap aws/tap` in the cask job: the macOS runner image ships that tap, and leaving it makes every `brew` command warn that it is untrusted
- `brew info --formula` / `brew install --formula` in the formula job: the tap ships both a formula and a cask named `glyph`, so brew warned about the ambiguity twice per run
- `sysctl kernel.apparmor_restrict_unprivileged_userns=0` (best effort) in the formula job: Ubuntu 24.04 blocks unprivileged user namespaces, so Homebrew's bubblewrap probe failed and it warned that it was building without sandboxing

## Risk classification

- [x] No risk areas touched

CI-only change; no application code is touched.

### Invariants at stake and evidence

None. The change is confined to `.github/workflows/release-smoke-test.yml`.

## Testing

The new jobs only run against a published release, so they cannot be exercised by PR CI. Verification plan after merge: dispatch **Release Smoke Test** with version `0.18.0` and confirm the `dmg`, `appimage`, and `nsis` rows report `verified` in the summary, and that the annotations panel is clean.

Asset names were taken from the v0.18.0 release (`Glyph_0.18.0_universal.dmg`, `Glyph_0.18.0_amd64.AppImage`, `Glyph_0.18.0_x64-setup.exe`), and the workflow YAML parses.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Closes #503
