### PR TITLE
ci: build the iOS app for the simulator

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -116,3 +116,21 @@ jobs:
           name: glyph-android-debug-apk
           path: src-tauri/gen/android/app/build/outputs/apk/universal/debug/*.apk
           retention-days: 14
+
+  build-ios:
+    name: iOS
+    # Simulator only: unsigned, so it needs no Apple Developer account. Device
+    # builds and IPAs require a paid signing identity and stay out of CI.
+    # The shared `cfg(mobile)` code is already covered by the Android job; what
+    # this catches is Xcode-project, Info.plist and Objective-C glue drift,
+    # which nothing else compiles.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: ./.github/actions/pnpm-setup
+      - uses: ./.github/actions/rust-setup
+        with:
+          targets: aarch64-apple-ios-sim
+      - run: pnpm install --frozen-lockfile
+      - name: Build iOS app (debug, simulator)
+        run: pnpm tauri ios build --debug --target aarch64-sim


### PR DESCRIPTION
## Summary

Nothing in CI compiles the Apple side of the project. `src-tauri/gen/apple` (Xcode project, `Info.plist`, entitlements, `main.mm`) is committed but never built, so it can drift silently until someone runs `tauri ios build` by hand. The Android job only covers the shared `cfg(mobile)` Rust code, which is a different surface.

Adds a `Build / iOS` job on `macos-latest` running `tauri ios build --debug --target aarch64-sim`.

Simulator builds are unsigned, so this needs no Apple Developer account. Device builds and IPAs require a paid signing identity ($99/year), so they stay out of CI until there is a reason to distribute.

## Changes

- New `build-ios` job in `.github/workflows/ci-build.yml`: checkout, pnpm setup, Rust with the `aarch64-apple-ios-sim` target, `pnpm tauri ios build --debug --target aarch64-sim`.
- Runs on PRs as well as pushes, which is the point: a mobile-only break should fail the PR, not `main`.

No artifact upload. A simulator `.app` is not installable on a device, so there is nothing worth keeping for 14 days.

## Risk classification

- [x] No risk areas touched

### Invariants at stake and evidence

None. CI-only change, no application code touched.

## Testing

This job cannot be exercised from a Windows workstation, so the PR run is the test. Two things to watch on the first run:

1. Whether `tauri ios build` completes without a signing identity for the simulator target. If Xcode demands a development team even for the simulator SDK, the fallback is `cargo build --lib --target aarch64-apple-ios-sim`, which keeps the iOS compile coverage and drops the Xcode packaging step.
2. Whether `pod install` is needed. `src-tauri/gen/apple/Podfile` is committed and `macos-latest` ships CocoaPods, but if the build cannot find the workspace, a `pod install` step goes in before it.

Adding a job does not affect the required-check list in the ruleset; `Build / iOS` reports as a new, non-required context until it is added there deliberately.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
