### PR TITLE
fix(deps): bump anyhow and event-listener to clear RUSTSEC unsoundness

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-broadcast"
@@ -1093,11 +1093,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Summary

Follow-up to #595, this time on the Rust side. `cargo audit` reports **0 vulnerabilities** across 627 crates, but 22 warnings. Two of them are unsound crates with semver-compatible fixes already published, so this is a lockfile-only bump.

- `anyhow` 1.0.102 -> 1.0.104: RUSTSEC-2026-0190, unsoundness in `Error::downcast_mut()`
- `event-listener` 5.4.1 -> 5.4.2: RUSTSEC-2026-0221, `!Send` tags can cross thread boundaries via `StackSlot`

That takes the audit from 22 warnings to 20, and unsound findings from 5 to 3.

### What is deliberately left alone

The remaining three unsound findings have no semver-compatible fix:

| Crate | Advisory | Why it stays |
| --- | --- | --- |
| `git2` 0.20.4 | RUSTSEC-2026-0183, RUSTSEC-2026-0184 | Fixed in 0.21.0, a major bump on a direct dependency built with `vendored-libgit2` and `vendored-openssl`. Neither advisory is reachable: the codebase calls neither `Remote::list()` nor any blame API. |
| `glib` 0.18.5 | RUSTSEC-2024-0429 | Comes in transitively on Linux via `gtk` 0.18 from Tauri. Fix needs glib >= 0.20, which gtk-rs 0.18 cannot reach. Already triaged as tolerable risk on alert #1. |

The other 17 warnings are all `unmaintained` with no patched version at all: the whole gtk-rs 0.18 GTK3 stack (`atk`, `gdk`, `gtk`, and friends) pinned by Tauri, plus `fxhash`, `proc-macro-error`, and the `unic-*` crates. Nothing to bump until upstream moves.

## Changes

- `src-tauri/Cargo.lock`: `anyhow` and `event-listener` patch bumps. No manifest version ranges change.

## Risk classification

- [x] No risk areas touched

### Invariants at stake and evidence

Lockfile-only patch bumps of two transitive crates. No source changes, no engineering invariants touched.

## Testing

```
cargo clippy --all-targets -- -D warnings   # clean
cargo test                                  # 433 passed, 0 failed
cargo audit                                 # 0 vulnerabilities, 20 warnings (was 22)
```

The `cargo-audit` job in `security.yml` runs bare `cargo audit`, which exits 0 on warnings, so CI was already green before and after. This PR just lowers the noise floor.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux
