### PR TITLE
feat(sidebar): make the tags section resizable

### DIFF
--- a/src/components/layout/BacklinksBlock.tsx
+++ b/src/components/layout/BacklinksBlock.tsx
@@ -1,72 +1,32 @@
-import { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useSidebarLayoutContext } from "@/contexts/SidebarLayoutContext";
 import { useTabsContext } from "@/contexts/TabsContext";
-import { usePanelResize } from "@/hooks/usePanelResize";
 import { BACKLINKS_HEIGHT_MIN } from "@/lib/settings";
 import { BacklinksSection } from "./BacklinksSection";
-import { ResizeHandle } from "./ResizeHandle";
-
-// Keep at least this much of the Files panel for the tree when dragging the
-// backlinks divider up.
-const BACKLINKS_TREE_RESERVE = 120;
+import { ResizableBlock } from "./ResizableBlock";
 
 interface BacklinksBlockProps {
   workspaceRoot: string;
   onOpen: (path: string) => void;
 }
 
-/** Backlinks pinned to the bottom of the Files panel, with the drag divider
- *  that resizes them against the tree above. Renders nothing without backlinks. */
+/** Backlinks pinned to the bottom of the Files panel, resizable against the
+ *  tree above. Renders nothing without backlinks. */
 export function BacklinksBlock({ workspaceRoot, onOpen }: BacklinksBlockProps) {
   const { t } = useTranslation("common");
   const { backlinks } = useTabsContext();
   const { backlinksHeight, setBacklinksHeight } = useSidebarLayoutContext();
-  const blockRef = useRef<HTMLDivElement>(null);
-
-  const maxHeight = useCallback(
-    () =>
-      Math.max(
-        BACKLINKS_HEIGHT_MIN,
-        (blockRef.current?.parentElement?.clientHeight ?? 0) - BACKLINKS_TREE_RESERVE,
-      ),
-    [],
-  );
-  // The idle height is DOM-measured so a drag starts from the rendered height
-  // even when the block is auto-sized; it is also the idle aria value, and on
-  // the first render the ref is not attached yet, so the minimum stands in.
-  const measure = useCallback(() => blockRef.current?.offsetHeight ?? BACKLINKS_HEIGHT_MIN, []);
-  const resize = usePanelResize({
-    size: measure,
-    min: BACKLINKS_HEIGHT_MIN,
-    max: maxHeight,
-    axis: "y",
-    // The block sits at the panel bottom: dragging the divider up grows it.
-    direction: -1,
-    onCommit: setBacklinksHeight,
-    onReset: () => setBacklinksHeight(null),
-  });
 
   if (backlinks.length === 0) return null;
 
   return (
-    <>
-      <ResizeHandle
-        axis="y"
-        label={t("sidebar.resizeBacklinks")}
-        value={resize.size ?? backlinksHeight ?? measure()}
-        min={BACKLINKS_HEIGHT_MIN}
-        max={maxHeight()}
-        className="mt-3 -mx-3 h-1.5 shrink-0"
-        {...resize.handleProps}
-      />
-      <div
-        ref={blockRef}
-        className="pt-1.5 border-t border-[var(--color-border)] shrink-0 overflow-y-auto"
-        style={{ height: resize.size ?? backlinksHeight ?? undefined }}
-      >
-        <BacklinksSection backlinks={backlinks} workspaceRoot={workspaceRoot} onOpen={onOpen} />
-      </div>
-    </>
+    <ResizableBlock
+      label={t("sidebar.resizeBacklinks")}
+      min={BACKLINKS_HEIGHT_MIN}
+      height={backlinksHeight}
+      onHeightCommit={setBacklinksHeight}
+    >
+      <BacklinksSection backlinks={backlinks} workspaceRoot={workspaceRoot} onOpen={onOpen} />
+    </ResizableBlock>
   );
 }

--- a/src/components/layout/FilesPanel.tsx
+++ b/src/components/layout/FilesPanel.tsx
@@ -16,7 +16,7 @@ import { BacklinksBlock } from "./BacklinksBlock";
 import { FileTree, type FileTreeHandle } from "./FileTree";
 import { PanelHeader } from "./PanelHeader";
 import { TagFileList } from "./TagFileList";
