### PR TITLE
feat(tab-bar): add buttons that open the command palette and graph

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useSidebarLayoutContext } from "@/contexts/SidebarLayoutContext";
-import { useTabsContext } from "@/contexts/TabsContext";
+import { useOpenGraph, useTabsContext } from "@/contexts/TabsContext";
 import { useZoomApi } from "@/contexts/ZoomContext";
 import { useAIController } from "@/hooks/useAIController";
 import { useAutoSave } from "@/hooks/useAutoSave";
@@ -61,6 +61,7 @@ export function AppShell() {
   const platform = usePlatform();
   const { settings, updateSettings, loaded } = useSettings();
   const tabs = useTabsContext();
+  const openGraphAction = useOpenGraph();
   const sidebar = useSidebarLayoutContext();
 
   // Opt-in crash/error reporting; inert in dev and until the user enables it.
@@ -95,7 +96,6 @@ export function AppShell() {
     workspace,
     openFolder,
     createWorkspace,
-    openGraph,
     openFile,
     openFileDialog,
     newDocument,
@@ -210,9 +210,7 @@ export function AppShell() {
       openFile: openFileDialog,
       openFolder: () => openFolder(),
       newWorkspace: createWorkspace,
-      // No-arg wrapper: menu/palette callers must not leak their event
-      // payload into openGraph's optional root parameter.
-      openGraph: () => openGraph(),
+      openGraph: openGraphAction,
       save: handleSave,
       toggleAutoSave: handleToggleAutoSave,
       closeTab: closeActiveTab,
@@ -248,7 +246,7 @@ export function AppShell() {
       openFileDialog,
       openFolder,
       createWorkspace,
-      openGraph,
+      openGraphAction,
       handleSave,
       handleToggleAutoSave,
       closeActiveTab,
@@ -346,7 +344,10 @@ export function AppShell() {
         notice={tabs.workspaceNotice}
         onDismiss={tabs.dismissWorkspaceNotice}
       />
-      <TabBar onToggleAIChat={aiController.configured ? aiController.togglePanel : null} />
+      <TabBar
+        onToggleAIChat={aiController.configured ? aiController.togglePanel : null}
+        onOpenPalette={palette.openPalette}
+      />
       <div className="relative flex flex-1 min-h-0">
         <SidebarDrawerBackdrop />
         <Sidebar side="left" />

--- a/src/components/icons/CommandPaletteIcon.tsx
+++ b/src/components/icons/CommandPaletteIcon.tsx
@@ -1,0 +1,20 @@
+export function CommandPaletteIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={`inline-block ${className}`}
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="1.4" y="2.4" width="11.2" height="9.2" rx="2" />
+      <path d="M4.3 6.1 5.9 7.6 4.3 9.1" />
+      <path d="M7.8 9.1h2.2" />
+    </svg>
+  );
+}

--- a/src/components/layout/ActionBarButton.test.tsx
+++ b/src/components/layout/ActionBarButton.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ActionBarButton } from "./ActionBarButton";
+
+describe("ActionBarButton", () => {
+  it("uses the label as both accessible name and tooltip", () => {
+    render(
+      <ActionBarButton onClick={vi.fn()} label="Open graph">
+        <span />
+      </ActionBarButton>,
+    );
+    expect(screen.getByRole("button", { name: "Open graph" }).getAttribute("title")).toBe(
+      "Open graph",
+    );
+  });
+
+  it("keeps a shorter tooltip separate from the accessible name", () => {
+    render(
+      <ActionBarButton onClick={vi.fn()} label="View mode" title="View">
+        <span />
+      </ActionBarButton>,
+    );
+    expect(screen.getByRole("button", { name: "View mode" }).getAttribute("title")).toBe("View");
+  });
+
+  it("marks the active state for styling", () => {
+    render(
+      <ActionBarButton onClick={vi.fn()} label="Edit mode" active>
+        <span />
+      </ActionBarButton>,
+    );
+    expect(screen.getByRole("button", { name: "Edit mode" }).hasAttribute("data-active")).toBe(
+      true,
+    );
+  });
+
+  it("leaves the active attribute off when inactive", () => {
+    render(
+      <ActionBarButton onClick={vi.fn()} label="Edit mode" active={false}>
+        <span />
+      </ActionBarButton>,
+    );
+    expect(screen.getByRole("button", { name: "Edit mode" }).hasAttribute("data-active")).toBe(
+      false,
+    );
+  });
+
+  it("fires its callback on click", () => {
+    const onClick = vi.fn();
+    render(
+      <ActionBarButton onClick={onClick} label="AI Chat">
+        <span />
+      </ActionBarButton>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "AI Chat" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/layout/ActionBarButton.test.tsx
+++ b/src/components/layout/ActionBarButton.test.tsx
@@ -2,44 +2,34 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ActionBarButton } from "./ActionBarButton";
 
+const defaultProps = {
+  onClick: vi.fn(),
+  label: "Open graph",
+  children: <span />,
+};
+
 describe("ActionBarButton", () => {
   it("uses the label as both accessible name and tooltip", () => {
-    render(
-      <ActionBarButton onClick={vi.fn()} label="Open graph">
-        <span />
-      </ActionBarButton>,
-    );
+    render(<ActionBarButton {...defaultProps} />);
     expect(screen.getByRole("button", { name: "Open graph" }).getAttribute("title")).toBe(
       "Open graph",
     );
   });
 
   it("keeps a shorter tooltip separate from the accessible name", () => {
-    render(
-      <ActionBarButton onClick={vi.fn()} label="View mode" title="View">
-        <span />
-      </ActionBarButton>,
-    );
+    render(<ActionBarButton {...defaultProps} label="View mode" title="View" />);
     expect(screen.getByRole("button", { name: "View mode" }).getAttribute("title")).toBe("View");
   });
 
   it("marks the active state for styling", () => {
-    render(
-      <ActionBarButton onClick={vi.fn()} label="Edit mode" active>
-        <span />
-      </ActionBarButton>,
-    );
+    render(<ActionBarButton {...defaultProps} label="Edit mode" active />);
     expect(screen.getByRole("button", { name: "Edit mode" }).hasAttribute("data-active")).toBe(
       true,
     );
   });
 
   it("leaves the active attribute off when inactive", () => {
-    render(
-      <ActionBarButton onClick={vi.fn()} label="Edit mode" active={false}>
-        <span />
-      </ActionBarButton>,
-    );
+    render(<ActionBarButton {...defaultProps} label="Edit mode" active={false} />);
     expect(screen.getByRole("button", { name: "Edit mode" }).hasAttribute("data-active")).toBe(
       false,
     );
@@ -47,11 +37,7 @@ describe("ActionBarButton", () => {
 
   it("fires its callback on click", () => {
     const onClick = vi.fn();
-    render(
-      <ActionBarButton onClick={onClick} label="AI Chat">
-        <span />
-      </ActionBarButton>,
-    );
+    render(<ActionBarButton {...defaultProps} label="AI Chat" onClick={onClick} />);
     fireEvent.click(screen.getByRole("button", { name: "AI Chat" }));
     expect(onClick).toHaveBeenCalledTimes(1);
   });

--- a/src/components/layout/ActionBarButton.tsx
+++ b/src/components/layout/ActionBarButton.tsx
@@ -1,0 +1,31 @@
+interface ActionBarButtonProps {
+  onClick: () => void;
+  /** Accessible name. Also the tooltip unless `title` overrides it. */
+  label: string;
+  title?: string;
+  active?: boolean;
+  children: React.ReactNode;
+}
+
+// The tab bar's icon button, shared by every action group in it (mode toggles,
+// AI chat, and the command palette and graph shortcuts).
+export function ActionBarButton({
+  onClick,
+  label,
+  title = label,
+  active,
+  children,
+}: ActionBarButtonProps) {
+  return (
+    <button
+      type="button"
+      className="mode-toggle-btn"
+      data-active={active || undefined}
+      onClick={onClick}
+      aria-label={label}
+      title={title}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -155,11 +155,11 @@ function renderTabBar(opts: RenderOpts = {}, onToggleAIChat: (() => void) | null
 
 describe("TabBar", () => {
   it("keeps the action buttons but shows no tabs when nothing is open", () => {
-    renderTabBar({
+    const { container } = renderTabBar({
       tabs: [],
       workspace: { root: "/vault", expanded: new Set(), nodes: new Map() },
     });
-    expect(screen.queryAllByRole("tab")).toHaveLength(0);
+    expect(container.querySelectorAll(".tab-item")).toHaveLength(0);
     expect(screen.getByRole("button", { name: "Command palette" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Open graph" })).toBeTruthy();
   });

--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -145,7 +145,7 @@ function renderTabBar(opts: RenderOpts = {}, onToggleAIChat: (() => void) | null
   return {
     ...render(
       <Wrapper value={value} sidebar={sidebar}>
-        <TabBar onToggleAIChat={onToggleAIChat} />
+        <TabBar onToggleAIChat={onToggleAIChat} onOpenPalette={vi.fn()} />
       </Wrapper>,
     ),
     value,
@@ -154,9 +154,14 @@ function renderTabBar(opts: RenderOpts = {}, onToggleAIChat: (() => void) | null
 }
 
 describe("TabBar", () => {
-  it("renders nothing when no tabs", () => {
-    const { container } = renderTabBar({ tabs: [] });
-    expect(container.firstChild).toBeNull();
+  it("keeps the action buttons but shows no tabs when nothing is open", () => {
+    renderTabBar({
+      tabs: [],
+      workspace: { root: "/vault", expanded: new Set(), nodes: new Map() },
+    });
+    expect(screen.queryAllByRole("tab")).toHaveLength(0);
+    expect(screen.getByRole("button", { name: "Command palette" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open graph" })).toBeTruthy();
   });
 
   it("shows the AI chat toggle only when a callback is provided", () => {

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -20,6 +20,8 @@ import { isLooseFilePath } from "@/lib/looseFile";
 import { displayName } from "@/lib/paths";
 import { isMobile } from "@/lib/platform";
 import { EDITOR_MODE, effectiveEditorMode } from "@/lib/settings";
+import { ActionBarButton } from "./ActionBarButton";
+import { TabBarActions } from "./TabBarActions";
 
 function tabLabel(tab: Tab, t: TFunction<"common">): string {
   if (tab.kind === "graph") {
@@ -34,9 +36,10 @@ interface TabBarProps {
   // `null` when no AI provider is configured, hiding the chat toggle (same
   // convention as StatusBar's onOpenSync).
   onToggleAIChat?: (() => void) | null;
+  onOpenPalette: () => void;
 }
 
-export function TabBar({ onToggleAIChat }: TabBarProps) {
+export function TabBar({ onToggleAIChat, onOpenPalette }: TabBarProps) {
   const { t } = useTranslation("common");
   const {
     tabs,
@@ -55,7 +58,17 @@ export function TabBar({ onToggleAIChat }: TabBarProps) {
   // Mobile has no native menu or keyboard shortcut, so the tab bar carries the
   // in-app controls: opening a file and toggling the outline drawer.
   const mobile = isMobile(usePlatform());
-  if (tabs.length === 0) return null;
+  // With nothing open the strip still carries the action buttons: on mobile
+  // they are the only route to the palette and the graph, and "workspace open,
+  // no document open" is exactly when the graph is most useful.
+  if (tabs.length === 0) {
+    return (
+      <div className="tab-bar-container" data-print-hide="true">
+        <div className="tab-bar-scroll" />
+        <TabBarActions onOpenPalette={onOpenPalette} />
+      </div>
+    );
+  }
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
   const activeFile = activeFileOf(activeTab);
@@ -125,75 +138,55 @@ export function TabBar({ onToggleAIChat }: TabBarProps) {
       {mobile && (
         <div className="mode-toggle">
           {activeFile !== null && tocEntries.length > 0 && (
-            <button
-              type="button"
-              className="mode-toggle-btn"
-              data-active={outlineVisible || undefined}
+            <ActionBarButton
               onClick={toggleOutline}
-              aria-label={outlineVisible ? t("sidebar.hideOutline") : t("sidebar.showOutline")}
-              title={outlineVisible ? t("sidebar.hideOutline") : t("sidebar.showOutline")}
+              label={outlineVisible ? t("sidebar.hideOutline") : t("sidebar.showOutline")}
+              active={outlineVisible}
             >
               <OutlineIcon active={outlineVisible} />
-            </button>
+            </ActionBarButton>
           )}
-          <button
-            type="button"
-            className="mode-toggle-btn"
-            onClick={openFileDialog}
-            aria-label={t("emptyState.openFile")}
-            title={t("emptyState.openFile")}
-          >
+          <ActionBarButton onClick={openFileDialog} label={t("emptyState.openFile")}>
             <OpenIcon />
-          </button>
+          </ActionBarButton>
         </div>
       )}
       {showModeToggle && (
         <div className="mode-toggle">
-          <button
-            type="button"
-            className="mode-toggle-btn"
-            data-active={shownMode === EDITOR_MODE.view || undefined}
+          <ActionBarButton
             onClick={() => onModeChange(activeTab.id, EDITOR_MODE.view)}
-            aria-label={t("tabBar.viewMode")}
+            label={t("tabBar.viewMode")}
             title={t("tabBar.view")}
+            active={shownMode === EDITOR_MODE.view}
           >
             <ViewModeIcon />
-          </button>
-          <button
-            type="button"
-            className="mode-toggle-btn"
-            data-active={shownMode === EDITOR_MODE.edit || undefined}
+          </ActionBarButton>
+          <ActionBarButton
             onClick={() => onModeChange(activeTab.id, EDITOR_MODE.edit)}
-            aria-label={t("tabBar.editMode")}
+            label={t("tabBar.editMode")}
             title={t("tabBar.edit")}
+            active={shownMode === EDITOR_MODE.edit}
           >
             <EditModeIcon />
-          </button>
+          </ActionBarButton>
           {showSplit && (
-            <button
-              type="button"
-              className="mode-toggle-btn"
-              data-active={activeFile.mode === EDITOR_MODE.split || undefined}
+            <ActionBarButton
               onClick={() => onModeChange(activeTab.id, EDITOR_MODE.split)}
-              aria-label={t("tabBar.splitMode")}
+              label={t("tabBar.splitMode")}
               title={t("tabBar.split")}
+              active={activeFile.mode === EDITOR_MODE.split}
             >
               <SplitModeIcon />
-            </button>
+            </ActionBarButton>
           )}
         </div>
       )}
+      <TabBarActions onOpenPalette={onOpenPalette} />
       {onToggleAIChat && (
         <div className="mode-toggle">
-          <button
-            type="button"
-            className="mode-toggle-btn"
-            onClick={onToggleAIChat}
-            aria-label={t("tabBar.aiChat")}
-            title={t("tabBar.aiChat")}
-          >
+          <ActionBarButton onClick={onToggleAIChat} label={t("tabBar.aiChat")}>
             <SparkleIcon />
-          </button>
+          </ActionBarButton>
         </div>
       )}
     </div>

--- a/src/components/layout/TabBarActions.test.tsx
+++ b/src/components/layout/TabBarActions.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
+import type { Workspace } from "@/hooks/useTabs";
+import { TabBarActions } from "./TabBarActions";
+
+const WORKSPACE: Workspace = { root: "/vault", expanded: new Set(), nodes: new Map() };
+
+function renderActions(
+  opts: {
+    workspace?: TabsContextValue["workspace"];
+    openGraph?: TabsContextValue["openGraph"];
+    onOpenPalette?: () => void;
+  } = {},
+) {
+  const context = {
+    workspace: opts.workspace === undefined ? WORKSPACE : opts.workspace,
+    openGraph: opts.openGraph ?? vi.fn(),
+  } as unknown as TabsContextValue;
+  render(
+    <TabsContext.Provider value={context}>
+      <TabBarActions onOpenPalette={opts.onOpenPalette ?? vi.fn()} />
+    </TabsContext.Provider>,
+  );
+}
+
+describe("TabBarActions", () => {
+  it("opens the command palette when its button is pressed", () => {
+    const onOpenPalette = vi.fn();
+    renderActions({ onOpenPalette });
+
+    fireEvent.click(screen.getByRole("button", { name: "Command palette" }));
+    expect(onOpenPalette).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the graph when its button is pressed", () => {
+    const openGraph = vi.fn();
+    renderActions({ openGraph });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open graph" }));
+    expect(openGraph).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the graph button without a workspace, where opening it is a no-op", () => {
+    renderActions({ workspace: null });
+
+    expect(screen.queryByRole("button", { name: "Open graph" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Command palette" })).toBeTruthy();
+  });
+
+  it("passes no root to openGraph, so the open workspace is used", () => {
+    const openGraph = vi.fn();
+    renderActions({ openGraph });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open graph" }));
+    expect(openGraph).toHaveBeenCalledWith();
+  });
+});

--- a/src/components/layout/TabBarActions.tsx
+++ b/src/components/layout/TabBarActions.tsx
@@ -10,9 +10,10 @@ interface TabBarActionsProps {
 export function TabBarActions({ onOpenPalette }: TabBarActionsProps) {
   const { t } = useTranslation("common");
   const { workspace } = useTabsContext();
+  const openGraph = useOpenGraph();
   const items = actionBarItems({
     openPalette: onOpenPalette,
-    openGraph: useOpenGraph(),
+    openGraph,
     hasWorkspace: workspace !== null,
   });
 

--- a/src/components/layout/TabBarActions.tsx
+++ b/src/components/layout/TabBarActions.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from "react-i18next";
+import { useOpenGraph, useTabsContext } from "@/contexts/TabsContext";
+import { actionBarItems } from "@/lib/actionBarItems";
+import { ActionBarButton } from "./ActionBarButton";
+
+interface TabBarActionsProps {
+  onOpenPalette: () => void;
+}
+
+export function TabBarActions({ onOpenPalette }: TabBarActionsProps) {
+  const { t } = useTranslation("common");
+  const { workspace } = useTabsContext();
+  const items = actionBarItems({
+    openPalette: onOpenPalette,
+    openGraph: useOpenGraph(),
+    hasWorkspace: workspace !== null,
+  });
+
+  return (
+    <div className="mode-toggle">
+      {items.map(({ id, labelKey, Icon, run }) => (
+        <ActionBarButton key={id} onClick={run} label={t(labelKey)}>
+          <Icon />
+        </ActionBarButton>
+      ))}
+    </div>
+  );
+}

--- a/src/contexts/TabsContext.ts
+++ b/src/contexts/TabsContext.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, useCallback, useContext } from "react";
 import type { TocEntry } from "@/hooks/useTableOfContents";
 import type { useTabs } from "@/hooks/useTabs";
 import type { WorkspaceNotice } from "@/hooks/useWorkspaceNotice";
@@ -39,4 +39,12 @@ export function useTabsContext(): TabsContextValue {
 // resolution.
 export function useWorkspaceRoot(): string | undefined {
   return useContext(TabsContext)?.workspace?.root;
+}
+
+// `openGraph` bound to no arguments, for menu handlers and click handlers.
+// Passing it raw would let the event land in its optional `root`, which then
+// fails the "root matches the open workspace" guard and silently does nothing.
+export function useOpenGraph(): () => void {
+  const { openGraph } = useTabsContext();
+  return useCallback(() => openGraph(), [openGraph]);
 }

--- a/src/hooks/useCommandPaletteController.ts
+++ b/src/hooks/useCommandPaletteController.ts
@@ -18,6 +18,7 @@ export interface CommandPaletteController {
   open: boolean;
   query: string;
   setQuery: (next: string) => void;
+  openPalette: () => void;
   close: () => void;
   commands: readonly Command[];
 }
@@ -46,9 +47,17 @@ export function useCommandPaletteController({
       open: palette.open,
       query: palette.query,
       setQuery: palette.setQuery,
+      openPalette: palette.openPalette,
       close: palette.closePalette,
       commands,
     }),
-    [palette.open, palette.query, palette.setQuery, palette.closePalette, commands],
+    [
+      palette.open,
+      palette.query,
+      palette.setQuery,
+      palette.openPalette,
+      palette.closePalette,
+      commands,
+    ],
   );
 }

--- a/src/lib/actionBarItems.test.ts
+++ b/src/lib/actionBarItems.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { type ActionBarOptions, actionBarItems } from "./actionBarItems";
+
+function options(overrides: Partial<ActionBarOptions> = {}): ActionBarOptions {
+  return { openPalette: vi.fn(), openGraph: vi.fn(), hasWorkspace: true, ...overrides };
+}
+
+describe("actionBarItems", () => {
+  it("offers the palette and the graph when a workspace is open", () => {
+    expect(actionBarItems(options()).map((i) => i.id)).toEqual(["commandPalette", "openGraph"]);
+  });
+
+  it("drops the graph without a workspace, where opening it would do nothing", () => {
+    const items = actionBarItems(options({ hasWorkspace: false }));
+    expect(items.map((i) => i.id)).toEqual(["commandPalette"]);
+  });
+
+  it("runs the callback it was given", () => {
+    const openPalette = vi.fn();
+    const openGraph = vi.fn();
+
+    for (const item of actionBarItems(options({ openPalette, openGraph }))) item.run();
+    expect(openPalette).toHaveBeenCalledTimes(1);
+    expect(openGraph).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries a label key and an icon for every item", () => {
+    for (const item of actionBarItems(options())) {
+      expect(item.labelKey).toMatch(/^tabBar\./);
+      expect(item.Icon).toBeTypeOf("function");
+    }
+  });
+});

--- a/src/lib/actionBarItems.ts
+++ b/src/lib/actionBarItems.ts
@@ -16,8 +16,8 @@ export interface ActionBarOptions {
   hasWorkspace: boolean;
 }
 
-// The palette and the graph otherwise need a keyboard shortcut or the native
-// menu, neither of which exists on mobile.
+// Shown on every platform: mobile has neither the shortcut nor the native menu,
+// and on desktop the buttons are what tells a user the features exist at all.
 export function actionBarItems(options: ActionBarOptions): ActionBarItem[] {
   const items: ActionBarItem[] = [
     {

--- a/src/lib/actionBarItems.ts
+++ b/src/lib/actionBarItems.ts
@@ -1,0 +1,41 @@
+import type { ComponentType } from "react";
+import { CommandPaletteIcon } from "@/components/icons/CommandPaletteIcon";
+import { GraphIcon } from "@/components/icons/GraphIcon";
+
+export interface ActionBarItem {
+  id: string;
+  /** Key in the `common` namespace. */
+  labelKey: string;
+  Icon: ComponentType<{ className?: string }>;
+  run: () => void;
+}
+
+export interface ActionBarOptions {
+  openPalette: () => void;
+  openGraph: () => void;
+  hasWorkspace: boolean;
+}
+
+// The palette and the graph otherwise need a keyboard shortcut or the native
+// menu, neither of which exists on mobile.
+export function actionBarItems(options: ActionBarOptions): ActionBarItem[] {
+  const items: ActionBarItem[] = [
+    {
+      id: "commandPalette",
+      labelKey: "tabBar.commandPalette",
+      Icon: CommandPaletteIcon,
+      run: options.openPalette,
+    },
+  ];
+  // Without a workspace `openGraph` is a no-op and the native menu item is
+  // disabled, so the button is hidden rather than silently doing nothing.
+  if (options.hasWorkspace) {
+    items.push({
+      id: "openGraph",
+      labelKey: "tabBar.openGraph",
+      Icon: GraphIcon,
+      run: options.openGraph,
+    });
+  }
+  return items;
+}

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -53,7 +53,9 @@
     "edit": "Bearbeiten",
     "splitMode": "Geteilter Modus",
     "split": "Geteilt",
-    "aiChat": "KI-Chat"
+    "aiChat": "KI-Chat",
+    "commandPalette": "Befehlspalette",
+    "openGraph": "Graph öffnen"
   },
   "updateBanner": {
     "available": "<strong>Glyph {{version}}</strong> ist verfügbar",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -53,7 +53,9 @@
     "edit": "Edit",
     "splitMode": "Split mode",
     "split": "Split",
-    "aiChat": "AI Chat"
+    "aiChat": "AI Chat",
+    "commandPalette": "Command palette",
+    "openGraph": "Open graph"
   },
   "updateBanner": {
     "available": "<strong>Glyph {{version}}</strong> is available",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -53,7 +53,9 @@
     "edit": "Editar",
     "splitMode": "Modo dividido",
     "split": "Dividir",
-    "aiChat": "Chat de IA"
+    "aiChat": "Chat de IA",
+    "commandPalette": "Paleta de comandos",
+    "openGraph": "Abrir grafo"
   },
   "updateBanner": {
     "available": "<strong>Glyph {{version}}</strong> está disponible",

--- a/src/locales/fa/common.json
+++ b/src/locales/fa/common.json
@@ -53,7 +53,9 @@
     "edit": "ویرایش",
     "splitMode": "حالت تقسیم",
     "split": "تقسیم",
-    "aiChat": "گفتگو با هوش مصنوعی"
+    "aiChat": "گفتگو با هوش مصنوعی",
+    "commandPalette": "پالت فرمان",
+    "openGraph": "باز کردن گراف"
   },
   "updateBanner": {
     "available": "<strong>Glyph {{version}}</strong> در دسترس است",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -53,7 +53,9 @@
     "edit": "编辑",
     "splitMode": "分屏模式",
     "split": "分屏",
-    "aiChat": "AI 聊天"
+    "aiChat": "AI 聊天",
+    "commandPalette": "命令面板",
+    "openGraph": "打开图谱"
   },
   "updateBanner": {
     "available": "<strong>Glyph {{version}}</strong> 可用",

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -36,6 +36,11 @@
   transition: background 0.1s ease, color 0.1s ease;
 }
 
+.mode-toggle-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
 .mode-toggle-btn:hover {
   background: var(--color-surface-tertiary);
   color: var(--color-text-primary);


### PR DESCRIPTION
## Summary

The command palette and the graph view had no clickable affordance anywhere in the app. The only ways in were `CmdOrCtrl+K` / `CmdOrCtrl+G` and the native View menu. Mobile has neither a menu bar nor a keyboard, so since phone and tablet support shipped both features were unreachable by touch. The graph's command-palette entry did not help, because reaching the palette needed the shortcut too.

This adds both to the tab bar's action group.

Closes #525

## Changes

- **Two icon buttons** in the tab bar: command palette and graph. They call the same callbacks as the keyboard shortcut and the menu item, so a button can never drift from its shortcut.
- **A small registry** (`src/lib/actionBarItems.ts`) behind them, so the next entry is a list item rather than another block of markup. Extensibility was an explicit scoping decision on the issue; plugin-contributed entries stay out, since those change the `ctx.*` surface and must ship ecosystem-wide with `plugin-template`, the `plugins` repo, and a matching `PLUGIN_API_VERSION`.
- **The graph button hides without a workspace**, matching the native menu, which disables its item in that state because `openGraph` is a no-op there.
- **The action group renders when no tabs are open.** `TabBar` previously returned nothing in that state, which would have hidden both buttons in the exact case they were built for: mobile with an empty workspace, where "no keyboard, no menu, no button" is the original problem again. It is also where the graph is most useful.
- **Refactor, behavior-preserving**: the tab bar's five near-identical `mode-toggle-btn` blocks collapse into one `ActionBarButton`, taking the file from 201 lines to 194, back under the soft cap. The 38 existing `TabBar` tests pass unchanged, which is the regression net for that extraction.
- **`useOpenGraph`**: the rule that `openGraph` must be called with no arguments (a click event landing in its optional `root` silently fails the "root matches the workspace" guard) was about to exist in two places, so it moves into a derived hook beside the context and is stated once.
- A `:focus-visible` ring on `.mode-toggle-btn`, matching the accent ring the rest of the app uses. These are primary affordances now.
- Labels in all five locales, reusing the existing wording from the palette and menu entries.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [x] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

No numbered invariant is at stake. The diff is presentation plus one derived hook: no persistence, no IPC, no filesystem path, no untrusted input. The only strings rendered are bundled locale values reaching `aria-label` and `title` as text, with `t()` called on module-literal keys.

It does add a new user-triggerable entry point into `openGraph`, which mutates tab state, so the state-machine rows were checked anyway:

- *Rapid repetition*: two clicks in one tick both use the functional `setState` updater, so the second sees the tab the first created and re-activates it instead of appending a duplicate.
- *Overlapping operations*: a click landing in the sub-frame window after `closeWorkspace` begins is caught by `openGraph`'s own `workspaceRef` guard. Hiding the button is UX; the guard is the boundary, matching how the native menu item behaves.
- *INV-4*: `openGraph` only appends a tab and moves the active id, so a pending autosave on a dirty tab stays scheduled.

**Accessibility** is the area this PR is in. The risk it carries is the opposite of the usual one: the buttons are new chrome. Both have accessible names from the locale files, are keyboard reachable, and now have a visible focus ring. Covered by `ActionBarButton.test.tsx` (accessible name, tooltip, active state) and `TabBarActions.test.tsx` (dispatch and visibility).

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated only, no manual run on any platform yet. `pnpm typecheck`, `pnpm check`, and `pnpm test` (285 files, 2979 tests) pass, and `pnpm test:coverage` reports no uncovered lines introduced by this diff. `cargo clippy` was not run because the diff touches no Rust.

Two things to look at on a real device before merge, both flagged by review rather than found by tests:

1. **The empty tab bar is new chrome.** With no tabs open the strip is now about 23px on desktop and 41px on mobile, where previously it was 0. It holds one or two icons at the inline end. This is deliberate, and it is what makes the buttons reachable on mobile with an empty workspace, but it is a visible change to the first-launch screen and worth eyeballing.
2. **The row is tight on a narrow phone.** With an AI provider configured, a 360px phone leaves roughly 40px of visible tab strip. Nothing breaks, since the button groups are `flex-shrink: 0` and the strip is `flex: 1; min-width: 0; overflow-x: auto`, so it scrolls rather than clips. A phone-scoped wrap is a small follow-up if it reads badly.

## Screenshots

None yet, see the two items above; the visual result is best judged on a device rather than from a description.
