### PR TITLE
fix(deps): pin undici 6.x to ^6.28.0 to clear Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
       "lodash-es": "4.18.0",
       "uuid": ">=14.0.0",
       "postcss": ">=8.5.18",
-      "esbuild": ">=0.28.1"
+      "esbuild": ">=0.28.1",
+      "undici@6": "^6.28.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   uuid: '>=14.0.0'
   postcss: '>=8.5.18'
   esbuild: '>=0.28.1'
+  undici@6: ^6.28.0
 
 importers:
 
@@ -3109,8 +3110,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
   undici@7.29.0:
@@ -3377,17 +3378,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.9
       '@octokit/request-error': 7.1.0
-      undici: 6.25.0
+      undici: 6.28.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.25.0
+      undici: 6.28.0
 
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.25.0
+      undici: 6.28.0
 
   '@actions/io@3.0.2': {}
 
@@ -6725,7 +6726,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.25.0: {}
+  undici@6.28.0: {}
 
   undici@7.29.0:
     optional: true


### PR DESCRIPTION
## Summary

Clears the three open Dependabot alerts on the repo, all of which point at `undici@6.25.0` resolved through the build-time Codecov plugin.

Chain: `@codecov/vite-plugin` (devDependency) -> `@codecov/bundler-plugin-core` -> `@actions/github` and `@actions/http-client` -> `undici@6.25.0`.

Advisories fixed (all patched in 6.28.0):

- GHSA-8xcm-r25x-g524: downstream response desynchronization via retry interceptor
- GHSA-m8rv-5g2x-5cg5: CRLF injection via blob-like body `type` property
- GHSA-v3r7-h72x-cjcm: cookie attribute injection via unsanitized domain and unparsed `setCookie` fields

The override is scoped to the 6.x branch (`undici@6`) rather than a bare `undici` range, so jsdom keeps its `undici@7.29.0` (unaffected) instead of both being collapsed onto one version.

## Changes

- `package.json`: add `"undici@6": "^6.28.0"` to `pnpm.overrides`
- `pnpm-lock.yaml`: `undici` 6.25.0 -> 6.28.0; `undici@7.29.0` untouched

## Risk classification

- [x] Network
- [x] No risk areas touched

### Invariants at stake and evidence

No runtime code changes. `undici` is not in the shipped app bundle: it reaches the tree only through the Codecov Vite plugin used at build time. No engineering invariants are touched.

## Testing

Gates run locally, all green:

```
pnpm typecheck   # clean
pnpm check       # 830 files, no fixes applied
pnpm test        # 348 files, 3108 tests passed
```

`cargo clippy` was not re-run: no Rust files are touched by this change.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux
