### PR TITLE
fix(i18n): normalize English spelling and the ellipsis character

### DIFF
--- a/src/components/canvas/CanvasEditor.menu.test.tsx
+++ b/src/components/canvas/CanvasEditor.menu.test.tsx
@@ -19,7 +19,7 @@ describe("CanvasEditor context menu", () => {
     const onChange = vi.fn();
     const { container } = render(<CanvasEditor content={oneText} onChange={onChange} />);
     fireEvent.contextMenu(nodesOf(container)[0]);
-    fireEvent.click(screen.getByText("Colour"));
+    fireEvent.click(screen.getByText("Color"));
     fireEvent.click(screen.getByText("Yellow"));
     expect(lastData(onChange).nodes[0]).toMatchObject({ color: "3" });
   });

--- a/src/components/canvas/CanvasEditor.test.tsx
+++ b/src/components/canvas/CanvasEditor.test.tsx
@@ -67,7 +67,7 @@ describe("CanvasEditor board operations", () => {
     const node = nodesOf(container)[0];
     fireEvent.pointerDown(node, { clientX: 0, clientY: 0, button: 0 });
     fireEvent.pointerUp(stageOf(container), { clientX: 0, clientY: 0 });
-    fireEvent.click(screen.getByLabelText("Colour 3"));
+    fireEvent.click(screen.getByLabelText("Color 3"));
     expect(lastData(onChange).nodes[0]).toMatchObject({ color: "3" });
   });
 
@@ -103,7 +103,7 @@ describe("CanvasEditor board operations", () => {
     const { container } = render(<CanvasEditor content={withEdge} onChange={onChange} />);
     fireEvent.pointerDown(container.querySelector(".glyph-canvas-edge-hit") as Element);
     // Toolbar is shown for the selected edge; clicking a swatch is a no-op.
-    fireEvent.click(screen.getByLabelText("Colour 1"));
+    fireEvent.click(screen.getByLabelText("Color 1"));
     expect(onChange).not.toHaveBeenCalled();
   });
 

