### PR TITLE
chore(ci): unbreak the Security workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,3 +61,10 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    groups:
+      # init/autobuild/analyze are separate Dependabot dependencies but must run
+      # the same version; a lone bump fails with "Loaded a configuration file for
+      # version 'X', but running version 'Y'". Group them into one PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
         language: [javascript-typescript]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
       - uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,8 +31,8 @@ jobs:
       - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
-      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
   cargo-audit:
     name: Cargo Audit

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2708,13 +2708,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.11:
-    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -5248,7 +5248,7 @@ snapshots:
       '@types/node': 25.9.5
       hash.js: 1.1.7
       jszip: 3.10.1
-      nanoid: 5.1.11
+      nanoid: 5.1.16
       xml: 1.0.1
       xml-js: 1.6.11
 
@@ -6263,9 +6263,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
-  nanoid@5.1.11: {}
+  nanoid@5.1.16: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -6365,7 +6365,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

The Security workflow is red for two unrelated reasons. This branch fixes both so it goes green.

**1. CodeQL version drift.** Dependabot treats `github/codeql-action/init`, `/autobuild`, and `/analyze` as three separate dependencies, so #604 bumped only `init` to v4.37.6 and left the other two on v4.37.3. CodeQL refuses to run with mixed versions:

```
##[error]We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps. Loaded a configuration file for version '4.37.6', but running version '4.37.3'
```

This branch carries Dependabot's `init` bump plus the two missing ones, and groups the sub-actions so they can never drift apart again. It supersedes #604.

**2. New nanoid advisory.** [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) (high) covers `nanoid >=4.0.0 <5.1.16`, reached transitively through `docx`. It published after the last green run on `main`, so `pnpm audit --prod` now fails on every PR and on `main`. `docx` already declares `nanoid: ^5.1.3`, so only the lockfile had to move: no `package.json` change and no override.

## Changes

- `.github/workflows/security.yml`: pin all three `github/codeql-action/*` steps to `5595ccaf912efad79be6eef63a5619ff05969be3` (`v4.37.6`, verified as the dereferenced commit of the `v4.37.6` tag)
- `.github/dependabot.yml`: new `codeql-action` group matching `github/codeql-action/*`, so `init`, `autobuild`, and `analyze` are bumped together in a single PR
- `pnpm-lock.yaml`: `nanoid` 5.1.11 to 5.1.16 (under `docx`). `postcss`'s `nanoid` 3.3.16 to 3.3.18 came along in the same resolve and was never in the affected range.

## Risk classification

- [x] No risk areas touched

### Invariants at stake and evidence

None. CI configuration plus a patch-level lockfile bump within the existing semver range. No application code, no persisted format, no runtime surface.

## Testing

Both failures are reproduced and fixed by CI on this PR itself, which is the same gate that was failing:

- **CodeQL Analysis (javascript-typescript): pass** on the first push, where it previously errored at `autobuild`. Failing run for reference: https://github.com/hamidfzm/glyph/actions/runs/31218725085/job/92998186396
- **npm Audit**: `pnpm audit --prod --ignore-registry-errors` reports `No known vulnerabilities found` locally against the updated lockfile, versus `1 high` before. Failing run for reference: https://github.com/hamidfzm/glyph/actions/runs/31220180413/job/93002809846

The `v4.37.6` SHA was confirmed against the upstream tag rather than copied:

```bash
gh api repos/github/codeql-action/git/ref/tags/v4.37.6 --jq .object.sha
gh api repos/github/codeql-action/git/tags/<tag-sha> --jq .object.sha
```

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