-import { TagsSection } from "./TagsSection";
+import { TagsBlock } from "./TagsBlock";
 import { ToolbarButton } from "./ToolbarButton";
 import { WorkspaceIndexWarning } from "./WorkspaceIndexWarning";
 
@@ -157,15 +157,11 @@ export function FilesPanel({ workspace, headerSide }: FilesPanelProps) {
           />
         )}
       </div>
-      {tags.length > 0 && (
-        <div className="pt-2 mt-2 border-t border-[var(--color-border)] shrink-0 max-h-40 overflow-y-auto">
-          <TagsSection
-            tags={tags}
-            selected={activeTag}
-            onSelect={(tag) => setTagFilter(tag ? { root: workspace.root, tag } : null)}
-          />
-        </div>
-      )}
+      <TagsBlock
+        tags={tags}
+        selected={activeTag}
+        onSelect={(tag) => setTagFilter(tag ? { root: workspace.root, tag } : null)}
+      />
       <WorkspaceIndexWarning />
       <BacklinksBlock workspaceRoot={workspace.root} onOpen={handleOpenFile} />
     </div>

--- a/src/components/layout/ResizableBlock.tsx
+++ b/src/components/layout/ResizableBlock.tsx
@@ -1,0 +1,72 @@
+import { type ReactNode, useCallback, useRef } from "react";
+import { usePanelResize } from "@/hooks/usePanelResize";
+import { ResizeHandle } from "./ResizeHandle";
+
+// Keep at least this much of the Files panel for the tree when dragging a
+// block divider up.
+const TREE_RESERVE = 120;
+
+interface ResizableBlockProps {
+  label: string;
+  min: number;
+  /** Persisted height; null keeps the block at its natural height. */
+  height: number | null;
+  onHeightCommit: (height: number | null) => void;
+  /** Cap for the natural height, applied only while no height is persisted. */
+  naturalMax?: number;
+  children: ReactNode;
+}
+
+/** A block pinned below the Files panel tree, with the drag divider that
+ *  resizes it against the tree above. */
+export function ResizableBlock({
+  label,
+  min,
+  height,
+  onHeightCommit,
+  naturalMax,
+  children,
+}: ResizableBlockProps) {
+  const blockRef = useRef<HTMLDivElement>(null);
+
+  const maxHeight = useCallback(
+    () => Math.max(min, (blockRef.current?.parentElement?.clientHeight ?? 0) - TREE_RESERVE),
+    [min],
+  );
+  // The idle height is DOM-measured so a drag starts from the rendered height
+  // even when the block is auto-sized; it is also the idle aria value, and on
+  // the first render the ref is not attached yet, so the minimum stands in.
+  const measure = useCallback(() => blockRef.current?.offsetHeight ?? min, [min]);
+  const resize = usePanelResize({
+    size: measure,
+    min,
+    max: maxHeight,
+    axis: "y",
+    // The block sits below the tree: dragging the divider up grows it.
+    direction: -1,
+    onCommit: onHeightCommit,
+    onReset: () => onHeightCommit(null),
+  });
+  const size = resize.size ?? height;
+
+  return (
+    <>
+      <ResizeHandle
+        axis="y"
+        label={label}
+        value={size ?? measure()}
+        min={min}
+        max={maxHeight()}
+        className="mt-3 -mx-3 h-1.5 shrink-0"
+        {...resize.handleProps}
+      />
+      <div
+        ref={blockRef}
+        className="pt-2 border-t border-[var(--color-border)] shrink-0 overflow-y-auto"
+        style={{ height: size ?? undefined, maxHeight: size === null ? naturalMax : undefined }}
+      >
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -1,11 +1,17 @@
 import { fireEvent, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type { MetadataIndex } from "@/lib/metadata";
 import { SIDEBAR_WIDTH_DEFAULT } from "@/lib/settings";
 import { makeWorkspace, renderBothSides, renderSidebar } from "@/test/fixtures/sidebar";
 
 vi.mock("@/lib/pickers", () => ({
   pickMoveDir: vi.fn(),
 }));
+
+// One tagged note, enough for the Files panel to render the tag cloud.
+function taggedIndex(): MetadataIndex {
+  return new Map([["/tmp/notes/readme.md", { tags: ["notes"], fields: new Map() }]]);
+}
 
 describe("Sidebar placement", () => {
   it("renders nothing when no active tab and no workspace", () => {
@@ -250,6 +256,42 @@ describe("Sidebar placement", () => {
     });
     fireEvent.doubleClick(screen.getByRole("separator", { name: "Resize backlinks" }));
     expect(setBacklinksHeight).toHaveBeenCalledExactlyOnceWith(null);
+  });
+
+  it("drags the tags divider and persists the height", () => {
+    const setTagsHeight = vi.fn();
+    renderSidebar({ workspace: makeWorkspace(), setTagsHeight, tabs: { metadata: taggedIndex() } });
+    const handle = screen.getByRole("separator", { name: "Resize tags" });
+    const block = handle.nextElementSibling as HTMLElement;
+    Object.defineProperty(block, "offsetHeight", { configurable: true, value: 100 });
+    Object.defineProperty(block.parentElement as HTMLElement, "clientHeight", {
+      configurable: true,
+      value: 500,
+    });
+    fireEvent.pointerDown(handle, { button: 0, clientY: 400 });
+    // The block sits below the tree: dragging the divider up grows it.
+    fireEvent.pointerMove(handle, { clientY: 360 });
+    expect(block.style.height).toBe("140px");
+    fireEvent.pointerUp(handle);
+    expect(setTagsHeight).toHaveBeenCalledExactlyOnceWith(140);
+  });
+
+  it("applies a persisted tags height when idle", () => {
+    renderSidebar({
+      workspace: makeWorkspace(),
+      tagsHeight: 120,
+      tabs: { metadata: taggedIndex() },
+    });
+    const handle = screen.getByRole("separator", { name: "Resize tags" });
+    expect((handle.nextElementSibling as HTMLElement).style.height).toBe("120px");
+    expect(handle).toHaveAttribute("aria-valuenow", "120");
+  });
+
+  it("double-click on the tags divider restores the automatic height", () => {
+    const setTagsHeight = vi.fn();
+    renderSidebar({ workspace: makeWorkspace(), setTagsHeight, tabs: { metadata: taggedIndex() } });
+    fireEvent.doubleClick(screen.getByRole("separator", { name: "Resize tags" }));
+    expect(setTagsHeight).toHaveBeenCalledExactlyOnceWith(null);
   });
 
   it("swaps sides when swapSidebarSides=true (file tab outline goes right)", () => {

--- a/src/components/layout/SidebarDrawerBackdrop.test.tsx
+++ b/src/components/layout/SidebarDrawerBackdrop.test.tsx
@@ -4,27 +4,16 @@ import {
   SidebarLayoutContext,
   type SidebarLayoutContextValue,
 } from "@/contexts/SidebarLayoutContext";
+import { sidebarLayoutValue } from "@/test/fixtures/sidebarLayout";
 import { SidebarDrawerBackdrop } from "./SidebarDrawerBackdrop";
 
 function renderBackdrop(overrides: Partial<SidebarLayoutContextValue> = {}) {
-  const value: SidebarLayoutContextValue = {
+  const value = sidebarLayoutValue({
     filesVisible: false,
     outlineVisible: false,
     compact: true,
-    closeCompactPanels: vi.fn(),
-    toggleFiles: vi.fn(),
-    toggleOutline: vi.fn(),
-    resetLayout: vi.fn(),
-    sidebarLayout: "split",
-    swapSidebarSides: false,
-    filesSidebarWidth: 200,
-    outlineSidebarWidth: 260,
-    backlinksHeight: null,
-    setFilesSidebarWidth: vi.fn(),
-    setOutlineSidebarWidth: vi.fn(),
-    setBacklinksHeight: vi.fn(),
     ...overrides,
-  };
+  });
   const utils = render(
     <SidebarLayoutContext.Provider value={value}>
       <SidebarDrawerBackdrop />

--- a/src/components/layout/TabBar.dnd.test.tsx
+++ b/src/components/layout/TabBar.dnd.test.tsx
@@ -8,28 +8,8 @@ import {
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import { activeFileOf, type FileTab, type Tab } from "@/lib/tabs";
 import { COMPLETE_INDEX_STATUS } from "@/lib/workspaceScan";
+import { sidebarLayoutValue } from "@/test/fixtures/sidebarLayout";
 import { TabBar } from "./TabBar";
-
-const buildSidebarContext = (
-  overrides: Partial<SidebarLayoutContextValue> = {},
-): SidebarLayoutContextValue => ({
-  filesVisible: true,
-  outlineVisible: true,
-  compact: false,
-  closeCompactPanels: vi.fn(),
-  toggleFiles: vi.fn(),
-  toggleOutline: vi.fn(),
-  resetLayout: vi.fn(),
-  sidebarLayout: "split",
-  swapSidebarSides: false,
-  filesSidebarWidth: 200,
-  outlineSidebarWidth: 260,
-  backlinksHeight: null,
-  setFilesSidebarWidth: vi.fn(),
-  setOutlineSidebarWidth: vi.fn(),
-  setBacklinksHeight: vi.fn(),
-  ...overrides,
-});
 
 const makeFileTab = (i: number): FileTab => ({
   id: `tab-${i}`,
@@ -138,7 +118,7 @@ function Wrapper({
 
 function renderTabBar(opts: RenderOpts = {}, onToggleAIChat: (() => void) | null = null) {
   const value = buildContext(opts);
-  const sidebar = buildSidebarContext(opts.sidebar);
+  const sidebar = sidebarLayoutValue(opts.sidebar);
   return {
     ...render(
       <Wrapper value={value} sidebar={sidebar}>

--- a/src/components/layout/TabBar.responsive.test.tsx
+++ b/src/components/layout/TabBar.responsive.test.tsx
@@ -8,28 +8,8 @@ import {
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import { activeFileOf, type FileTab, type Tab } from "@/lib/tabs";
 import { COMPLETE_INDEX_STATUS } from "@/lib/workspaceScan";
+import { sidebarLayoutValue } from "@/test/fixtures/sidebarLayout";
 import { TabBar } from "./TabBar";
-
-const buildSidebarContext = (
-  overrides: Partial<SidebarLayoutContextValue> = {},
-): SidebarLayoutContextValue => ({
-  filesVisible: true,
-  outlineVisible: true,
-  compact: false,
-  closeCompactPanels: vi.fn(),
-  toggleFiles: vi.fn(),
-  toggleOutline: vi.fn(),
-  resetLayout: vi.fn(),
-  sidebarLayout: "split",
-  swapSidebarSides: false,
-  filesSidebarWidth: 200,
-  outlineSidebarWidth: 260,
-  backlinksHeight: null,
-  setFilesSidebarWidth: vi.fn(),
-  setOutlineSidebarWidth: vi.fn(),
-  setBacklinksHeight: vi.fn(),
-  ...overrides,
-});
 
 const makeFileTab = (i: number): FileTab => ({
   id: `tab-${i}`,
@@ -138,7 +118,7 @@ function Wrapper({
 
 function renderTabBar(opts: RenderOpts = {}, onToggleAIChat: (() => void) | null = null) {
   const value = buildContext(opts);
-  const sidebar = buildSidebarContext(opts.sidebar);
+  const sidebar = sidebarLayoutValue(opts.sidebar);
   return {
     ...render(
       <Wrapper value={value} sidebar={sidebar}>

--- a/src/components/layout/TabBar.test.tsx
+++ b/src/components/layout/TabBar.test.tsx
@@ -8,28 +8,8 @@ import {
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import { activeFileOf, type FileTab, type GraphTab, type Tab } from "@/lib/tabs";
 import { COMPLETE_INDEX_STATUS } from "@/lib/workspaceScan";
+import { sidebarLayoutValue } from "@/test/fixtures/sidebarLayout";
 import { TabBar } from "./TabBar";
-
-const buildSidebarContext = (
-  overrides: Partial<SidebarLayoutContextValue> = {},
-): SidebarLayoutContextValue => ({
-  filesVisible: true,
-  outlineVisible: true,
-  compact: false,
-  closeCompactPanels: vi.fn(),
-  toggleFiles: vi.fn(),
-  toggleOutline: vi.fn(),
-  resetLayout: vi.fn(),
-  sidebarLayout: "split",
-  swapSidebarSides: false,
-  filesSidebarWidth: 200,
-  outlineSidebarWidth: 260,
-  backlinksHeight: null,
-  setFilesSidebarWidth: vi.fn(),
-  setOutlineSidebarWidth: vi.fn(),
-  setBacklinksHeight: vi.fn(),
-  ...overrides,
-});
 
 const makeFileTab = (i: number): FileTab => ({
   id: `tab-${i}`,
@@ -145,7 +125,7 @@ function Wrapper({
 
 function renderTabBar(opts: RenderOpts = {}, onToggleAIChat: (() => void) | null = null) {
   const value = buildContext(opts);
-  const sidebar = buildSidebarContext(opts.sidebar);
+  const sidebar = sidebarLayoutValue(opts.sidebar);
   return {
     ...render(
       <Wrapper value={value} sidebar={sidebar}>
@@ -397,7 +377,7 @@ describe("TabBar", () => {
       expect(screen.getByRole("menu")).toBeInTheDocument();
 
       rerender(
-        <Wrapper value={{ ...value, tabs: [makeFileTab(0)] }} sidebar={buildSidebarContext()}>
+        <Wrapper value={{ ...value, tabs: [makeFileTab(0)] }} sidebar={sidebarLayoutValue()}>
           <TabBar onToggleAIChat={null} onOpenPalette={vi.fn()} />
         </Wrapper>,
       );

--- a/src/components/layout/TagsBlock.tsx
+++ b/src/components/layout/TagsBlock.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from "react-i18next";
+import { useSidebarLayoutContext } from "@/contexts/SidebarLayoutContext";
+import type { TagCount } from "@/lib/metadata";
+import { TAGS_HEIGHT_MIN } from "@/lib/settings";
+import { ResizableBlock } from "./ResizableBlock";
+import { TagsSection } from "./TagsSection";
+
+// Height the tag cloud grows to on its own before scrolling, until the user
+// drags the divider.
+const TAGS_HEIGHT_NATURAL_MAX = 160;
+
+interface TagsBlockProps {
+  tags: TagCount[];
+  /** The tag currently filtering the file list, if any. */
+  selected: string | null;
+  onSelect: (tag: string | null) => void;
+}
+
+/** The workspace tag cloud in the Files panel, resizable against the tree
+ *  above. Renders nothing without tags. */
+export function TagsBlock({ tags, selected, onSelect }: TagsBlockProps) {
+  const { t } = useTranslation("common");
+  const { tagsHeight, setTagsHeight } = useSidebarLayoutContext();
+
+  if (tags.length === 0) return null;
+
+  return (
+    <ResizableBlock
+      label={t("sidebar.resizeTags")}
+      min={TAGS_HEIGHT_MIN}
+      height={tagsHeight}
+      onHeightCommit={setTagsHeight}
+      naturalMax={TAGS_HEIGHT_NATURAL_MAX}
+    >
+      <TagsSection tags={tags} selected={selected} onSelect={onSelect} />
+    </ResizableBlock>
+  );
+}

--- a/src/contexts/SidebarLayoutContext.ts
+++ b/src/contexts/SidebarLayoutContext.ts
@@ -15,6 +15,7 @@ export interface SidebarLayoutContextValue extends SidebarLayoutApi {
   filesSidebarWidth: number;
   outlineSidebarWidth: number;
   backlinksHeight: number | null;
+  tagsHeight: number | null;
 }
 
 export const SidebarLayoutContext = createContext<SidebarLayoutContextValue | null>(null);

--- a/src/contexts/SidebarLayoutProvider.tsx
+++ b/src/contexts/SidebarLayoutProvider.tsx
@@ -19,6 +19,7 @@ export function SidebarLayoutProvider({ children }: { children: ReactNode }) {
       filesSidebarWidth: settings.layout.filesSidebarWidth,
       outlineSidebarWidth: settings.layout.outlineSidebarWidth,
       backlinksHeight: settings.layout.backlinksHeight,
+      tagsHeight: settings.layout.tagsHeight,
     }),
     [
       layout,
@@ -27,6 +28,7 @@ export function SidebarLayoutProvider({ children }: { children: ReactNode }) {
       settings.layout.filesSidebarWidth,
       settings.layout.outlineSidebarWidth,
       settings.layout.backlinksHeight,
+      settings.layout.tagsHeight,
     ],
   );
 

--- a/src/hooks/useSidebarLayout.test.ts
+++ b/src/hooks/useSidebarLayout.test.ts
@@ -70,8 +70,10 @@ describe("useSidebarLayout", () => {
       result.current.setFilesSidebarWidth(300);
       result.current.setOutlineSidebarWidth(280);
       result.current.setBacklinksHeight(150);
+      result.current.setTagsHeight(120);
       result.current.setBacklinksHeight(null);
     });
+    expect(updateSettings).toHaveBeenCalledWith("layout.tagsHeight", 120);
     expect(updateSettings).toHaveBeenCalledWith("layout.filesSidebarWidth", 300);
     expect(updateSettings).toHaveBeenCalledWith("layout.outlineSidebarWidth", 280);
     expect(updateSettings).toHaveBeenCalledWith("layout.backlinksHeight", 150);
@@ -98,6 +100,7 @@ describe("useSidebarLayout", () => {
     expect(updateSettings).toHaveBeenCalledWith("layout.outlineSidebarWidth", 224);
     expect(updateSettings).toHaveBeenCalledWith("layout.aiPanelWidth", 340);
     expect(updateSettings).toHaveBeenCalledWith("layout.backlinksHeight", null);
+    expect(updateSettings).toHaveBeenCalledWith("layout.tagsHeight", null);
   });
 });
 

--- a/src/hooks/useSidebarLayout.ts
+++ b/src/hooks/useSidebarLayout.ts
@@ -78,6 +78,11 @@ export function useSidebarLayout({
     [updateSettings],
   );
 
+  const setTagsHeight = useCallback(
+    (height: number | null) => updateSettings("layout.tagsHeight", height),
+    [updateSettings],
+  );
+
   const resetLayout = useCallback(() => {
     updateSettings("layout.filesSidebarVisible", true);
     updateSettings("layout.outlineSidebarVisible", true);
@@ -87,6 +92,7 @@ export function useSidebarLayout({
     updateSettings("layout.outlineSidebarWidth", SIDEBAR_WIDTH_DEFAULT);
     updateSettings("layout.aiPanelWidth", AI_PANEL_WIDTH_DEFAULT);
     updateSettings("layout.backlinksHeight", null);
+    updateSettings("layout.tagsHeight", null);
   }, [updateSettings]);
 
   return {
@@ -101,6 +107,7 @@ export function useSidebarLayout({
     setFilesSidebarWidth,
     setOutlineSidebarWidth,
     setBacklinksHeight,
+    setTagsHeight,
     resetLayout,
   };
 }

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -32,6 +32,7 @@ describe("DEFAULT_SETTINGS", () => {
     expect(DEFAULT_SETTINGS.layout.outlineSidebarWidth).toBe(SIDEBAR_WIDTH_DEFAULT);
     expect(DEFAULT_SETTINGS.layout.aiPanelWidth).toBe(AI_PANEL_WIDTH_DEFAULT);
     expect(DEFAULT_SETTINGS.layout.backlinksHeight).toBeNull();
+    expect(DEFAULT_SETTINGS.layout.tagsHeight).toBeNull();
   });
 
   it("keeps resize bounds ordered around the defaults", () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -30,6 +30,8 @@ export interface LayoutSettings {
   // Pixel height of the backlinks block inside the Files panel. null keeps its
   // natural height until the user drags the divider.
   backlinksHeight: number | null;
+  // Same, for the tag cloud block.
+  tagsHeight: number | null;
   sidebarLayout: SidebarLayout;
   // Mirrors the sidebar layout. Default Files-left / Outline-right; when true
   // it becomes Files-right / Outline-left. Affects all layout modes.
@@ -46,6 +48,7 @@ export const AI_PANEL_WIDTH_DEFAULT = 340;
 export const AI_PANEL_WIDTH_MIN = 280;
 export const AI_PANEL_WIDTH_MAX_FRACTION = 0.45;
 export const BACKLINKS_HEIGHT_MIN = 80;
+export const TAGS_HEIGHT_MIN = 56;
 
 // Editor modes for a document tab. Defined as a constant object so call sites
 // reference `EDITOR_MODE.view` etc. instead of bare string literals; the
@@ -232,6 +235,7 @@ export const DEFAULT_SETTINGS: Settings = {
     outlineSidebarWidth: SIDEBAR_WIDTH_DEFAULT,
     aiPanelWidth: AI_PANEL_WIDTH_DEFAULT,
     backlinksHeight: null,
+    tagsHeight: null,
     sidebarLayout: "beside",
     swapSidebarSides: false,
   },

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -38,6 +38,7 @@
     "outline": "Gliederung",
     "resize": "Größe der Seitenleiste ändern",
     "resizeBacklinks": "Größe der Rückverweise ändern",
+    "resizeTags": "Größe der Tags ändern",
     "indexIncomplete": "Index unvollständig"
   },
   "backlinks": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -38,6 +38,7 @@
     "outline": "Outline",
     "resize": "Resize sidebar",
     "resizeBacklinks": "Resize backlinks",
+    "resizeTags": "Resize tags",
     "indexIncomplete": "Index incomplete"
   },
   "backlinks": {

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -38,6 +38,7 @@
     "outline": "Esquema",
     "resize": "Cambiar tamaño de la barra lateral",
     "resizeBacklinks": "Cambiar tamaño de los enlaces entrantes",
+    "resizeTags": "Cambiar tamaño de las etiquetas",
     "indexIncomplete": "Índice incompleto"
   },
   "backlinks": {

--- a/src/locales/fa/common.json
+++ b/src/locales/fa/common.json
@@ -38,6 +38,7 @@
     "outline": "رئوس مطالب",
     "resize": "تغییر اندازه نوار کناری",
     "resizeBacklinks": "تغییر اندازه پیوندهای ورودی",
+    "resizeTags": "تغییر اندازه برچسب‌ها",
     "indexIncomplete": "نمایه ناقص"
   },
   "backlinks": {

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -38,6 +38,7 @@
     "outline": "大纲",
     "resize": "调整侧边栏大小",
     "resizeBacklinks": "调整反向链接大小",
+    "resizeTags": "调整标签大小",
     "indexIncomplete": "索引不完整"
   },
   "backlinks": {

--- a/src/test/fixtures/sidebar.tsx
+++ b/src/test/fixtures/sidebar.tsx
@@ -10,6 +10,7 @@ import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import type { TocEntry } from "@/hooks/useTableOfContents";
 import type { SidebarLayout } from "@/lib/settings";
 import type { FileTab, Tab, Workspace } from "@/lib/tabs";
+import { sidebarLayoutValue } from "./sidebarLayout";
 import { tabsContextValue } from "./tabsContext";
 
 // Shared setup for the Sidebar suites: the tab/workspace fixtures plus the two
@@ -69,6 +70,8 @@ export interface RenderOpts {
   setOutlineSidebarWidth?: (width: number) => void;
   setBacklinksHeight?: (height: number | null) => void;
   backlinksHeight?: number | null;
+  setTagsHeight?: (height: number | null) => void;
+  tagsHeight?: number | null;
   tabs?: Partial<TabsContextValue>;
 }
 
@@ -85,23 +88,22 @@ function buildTabsContext(opts: RenderOpts): TabsContextValue {
 }
 
 function buildSidebarContext(opts: RenderOpts): SidebarLayoutContextValue {
-  return {
+  return sidebarLayoutValue({
     filesVisible: opts.filesVisible ?? true,
     outlineVisible: opts.outlineVisible ?? true,
     compact: opts.compact ?? false,
     closeCompactPanels: opts.closeCompactPanels ?? vi.fn(),
     toggleFiles: opts.toggleFiles ?? vi.fn(),
     toggleOutline: opts.toggleOutline ?? vi.fn(),
-    resetLayout: vi.fn(),
     sidebarLayout: opts.sidebarLayout ?? "split",
     swapSidebarSides: opts.swapSidebarSides ?? false,
-    filesSidebarWidth: 200,
-    outlineSidebarWidth: 260,
     backlinksHeight: opts.backlinksHeight ?? null,
+    tagsHeight: opts.tagsHeight ?? null,
     setFilesSidebarWidth: opts.setFilesSidebarWidth ?? vi.fn(),
     setOutlineSidebarWidth: opts.setOutlineSidebarWidth ?? vi.fn(),
     setBacklinksHeight: opts.setBacklinksHeight ?? vi.fn(),
-  };
+    setTagsHeight: opts.setTagsHeight ?? vi.fn(),
+  });
 }
 
 export function Wrapper({ opts, children }: { opts: RenderOpts; children: ReactNode }) {

--- a/src/test/fixtures/sidebarLayout.ts
+++ b/src/test/fixtures/sidebarLayout.ts
@@ -1,0 +1,29 @@
+import { vi } from "vitest";
+import type { SidebarLayoutContextValue } from "@/contexts/SidebarLayoutContext";
+
+/** The full SidebarLayoutContext surface as inert defaults, so a test only
+ *  spells out the fields it asserts on. */
+export function sidebarLayoutValue(
+  overrides: Partial<SidebarLayoutContextValue> = {},
+): SidebarLayoutContextValue {
+  return {
+    filesVisible: true,
+    outlineVisible: true,
+    compact: false,
+    closeCompactPanels: vi.fn(),
+    toggleFiles: vi.fn(),
+    toggleOutline: vi.fn(),
+    resetLayout: vi.fn(),
+    sidebarLayout: "split",
+    swapSidebarSides: false,
+    filesSidebarWidth: 200,
+    outlineSidebarWidth: 260,
+    backlinksHeight: null,
+    tagsHeight: null,
+    setFilesSidebarWidth: vi.fn(),
+    setOutlineSidebarWidth: vi.fn(),
+    setBacklinksHeight: vi.fn(),
+    setTagsHeight: vi.fn(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

The tag cloud in the Files panel was capped at a fixed 160px, so a workspace with many tags scrolled inside a strip the user could not grow. It now carries the same drag divider as the backlinks block below it.

## Changes

- `TagsBlock` wraps the tag cloud with a resize handle: drag to resize, arrow keys nudge when focused, double-click restores the automatic height.
- The height persists as `layout.tagsHeight` (null = automatic, capped at 160px until the user drags), and Reset View clears it alongside the other layout sizes.
- The resize plumbing that `BacklinksBlock` owned moves into a shared `ResizableBlock`; `BacklinksBlock` keeps its previous behaviour.
- Four test files that hand-rolled a full `SidebarLayoutContext` value now share `src/test/fixtures/sidebarLayout.ts`.
- `sidebar.resizeTags` added to all five locales.

## Risk classification

- [x] Migrations / persisted-format changes
- [x] Accessibility

### Invariants at stake and evidence

`layout.tagsHeight` is a new optional settings key defaulting to `null`; existing settings files without it fall back to the default, same as `backlinksHeight` did. Covered by `settings.test.ts` and `useSidebarLayout.test.ts`.

Accessibility: the divider is the existing `ResizeHandle` (`separator` role, `aria-valuenow/min/max`, focusable, arrow-key resize). `Sidebar.test.tsx` asserts the drag, the persisted idle height with its aria value, and the double-click reset.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

`pnpm typecheck && pnpm check && pnpm test` (3113 tests) pass. Also ran the dev build on Windows and confirmed the tags block renders with its divider in the Files panel; the drag itself was only exercised through the tests, not by hand.