--- a/src/components/canvas/CanvasSelectionToolbar.test.tsx
+++ b/src/components/canvas/CanvasSelectionToolbar.test.tsx
@@ -16,14 +16,14 @@ describe("CanvasSelectionToolbar", () => {
   it("sets a preset colour when a preset swatch is clicked", () => {
     const onSetColor = vi.fn();
     render(<CanvasSelectionToolbar count={1} onSetColor={onSetColor} onDelete={vi.fn()} />);
-    fireEvent.click(screen.getByLabelText("Colour 3"));
+    fireEvent.click(screen.getByLabelText("Color 3"));
     expect(onSetColor).toHaveBeenCalledWith("3");
   });
 
   it("commits a custom colour when the picker's change event fires", () => {
     const onSetColor = vi.fn();
     render(<CanvasSelectionToolbar count={1} onSetColor={onSetColor} onDelete={vi.fn()} />);
-    const picker = screen.getByLabelText("Custom colour") as HTMLInputElement;
+    const picker = screen.getByLabelText("Custom color") as HTMLInputElement;
     fireEvent.change(picker, { target: { value: "#123456" } });
     expect(onSetColor).toHaveBeenCalledWith("#123456");
   });

--- a/src/components/canvas/canvasMenuItems.test.ts
+++ b/src/components/canvas/canvasMenuItems.test.ts
@@ -37,7 +37,7 @@ describe("buildCanvasMenuItems", () => {
   it("offers edit, colour, and delete for a text node", () => {
     const actions = makeActions();
     const items = buildCanvasMenuItems({ kind: "node", node: textNode }, actions, t);
-    expect(labels(items)).toEqual(["Edit text", "Colour", "—", "Delete"]);
+    expect(labels(items)).toEqual(["Edit text", "Color", "—", "Delete"]);
     (items[0] as ContextMenuActionItem).onSelect();
     expect(actions.startEdit).toHaveBeenCalledWith("a");
     (items[3] as ContextMenuActionItem).onSelect();
@@ -64,7 +64,7 @@ describe("buildCanvasMenuItems", () => {
       "Edit URL",
     );
     expect(labels(buildCanvasMenuItems({ kind: "node", node: file }, actions, t))).toEqual([
-      "Colour",
+      "Color",
       "—",
       "Delete",
     ]);
@@ -83,7 +83,7 @@ describe("buildCanvasMenuItems", () => {
       "Green",
       "Cyan",
       "Purple",
-      "Clear colour",
+      "Clear color",
     ]);
     colour.items[2].onSelect();
     expect(actions.setNodeColor).toHaveBeenCalledWith("a", "3");

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -64,7 +64,7 @@
     },
     "codeFont": {
       "label": "Code-Schrift",
-      "placeholder": "Standard (SF Mono, Fira Code...)"
+      "placeholder": "Standard (SF Mono, Fira Code…)"
     },
     "codeTheme": {
       "label": "Code-Theme",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -82,7 +82,7 @@
     "dismiss": "Dismiss workspace notice"
   },
   "search": {
-    "placeholder": "Find in document...",
+    "placeholder": "Find in document…",
     "label": "Search",
     "noResults": "No results",
     "matchCount": "{{current}} of {{total}}",
@@ -140,8 +140,8 @@
     "editUrl": "Edit URL",
     "editEdgeLabel": "Edit label",
     "deleteConnection": "Delete connection",
-    "clearColor": "Clear colour",
-    "color": "Colour",
+    "clearColor": "Clear color",
+    "color": "Color",
     "delete": "Delete",
     "colorRed": "Red",
     "colorOrange": "Orange",
@@ -221,9 +221,9 @@
   },
   "canvasSelection": {
     "toolbar": "Selection",
-    "clearColor": "Clear colour",
-    "colorLabel": "Colour {{color}}",
-    "customColor": "Custom colour",
+    "clearColor": "Clear color",
+    "colorLabel": "Color {{color}}",
+    "customColor": "Custom color",
     "delete": "Delete",
     "deleteCount": "Delete ({{count}})"
   },
@@ -241,7 +241,7 @@
   },
   "graph": {
     "label": "Workspace graph",
-    "reset": "Re-centre and fit the graph",
+    "reset": "Re-center and fit the graph",
     "resetView": "Reset view",
     "emptyState": "No notes to graph yet. Add markdown files to this workspace."
   },
@@ -260,14 +260,14 @@
   },
   "embed": {
     "openSource": "Open embedded note",
-    "loading": "Loading embed...",
+    "loading": "Loading embed…",
     "broken": "Embedded note not found: {{target}}",
     "circular": "Circular embed: {{target}}",
     "headingNotFound": "Heading not found: {{heading}}",
     "error": "Could not load embed: {{target}}"
   },
   "wikilinkPreview": {
-    "loading": "Loading preview...",
+    "loading": "Loading preview…",
     "notFound": "Note not found: {{target}}",
     "createNote": "Create note",
     "headingNotFound": "Heading not found: {{heading}}",

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -64,7 +64,7 @@
     },
     "codeFont": {
       "label": "Code Font",
-      "placeholder": "Default (SF Mono, Fira Code...)"
+      "placeholder": "Default (SF Mono, Fira Code…)"
     },
     "codeTheme": {
       "label": "Code Theme",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -82,7 +82,7 @@
     "dismiss": "Descartar aviso del espacio de trabajo"
   },
   "search": {
-    "placeholder": "Buscar en el documento...",
+    "placeholder": "Buscar en el documento…",
     "label": "Buscar",
     "noResults": "Sin resultados",
     "matchCount": "{{current}} de {{total}}",
@@ -257,14 +257,14 @@
   },
   "embed": {
     "openSource": "Abrir nota insertada",
-    "loading": "Cargando inserción...",
+    "loading": "Cargando inserción…",
     "broken": "Nota insertada no encontrada: {{target}}",
     "circular": "Inserción circular: {{target}}",
     "headingNotFound": "Encabezado no encontrado: {{heading}}",
     "error": "No se pudo cargar la inserción: {{target}}"
   },
   "wikilinkPreview": {
-    "loading": "Cargando vista previa...",
+    "loading": "Cargando vista previa…",
     "notFound": "Nota no encontrada: {{target}}",
     "createNote": "Crear nota",
     "headingNotFound": "Encabezado no encontrado: {{heading}}",

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -64,7 +64,7 @@
     },
     "codeFont": {
       "label": "Fuente del código",
-      "placeholder": "Predeterminada (SF Mono, Fira Code...)"
+      "placeholder": "Predeterminada (SF Mono, Fira Code…)"
     },
     "codeTheme": {
       "label": "Tema del código",

--- a/src/locales/fa/common.json
+++ b/src/locales/fa/common.json
@@ -82,7 +82,7 @@
     "dismiss": "بستن اعلان فضای کاری"
   },
   "search": {
-    "placeholder": "جستجو در سند...",
+    "placeholder": "جستجو در سند…",
     "label": "جستجو",
     "noResults": "نتیجه‌ای یافت نشد",
     "matchCount": "{{current}} از {{total}}",

--- a/src/locales/fa/settings.json
+++ b/src/locales/fa/settings.json
@@ -64,7 +64,7 @@
     },
     "codeFont": {
       "label": "فونت کد",
-      "placeholder": "پیش‌فرض (SF Mono، Fira Code...)"
+      "placeholder": "پیش‌فرض (SF Mono، Fira Code…)"
     },
     "codeTheme": {
       "label": "پوسته کد",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -257,7 +257,7 @@
   },
   "embed": {
     "openSource": "打开嵌入的笔记",
-    "loading": "正在加载嵌入内容...",
+    "loading": "正在加载嵌入内容…",
     "broken": "找不到嵌入的笔记：{{target}}",
     "circular": "循环嵌入：{{target}}",
     "headingNotFound": "找不到标题：{{heading}}",

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -64,7 +64,7 @@
     },
     "codeFont": {
       "label": "代码字体",
-      "placeholder": "默认 (SF Mono, Fira Code...)"
+      "placeholder": "默认 (SF Mono, Fira Code…)"
     },
     "codeTheme": {
       "label": "代码主题",


### PR DESCRIPTION
## Summary

Closes #620.

The English bundle is the i18n source of truth, but it mixed British and American spelling and mixed `...` with `…`. Because every other locale was translated from whatever English happened to say at the time, the inconsistency had already spread outward unevenly, which is the part that made it worth fixing rather than tolerating.

While implementing I found two things the issue had wrong, and corrected the issue body to match:

- The issue claimed `de` and `fa` had already normalized all three loading strings. Only `de` had. `fa` still had `search.placeholder` on `...` while its other two strings used `…`, and `zh` had the mirror-image problem on `embed.loading`. So two bundles had adjacent loading strings that disagreed with each other.
- The issue missed `appearance.codeFont.placeholder`, which used `...` in all five bundles. Rather than leave one ASCII ellipsis behind after a change whose whole point is normalizing the ellipsis, this fixes that key too, so no `...` remains anywhere under `src/locales/`.

## Changes

- **en spelling**: six values in `en/common.json` moved to American spelling. `canvasMenu.clearColor`, `canvasMenu.color`, `canvasSelection.clearColor`, `canvasSelection.colorLabel`, `canvasSelection.customColor`, and `graph.reset`. These were the only British spellings in any locale bundle, and they sat directly against "Color Theme" and "Print Backgrounds & Colors" in `en/settings.json`.
- **Ellipsis, all five bundles**: every `...` is now `…`. That covers the three `en/common.json` keys plus `appearance.codeFont.placeholder`, and the corresponding keys in `de`, `es`, `fa`, and `zh`. Nine files, and a grep for `...` under `src/locales/` now returns nothing.
- **Tests**: four canvas test files compared against the old English labels ("Colour", "Clear colour", "Colour 3", "Custom colour"), so those string comparisons move with the bundle.

Deliberately not in this PR: the British spelling used in identifiers, comments, and test titles across `src/components/canvas/`, `src/lib/canvas/`, and `src/lib/graph*` (variables named `colour`, `centre` in the geometry helpers). That is roughly 110 occurrences across 40 files, has no user-visible effect, and mixing a rename that size into a string-normalization diff would bury the part a reviewer actually needs to check. It is noted as out of scope on the issue.

No key is added, renamed, or removed, so `src/locales/localeParity.test.ts` is unaffected.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

None. The diff changes string values in nine locale JSON files and the assertions in four test files that compare against them. No key structure changes, so locale parity is untouched, and no code path reads these values for anything but display.

Worth noting for review: `canvasSelection.colorLabel` and `canvasMenu.color` are read back through `getByLabelText` and `getByText` in the canvas tests, which is exactly why those tests failed until updated. That is the intended coupling, and it caught the change rather than letting it slip through silently.

## Testing

`pnpm typecheck && pnpm check && pnpm test` all pass (3160 tests across 353 files), plus `cargo clippy --all-targets -- -D warnings` clean via the pre-commit hook.

The suite was run before the test updates specifically to let it name the assertions that depended on the old strings, rather than guessing at them. It reported exactly 8 failures across 4 canvas files, all of them string comparisons, and all 8 are green now.

One unrelated flake surfaced during that run: `src/lib/export/site/exportSite.test.ts > inlines mermaid diagrams and restores the app theme afterwards` failed once under full parallel load at 7185ms, then passed in isolation at 227ms and has passed on every subsequent full run. It is a timing flake around the shared theme state, not related to this change, and is not addressed here.

The gates were run on Windows. The boxes below are unchecked because the app itself was not launched and the strings were not eyeballed in the running UI on any platform.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable: text-only change. The affected strings are the canvas colour submenu and selection toolbar, the graph reset tooltip, the in-document search placeholder, two loading placeholders, and the code-font settings placeholder.
