### PR TITLE
feat(a11y): respect the OS reduced-motion preference

### DIFF
--- a/src/hooks/useGraphSimulation.test.ts
+++ b/src/hooks/useGraphSimulation.test.ts
@@ -1,8 +1,17 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WikilinkRef } from "@/lib/backlinks";
 import { buildWorkspaceGraph } from "@/lib/graph";
 import { useGraphSimulation } from "./useGraphSimulation";
+
+const { reducedMotion } = vi.hoisted(() => ({ reducedMotion: { value: false } }));
+vi.mock("./useReducedMotion", () => ({
+  useReducedMotion: () => reducedMotion.value,
+}));
+
+afterEach(() => {
+  reducedMotion.value = false;
+});
 
 const FILES = ["/v/a.md", "/v/b.md", "/v/c.md"];
 const REFS: WikilinkRef[] = [
@@ -86,6 +95,52 @@ describe("useGraphSimulation", () => {
     for (const node of result.current.layout.nodes) {
       expect(Number.isFinite(node.x)).toBe(true);
     }
+    unmount();
+  });
+
+  it("paints once at the end when reduced motion is on", async () => {
+    reducedMotion.value = true;
+    const graph = buildWorkspaceGraph(FILES, REFS);
+    const { result, unmount } = renderHook(() => useGraphSimulation(graph, FAST));
+    await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
+
+    // The layout still runs across frames (a synchronous pass would block the
+    // thread), but only the settled state is painted, so nothing animates.
+    expect(result.current.version).toBe(1);
+    for (const node of result.current.layout.nodes) {
+      expect(Number.isFinite(node.x)).toBe(true);
+      expect(Number.isFinite(node.y)).toBe(true);
+    }
+    unmount();
+  });
+
+  it("keeps painting every frame during a reheat under reduced motion", async () => {
+    reducedMotion.value = true;
+    const graph = buildWorkspaceGraph(FILES, REFS);
+    const { result, unmount } = renderHook(() => useGraphSimulation(graph, FAST));
+    await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
+    const versionWhenSettled = result.current.version;
+
+    // A reheat tracks the pointer during a drag, so it must not withhold frames.
+    act(() => {
+      result.current.reheat();
+    });
+    await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
+    expect(result.current.version - versionWhenSettled).toBeGreaterThan(1);
+    unmount();
+  });
+
+  it("switches to animating when the preference is turned off mid-layout", async () => {
+    reducedMotion.value = true;
+    const graph = buildWorkspaceGraph(FILES, REFS);
+    const { result, rerender, unmount } = renderHook(() => useGraphSimulation(graph, FAST));
+    await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
+    expect(result.current.version).toBe(1);
+
+    reducedMotion.value = false;
+    rerender();
+    await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
+    expect(result.current.version).toBeGreaterThan(1);
     unmount();
   });
 

--- a/src/hooks/useGraphSimulation.test.ts
+++ b/src/hooks/useGraphSimulation.test.ts
@@ -21,6 +21,8 @@ const REFS: WikilinkRef[] = [
 
 // High ticksPerFrame keeps the rAF count low so tests settle in a few frames.
 const FAST = { ticksPerFrame: 100 };
+// Enough frames to interrupt a pass while it is still in flight.
+const SLOW = { ticksPerFrame: 10 };
 
 describe("useGraphSimulation", () => {
   it("exposes a layout for the given graph immediately", () => {
@@ -35,7 +37,8 @@ describe("useGraphSimulation", () => {
     const graph = buildWorkspaceGraph(FILES, REFS);
     const { result, unmount } = renderHook(() => useGraphSimulation(graph, FAST));
     await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
-    expect(result.current.version).toBeGreaterThan(0);
+    // Every frame paints, so the layout is seen moving rather than jumping.
+    expect(result.current.version).toBeGreaterThan(1);
     for (const node of result.current.layout.nodes) {
       expect(Number.isFinite(node.x)).toBe(true);
       expect(Number.isFinite(node.y)).toBe(true);
@@ -130,12 +133,27 @@ describe("useGraphSimulation", () => {
     unmount();
   });
 
+  it("starts painting when a reheat lands on a pass that is still in flight", async () => {
+    reducedMotion.value = true;
+    const graph = buildWorkspaceGraph(FILES, REFS);
+    const { result, unmount } = renderHook(() => useGraphSimulation(graph, SLOW));
+    // Grabbing a node before the first pass settles must upgrade that pass,
+    // otherwise the canvas stays frozen for the whole drag.
+    expect(result.current.settled).toBe(false);
+    act(() => {
+      result.current.reheat();
+    });
+
+    await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
+    expect(result.current.version).toBeGreaterThan(1);
+    unmount();
+  });
+
   it("switches to animating when the preference is turned off mid-layout", async () => {
     reducedMotion.value = true;
     const graph = buildWorkspaceGraph(FILES, REFS);
-    const { result, rerender, unmount } = renderHook(() => useGraphSimulation(graph, FAST));
-    await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
-    expect(result.current.version).toBe(1);
+    const { result, rerender, unmount } = renderHook(() => useGraphSimulation(graph, SLOW));
+    expect(result.current.settled).toBe(false);
 
     reducedMotion.value = false;
     rerender();

--- a/src/hooks/useGraphSimulation.ts
+++ b/src/hooks/useGraphSimulation.ts
@@ -8,6 +8,7 @@ import {
   type NodePosition,
   tickLayout,
 } from "@/lib/graphSimulation";
+import { useReducedMotion } from "./useReducedMotion";
 
 export interface UseGraphSimulationOptions {
   /** Simulation steps per animation frame. Tuned for 60fps; tests raise it. */
@@ -47,6 +48,7 @@ export function useGraphSimulation(
 ): GraphSimulationState {
   const ticksPerFrame = options?.ticksPerFrame ?? DEFAULT_TICKS_PER_FRAME;
   const maxTicks = options?.maxTicks ?? LAYOUT_MAX_TICKS;
+  const reducedMotion = useReducedMotion();
   const previousPositions = useRef<Map<string, NodePosition> | null>(null);
   const [version, setVersion] = useState(0);
   const [settled, setSettled] = useState(false);
@@ -62,44 +64,53 @@ export function useGraphSimulation(
     [graph],
   );
 
-  const runLoop = useCallback(() => {
-    if (runningRef.current) return;
-    runningRef.current = true;
-    setSettled(false);
+  // `paintEveryFrame` off still ticks on animation frames (a synchronous pass
+  // would block the thread for seconds on a large graph); it just withholds the
+  // redraws in between, so the layout appears settled in one step.
+  const runLoop = useCallback(
+    (paintEveryFrame: boolean) => {
+      if (runningRef.current) return;
+      runningRef.current = true;
+      setSettled(false);
 
-    const step = () => {
-      const done = tickLayout(layout, ticksPerFrame);
-      budgetRef.current -= ticksPerFrame;
-      previousPositions.current = capturePositions(layout);
-      setVersion((v) => v + 1);
-      if (done || budgetRef.current <= 0) {
-        runningRef.current = false;
-        setSettled(true);
-        return;
-      }
+      const step = () => {
+        const done = tickLayout(layout, ticksPerFrame);
+        budgetRef.current -= ticksPerFrame;
+        previousPositions.current = capturePositions(layout);
+        const finished = done || budgetRef.current <= 0;
+        if (paintEveryFrame || finished) setVersion((v) => v + 1);
+        if (finished) {
+          runningRef.current = false;
+          setSettled(true);
+          return;
+        }
+        frameRef.current = requestAnimationFrame(step);
+      };
       frameRef.current = requestAnimationFrame(step);
-    };
-    frameRef.current = requestAnimationFrame(step);
-  }, [layout, ticksPerFrame]);
+    },
+    [layout, ticksPerFrame],
+  );
 
   // Fresh layout (mount or graph change): refill the budget and run.
   useEffect(() => {
     budgetRef.current = maxTicks;
-    runLoop();
+    runLoop(!reducedMotion);
     return () => {
       cancelAnimationFrame(frameRef.current);
       runningRef.current = false;
       layout.simulation.stop();
     };
-  }, [layout, maxTicks, runLoop]);
+  }, [layout, maxTicks, runLoop, reducedMotion]);
 
   const reheat = useCallback(
     (alpha = REHEAT_ALPHA) => {
       const sim = layout.simulation;
       sim.alpha(Math.max(sim.alpha(), alpha));
       // Refill the budget so a sustained drag keeps animating, then resume.
+      // Always paints: a reheat tracks the pointer, and withholding frames
+      // would freeze the node under the user's finger.
       budgetRef.current = maxTicks;
-      runLoop();
+      runLoop(true);
     },
     [layout, maxTicks, runLoop],
   );

--- a/src/hooks/useGraphSimulation.ts
+++ b/src/hooks/useGraphSimulation.ts
@@ -64,37 +64,38 @@ export function useGraphSimulation(
     [graph],
   );
 
-  // `paintEveryFrame` off still ticks on animation frames (a synchronous pass
-  // would block the thread for seconds on a large graph); it just withholds the
-  // redraws in between, so the layout appears settled in one step.
-  const runLoop = useCallback(
-    (paintEveryFrame: boolean) => {
-      if (runningRef.current) return;
-      runningRef.current = true;
-      setSettled(false);
+  // Off still ticks on animation frames (a synchronous pass would block the
+  // thread for seconds on a large graph); it only withholds the redraws in
+  // between, so the layout appears settled in one step. A ref, not an argument,
+  // so a reheat can upgrade a pass that is already in flight.
+  const paintEveryFrameRef = useRef(true);
 
-      const step = () => {
-        const done = tickLayout(layout, ticksPerFrame);
-        budgetRef.current -= ticksPerFrame;
-        previousPositions.current = capturePositions(layout);
-        const finished = done || budgetRef.current <= 0;
-        if (paintEveryFrame || finished) setVersion((v) => v + 1);
-        if (finished) {
-          runningRef.current = false;
-          setSettled(true);
-          return;
-        }
-        frameRef.current = requestAnimationFrame(step);
-      };
+  const runLoop = useCallback(() => {
+    if (runningRef.current) return;
+    runningRef.current = true;
+    setSettled(false);
+
+    const step = () => {
+      const done = tickLayout(layout, ticksPerFrame);
+      budgetRef.current -= ticksPerFrame;
+      previousPositions.current = capturePositions(layout);
+      const finished = done || budgetRef.current <= 0;
+      if (paintEveryFrameRef.current || finished) setVersion((v) => v + 1);
+      if (finished) {
+        runningRef.current = false;
+        setSettled(true);
+        return;
+      }
       frameRef.current = requestAnimationFrame(step);
-    },
-    [layout, ticksPerFrame],
-  );
+    };
+    frameRef.current = requestAnimationFrame(step);
+  }, [layout, ticksPerFrame]);
 
   // Fresh layout (mount or graph change): refill the budget and run.
   useEffect(() => {
     budgetRef.current = maxTicks;
-    runLoop(!reducedMotion);
+    paintEveryFrameRef.current = !reducedMotion;
+    runLoop();
     return () => {
       cancelAnimationFrame(frameRef.current);
       runningRef.current = false;
@@ -107,10 +108,12 @@ export function useGraphSimulation(
       const sim = layout.simulation;
       sim.alpha(Math.max(sim.alpha(), alpha));
       // Refill the budget so a sustained drag keeps animating, then resume.
-      // Always paints: a reheat tracks the pointer, and withholding frames
-      // would freeze the node under the user's finger.
+      // Always paints, upgrading a non-painting pass if one is mid-flight: a
+      // reheat tracks the pointer, and withholding frames would freeze the
+      // node under the user's finger.
       budgetRef.current = maxTicks;
-      runLoop(true);
+      paintEveryFrameRef.current = true;
+      runLoop();
     },
     [layout, maxTicks, runLoop],
   );

--- a/src/hooks/useMediaQuery.test.ts
+++ b/src/hooks/useMediaQuery.test.ts
@@ -1,38 +1,9 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
 import { TABLET_QUERY, useCanSplit, useMediaQuery } from "./useMediaQuery";
 
-const originalMatchMedia = window.matchMedia;
-
-// Minimal MediaQueryList stub that records its change listeners so a test can
-// flip `matches` and fire them, the way a real resize/rotation would.
-function stubMatchMedia(matches: boolean) {
-  const listeners = new Set<() => void>();
-  const mql = {
-    matches,
-    addEventListener: vi.fn((_: string, fn: () => void) => {
-      listeners.add(fn);
-    }),
-    removeEventListener: vi.fn((_: string, fn: () => void) => {
-      listeners.delete(fn);
-    }),
-  };
-  const matchMedia = vi.fn(() => mql);
-  window.matchMedia = matchMedia as unknown as typeof window.matchMedia;
-  return {
-    matchMedia,
-    mql,
-    fire(next: boolean) {
-      mql.matches = next;
-      for (const fn of listeners) fn();
-    },
-    listenerCount: () => listeners.size,
-  };
-}
-
-afterEach(() => {
-  window.matchMedia = originalMatchMedia;
-});
+afterEach(restoreMatchMedia);
 
 describe("useMediaQuery", () => {
   it("reports whether the query currently matches", () => {

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 /**
  * Subscribe to a CSS media query and re-render when it flips. Used for
@@ -7,15 +7,20 @@ import { useSyncExternalStore } from "react";
  * `matchMedia` is unavailable, so a non-browser render never throws.
  */
 export function useMediaQuery(query: string): boolean {
-  return useSyncExternalStore(
-    (onChange) => {
+  // Memoised so the listener isn't torn down and rebuilt on every render; the
+  // graph simulation reads this while re-rendering at frame rate.
+  const subscribe = useCallback(
+    (onChange: () => void) => {
       if (typeof window === "undefined" || !window.matchMedia) return () => {};
       const mql = window.matchMedia(query);
       mql.addEventListener("change", onChange);
       return () => mql.removeEventListener("change", onChange);
     },
-    () =>
-      typeof window !== "undefined" && window.matchMedia ? window.matchMedia(query).matches : false,
+    [query],
+  );
+
+  return useSyncExternalStore(subscribe, () =>
+    typeof window !== "undefined" && window.matchMedia ? window.matchMedia(query).matches : false,
   );
 }
 

--- a/src/hooks/useReducedMotion.test.ts
+++ b/src/hooks/useReducedMotion.test.ts
@@ -1,0 +1,33 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { REDUCED_MOTION_QUERY } from "@/lib/reducedMotion";
+import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
+import { useReducedMotion } from "./useReducedMotion";
+
+afterEach(restoreMatchMedia);
+
+describe("useReducedMotion", () => {
+  it("asks for the reduced-motion query", () => {
+    const media = stubMatchMedia(true);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(media.matchMedia).toHaveBeenCalledWith(REDUCED_MOTION_QUERY);
+    expect(result.current).toBe(true);
+  });
+
+  it("is false when the OS has no motion preference", () => {
+    stubMatchMedia(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it("re-renders when the preference is turned on after mount", () => {
+    const media = stubMatchMedia(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      media.fire(true);
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,8 @@
+import { REDUCED_MOTION_QUERY } from "@/lib/reducedMotion";
+import { useMediaQuery } from "./useMediaQuery";
+
+// Only JS-driven animation needs this; CSS is covered by the global duration
+// reset in `app.css`.
+export function useReducedMotion(): boolean {
+  return useMediaQuery(REDUCED_MOTION_QUERY);
+}

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,4 +1,5 @@
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { scrollBehavior } from "@/lib/reducedMotion";
 
 interface UseSearchOptions {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -89,7 +90,7 @@ function setActiveMatch(container: HTMLElement, index: number) {
   const active = marks[index];
   if (active) {
     active.classList.add("search-highlight-active");
-    active.scrollIntoView({ behavior: "smooth", block: "center" });
+    active.scrollIntoView({ behavior: scrollBehavior(), block: "center" });
   }
 }
 

--- a/src/lib/documentHighlight.ts
+++ b/src/lib/documentHighlight.ts
@@ -1,5 +1,6 @@
 // Locates a quoted passage inside the rendered markdown viewer and flashes it,
 // so the user can see which part of the document an AI reply refers to.
+import { scrollBehavior } from "./reducedMotion";
 
 const BLOCK_SELECTOR = "p, li, h1, h2, h3, h4, h5, h6, blockquote, pre, td, th";
 const FLASH_CLASS = "ai-flash";
@@ -39,7 +40,7 @@ export function locateInDocument(text: string): boolean {
   for (const previous of container.querySelectorAll(`.${FLASH_CLASS}`)) {
     previous.classList.remove(FLASH_CLASS);
   }
-  block.scrollIntoView({ behavior: "smooth", block: "center" });
+  block.scrollIntoView({ behavior: scrollBehavior(), block: "center" });
   block.classList.add(FLASH_CLASS);
   window.setTimeout(() => block.classList.remove(FLASH_CLASS), FLASH_DURATION_MS);
   return true;

--- a/src/lib/reducedMotion.test.ts
+++ b/src/lib/reducedMotion.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
+import { prefersReducedMotion, REDUCED_MOTION_QUERY, scrollBehavior } from "./reducedMotion";
+
+afterEach(restoreMatchMedia);
+
+describe("prefersReducedMotion", () => {
+  it("reports the OS preference", () => {
+    const media = stubMatchMedia(true);
+    expect(prefersReducedMotion()).toBe(true);
+    expect(media.matchMedia).toHaveBeenCalledWith(REDUCED_MOTION_QUERY);
+  });
+
+  it("is false when the preference is off", () => {
+    stubMatchMedia(false);
+    expect(prefersReducedMotion()).toBe(false);
+  });
+
+  it("is false where matchMedia is unavailable", () => {
+    (window as { matchMedia?: typeof window.matchMedia }).matchMedia = undefined;
+    expect(prefersReducedMotion()).toBe(false);
+  });
+});
+
+describe("scrollBehavior", () => {
+  it("jumps instead of animating when reduced motion is on", () => {
+    stubMatchMedia(true);
+    expect(scrollBehavior()).toBe("auto");
+  });
+
+  it("scrolls smoothly otherwise", () => {
+    stubMatchMedia(false);
+    expect(scrollBehavior()).toBe("smooth");
+  });
+});

--- a/src/lib/reducedMotion.test.ts
+++ b/src/lib/reducedMotion.test.ts
@@ -1,35 +1,23 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
-import { prefersReducedMotion, REDUCED_MOTION_QUERY, scrollBehavior } from "./reducedMotion";
+import { REDUCED_MOTION_QUERY, scrollBehavior } from "./reducedMotion";
 
 afterEach(restoreMatchMedia);
 
-describe("prefersReducedMotion", () => {
-  it("reports the OS preference", () => {
+describe("scrollBehavior", () => {
+  it("jumps instead of animating when reduced motion is on", () => {
     const media = stubMatchMedia(true);
-    expect(prefersReducedMotion()).toBe(true);
+    expect(scrollBehavior()).toBe("instant");
     expect(media.matchMedia).toHaveBeenCalledWith(REDUCED_MOTION_QUERY);
   });
 
-  it("is false when the preference is off", () => {
+  it("scrolls smoothly when the preference is off", () => {
     stubMatchMedia(false);
-    expect(prefersReducedMotion()).toBe(false);
+    expect(scrollBehavior()).toBe("smooth");
   });
 
-  it("is false where matchMedia is unavailable", () => {
+  it("scrolls smoothly where matchMedia is unavailable", () => {
     (window as { matchMedia?: typeof window.matchMedia }).matchMedia = undefined;
-    expect(prefersReducedMotion()).toBe(false);
-  });
-});
-
-describe("scrollBehavior", () => {
-  it("jumps instead of animating when reduced motion is on", () => {
-    stubMatchMedia(true);
-    expect(scrollBehavior()).toBe("auto");
-  });
-
-  it("scrolls smoothly otherwise", () => {
-    stubMatchMedia(false);
     expect(scrollBehavior()).toBe("smooth");
   });
 });

--- a/src/lib/reducedMotion.ts
+++ b/src/lib/reducedMotion.ts
@@ -1,0 +1,16 @@
+export const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/** Reads the OS preference outside React. Components use `useReducedMotion`. */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+/**
+ * Scroll behavior for `scrollIntoView`. An explicit "smooth" animates whatever
+ * the CSS `scroll-behavior` says, so the global reset in `app.css` cannot cover
+ * these call sites and they have to ask.
+ */
+export function scrollBehavior(): ScrollBehavior {
+  return prefersReducedMotion() ? "auto" : "smooth";
+}

--- a/src/lib/reducedMotion.ts
+++ b/src/lib/reducedMotion.ts
@@ -1,16 +1,13 @@
 export const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 
-/** Reads the OS preference outside React. Components use `useReducedMotion`. */
-export function prefersReducedMotion(): boolean {
-  if (typeof window === "undefined" || !window.matchMedia) return false;
-  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
-}
-
 /**
  * Scroll behavior for `scrollIntoView`. An explicit "smooth" animates whatever
  * the CSS `scroll-behavior` says, so the global reset in `app.css` cannot cover
- * these call sites and they have to ask.
+ * these call sites and they have to ask. Components read the preference
+ * through `useReducedMotion` instead.
  */
 export function scrollBehavior(): ScrollBehavior {
-  return prefersReducedMotion() ? "auto" : "smooth";
+  const canAsk = typeof window !== "undefined" && Boolean(window.matchMedia);
+  if (canAsk && window.matchMedia(REDUCED_MOTION_QUERY).matches) return "instant";
+  return "smooth";
 }

--- a/src/lib/scrollToHeading.ts
+++ b/src/lib/scrollToHeading.ts
@@ -1,6 +1,8 @@
-// Smooth-scrolls to an anchor by id and notifies the outline so it can
-// highlight the new active entry without waiting on the IntersectionObserver,
-// which lags during programmatic scrolls.
+// Scrolls to an anchor by id and notifies the outline so it can highlight the
+// new active entry without waiting on the IntersectionObserver, which lags
+// during programmatic scrolls.
+import { scrollBehavior } from "./reducedMotion";
+
 const ACTIVE_HEADING_EVENT = "glyph:active-heading";
 
 // Pick `start` when the target can scroll to the top of its scroll container,
@@ -24,7 +26,7 @@ function autoBlock(target: HTMLElement): ScrollLogicalPosition {
 export function scrollToHeading(id: string): boolean {
   const target = document.getElementById(id);
   if (!target) return false;
-  target.scrollIntoView({ behavior: "smooth", block: autoBlock(target) });
+  target.scrollIntoView({ behavior: scrollBehavior(), block: autoBlock(target) });
   window.dispatchEvent(new CustomEvent(ACTIVE_HEADING_EVENT, { detail: { id } }));
   return true;
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -96,3 +96,33 @@ body {
   scrollbar-width: thin;
   scrollbar-color: var(--color-text-tertiary) transparent;
 }
+
+/* One global opt-out so every stylesheet, including ones added later, honours
+   the OS preference. Durations collapse instead of hitting 0s so transitionend
+   and animationend still fire and no listener is left waiting. JS-driven
+   animation reads the same preference through `useReducedMotion` (React) or
+   `prefersReducedMotion` (plain modules). A surface that needs to keep moving
+   opts out with a class selector plus `!important`, which outranks the
+   universal selector here; see `.wikilink-preview` and the indicators below. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* Busy indicators keep looping: frozen mid-spin they read as a hung app,
+     which is worse than the motion. Both are small and stay in one place. */
+  .animate-spin {
+    animation-duration: 1s !important;
+    animation-iteration-count: infinite !important;
+  }
+
+  .ai-typing span {
+    animation-duration: 1.2s !important;
+    animation-iteration-count: infinite !important;
+  }
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -97,13 +97,10 @@ body {
   scrollbar-color: var(--color-text-tertiary) transparent;
 }
 
-/* One global opt-out so every stylesheet, including ones added later, honours
-   the OS preference. Durations collapse instead of hitting 0s so transitionend
-   and animationend still fire and no listener is left waiting. JS-driven
-   animation reads the same preference through `useReducedMotion` (React) or
-   `prefersReducedMotion` (plain modules). A surface that needs to keep moving
-   opts out with a class selector plus `!important`, which outranks the
-   universal selector here; see `.wikilink-preview` and the indicators below. */
+/* One global opt-out, so stylesheets added later are covered without being
+   touched. A surface that must keep moving opts back out with a class selector
+   plus `!important`, which outranks the universal selector here. JS-driven
+   motion reads the preference through `useReducedMotion` instead. */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -114,8 +111,7 @@ body {
     scroll-behavior: auto !important;
   }
 
-  /* Busy indicators keep looping: frozen mid-spin they read as a hung app,
-     which is worse than the motion. Both are small and stay in one place. */
+  /* Busy indicators keep looping: frozen mid-spin they read as a hung app. */
   .animate-spin {
     animation-duration: 1s !important;
     animation-iteration-count: infinite !important;
@@ -124,5 +120,14 @@ body {
   .ai-typing span {
     animation-duration: 1.2s !important;
     animation-iteration-count: infinite !important;
+  }
+
+  /* The located block is marked by a static tint rather than a pulse. Left to
+     the reset it would flash for a hundredth of a millisecond and vanish, which
+     removes the answer to "which block?" instead of removing motion. */
+  .ai-flash {
+    animation: none !important;
+    background-color: color-mix(in srgb, var(--color-accent) 20%, transparent);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 20%, transparent);
   }
 }

--- a/src/styles/wikilinkPreview.css
+++ b/src/styles/wikilinkPreview.css
@@ -35,8 +35,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  /* Opacity-only fades are safe under reduced motion and help the popover read
+     as arriving, so this one opts out of the global duration reset in app.css. */
   .wikilink-preview {
-    transition: opacity 120ms ease;
+    transition: opacity 120ms ease !important;
   }
 
   @starting-style {

--- a/src/test/matchMedia.ts
+++ b/src/test/matchMedia.ts
@@ -1,0 +1,36 @@
+import { vi } from "vitest";
+
+/**
+ * Minimal MediaQueryList stub that records its change listeners, so a test can
+ * flip `matches` and fire them the way a resize, rotation, or OS preference
+ * change would. Restore with `restoreMatchMedia` in `afterEach`.
+ */
+export function stubMatchMedia(matches: boolean) {
+  const listeners = new Set<() => void>();
+  const mql = {
+    matches,
+    addEventListener: vi.fn((_: string, fn: () => void) => {
+      listeners.add(fn);
+    }),
+    removeEventListener: vi.fn((_: string, fn: () => void) => {
+      listeners.delete(fn);
+    }),
+  };
+  const matchMedia = vi.fn(() => mql);
+  window.matchMedia = matchMedia as unknown as typeof window.matchMedia;
+  return {
+    matchMedia,
+    mql,
+    fire(next: boolean) {
+      mql.matches = next;
+      for (const fn of listeners) fn();
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+const originalMatchMedia = window.matchMedia;
+
+export function restoreMatchMedia() {
+  window.matchMedia = originalMatchMedia;
+}


### PR DESCRIPTION
## Summary

Glyph played every animation at full motion regardless of the OS `prefers-reduced-motion` setting, and there was no shared signal a new animation could read.

This adds one global CSS opt-out plus a small JS reader, so the preference is honoured today and stays honoured as animations are added, without each stylesheet having to remember.

Closes #522

## Changes

- **Global CSS reset** in `app.css` collapses transition and animation durations under `@media (prefers-reduced-motion: reduce)`. Stylesheets added later are covered without being touched.
- **Carve-outs for surfaces that must not go still.** The export spinner and the AI typing dots keep looping, because frozen mid-spin they read as a hung app. The located-block highlight (`.ai-flash`) becomes a static tint: left to the reset it flashed for a hundredth of a millisecond and reverted, so "locate in document" scrolled without showing which block it found, removing information rather than motion. The wikilink preview keeps its opacity-only fade. Each opts out with a class selector plus `!important`, which outranks the universal reset.
- **JS reader** for what CSS cannot reach: `useReducedMotion` (a thin wrapper over the existing `useMediaQuery`) for components, and `scrollBehavior()` for plain modules. An explicit `behavior: "smooth"` animates regardless of the CSS property, so the three `scrollIntoView` call sites now ask. Stepping through search matches was the notable one: it repeatedly smooth-scrolled the viewport, which is the exact trigger the preference exists for.
- **Graph force layout** withholds its intermediate redraws when reduced, so the layout appears settled in one step. It still ticks across animation frames, since a synchronous pass would block the thread for seconds on a large graph. A reheat always paints and upgrades a non-painting pass that is already in flight, because it tracks the pointer during a drag.
- `useMediaQuery` memoises its subscribe callback, now that it is read from a component re-rendering at frame rate.
- The `matchMedia` test stub moves to `src/test/matchMedia.ts`, shared by three test files.

## Risk classification

- [ ] Persistence / data loss
- [x] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [x] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

**Asynchronous ordering.** The change alters the graph's `requestAnimationFrame` loop, which is where the ordering risk sits. No numbered invariant is at stake: nothing here persists, crosses IPC, touches the filesystem, or renders untrusted input. The closest is INV-4 (owners flush before they die), and the loop's cleanup still cancels the pending frame and clears the running flag in the same tick; nothing durable is lost when a pass is cancelled, because positions re-seed from `previousPositions` on the next layout.

Adversarial matrix rows covered by `useGraphSimulation.test.ts`:

- *Overlapping operations*: "starts painting when a reheat lands on a pass that is still in flight" pins the case where a drag begins before the first pass settles. Without the fix the canvas stays frozen for the whole drag.
- *Lifecycle transitions*: "switches to animating when the preference is turned off mid-layout" flips the OS preference while a pass is running.
- *Rapid repetition*: "resumes animating when reheated after settling" fires two synchronous reheats into the already-running guard.

Both failure modes were verified by mutation: reverting the reheat upgrade fails 2 tests, and making the layout never paint fails 2 others. Before this branch's review pass, both mutants survived the entire suite.

**Accessibility.** This PR is the accessibility change. The risk it carries is over-suppression, so the three surfaces where stillness would destroy meaning (spinner, typing dots, located-block highlight) are carved out and named above.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated only, no manual run on any platform yet. `pnpm typecheck`, `pnpm check`, and `pnpm test` (282 files, 2966 tests) all pass, and `pnpm test:coverage` reports no uncovered lines introduced by this diff. `cargo clippy` was not run because the diff touches no Rust.

Worth exercising by hand before merge, with reduced motion enabled at the OS level: dragging a graph node immediately after opening the graph view, the AI "locate in document" highlight, the export spinner, and stepping through search matches.

## Screenshots

Not applicable: the change is the absence of motion.
