### PR TITLE
fix(windows): stop the abort-on-exit panic from tao's event loop

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ mod windows_runtime;
 mod workspace;
 
 use std::sync::{Arc, Mutex};
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use tauri::RunEvent;
 use tauri::{DragDropEvent, Manager, WindowEvent};
 #[cfg(desktop)]
@@ -483,6 +483,16 @@ pub fn run() {
                 .filter_map(|url| url.to_file_path().ok())
                 .collect();
             handle_opened_paths(_app_handle, paths);
+        }
+        // Windows only: after the event loop is torn down, a late Win32 message
+        // reaching tao's runner panics outside any catch_unwind, which aborts
+        // the process on exit (tauri-apps/tao#1180). Plugin `on_event` handlers
+        // (window state, stores) run before this callback, so everything that
+        // must persist is already written by the time `Exit` arrives.
+        #[cfg(target_os = "windows")]
+        if matches!(_event, RunEvent::Exit) {
+            telemetry::flush();
+            std::process::exit(0);
         }
     });
 }

--- a/src-tauri/src/telemetry.rs
+++ b/src-tauri/src/telemetry.rs
@@ -142,6 +142,16 @@ pub fn set_error_reporting(enabled: bool, state: State<'_, TelemetryState>) -> R
     set_enabled(&state, enabled)
 }
 
+/// Send everything still queued. Needed on the Windows exit path, which calls
+/// `process::exit` and so never drops the guard that would flush on its own.
+/// No-op when reporting is off (no client installed).
+#[cfg(target_os = "windows")]
+pub fn flush() {
+    if let Some(client) = sentry::Hub::current().client() {
+        client.flush(Some(std::time::Duration::from_secs(2)));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -237,6 +247,14 @@ mod tests {
         assert!(state.0.lock().unwrap().is_none());
         assert!(set_enabled(&state, false).is_ok());
         assert!(state.0.lock().unwrap().is_none());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn flush_is_a_no_op_without_a_client() {
+        // The Windows exit path calls this before `process::exit`, including
+        // when the user never opted in.
+        flush();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

On Windows, Glyph aborts on quit. A Win32 message dispatched into tao's event-loop runner after the loop is torn down hits `panic!("cannot move state from Destroyed")` (`tao-0.35/src/platform_impl/windows/event_loop/runner.rs:371`). That panic is not wrapped by tao's `catch_unwind`, so it unwinds out of the window procedure and aborts the process. Upstream: [tauri-apps/tao#1180](https://github.com/tauri-apps/tao/issues/1180) (open; the proposed fix, [tao#1285](https://github.com/tauri-apps/tao/pull/1285), was closed unmerged).

Sentry: https://glyph-md.sentry.io/share/issue/55d74f57512a488b9d3225d80c693897/

Fixes GLYPH-3

The fix quits at `RunEvent::Exit`, before teardown can pump another message into the destroyed runner.

## Changes

- `src-tauri/src/lib.rs`: on Windows, `RunEvent::Exit` flushes telemetry and calls `std::process::exit(0)`.
- `src-tauri/src/telemetry.rs`: `flush()` (Windows only), since `process::exit` skips the Sentry guard's `Drop`.

## Risk classification

- [x] Persistence / data loss
- [x] Destructive lifecycle (close, unmount, workspace switch, app exit)

### Invariants at stake and evidence

**INV-4 (owners flush before they die).** Nothing pending may be dropped on app exit, so the early exit must run after every persistence hook.

Ordering evidence, from `tauri-2.11/src/app.rs`: `on_event_loop_event` calls `manager.plugins.on_event(app_handle, &event)` and only then invokes the app's run callback (`RuntimeRunEvent::Exit => { let event = on_event_loop_event(...); callback(&app_handle, event); ... }`). So by the time this callback sees `RunEvent::Exit`:

- `tauri-plugin-window-state` has already run `save_window_state` (its `on_event` handler for `RunEvent::Exit`),
- `tauri-plugin-store` has already flushed autosaved stores,
- the frontend flush already happened earlier, in `useWindowClose`'s `onCloseRequested` interception, before the window was allowed to close.

Only work skipped is Tauri's `cleanup_before_exit` (clears resource tables, hides windows), which is process-death cosmetics. Glyph does not use `restart_on_exit`.

Non-Windows targets are untouched: both the exit arm and `flush()` are `#[cfg(target_os = "windows")]`.

## Testing

- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 423 passed
- `pnpm typecheck && pnpm test`: green (pre-commit gate)
- `telemetry::flush_is_a_no_op_without_a_client` covers the opted-out exit path

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
