### PR TITLE
feat(ui): fluid interaction foundation with springs, materials, and press states

### DIFF
--- a/docs/motion.md
+++ b/docs/motion.md
@@ -1,0 +1,66 @@
+# Motion, Materials, and Press States
+
+Glyph's interaction foundation (issue #529). Three pieces: an interruptible
+spring layer, translucent materials for floating chrome, and instant press
+feedback. All motion animates only `transform` and `opacity`, and everything
+respects `prefers-reduced-motion` (see the global reset in `src/styles/app.css`)
+and `prefers-reduced-transparency` (fallbacks in `src/styles/motion.css`).
+
+## Springs (`src/lib/spring.ts`)
+
+Springs are parameterized as **response** (seconds, lower = snappier) and
+**damping ratio** (1 = critically damped, no overshoot). `SPRING_DEFAULT`
+(`response 0.3, dampingRatio 1`) fits UI chrome; reserve damping below 1 for
+surfaces the user just flicked. There is no fixed duration anywhere: settle
+time emerges from the parameters, and a spring can be retargeted mid-flight
+without a jump because it always continues from its current value and velocity.
+
+- `stepSpring` / `isSettled`: the pure integrator.
+- `createSpringAnimation`: the rAF driver. `animateTo(target, velocity?)`
+  retargets (the optional velocity is the gesture handoff), `moveTo(value)`
+  hands the value to a drag, `stop()` freezes in place (grabbing a moving
+  surface). Under reduced motion it snaps to the target and settles instantly.
+
+## Presence (`src/hooks/useSpringPresence.ts`)
+
+Mount/unmount with a real exit phase. The hook writes `--presence` (0 closed,
+1 open) on the bound element each frame, and marks the element `inert` while
+exiting so a dismissing surface can't take clicks, keystrokes, focus, or
+screen-reader attention; the surface's CSS maps `--presence` onto
+transform/opacity (see the mappings in `src/styles/motion.css`). Used by the
+command palette and the settings modal. Enter and exit run along the same
+path, and reopening mid-close reverses from wherever the surface currently is.
+
+## The gesture sheet (`src/hooks/useDrawerGesture.ts`)
+
+The compact sidebar drawer is the first momentum surface: springs in on mount,
+tracks a horizontal drag 1:1 (vertical scrolls win via an axis threshold),
+rubberbands past the open edge, and on release projects the momentum
+(`project` in `src/lib/gesture.ts`) to decide open vs dismiss, handing the
+release velocity to the settle spring. Dismissals registered in
+`useSidebarLayout`'s `drawerDismissals` let `closeCompactPanels` (backdrop
+tap, opening a file) play the same exit spring before unmounting.
+
+## Materials
+
+Floating chrome (command palette, modals, sidebar drawer, status bar) sits on
+a translucent layer: `--glyph-material-bg` / `--glyph-material-edge` (theme
+colors in `app.css`) and `--glyph-material-blur` / `--glyph-sidebar-filter`
+(platform vars in `platform.css`), applied in `motion.css`. The inset top
+highlight is the light catching the material's edge. Blur is spent only where
+content actually passes behind the surface: overlays always blur, the docked
+sidebar blurs per platform via `--glyph-sidebar-filter` (macOS vibrancy,
+`none` elsewhere), and the docked status bar takes the tint without a filter.
+`prefers-reduced-transparency` swaps every material for the solid surface
+color; tune a platform's treatment via the vars rather than per component.
+
+## Press states
+
+Feedback lands on pointer-down, never on release:
+
+- Button-like controls compress: the `pressable` class (or the grouped
+  `:active` rules in `motion.css` for stylesheet-styled controls).
+- Rows and list items tint: `active:bg-[var(--color-border)]` next to their
+  hover class, or an accent tint where selection already uses accent.
+
+New interactive controls get one of these on day one.

--- a/src/components/layout/AppModals.test.tsx
+++ b/src/components/layout/AppModals.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AppModals as AppModalsState } from "@/hooks/useAppModals";
+import { restoreRaf, stubRaf } from "@/test/raf";
 import { AppModals } from "./AppModals";
 
 vi.mock("@/components/modals/settings/lazySettings", () => ({
@@ -49,5 +50,21 @@ describe("AppModals", () => {
     for (const other of CASES.filter((c) => c.flag !== flag)) {
       expect(screen.queryByText(other.text)).not.toBeInTheDocument();
     }
+  });
+
+  describe("settings exit spring", () => {
+    afterEach(restoreRaf);
+
+    it("keeps settings mounted while the close spring runs, then unmounts", () => {
+      const raf = stubRaf();
+      const { rerender } = render(<AppModals modals={state("settingsOpen")} />);
+      act(() => raf.settle());
+
+      rerender(<AppModals modals={state()} />);
+      expect(screen.getByText("settings modal")).toBeInTheDocument();
+
+      act(() => raf.settle());
+      expect(screen.queryByText("settings modal")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/layout/AppModals.tsx
+++ b/src/components/layout/AppModals.tsx
@@ -2,13 +2,21 @@ import { SettingsModal } from "@/components/modals/settings/lazySettings";
 import { WorkspaceSettingsModal } from "@/components/modals/workspace/WorkspaceSettingsModal";
 import { PluginsModal } from "@/components/plugins/PluginsModal";
 import type { AppModals as AppModalsState } from "@/hooks/useAppModals";
+import { useSpringPresence } from "@/hooks/useSpringPresence";
 
 /** The shell's overlay modals. Each is mounted only while open so its chunk
- *  loads on first use rather than at startup. */
+ *  loads on first use rather than at startup. Settings opens and closes on a
+ *  spring: the display-contents wrapper carries `--presence` (inherited by
+ *  the overlay) and `data-spring` opts its CSS out of the keyframe path. */
 export function AppModals({ modals }: { modals: AppModalsState }) {
+  const settings = useSpringPresence(modals.settingsOpen);
   return (
     <>
-      {modals.settingsOpen && <SettingsModal open onClose={modals.closeSettings} />}
+      {settings.mounted && (
+        <div className="contents" data-spring ref={settings.ref}>
+          <SettingsModal open onClose={modals.closeSettings} />
+        </div>
+      )}
       {modals.workspaceSettingsTab && (
         <WorkspaceSettingsModal
           open

--- a/src/components/layout/BacklinksSection.tsx
+++ b/src/components/layout/BacklinksSection.tsx
@@ -38,7 +38,7 @@ export function BacklinksSection({ backlinks, workspaceRoot, onOpen }: Backlinks
               <button
                 type="button"
                 onClick={() => onOpen(b.source, b.line)}
-                className="block w-full text-start text-sm px-2 py-1 rounded-[var(--glyph-radius-sm)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] hover:text-[var(--color-text-primary)] transition-colors"
+                className="block w-full text-start text-sm px-2 py-1 rounded-[var(--glyph-radius-sm)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] active:bg-[var(--color-border)] hover:text-[var(--color-text-primary)] transition-colors"
                 title={`${b.source}:${b.line}`}
               >
                 <div className="truncate font-medium">

--- a/src/components/layout/EdgeExpand.tsx
+++ b/src/components/layout/EdgeExpand.tsx
@@ -25,7 +25,7 @@ export function EdgeExpand({ side, onClick, title, panel }: EdgeExpandProps) {
       onClick={onClick}
       title={title}
       aria-label={title}
-      className={`shrink-0 w-7 flex items-center justify-center ${borderClass} border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-tertiary)] transition-colors cursor-pointer`}
+      className={`shrink-0 w-7 flex items-center justify-center ${borderClass} border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-tertiary)] active:bg-[var(--color-border)] transition-colors cursor-pointer`}
       style={{ background: "var(--color-surface-secondary)" }}
     >
       <Icon />

--- a/src/components/layout/EmptyState.tsx
+++ b/src/components/layout/EmptyState.tsx
@@ -59,14 +59,14 @@ export function EmptyState({
           <button
             type="button"
             onClick={onNewNote}
-            className="px-4 py-2 text-sm font-medium text-white bg-[var(--color-accent)] hover:bg-[var(--color-accent-hover)] rounded-[var(--glyph-radius)] transition-colors"
+            className="pressable px-4 py-2 text-sm font-medium text-white bg-[var(--color-accent)] hover:bg-[var(--color-accent-hover)] rounded-[var(--glyph-radius)] transition-colors"
           >
             {t("emptyState.newNote")}
           </button>
           <button
             type="button"
             onClick={onNewCanvas}
-            className="px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] bg-[var(--color-surface-secondary)] hover:bg-[var(--color-surface-tertiary)] border border-[var(--color-border)] rounded-[var(--glyph-radius)] transition-colors"
+            className="pressable px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] bg-[var(--color-surface-secondary)] hover:bg-[var(--color-surface-tertiary)] border border-[var(--color-border)] rounded-[var(--glyph-radius)] transition-colors"
           >
             {t("emptyState.newCanvas")}
           </button>
@@ -77,14 +77,14 @@ export function EmptyState({
           <button
             type="button"
             onClick={onNewDocument}
-            className="px-4 py-2 text-sm font-medium text-white bg-[var(--color-accent)] hover:bg-[var(--color-accent-hover)] rounded-[var(--glyph-radius)] transition-colors"
+            className="pressable px-4 py-2 text-sm font-medium text-white bg-[var(--color-accent)] hover:bg-[var(--color-accent-hover)] rounded-[var(--glyph-radius)] transition-colors"
           >
             {t("emptyState.newDocument")}
           </button>
           <button
             type="button"
             onClick={onOpenFile}
-            className="px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] bg-[var(--color-surface-secondary)] hover:bg-[var(--color-surface-tertiary)] border border-[var(--color-border)] rounded-[var(--glyph-radius)] transition-colors"
+            className="pressable px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] bg-[var(--color-surface-secondary)] hover:bg-[var(--color-surface-tertiary)] border border-[var(--color-border)] rounded-[var(--glyph-radius)] transition-colors"
           >
             {t("emptyState.openFile")}
           </button>
@@ -93,14 +93,14 @@ export function EmptyState({
             <button
               type="button"
               onClick={onOpenFolder}
-              className="px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] bg-[var(--color-surface-secondary)] hover:bg-[var(--color-surface-tertiary)] border border-[var(--color-border)] rounded-[var(--glyph-radius)] transition-colors"
+              className="pressable px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] bg-[var(--color-surface-secondary)] hover:bg-[var(--color-surface-tertiary)] border border-[var(--color-border)] rounded-[var(--glyph-radius)] transition-colors"
             >
               {t("emptyState.openFolder")}
             </button>
             <button
               type="button"
               onClick={onNewWorkspace}
-              className="px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] bg-[var(--color-surface-secondary)] hover:bg-[var(--color-surface-tertiary)] border border-[var(--color-border)] rounded-[var(--glyph-radius)] transition-colors"
+              className="pressable px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] bg-[var(--color-surface-secondary)] hover:bg-[var(--color-surface-tertiary)] border border-[var(--color-border)] rounded-[var(--glyph-radius)] transition-colors"
             >
               {t("emptyState.newWorkspace")}
             </button>

--- a/src/components/layout/FileTreeEntry.tsx
+++ b/src/components/layout/FileTreeEntry.tsx
@@ -69,7 +69,7 @@ export function FileTreeEntry(props: FileTreeEntryProps) {
           type="button"
           onClick={() => onToggle(entry.path)}
           onContextMenu={(e) => props.onContextMenu(e, entry)}
-          className="w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] flex items-center gap-1.5"
+          className="w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] active:bg-[var(--color-border)] flex items-center gap-1.5"
           style={indentStyle}
           title={entry.path}
         >
@@ -102,7 +102,7 @@ export function FileTreeEntry(props: FileTreeEntryProps) {
         className={`w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors flex items-center gap-1.5 ${
           isActive
             ? "bg-[var(--color-accent)] text-white font-medium"
-            : "text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)]"
+            : "text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] active:bg-[var(--color-border)]"
         }`}
         style={indentStyle}
         title={entry.path}

--- a/src/components/layout/OutlineSection.tsx
+++ b/src/components/layout/OutlineSection.tsx
@@ -21,7 +21,7 @@ export function OutlineSection({ entries, activeId }: { entries: TocEntry[]; act
             className={`outline-item w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors ${
               activeId === entry.id
                 ? "bg-[var(--color-accent)] text-white font-medium"
-                : "text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)]"
+                : "text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] active:bg-[var(--color-border)]"
             }`}
             style={{ paddingLeft: `${(entry.level - 1) * 12 + 8}px` }}
             title={entry.text}

--- a/src/components/layout/PanelHeader.tsx
+++ b/src/components/layout/PanelHeader.tsx
@@ -27,7 +27,7 @@ export function PanelHeader({ label, side, onCollapse, collapseTitle, actions }:
         <button
           type="button"
           onClick={onCollapse}
-          className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] p-0.5 rounded-[var(--glyph-radius-sm)] hover:bg-[var(--color-surface-tertiary)] transition-colors"
+          className="pressable text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] p-0.5 rounded-[var(--glyph-radius-sm)] hover:bg-[var(--color-surface-tertiary)] transition-colors"
           title={collapseTitle}
           aria-label={collapseTitle}
         >

--- a/src/components/layout/ResizeHandle.tsx
+++ b/src/components/layout/ResizeHandle.tsx
@@ -29,6 +29,7 @@ export function ResizeHandle({
   const cursor = axis === "x" ? "cursor-col-resize h-auto" : "cursor-row-resize";
   return (
     <hr
+      data-resize-handle
       tabIndex={0}
       aria-orientation={axis === "x" ? "vertical" : "horizontal"}
       aria-label={label}

--- a/src/components/layout/SidebarDrawerBackdrop.tsx
+++ b/src/components/layout/SidebarDrawerBackdrop.tsx
@@ -14,7 +14,7 @@ export function SidebarDrawerBackdrop() {
     <button
       type="button"
       aria-label={t("sidebar.closeDrawer")}
-      className="absolute inset-0 z-10 bg-black/40"
+      className="sidebar-drawer-backdrop absolute inset-0 z-10 bg-black/40"
       onClick={closeCompactPanels}
     />
   );

--- a/src/components/layout/SidebarPanel.tsx
+++ b/src/components/layout/SidebarPanel.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from "react-i18next";
 import { useSidebarLayoutContext } from "@/contexts/SidebarLayoutContext";
+import { useDrawerGesture } from "@/hooks/useDrawerGesture";
 import { usePanelResize } from "@/hooks/usePanelResize";
+import { drawerPhysicalEdge } from "@/lib/gesture";
 import { SIDEBAR_WIDTH_DEFAULT, SIDEBAR_WIDTH_MAX, SIDEBAR_WIDTH_MIN } from "@/lib/settings";
 import { ResizeHandle } from "./ResizeHandle";
 
@@ -20,7 +22,7 @@ export function SidebarPanel({
   children: React.ReactNode;
 }) {
   const { t } = useTranslation("common");
-  const { compact } = useSidebarLayoutContext();
+  const { compact, closeCompactPanels, drawerDismissals } = useSidebarLayoutContext();
   const { size, handleProps } = usePanelResize({
     size: width,
     min: SIDEBAR_WIDTH_MIN,
@@ -32,19 +34,31 @@ export function SidebarPanel({
     onCommit: onWidthCommit,
     onReset: () => onWidthCommit(SIDEBAR_WIDTH_DEFAULT),
   });
+  // Same LTR/RTL resolution as `direction`, for the drawer's travel axis.
+  const physicalEdge = drawerPhysicalEdge(side, document.documentElement.dir === "rtl");
+  const drawer = useDrawerGesture({
+    enabled: compact,
+    edge: physicalEdge,
+    dismissals: drawerDismissals,
+    close: closeCompactPanels,
+  });
   const borderClass = side === "left" ? "border-e" : "border-s";
   // Compact (phone): the panel is a drawer overlaying the document, absolutely
   // positioned against its edge and capped so it never covers the whole screen,
-  // rather than a flex column that squeezes the content into a sliver.
+  // rather than a flex column that squeezes the content into a sliver. It is
+  // also a gesture sheet: springs in, drags 1:1, flicks shut.
   const layoutClass = compact
-    ? `absolute inset-y-0 ${side === "left" ? "start-0" : "end-0"} z-20 max-w-[85%] shadow-xl`
+    ? `sidebar-drawer absolute inset-y-0 ${side === "left" ? "start-0" : "end-0"} z-20 max-w-[85%] shadow-xl`
     : "relative shrink-0";
   return (
     <nav
+      ref={drawer.ref}
       data-print-hide="true"
       data-sidebar={side}
-      className={`${layoutClass} flex ${borderClass} border-[var(--color-border)] select-none`}
-      style={{ width: size, background: "var(--glyph-sidebar-bg)" }}
+      data-drawer-edge={compact ? physicalEdge : undefined}
+      className={`sidebar-panel ${layoutClass} flex ${borderClass} border-[var(--color-border)] select-none`}
+      style={{ width: size }}
+      {...(compact ? drawer.handlers : {})}
     >
       <div className="flex-1 min-w-0 flex flex-col overflow-y-auto pt-3">{children}</div>
       <ResizeHandle

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -39,7 +39,7 @@ export function StatusBar({ onOpenSync }: StatusBarProps) {
   return (
     <div
       data-print-hide="true"
-      className="status-bar flex items-center gap-4 px-4 min-h-7 border-t border-[var(--color-border)] bg-[var(--color-surface-secondary)] text-xs text-[var(--color-text-secondary)] select-none shrink-0"
+      className="status-bar flex items-center gap-4 px-4 min-h-7 border-t border-[var(--color-border)] text-xs text-[var(--color-text-secondary)] select-none shrink-0"
     >
       {filePath && (
         // Hidden on mobile (see platform.css): the path there is an opaque

--- a/src/components/layout/TagFileList.tsx
+++ b/src/components/layout/TagFileList.tsx
@@ -44,7 +44,7 @@ export function TagFileList({
               className={`w-full text-start text-sm px-2 py-1 rounded-[var(--glyph-radius-sm)] truncate transition-colors ${
                 activeFilePath === path
                   ? "bg-[var(--color-accent)] text-white font-medium"
-                  : "text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)]"
+                  : "text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] active:bg-[var(--color-border)]"
               }`}
               title={path}
             >

--- a/src/components/layout/ToolbarButton.tsx
+++ b/src/components/layout/ToolbarButton.tsx
@@ -20,7 +20,7 @@ export function ToolbarButton({
     <button
       type="button"
       onClick={onClick}
-      className={`p-0.5 rounded-[var(--glyph-radius-sm)] hover:bg-[var(--color-surface-tertiary)] transition-colors ${tone}`}
+      className={`pressable p-0.5 rounded-[var(--glyph-radius-sm)] hover:bg-[var(--color-surface-tertiary)] transition-colors ${tone}`}
       title={title}
       aria-label={title}
       aria-pressed={pressed}

--- a/src/components/menu/contextMenuStyles.ts
+++ b/src/components/menu/contextMenuStyles.ts
@@ -12,4 +12,4 @@ export const SURFACE_CLASS =
 
 // A single menu row (action button or submenu trigger).
 export const ITEM_CLASS =
-  "flex w-full items-center justify-between gap-6 rounded-[var(--glyph-radius-sm)] px-2.5 py-1.5 text-left transition-colors hover:bg-[color-mix(in_srgb,var(--color-accent)_16%,transparent)] focus:bg-[color-mix(in_srgb,var(--color-accent)_16%,transparent)] focus:outline-none";
+  "flex w-full items-center justify-between gap-6 rounded-[var(--glyph-radius-sm)] px-2.5 py-1.5 text-left transition-colors hover:bg-[color-mix(in_srgb,var(--color-accent)_16%,transparent)] focus:bg-[color-mix(in_srgb,var(--color-accent)_16%,transparent)] active:bg-[color-mix(in_srgb,var(--color-accent)_26%,transparent)] focus:outline-none";

--- a/src/components/modals/CommandPalette.test.tsx
+++ b/src/components/modals/CommandPalette.test.tsx
@@ -307,6 +307,7 @@ describe("CommandPalette", () => {
       rerender(<CommandPalette {...props} open={false} />);
       const input = screen.getByLabelText("Command palette query");
       fireEvent.keyDown(input, { key: "Enter" });
+      fireEvent.click(screen.getByText("Xx"));
       expect(run).not.toHaveBeenCalled();
       fireEvent.keyDown(input, { key: "Escape" });
       expect(onClose).not.toHaveBeenCalled();

--- a/src/components/modals/CommandPalette.test.tsx
+++ b/src/components/modals/CommandPalette.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import type { Command } from "@/lib/commands";
 import { buildMetadataIndex } from "@/lib/metadata";
+import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
+import { restoreRaf, stubRaf } from "@/test/raf";
 import { CommandPalette } from "./CommandPalette";
 
 function cmd(over: Partial<Command>): Command {
@@ -244,6 +246,79 @@ describe("CommandPalette", () => {
   it("focuses the input when opened", () => {
     renderPalette({});
     expect(document.activeElement).toBe(screen.getByLabelText("Command palette query"));
+  });
+
+  describe("spring presence", () => {
+    afterEach(() => {
+      restoreRaf();
+      restoreMatchMedia();
+    });
+
+    const paletteProps = {
+      query: "",
+      commands: [],
+      onQueryChange: vi.fn(),
+      onClose: vi.fn(),
+    };
+
+    it("stays mounted while the close spring runs, then unmounts", () => {
+      const raf = stubRaf();
+      const { container, rerender } = render(<CommandPalette {...paletteProps} open />);
+      act(() => raf.settle());
+
+      rerender(<CommandPalette {...paletteProps} open={false} />);
+      const overlay = container.querySelector(".command-palette-overlay");
+      expect(overlay).toBeInTheDocument();
+      // Ghost input is inert while closing.
+      expect(overlay?.hasAttribute("inert")).toBe(true);
+
+      act(() => raf.settle());
+      expect(container.querySelector(".command-palette-overlay")).not.toBeInTheDocument();
+    });
+
+    it("reopening mid-close keeps the same node and reverses", () => {
+      const raf = stubRaf();
+      const { container, rerender } = render(<CommandPalette {...paletteProps} open />);
+      act(() => raf.settle());
+
+      rerender(<CommandPalette {...paletteProps} open={false} />);
+      act(() => raf.frame());
+      const overlay = container.querySelector(".command-palette-overlay") as HTMLElement;
+
+      rerender(<CommandPalette {...paletteProps} open />);
+      expect(container.querySelector(".command-palette-overlay")).toBe(overlay);
+      expect(overlay.hasAttribute("inert")).toBe(false);
+      act(() => raf.settle());
+      expect(overlay.style.getPropertyValue("--presence")).toBe("1");
+    });
+
+    it("does not run commands from a closing palette", () => {
+      const raf = stubRaf();
+      const run = vi.fn();
+      const onClose = vi.fn();
+      const props = {
+        ...paletteProps,
+        commands: [cmd({ id: "x", title: "Xx", run })],
+        onClose,
+      };
+      const { rerender } = render(<CommandPalette {...props} open />);
+      act(() => raf.settle());
+
+      rerender(<CommandPalette {...props} open={false} />);
+      const input = screen.getByLabelText("Command palette query");
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(run).not.toHaveBeenCalled();
+      fireEvent.keyDown(input, { key: "Escape" });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("closes instantly under reduced motion", () => {
+      stubRaf();
+      stubMatchMedia(true);
+      const { container, rerender } = render(<CommandPalette {...paletteProps} open />);
+      rerender(<CommandPalette {...paletteProps} open={false} />);
+      expect(container.querySelector(".command-palette-overlay")).not.toBeInTheDocument();
+    });
   });
 
   it("narrows Files rows to a tag query using the workspace metadata", () => {

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -1,6 +1,7 @@
 import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMetadataIndex } from "@/contexts/TabsContext";
+import { useSpringPresence } from "@/hooks/useSpringPresence";
 import { type Command, type CommandSection, rankCommands } from "@/lib/commands";
 import { CommandPaletteItem } from "./CommandPaletteItem";
 
@@ -40,12 +41,17 @@ export function CommandPalette({
     setSelectedIndex(0);
   }, [ranked]);
 
-  // Focus the input whenever the palette opens.
-  useEffect(() => {
-    if (open) inputRef.current?.focus();
-  }, [open]);
+  // Spring open/close: stays mounted while the exit spring runs, and
+  // reopening mid-close reverses from wherever it is.
+  const presence = useSpringPresence(open);
 
-  if (!open) return null;
+  // Focus the input whenever the palette opens (the element only exists once
+  // presence has mounted it).
+  useEffect(() => {
+    if (open && presence.mounted) inputRef.current?.focus();
+  }, [open, presence.mounted]);
+
+  if (!presence.mounted) return null;
 
   const runAtIndex = (index: number) => {
     const hit = ranked[index];
@@ -54,7 +60,11 @@ export function CommandPalette({
     hit.command.run();
   };
 
+  // While the exit spring runs the palette is still mounted; `inert` covers
+  // real browsers, but the guards keep a key repeat from re-running a command
+  // in environments that don't enforce it.
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (!open) return;
     if (event.key === "Escape") {
       event.preventDefault();
       event.stopPropagation();
@@ -78,6 +88,7 @@ export function CommandPalette({
   };
 
   const handleOverlayKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!open) return;
     if (event.key === "Escape") {
       event.preventDefault();
       onClose();
@@ -94,9 +105,10 @@ export function CommandPalette({
 
   return (
     <div
+      ref={presence.ref}
       className="command-palette-overlay"
       onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+        if (open && e.target === e.currentTarget) onClose();
       }}
       onKeyDown={handleOverlayKeyDown}
       role="dialog"

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -54,6 +54,7 @@ export function CommandPalette({
   if (!presence.mounted) return null;
 
   const runAtIndex = (index: number) => {
+    if (!open) return;
     const hit = ranked[index];
     if (!hit) return;
     onClose();

--- a/src/hooks/useDrawerGesture.test.tsx
+++ b/src/hooks/useDrawerGesture.test.tsx
@@ -1,0 +1,233 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { restoreRaf, stubRaf } from "@/test/raf";
+import { useDrawerGesture } from "./useDrawerGesture";
+
+type Dismissals = Set<(onDone: () => void) => void>;
+
+function Harness({
+  enabled,
+  dismissals,
+  close,
+}: {
+  enabled: boolean;
+  dismissals: Dismissals;
+  close: () => void;
+}) {
+  const drawer = useDrawerGesture({ enabled, edge: "left", dismissals, close });
+  return (
+    <div data-testid="parent">
+      <nav data-testid="drawer" ref={drawer.ref} {...drawer.handlers}>
+        <button type="button" data-testid="row" onClick={rowClick}>
+          row
+        </button>
+        <hr data-testid="resize" />
+      </nav>
+    </div>
+  );
+}
+
+const rowClick = vi.fn();
+
+function setup(enabled = true) {
+  const raf = stubRaf();
+  const dismissals: Dismissals = new Set();
+  const settled = vi.fn();
+  // Mimics useSidebarLayout.closeCompactPanels: run the registered dismissals.
+  const close = vi.fn(() => {
+    for (const dismiss of [...dismissals]) dismiss(settled);
+  });
+  const view = render(<Harness enabled={enabled} dismissals={dismissals} close={close} />);
+  const drawer = screen.getByTestId("drawer");
+  Object.defineProperty(drawer, "offsetWidth", { value: 300, configurable: true });
+  return { raf, dismissals, settled, close, drawer, view };
+}
+
+const presence = (el: HTMLElement) => el.style.getPropertyValue("--presence");
+
+function drag(drawer: HTMLElement, from: number, to: number) {
+  fireEvent.pointerDown(drawer, { button: 0, pointerId: 1, clientX: from, clientY: 100 });
+  // First move only engages (crosses the threshold); the second one tracks.
+  fireEvent.pointerMove(drawer, { pointerId: 1, clientX: from - 20, clientY: 100 });
+  fireEvent.pointerMove(drawer, { pointerId: 1, clientX: to, clientY: 100 });
+}
+
+afterEach(() => {
+  restoreRaf();
+  rowClick.mockClear();
+});
+
+describe("useDrawerGesture", () => {
+  it("springs in from the edge on mount and mirrors presence per edge on the parent", () => {
+    const { raf, drawer } = setup();
+    expect(presence(drawer)).toBe("0");
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("1");
+    expect(screen.getByTestId("parent").style.getPropertyValue("--presence-left")).toBe("1");
+  });
+
+  it("does nothing when disabled (desktop sidebar)", () => {
+    const { raf, drawer, dismissals } = setup(false);
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("");
+    expect(dismissals.size).toBe(0);
+    fireEvent.pointerDown(drawer, { button: 0, pointerId: 1, clientX: 250, clientY: 100 });
+    fireEvent.pointerUp(drawer, { pointerId: 1, clientX: 250, clientY: 100 });
+    expect(presence(drawer)).toBe("");
+  });
+
+  it("a tap leaves the drawer open and the row click through", () => {
+    const { raf, drawer, close } = setup();
+    act(() => raf.settle());
+    fireEvent.pointerDown(drawer, { button: 0, pointerId: 1, clientX: 250, clientY: 100 });
+    fireEvent.pointerUp(drawer, { pointerId: 1, clientX: 250, clientY: 100 });
+    fireEvent.click(screen.getByTestId("row"));
+    expect(rowClick).toHaveBeenCalledOnce();
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("1");
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("tracks a horizontal drag 1:1 and dismisses when released near the edge", () => {
+    const { raf, drawer, close, settled } = setup();
+    act(() => raf.settle());
+
+    drag(drawer, 250, 40);
+    // Baselined at the engage point (230): 1 + (40 - 230) / 300.
+    expect(Number(presence(drawer))).toBeCloseTo(0.367, 2);
+
+    fireEvent.pointerUp(drawer, { pointerId: 1, clientX: 40, clientY: 100 });
+    expect(close).toHaveBeenCalledOnce();
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("0");
+    expect(settled).toHaveBeenCalledOnce();
+  });
+
+  it("swallows the trailing click after a real drag", () => {
+    const { raf, drawer } = setup();
+    act(() => raf.settle());
+    drag(drawer, 250, 200);
+    fireEvent.pointerUp(drawer, { pointerId: 1, clientX: 200, clientY: 100 });
+    fireEvent.click(screen.getByTestId("row"));
+    expect(rowClick).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("row"));
+    expect(rowClick).toHaveBeenCalledOnce();
+  });
+
+  it("springs back open when released past the midpoint", () => {
+    const { raf, drawer, close } = setup();
+    act(() => raf.settle());
+
+    drag(drawer, 250, 200);
+    fireEvent.pointerUp(drawer, { pointerId: 1, clientX: 200, clientY: 100 });
+    expect(close).not.toHaveBeenCalled();
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("1");
+  });
+
+  it("ignores secondary buttons, the resize handle, and never drags below closed", () => {
+    const { raf, drawer } = setup();
+    act(() => raf.settle());
+
+    // Right-click starts no drag.
+    fireEvent.pointerDown(drawer, { button: 2, pointerId: 3, clientX: 250, clientY: 100 });
+    fireEvent.pointerMove(drawer, { pointerId: 3, clientX: 100, clientY: 100 });
+    expect(presence(drawer)).toBe("1");
+
+    // The resize handle's hr owns its own drag.
+    fireEvent.pointerDown(screen.getByTestId("resize"), {
+      button: 0,
+      pointerId: 4,
+      clientX: 250,
+      clientY: 100,
+    });
+    fireEvent.pointerMove(drawer, { pointerId: 4, clientX: 100, clientY: 100 });
+    expect(presence(drawer)).toBe("1");
+
+    // Dragging far past closed clamps at 0 instead of going negative.
+    drag(drawer, 250, -400);
+    expect(presence(drawer)).toBe("0");
+  });
+
+  it("rubberbands instead of following past the open edge", () => {
+    const { raf, drawer } = setup();
+    act(() => raf.settle());
+
+    drag(drawer, 250, 400);
+    const over = Number(presence(drawer));
+    expect(over).toBeGreaterThan(1);
+    expect(over).toBeLessThan(1.5);
+  });
+
+  it("cedes to a vertical scroll and puts the drawer back", () => {
+    const { raf, drawer, close } = setup();
+    act(() => raf.settle());
+
+    fireEvent.pointerDown(drawer, { button: 0, pointerId: 1, clientX: 250, clientY: 100 });
+    fireEvent.pointerMove(drawer, { pointerId: 1, clientX: 252, clientY: 160 });
+    fireEvent.pointerMove(drawer, { pointerId: 1, clientX: 100, clientY: 300 });
+    expect(presence(drawer)).toBe("1");
+    fireEvent.pointerUp(drawer, { pointerId: 1, clientX: 100, clientY: 300 });
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("1");
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("a grab mid-close freezes the sheet where it is", () => {
+    const { raf, drawer, close } = setup();
+    act(() => raf.settle());
+
+    drag(drawer, 250, 40);
+    fireEvent.pointerUp(drawer, { pointerId: 1, clientX: 40, clientY: 100 });
+    expect(close).toHaveBeenCalledOnce();
+    act(() => {
+      raf.frame();
+      raf.frame();
+    });
+    const midway = Number(presence(drawer));
+    expect(midway).toBeGreaterThan(0);
+
+    fireEvent.pointerDown(drawer, { button: 0, pointerId: 2, clientX: 100, clientY: 100 });
+    act(() => raf.frame());
+    expect(Number(presence(drawer))).toBe(midway);
+    fireEvent.pointerUp(drawer, { pointerId: 2, clientX: 100, clientY: 100 });
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("1");
+  });
+
+  it("pointer cancel restores the open position and does not eat the next tap", () => {
+    const { raf, drawer } = setup();
+    act(() => raf.settle());
+
+    drag(drawer, 250, 150);
+    fireEvent.pointerCancel(drawer, { pointerId: 1 });
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("1");
+
+    fireEvent.click(screen.getByTestId("row"));
+    expect(rowClick).toHaveBeenCalledOnce();
+  });
+
+  it("still settles the layout state when unmounted mid-dismissal", () => {
+    const { raf, drawer, settled, dismissals, close, view } = setup();
+    act(() => raf.settle());
+
+    drag(drawer, 250, 40);
+    fireEvent.pointerUp(drawer, { pointerId: 1, clientX: 40, clientY: 100 });
+    act(() => raf.frame());
+    expect(settled).not.toHaveBeenCalled();
+
+    view.rerender(<Harness enabled={false} dismissals={dismissals} close={close} />);
+    expect(settled).toHaveBeenCalledOnce();
+  });
+
+  it("cleans the parent's --presence up when the drawer leaves compact mode", () => {
+    const { raf, dismissals, close, view } = setup();
+    act(() => raf.settle());
+    expect(screen.getByTestId("parent").style.getPropertyValue("--presence-left")).toBe("1");
+
+    view.rerender(<Harness enabled={false} dismissals={dismissals} close={close} />);
+    expect(screen.getByTestId("parent").style.getPropertyValue("--presence-left")).toBe("");
+    expect(dismissals.size).toBe(0);
+  });
+});

--- a/src/hooks/useDrawerGesture.test.tsx
+++ b/src/hooks/useDrawerGesture.test.tsx
@@ -21,7 +21,7 @@ function Harness({
         <button type="button" data-testid="row" onClick={rowClick}>
           row
         </button>
-        <hr data-testid="resize" />
+        <hr data-resize-handle data-testid="resize" />
       </nav>
     </div>
   );
@@ -48,8 +48,8 @@ const presence = (el: HTMLElement) => el.style.getPropertyValue("--presence");
 function drag(drawer: HTMLElement, from: number, to: number) {
   fireEvent.pointerDown(drawer, { button: 0, pointerId: 1, clientX: from, clientY: 100 });
   // First move only engages (crosses the threshold); the second one tracks.
-  fireEvent.pointerMove(drawer, { pointerId: 1, clientX: from - 20, clientY: 100 });
-  fireEvent.pointerMove(drawer, { pointerId: 1, clientX: to, clientY: 100 });
+  fireEvent.pointerMove(drawer, { pointerId: 1, buttons: 1, clientX: from - 20, clientY: 100 });
+  fireEvent.pointerMove(drawer, { pointerId: 1, buttons: 1, clientX: to, clientY: 100 });
 }
 
 afterEach(() => {
@@ -164,8 +164,8 @@ describe("useDrawerGesture", () => {
     act(() => raf.settle());
 
     fireEvent.pointerDown(drawer, { button: 0, pointerId: 1, clientX: 250, clientY: 100 });
-    fireEvent.pointerMove(drawer, { pointerId: 1, clientX: 252, clientY: 160 });
-    fireEvent.pointerMove(drawer, { pointerId: 1, clientX: 100, clientY: 300 });
+    fireEvent.pointerMove(drawer, { pointerId: 1, buttons: 1, clientX: 252, clientY: 160 });
+    fireEvent.pointerMove(drawer, { pointerId: 1, buttons: 1, clientX: 100, clientY: 300 });
     expect(presence(drawer)).toBe("1");
     fireEvent.pointerUp(drawer, { pointerId: 1, clientX: 100, clientY: 300 });
     act(() => raf.settle());
@@ -193,6 +193,49 @@ describe("useDrawerGesture", () => {
     fireEvent.pointerUp(drawer, { pointerId: 2, clientX: 100, clientY: 100 });
     act(() => raf.settle());
     expect(presence(drawer)).toBe("1");
+  });
+
+  it("a rescued drawer is not closed later by the stale dismissal", () => {
+    const { raf, drawer, close, settled, dismissals, view } = setup();
+    act(() => raf.settle());
+
+    // Backdrop-style dismissal arms the completion, spring heads to 0.
+    act(() => {
+      for (const dismiss of [...dismissals]) dismiss(settled);
+    });
+    act(() => raf.frame());
+
+    // Grab mid-close and drag it back open past the midpoint.
+    fireEvent.pointerDown(drawer, { button: 0, pointerId: 5, clientX: 100, clientY: 100 });
+    fireEvent.pointerMove(drawer, { pointerId: 5, buttons: 1, clientX: 120, clientY: 100 });
+    fireEvent.pointerMove(drawer, { pointerId: 5, buttons: 1, clientX: 280, clientY: 100 });
+    fireEvent.pointerUp(drawer, { pointerId: 5, clientX: 280, clientY: 100 });
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("1");
+    expect(settled).not.toHaveBeenCalled();
+
+    // Leaving compact mode must not fire the disarmed completion either.
+    view.rerender(<Harness enabled={false} dismissals={dismissals} close={close} />);
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it("cancels a mouse drag that was released outside before engaging", () => {
+    const { raf, drawer, close } = setup();
+    act(() => raf.settle());
+
+    // Down, tiny move, release off-element (no pointerup reaches the nav),
+    // then a buttonless hover move: the drag must not resume.
+    fireEvent.pointerDown(drawer, { button: 0, pointerId: 6, clientX: 250, clientY: 100 });
+    fireEvent.pointerMove(drawer, { pointerId: 6, buttons: 1, clientX: 247, clientY: 100 });
+    fireEvent.pointerMove(drawer, { pointerId: 6, buttons: 0, clientX: 60, clientY: 100 });
+    act(() => raf.settle());
+    expect(presence(drawer)).toBe("1");
+
+    fireEvent.pointerMove(drawer, { pointerId: 6, buttons: 0, clientX: 40, clientY: 100 });
+    expect(presence(drawer)).toBe("1");
+    fireEvent.click(screen.getByTestId("row"));
+    expect(rowClick).toHaveBeenCalledOnce();
+    expect(close).not.toHaveBeenCalled();
   });
 
   it("pointer cancel restores the open position and does not eat the next tap", () => {

--- a/src/hooks/useDrawerGesture.test.tsx
+++ b/src/hooks/useDrawerGesture.test.tsx
@@ -243,6 +243,10 @@ describe("useDrawerGesture", () => {
     act(() => raf.settle());
 
     drag(drawer, 250, 150);
+    // A stray pointer's cancel does not end someone else's drag.
+    fireEvent.pointerCancel(drawer, { pointerId: 99 });
+    expect(Number(presence(drawer))).toBeLessThan(1);
+
     fireEvent.pointerCancel(drawer, { pointerId: 1 });
     act(() => raf.settle());
     expect(presence(drawer)).toBe("1");

--- a/src/hooks/useDrawerGesture.ts
+++ b/src/hooks/useDrawerGesture.ts
@@ -1,0 +1,210 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+import {
+  createVelocityTracker,
+  drawerOpenSign,
+  drawerReleaseTarget,
+  rubberband,
+} from "@/lib/gesture";
+import { createSpringAnimation, type SpringAnimation } from "@/lib/spring";
+
+// A drag must move this far before it counts as a drawer gesture (and not a
+// tap or a vertical scroll); the dominant axis then wins.
+const DRAG_THRESHOLD = 8;
+
+interface UseDrawerGestureOptions {
+  /** Only the compact (phone) drawer is a gesture sheet. */
+  enabled: boolean;
+  /** Physical screen edge the drawer clings to, RTL already resolved. */
+  edge: "left" | "right";
+  /** Shared registry from useSidebarLayout; closing animates via these. */
+  dismissals: Set<(onDone: () => void) => void>;
+  /** The animated compact-drawer close (runs the registered dismissals). */
+  close: () => void;
+}
+
+interface DragState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  startValue: number;
+  width: number;
+  engaged: boolean;
+  rejected: boolean;
+}
+
+/**
+ * Makes the compact sidebar drawer a momentum sheet: spring in on mount,
+ * 1:1 horizontal drag with rubberbanding past the open edge, momentum
+ * projection deciding open vs dismiss at release, and the release velocity
+ * handed to the settle spring. The spring writes `--presence` on the drawer
+ * and on its parent (where the sibling backdrop reads it for its fade).
+ */
+export function useDrawerGesture(options: UseDrawerGestureOptions) {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const elRef = useRef<HTMLElement | null>(null);
+  const parentRef = useRef<HTMLElement | null>(null);
+  const springRef = useRef<SpringAnimation | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const trackerRef = useRef(createVelocityTracker());
+  const doneRef = useRef<(() => void) | null>(null);
+  const releaseVelocityRef = useRef<number | null>(null);
+  const draggedRef = useRef(false);
+
+  const ref = useCallback((el: HTMLElement | null) => {
+    elRef.current = el;
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = elRef.current;
+    if (!options.enabled || !el) return;
+    parentRef.current = el.parentElement;
+    // The parent copy is per-edge so two mounted drawers (files left,
+    // outline right) don't fight over one property; the backdrop takes the
+    // max of both.
+    const parentVar = `--presence-${options.edge}`;
+    const spring = createSpringAnimation({
+      initial: 0,
+      onFrame: (value) => {
+        const presence = String(value);
+        elRef.current?.style.setProperty("--presence", presence);
+        parentRef.current?.style.setProperty(parentVar, presence);
+      },
+      onSettle: (target) => {
+        if (target !== 0) return;
+        const done = doneRef.current;
+        doneRef.current = null;
+        done?.();
+      },
+    });
+    springRef.current = spring;
+    el.style.setProperty("--presence", "0");
+    spring.animateTo(1);
+
+    const dismiss = (onDone: () => void) => {
+      doneRef.current = onDone;
+      springRef.current?.animateTo(0, releaseVelocityRef.current ?? undefined);
+      releaseVelocityRef.current = null;
+    };
+    optionsRef.current.dismissals.add(dismiss);
+
+    return () => {
+      optionsRef.current.dismissals.delete(dismiss);
+      springRef.current?.stop();
+      springRef.current = null;
+      // A dismissal interrupted by unmount (e.g. resizing out of compact)
+      // still settles the layout state, or the drawer pops back open later.
+      const done = doneRef.current;
+      doneRef.current = null;
+      done?.();
+      parentRef.current?.style.removeProperty(parentVar);
+      parentRef.current = null;
+    };
+  }, [options.enabled, options.edge]);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLElement>) => {
+    const el = elRef.current;
+    const spring = springRef.current;
+    if (!optionsRef.current.enabled || !el || !spring) return;
+    if (event.button !== 0) return;
+    // The resize handle owns its own drag.
+    if ((event.target as Element).closest("hr")) return;
+    // Grab: freeze wherever the drawer is; a tap resumes on release.
+    spring.stop();
+    draggedRef.current = false;
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startValue: spring.value(),
+      width: el.offsetWidth,
+      engaged: false,
+      rejected: false,
+    };
+    trackerRef.current.reset();
+    trackerRef.current.add(
+      event.clientX * drawerOpenSign(optionsRef.current.edge),
+      event.timeStamp,
+    );
+  }, []);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLElement>) => {
+    const drag = dragRef.current;
+    const spring = springRef.current;
+    if (!drag || drag.rejected || !spring || event.pointerId !== drag.pointerId) return;
+    // Pointer x is mapped so positive always means "toward open".
+    const sign = drawerOpenSign(optionsRef.current.edge);
+    trackerRef.current.add(event.clientX * sign, event.timeStamp);
+    if (!drag.engaged) {
+      const dx = Math.abs(event.clientX - drag.startX);
+      const dy = Math.abs(event.clientY - drag.startY);
+      if (dy > DRAG_THRESHOLD && dy > dx) {
+        drag.rejected = true;
+        return;
+      }
+      if (dx <= DRAG_THRESHOLD || dx <= dy) return;
+      drag.engaged = true;
+      draggedRef.current = true;
+      // Re-baseline at the engage point so the drawer doesn't hop by the
+      // accumulated slop on this first tracked frame.
+      drag.startX = event.clientX;
+      elRef.current?.setPointerCapture?.(event.pointerId);
+    }
+    const raw = drag.startValue + ((event.clientX - drag.startX) * sign) / drag.width;
+    let next = raw;
+    if (raw < 0) next = 0;
+    if (raw > 1) next = 1 + rubberband((raw - 1) * drag.width, drag.width) / drag.width;
+    spring.moveTo(next);
+  }, []);
+
+  const handlePointerEnd = useCallback((event: React.PointerEvent<HTMLElement>) => {
+    const drag = dragRef.current;
+    const spring = springRef.current;
+    if (!drag || !spring || event.pointerId !== drag.pointerId) return;
+    dragRef.current = null;
+    if (!drag.engaged) {
+      // A plain tap (or a rejected vertical scroll) puts the drawer back.
+      spring.animateTo(1);
+      return;
+    }
+    const velocity = trackerRef.current.velocity(event.timeStamp);
+    const presenceVelocity = velocity / drag.width;
+    if (drawerReleaseTarget(spring.value() * drag.width, velocity, drag.width) === 0) {
+      releaseVelocityRef.current = presenceVelocity;
+      optionsRef.current.close();
+      return;
+    }
+    spring.animateTo(1, presenceVelocity);
+  }, []);
+
+  const handlePointerCancel = useCallback((event: React.PointerEvent<HTMLElement>) => {
+    const drag = dragRef.current;
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    dragRef.current = null;
+    // A canceled pointer fires no trailing click, so nothing would consume
+    // the swallow flag and the next real tap would be eaten.
+    draggedRef.current = false;
+    springRef.current?.animateTo(1);
+  }, []);
+
+  // After a real drag, the pointerup still produces a click on whatever row
+  // the finger ended over; swallow that one click.
+  const handleClickCapture = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    if (!draggedRef.current) return;
+    draggedRef.current = false;
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  return {
+    ref,
+    handlers: {
+      onPointerDown: handlePointerDown,
+      onPointerMove: handlePointerMove,
+      onPointerUp: handlePointerEnd,
+      onPointerCancel: handlePointerCancel,
+      onClickCapture: handleClickCapture,
+    },
+  };
+}

--- a/src/hooks/useDrawerGesture.ts
+++ b/src/hooks/useDrawerGesture.ts
@@ -109,9 +109,13 @@ export function useDrawerGesture(options: UseDrawerGestureOptions) {
     if (!optionsRef.current.enabled || !el || !spring) return;
     if (event.button !== 0) return;
     // The resize handle owns its own drag.
-    if ((event.target as Element).closest("hr")) return;
-    // Grab: freeze wherever the drawer is; a tap resumes on release.
+    if ((event.target as Element).closest("[data-resize-handle]")) return;
+    // Grab: freeze wherever the drawer is; a tap resumes on release. The
+    // grab also disarms any pending dismissal completion, or a rescued
+    // drawer would be silently closed by the stale callback later; a real
+    // dismissal re-arms it through close().
     spring.stop();
+    doneRef.current = null;
     draggedRef.current = false;
     dragRef.current = {
       pointerId: event.pointerId,
@@ -133,6 +137,14 @@ export function useDrawerGesture(options: UseDrawerGestureOptions) {
     const drag = dragRef.current;
     const spring = springRef.current;
     if (!drag || drag.rejected || !spring || event.pointerId !== drag.pointerId) return;
+    // A mouse released outside the drawer before engage never delivers its
+    // pointerup here (capture starts at engage), so a later buttonless hover
+    // would resume the drag. Treat it as a cancel.
+    if (event.buttons === 0) {
+      dragRef.current = null;
+      spring.animateTo(1);
+      return;
+    }
     // Pointer x is mapped so positive always means "toward open".
     const sign = drawerOpenSign(optionsRef.current.edge);
     trackerRef.current.add(event.clientX * sign, event.timeStamp);

--- a/src/hooks/useSidebarLayout.test.ts
+++ b/src/hooks/useSidebarLayout.test.ts
@@ -168,4 +168,29 @@ describe("useSidebarLayout on a compact viewport", () => {
     expect(result.current.filesVisible).toBe(false);
     expect(result.current.outlineVisible).toBe(false);
   });
+
+  it("defers the close to a registered drawer dismissal until it settles", () => {
+    const { result } = renderCompact();
+    act(() => {
+      result.current.toggleFiles();
+    });
+
+    let settle: (() => void) | undefined;
+    const dismiss = vi.fn((onDone: () => void) => {
+      settle = onDone;
+    });
+    result.current.drawerDismissals.add(dismiss);
+
+    act(() => {
+      result.current.closeCompactPanels();
+    });
+    expect(dismiss).toHaveBeenCalledOnce();
+    // The drawer stays mounted while its exit spring plays.
+    expect(result.current.filesVisible).toBe(true);
+
+    act(() => {
+      settle?.();
+    });
+    expect(result.current.filesVisible).toBe(false);
+  });
 });

--- a/src/hooks/useSidebarLayout.ts
+++ b/src/hooks/useSidebarLayout.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useCanSplit } from "@/hooks/useMediaQuery";
 import { AI_PANEL_WIDTH_DEFAULT, type Settings, SIDEBAR_WIDTH_DEFAULT } from "@/lib/settings";
 
@@ -57,11 +57,25 @@ export function useSidebarLayout({
     updateSettings("layout.outlineSidebarVisible", next);
   }, [compact, outlineVisible, updateSettings]);
 
-  // Dismiss the compact drawers (backdrop tap, or after opening a file).
-  const closeCompactPanels = useCallback(() => {
+  // Mounted compact drawers register an animated dismissal here (see
+  // useDrawerGesture), so closing plays the exit spring before the state
+  // flips and unmounts them.
+  const drawerDismissals = useRef(new Set<(onDone: () => void) => void>()).current;
+
+  const settleCompactPanelsClosed = useCallback(() => {
     setCompactFilesOpen(false);
     setCompactOutlineOpen(false);
   }, []);
+
+  // Dismiss the compact drawers (backdrop tap, or after opening a file):
+  // animated when a drawer is mounted, immediate otherwise.
+  const closeCompactPanels = useCallback(() => {
+    if (drawerDismissals.size === 0) {
+      settleCompactPanelsClosed();
+      return;
+    }
+    for (const dismiss of [...drawerDismissals]) dismiss(settleCompactPanelsClosed);
+  }, [drawerDismissals, settleCompactPanelsClosed]);
 
   const setFilesSidebarWidth = useCallback(
     (width: number) => updateSettings("layout.filesSidebarWidth", width),
@@ -102,6 +116,7 @@ export function useSidebarLayout({
     // this to switch the panel to an overlay and show a dismiss backdrop.
     compact,
     closeCompactPanels,
+    drawerDismissals,
     toggleFiles,
     toggleOutline,
     setFilesSidebarWidth,

--- a/src/hooks/useSpringPresence.test.tsx
+++ b/src/hooks/useSpringPresence.test.tsx
@@ -1,0 +1,81 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
+import { restoreRaf, stubRaf } from "@/test/raf";
+import { useSpringPresence } from "./useSpringPresence";
+
+function Probe({ open }: { open: boolean }) {
+  const presence = useSpringPresence(open);
+  if (!presence.mounted) return null;
+  return <div data-testid="surface" ref={presence.ref} />;
+}
+
+afterEach(() => {
+  restoreRaf();
+  restoreMatchMedia();
+});
+
+describe("useSpringPresence", () => {
+  it("renders nothing while closed", () => {
+    stubRaf();
+    render(<Probe open={false} />);
+    expect(screen.queryByTestId("surface")).not.toBeInTheDocument();
+  });
+
+  it("mounts hidden and springs open to 1", () => {
+    const raf = stubRaf();
+    render(<Probe open />);
+    const surface = screen.getByTestId("surface");
+    expect(surface.style.getPropertyValue("--presence")).toBe("0");
+    act(() => raf.settle());
+    expect(surface.style.getPropertyValue("--presence")).toBe("1");
+    expect(surface.hasAttribute("inert")).toBe(false);
+  });
+
+  it("keeps the node mounted through the exit, then unmounts", () => {
+    const raf = stubRaf();
+    const { rerender } = render(<Probe open />);
+    act(() => raf.settle());
+
+    rerender(<Probe open={false} />);
+    const surface = screen.getByTestId("surface");
+    expect(surface.hasAttribute("inert")).toBe(true);
+    act(() => raf.frame());
+    expect(screen.getByTestId("surface")).toBeInTheDocument();
+    act(() => raf.settle());
+    expect(screen.queryByTestId("surface")).not.toBeInTheDocument();
+  });
+
+  it("reopening mid-close reverses in place without unmounting", () => {
+    const raf = stubRaf();
+    const { rerender } = render(<Probe open />);
+    act(() => raf.settle());
+
+    rerender(<Probe open={false} />);
+    act(() => {
+      raf.frame();
+      raf.frame();
+    });
+    const midway = Number(screen.getByTestId("surface").style.getPropertyValue("--presence"));
+    expect(midway).toBeLessThan(1);
+
+    rerender(<Probe open />);
+    const surface = screen.getByTestId("surface");
+    expect(surface.hasAttribute("inert")).toBe(false);
+    act(() => raf.frame());
+    const resumed = Number(surface.style.getPropertyValue("--presence"));
+    expect(Math.abs(resumed - midway)).toBeLessThan(0.2);
+    act(() => raf.settle());
+    expect(surface.style.getPropertyValue("--presence")).toBe("1");
+  });
+
+  it("opens and closes instantly under reduced motion", () => {
+    stubRaf();
+    stubMatchMedia(true);
+    const { rerender } = render(<Probe open />);
+    expect(screen.getByTestId("surface").style.getPropertyValue("--presence")).toBe("1");
+
+    rerender(<Probe open={false} />);
+    expect(screen.queryByTestId("surface")).not.toBeInTheDocument();
+  });
+});

--- a/src/hooks/useSpringPresence.ts
+++ b/src/hooks/useSpringPresence.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createSpringAnimation, type SpringAnimation } from "@/lib/spring";
+
+/**
+ * Mount/unmount presence driven by a spring. The hook writes `--presence`
+ * (0 closed, 1 open) on the bound element every frame and the surface's CSS
+ * maps it onto transform/opacity, so all motion stays compositor-friendly.
+ * Closing keeps the node mounted but `inert` (no pointer, focus, keyboard, or
+ * AT exposure) until the spring settles; reopening mid-close retargets
+ * from the current value, so the surface reverses without a jump. Under
+ * reduced motion the spring snaps, so open/close become instant.
+ */
+export function useSpringPresence(open: boolean) {
+  const [mounted, setMounted] = useState(open);
+  const elRef = useRef<HTMLElement | null>(null);
+  const springRef = useRef<SpringAnimation | null>(null);
+  const openRef = useRef(open);
+  openRef.current = open;
+
+  const ref = useCallback((el: HTMLElement | null) => {
+    elRef.current = el;
+    if (!el) return;
+    springRef.current ??= createSpringAnimation({
+      initial: 0,
+      onFrame: (value) => {
+        elRef.current?.style.setProperty("--presence", String(value));
+      },
+      onSettle: (target) => {
+        if (target === 0 && !openRef.current) setMounted(false);
+      },
+    });
+    // Style the element before its first paint so an opening surface starts
+    // hidden instead of flashing fully visible for one frame.
+    el.style.setProperty("--presence", String(springRef.current.value()));
+    el.toggleAttribute("inert", !openRef.current);
+  }, []);
+
+  useEffect(() => {
+    if (open) setMounted(true);
+  }, [open]);
+
+  useEffect(() => {
+    if (!mounted) return;
+    elRef.current?.toggleAttribute("inert", !open);
+    springRef.current?.animateTo(open ? 1 : 0);
+  }, [open, mounted]);
+
+  useEffect(() => () => springRef.current?.stop(), []);
+
+  return { mounted, ref };
+}

--- a/src/lib/gesture.test.ts
+++ b/src/lib/gesture.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  createVelocityTracker,
+  drawerOpenSign,
+  drawerPhysicalEdge,
+  drawerReleaseTarget,
+  project,
+  rubberband,
+} from "./gesture";
+
+describe("createVelocityTracker", () => {
+  it("measures px/s over the recent samples", () => {
+    const tracker = createVelocityTracker();
+    tracker.add(0, 0);
+    tracker.add(50, 50);
+    tracker.add(100, 100);
+    expect(tracker.velocity(100)).toBe(1000);
+  });
+
+  it("ignores movement older than the window: a pause reads as a place, not a flick", () => {
+    const tracker = createVelocityTracker();
+    tracker.add(0, 0);
+    tracker.add(200, 80);
+    tracker.add(200, 400);
+    expect(tracker.velocity(400)).toBe(0);
+  });
+
+  it("returns 0 without at least two samples", () => {
+    const tracker = createVelocityTracker();
+    expect(tracker.velocity(0)).toBe(0);
+    tracker.add(10, 0);
+    expect(tracker.velocity(0)).toBe(0);
+  });
+
+  it("returns 0 when samples share a timestamp", () => {
+    const tracker = createVelocityTracker();
+    tracker.add(0, 5);
+    tracker.add(40, 5);
+    expect(tracker.velocity(5)).toBe(0);
+  });
+
+  it("reset clears the history", () => {
+    const tracker = createVelocityTracker();
+    tracker.add(0, 0);
+    tracker.add(100, 50);
+    tracker.reset();
+    tracker.add(0, 60);
+    expect(tracker.velocity(60)).toBe(0);
+  });
+});
+
+describe("project", () => {
+  it("uses exponential scroll decay", () => {
+    expect(project(1000)).toBeCloseTo(499, 0);
+  });
+
+  it("keeps the sign of the velocity", () => {
+    expect(project(-500)).toBeLessThan(0);
+    expect(project(0)).toBe(0);
+  });
+});
+
+describe("rubberband", () => {
+  it("resists progressively and never exceeds the dimension", () => {
+    const small = rubberband(10, 300);
+    const large = rubberband(200, 300);
+    const huge = rubberband(100000, 300);
+    expect(small).toBeGreaterThan(0);
+    expect(large).toBeGreaterThan(small);
+    expect(huge).toBeLessThan(300);
+  });
+
+  it("follows closely near the edge", () => {
+    expect(rubberband(10, 300)).toBeGreaterThan(4);
+    expect(rubberband(10, 300)).toBeLessThan(10);
+  });
+});
+
+describe("drawerOpenSign", () => {
+  it("flips the axis for a right-edge drawer", () => {
+    expect(drawerOpenSign("left")).toBe(1);
+    expect(drawerOpenSign("right")).toBe(-1);
+  });
+});
+
+describe("drawerPhysicalEdge", () => {
+  it("mirrors the slot side only under RTL", () => {
+    expect(drawerPhysicalEdge("left", false)).toBe("left");
+    expect(drawerPhysicalEdge("right", false)).toBe("right");
+    expect(drawerPhysicalEdge("left", true)).toBe("right");
+    expect(drawerPhysicalEdge("right", true)).toBe("left");
+  });
+});
+
+describe("drawerReleaseTarget", () => {
+  it("settles open past the midpoint with no momentum", () => {
+    expect(drawerReleaseTarget(180, 0, 300)).toBe(1);
+    expect(drawerReleaseTarget(120, 0, 300)).toBe(0);
+  });
+
+  it("a flick toward closed dismisses even from an open position", () => {
+    expect(drawerReleaseTarget(220, -600, 300)).toBe(0);
+  });
+
+  it("a flick toward open keeps it open even from a closed position", () => {
+    expect(drawerReleaseTarget(80, 600, 300)).toBe(1);
+  });
+});

--- a/src/lib/gesture.ts
+++ b/src/lib/gesture.ts
@@ -1,0 +1,78 @@
+// Pure gesture math for momentum-driven surfaces (the drawer sheet). The
+// pointer-event plumbing lives in hooks; everything here is testable data-in
+// data-out. See docs/motion.md.
+
+export interface VelocityTracker {
+  add(position: number, time: number): void;
+  /** Velocity in px/s over the recent samples; 0 when there aren't enough. */
+  velocity(time: number): number;
+  reset(): void;
+}
+
+// Only the last ~100ms of movement should count: a long drag that pauses
+// before release is a place, not a flick.
+const VELOCITY_WINDOW_MS = 100;
+
+export function createVelocityTracker(): VelocityTracker {
+  let samples: { position: number; time: number }[] = [];
+  return {
+    add(position, time) {
+      samples.push({ position, time });
+      samples = samples.filter((s) => time - s.time <= VELOCITY_WINDOW_MS);
+    },
+    velocity(time) {
+      const recent = samples.filter((s) => time - s.time <= VELOCITY_WINDOW_MS);
+      if (recent.length < 2) return 0;
+      const first = recent[0];
+      const last = recent[recent.length - 1];
+      const elapsedMs = last.time - first.time;
+      if (elapsedMs <= 0) return 0;
+      return ((last.position - first.position) / elapsedMs) * 1000;
+    },
+    reset() {
+      samples = [];
+    },
+  };
+}
+
+// Scroll-style deceleration; 0.998 is the normal-scroll feel.
+const DECELERATION_RATE = 0.998;
+
+/**
+ * How far a flick coasts before stopping (scroll-style exponential decay),
+ * so a release animates to where the gesture was going, not where it ended.
+ */
+export function project(velocity: number): number {
+  return ((velocity / 1000) * DECELERATION_RATE) / (1 - DECELERATION_RATE);
+}
+
+// How much of the overshoot a rubberbanded surface still follows.
+const RUBBERBAND_CONSTANT = 0.55;
+
+/** Progressive resistance past an edge: follows less the further past it. */
+export function rubberband(overshoot: number, dimension: number): number {
+  return (
+    (overshoot * dimension * RUBBERBAND_CONSTANT) /
+    (dimension + RUBBERBAND_CONSTANT * Math.abs(overshoot))
+  );
+}
+
+/** Sign that maps pointer-x movement onto "toward open" for a drawer edge. */
+export function drawerOpenSign(edge: "left" | "right"): 1 | -1 {
+  return edge === "left" ? 1 : -1;
+}
+
+/** The physical screen edge of a drawer slot once RTL mirroring is applied. */
+export function drawerPhysicalEdge(side: "left" | "right", rtl: boolean): "left" | "right" {
+  if (!rtl) return side;
+  return side === "left" ? "right" : "left";
+}
+
+/**
+ * Where a released drawer goes: project the momentum forward and snap to the
+ * nearer end. `position` is px from fully closed, `velocity` px/s toward open.
+ */
+export function drawerReleaseTarget(position: number, velocity: number, width: number): 0 | 1 {
+  const projected = position + project(velocity);
+  return projected < width / 2 ? 0 : 1;
+}

--- a/src/lib/spring.test.ts
+++ b/src/lib/spring.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
+import { restoreRaf, stubRaf } from "@/test/raf";
+import {
+  createSpringAnimation,
+  isSettled,
+  SPRING_DEFAULT,
+  type SpringState,
+  stepSpring,
+} from "./spring";
+
+function run(from: number, target: number, config = SPRING_DEFAULT, velocity = 0) {
+  let state: SpringState = { value: from, velocity };
+  const values: number[] = [];
+  for (let i = 0; i < 600 && !isSettled(state, target); i++) {
+    state = stepSpring(state, target, config, 1 / 60);
+    values.push(state.value);
+  }
+  return { state, values };
+}
+
+describe("stepSpring", () => {
+  it("converges to the target", () => {
+    const { state } = run(0, 1);
+    expect(state.value).toBeCloseTo(1, 2);
+    expect(isSettled(state, 1)).toBe(true);
+  });
+
+  it("never overshoots when critically damped", () => {
+    const { values } = run(0, 1);
+    for (const v of values) expect(v).toBeLessThanOrEqual(1.001);
+  });
+
+  it("overshoots below damping ratio 1", () => {
+    const { values } = run(0, 1, { response: 0.3, dampingRatio: 0.5 });
+    expect(Math.max(...values)).toBeGreaterThan(1.01);
+  });
+
+  it("survives a huge frame gap without exploding", () => {
+    const state = stepSpring({ value: 0, velocity: 0 }, 1, SPRING_DEFAULT, 5);
+    expect(state.value).toBeGreaterThan(0);
+    expect(state.value).toBeLessThanOrEqual(1.001);
+  });
+
+  it("an initial velocity carries the value along", () => {
+    const pushed = stepSpring({ value: 0.5, velocity: -4 }, 1, SPRING_DEFAULT, 1 / 60);
+    const still = stepSpring({ value: 0.5, velocity: 0 }, 1, SPRING_DEFAULT, 1 / 60);
+    expect(pushed.value).toBeLessThan(still.value);
+  });
+});
+
+describe("createSpringAnimation", () => {
+  afterEach(() => {
+    restoreRaf();
+    restoreMatchMedia();
+  });
+
+  it("animates to the target and settles exactly on it", () => {
+    const raf = stubRaf();
+    const frames: number[] = [];
+    const onSettle = vi.fn();
+    const spring = createSpringAnimation({ initial: 0, onFrame: (v) => frames.push(v), onSettle });
+    spring.animateTo(1);
+    raf.settle();
+    expect(frames[frames.length - 1]).toBe(1);
+    expect(onSettle).toHaveBeenCalledWith(1);
+    expect(spring.value()).toBe(1);
+  });
+
+  it("retargets mid-flight from the current value, without a jump", () => {
+    const raf = stubRaf();
+    const frames: number[] = [];
+    const spring = createSpringAnimation({ initial: 0, onFrame: (v) => frames.push(v) });
+    spring.animateTo(1);
+    raf.frame();
+    raf.frame();
+    const grabbed = spring.value();
+    expect(grabbed).toBeGreaterThan(0);
+    spring.animateTo(0);
+    raf.frame();
+    const next = frames[frames.length - 1];
+    expect(Math.abs(next - grabbed)).toBeLessThan(0.2);
+    raf.settle();
+    expect(spring.value()).toBe(0);
+  });
+
+  it("moveTo stops the loop and pins the value", () => {
+    const raf = stubRaf();
+    const spring = createSpringAnimation({ initial: 0, onFrame: () => {} });
+    spring.animateTo(1);
+    raf.frame();
+    spring.moveTo(0.42);
+    expect(spring.value()).toBe(0.42);
+    expect(raf.pendingCount()).toBe(0);
+  });
+
+  it("stop freezes in place without settling", () => {
+    const raf = stubRaf();
+    const onSettle = vi.fn();
+    const spring = createSpringAnimation({ initial: 0, onFrame: () => {}, onSettle });
+    spring.animateTo(1);
+    raf.frame();
+    spring.stop();
+    expect(raf.pendingCount()).toBe(0);
+    expect(onSettle).not.toHaveBeenCalled();
+    expect(spring.value()).toBeGreaterThan(0);
+    expect(spring.value()).toBeLessThan(1);
+  });
+
+  it("a handed-off velocity moves the first frames faster", () => {
+    const raf = stubRaf();
+    let coasted = 0;
+    const spring = createSpringAnimation({ initial: 0.5, onFrame: (v) => (coasted = v) });
+    spring.animateTo(0, -6);
+    raf.frame();
+    const withVelocity = 0.5 - coasted;
+
+    restoreRaf();
+    const raf2 = stubRaf();
+    let still = 0;
+    const spring2 = createSpringAnimation({ initial: 0.5, onFrame: (v) => (still = v) });
+    spring2.animateTo(0);
+    raf2.frame();
+    expect(withVelocity).toBeGreaterThan(0.5 - still);
+  });
+
+  it("snaps instantly under reduced motion", () => {
+    stubMatchMedia(true);
+    const raf = stubRaf();
+    const frames: number[] = [];
+    const onSettle = vi.fn();
+    const spring = createSpringAnimation({ initial: 0, onFrame: (v) => frames.push(v), onSettle });
+    spring.animateTo(1);
+    expect(frames).toEqual([1]);
+    expect(onSettle).toHaveBeenCalledWith(1);
+    expect(raf.pendingCount()).toBe(0);
+  });
+});

--- a/src/lib/spring.ts
+++ b/src/lib/spring.ts
@@ -1,0 +1,128 @@
+import { REDUCED_MOTION_QUERY } from "./reducedMotion";
+
+// Springs are parameterized the designer-facing way (response seconds +
+// damping ratio) rather than mass/stiffness/damping. See docs/motion.md.
+export interface SpringConfig {
+  /** Roughly how long the spring takes to feel settled, in seconds. */
+  response: number;
+  /** 1 = critically damped (no overshoot); below 1 overshoots and oscillates. */
+  dampingRatio: number;
+}
+
+/** Default for UI chrome: no overshoot, quick settle. */
+export const SPRING_DEFAULT: SpringConfig = { response: 0.3, dampingRatio: 1 };
+
+export interface SpringState {
+  value: number;
+  velocity: number;
+}
+
+// Semi-implicit Euler is only stable for stiff springs at small steps, and a
+// backgrounded tab can hand rAF a multi-second gap, so integrate in fixed
+// substeps and cap the total so a huge gap settles instead of exploding.
+const SUBSTEP = 1 / 120;
+const MAX_FRAME_DELTA = 0.25;
+
+export function stepSpring(
+  state: SpringState,
+  target: number,
+  config: SpringConfig,
+  dt: number,
+): SpringState {
+  const omega = (2 * Math.PI) / config.response;
+  const stiffness = omega * omega;
+  const damping = 2 * config.dampingRatio * omega;
+  let { value, velocity } = state;
+  let remaining = Math.min(dt, MAX_FRAME_DELTA);
+  while (remaining > 0) {
+    const step = Math.min(remaining, SUBSTEP);
+    const acceleration = -stiffness * (value - target) - damping * velocity;
+    velocity += acceleration * step;
+    value += velocity * step;
+    remaining -= step;
+  }
+  return { value, velocity };
+}
+
+const REST_DELTA = 0.001;
+
+export function isSettled(state: SpringState, target: number): boolean {
+  return Math.abs(state.value - target) < REST_DELTA && Math.abs(state.velocity) < REST_DELTA * 10;
+}
+
+function prefersReducedMotion(): boolean {
+  const canAsk = typeof window !== "undefined" && Boolean(window.matchMedia);
+  return canAsk && window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+export interface SpringAnimation {
+  /**
+   * Animate toward a new target from the current value. Mid-flight calls
+   * retarget without a jump; `velocity` (units/s) overrides the carried
+   * velocity for gesture handoff.
+   */
+  animateTo(target: number, velocity?: number): void;
+  /** Take over the value directly (a drag following the pointer); stops the loop. */
+  moveTo(value: number): void;
+  value(): number;
+  /** Cancel the loop, keeping the current value. */
+  stop(): void;
+}
+
+export function createSpringAnimation(options: {
+  initial: number;
+  config?: SpringConfig;
+  onFrame: (value: number) => void;
+  onSettle?: (target: number) => void;
+}): SpringAnimation {
+  const { config = SPRING_DEFAULT, onFrame, onSettle } = options;
+  let state: SpringState = { value: options.initial, velocity: 0 };
+  let target = options.initial;
+  let frame = 0;
+  let last = 0;
+
+  const stopLoop = () => {
+    if (frame) cancelAnimationFrame(frame);
+    frame = 0;
+  };
+
+  const tick = (now: number) => {
+    state = stepSpring(state, target, config, (now - last) / 1000);
+    last = now;
+    if (isSettled(state, target)) {
+      state = { value: target, velocity: 0 };
+      frame = 0;
+      onFrame(target);
+      onSettle?.(target);
+      return;
+    }
+    onFrame(state.value);
+    frame = requestAnimationFrame(tick);
+  };
+
+  return {
+    animateTo(next, velocity) {
+      target = next;
+      if (velocity !== undefined) state = { value: state.value, velocity };
+      if (prefersReducedMotion() || typeof requestAnimationFrame === "undefined") {
+        stopLoop();
+        state = { value: next, velocity: 0 };
+        onFrame(next);
+        onSettle?.(next);
+        return;
+      }
+      if (!frame) {
+        last = performance.now();
+        frame = requestAnimationFrame(tick);
+      }
+    },
+    moveTo(value) {
+      stopLoop();
+      state = { value, velocity: 0 };
+      target = value;
+      onFrame(value);
+    },
+    value: () => state.value,
+    stop: stopLoop,
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -14,6 +14,7 @@
 @import "./imageViewer.css";
 @import "./print.css";
 @import "./ai-chat.css";
+@import "./motion.css";
 
 :root {
   /* Native widgets (select popups, scrollbars) follow the app theme; WebKitGTK renders them unreadable otherwise. */
@@ -43,6 +44,10 @@
   --color-alert-caution: #cf222e;
   --color-error: #d70015;
   --color-error-bg: rgba(215, 0, 21, 0.08);
+  /* Translucent material for floating chrome (palette, modals, status bar).
+     Plain rgba, not color-mix, for the same html2canvas reason as above. */
+  --glyph-material-bg: rgba(245, 245, 247, 0.85);
+  --glyph-material-edge: rgba(255, 255, 255, 0.35);
 }
 
 /* Scoped to :root so a non-theme "dark" class on a subtree can't flip its native controls. */
@@ -70,6 +75,10 @@
   --color-alert-caution: #f85149;
   --color-error: #ff6961;
   --color-error-bg: rgba(255, 105, 97, 0.14);
+  /* Surface-secondary's RGB, not surface's: composited over the page it must
+     stay one step lighter, or the chrome dissolves into the document. */
+  --glyph-material-bg: rgba(44, 44, 46, 0.85);
+  --glyph-material-edge: rgba(255, 255, 255, 0.08);
 }
 
 html,

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -1,3 +1,5 @@
+/* Open/close is a spring: useSpringPresence writes `--presence` and
+   motion.css maps it onto this overlay's opacity and the panel's transform. */
 .command-palette-overlay {
   position: fixed;
   inset: 0;
@@ -7,42 +9,19 @@
   justify-content: center;
   padding-top: 12vh;
   z-index: 100;
-  animation: command-palette-fade-in 0.12s ease-out;
-}
-
-@keyframes command-palette-fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
 }
 
 .command-palette {
-  background: var(--color-surface);
+  /* Background and box-shadow come from the material rules in motion.css. */
   border: 1px solid var(--color-border);
   border-radius: var(--glyph-radius);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
   width: 640px;
   max-width: 92vw;
   max-height: 60vh;
   display: flex;
   flex-direction: column;
-  animation: command-palette-slide-down 0.12s ease-out;
   font-size: 13px;
   overflow: hidden;
-}
-
-@keyframes command-palette-slide-down {
-  from {
-    transform: translateY(-10px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
 }
 
 .command-palette-input {

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -1,0 +1,137 @@
+/* Fluid-interaction foundation: translucent materials, spring-driven
+   presence mappings, and press states. Springs write `--presence` (0 closed,
+   1 open) from JS; rules here only map it onto transform/opacity, so the
+   motion itself stays compositor-friendly. Imported last on purpose: the
+   [data-spring] overrides must outrank the per-surface keyframes. */
+
+/* --- Materials ------------------------------------------------------------
+   Floating chrome sits on a translucent blurred layer; the inset highlight is
+   the light catching the material's top edge. */
+
+.command-palette,
+.settings-modal {
+  background: var(--glyph-material-bg);
+  -webkit-backdrop-filter: blur(var(--glyph-material-blur)) saturate(180%);
+  backdrop-filter: blur(var(--glyph-material-blur)) saturate(180%);
+  /* The inset line is the light catching the material's top edge. */
+  box-shadow:
+    inset 0 1px 0 var(--glyph-material-edge),
+    0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+/* The filter is a platform var (macOS vibrancy; `none` elsewhere) so a flat
+   backdrop never pays for a compositing layer. */
+.sidebar-panel {
+  background: var(--glyph-sidebar-bg);
+  -webkit-backdrop-filter: var(--glyph-sidebar-filter);
+  backdrop-filter: var(--glyph-sidebar-filter);
+}
+
+/* Docked bar: nothing scrolls behind it, so it gets the material tint
+   without a pointless blur pass. */
+.status-bar {
+  background: var(--glyph-material-bg);
+}
+
+/* --- Spring presence mappings ---------------------------------------------
+   Enter and exit run along the same path (the spring just changes target), so
+   a surface always leaves the way it came. */
+
+.command-palette-overlay {
+  opacity: var(--presence, 1);
+}
+
+.command-palette {
+  /* Anchored to the trigger edge: it grows down from the top, not from its
+     center. */
+  transform-origin: 50% 0;
+  transform: translateY(calc((1 - var(--presence, 1)) * -12px))
+    scale(calc(0.98 + 0.02 * var(--presence, 1)));
+}
+
+[data-spring] .settings-overlay {
+  animation: none;
+  opacity: var(--presence, 1);
+}
+
+[data-spring] .settings-modal {
+  animation: none;
+  transform: translateY(calc((1 - var(--presence, 1)) * 12px))
+    scale(calc(0.98 + 0.02 * var(--presence, 1)));
+}
+
+/* --- Compact sidebar drawer (gesture sheet) -------------------------------- */
+
+.sidebar-drawer {
+  /* Vertical pans scroll the tree natively; horizontal drags reach the
+     drawer's pointer handlers. */
+  touch-action: pan-y;
+  /* Unlike the docked sidebar, the drawer overlays the document on every
+     platform, so it always gets the full material. */
+  background: var(--glyph-material-bg);
+  -webkit-backdrop-filter: blur(var(--glyph-material-blur)) saturate(180%);
+  backdrop-filter: blur(var(--glyph-material-blur)) saturate(180%);
+}
+
+.sidebar-drawer[data-drawer-edge="left"] {
+  transform: translateX(calc((var(--presence, 1) - 1) * 100%));
+}
+
+.sidebar-drawer[data-drawer-edge="right"] {
+  transform: translateX(calc((1 - var(--presence, 1)) * 100%));
+}
+
+/* Each drawer mirrors its presence per edge on the shared parent; the one
+   backdrop dims for whichever is furthest open. */
+.sidebar-drawer-backdrop {
+  opacity: max(var(--presence-left, 0), var(--presence-right, 0));
+}
+
+/* Solid fallback for every material surface. Last so it wins the ties. */
+@media (prefers-reduced-transparency: reduce) {
+  .command-palette,
+  .settings-modal {
+    background: var(--color-surface);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+
+  .sidebar-panel,
+  .sidebar-drawer,
+  .status-bar {
+    background: var(--color-surface-secondary);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
+/* --- Press states -----------------------------------------------------------
+   Feedback lands on pointer-down, not on release. Buttons compress; rows and
+   list items tint. The transition only eases the press; release snaps back. */
+
+.pressable:active {
+  transform: scale(0.96);
+  transition: transform 100ms ease-out;
+}
+
+.settings-primary-btn:active,
+.settings-secondary-btn:active,
+.settings-danger-btn:active,
+.settings-reset-btn:active,
+.settings-close:active,
+.lightbox-button:active,
+.tab-close:active,
+.mode-toggle-btn:active {
+  transform: scale(0.96);
+  transition: transform 100ms ease-out;
+}
+
+.settings-tab:active,
+.settings-segmented button:active,
+.tab-activate:active {
+  background: var(--color-surface-tertiary);
+}
+
+.command-palette-item:active {
+  background: color-mix(in srgb, var(--color-accent) 26%, transparent);
+}

--- a/src/styles/platform.css
+++ b/src/styles/platform.css
@@ -3,7 +3,8 @@
   --glyph-radius: 6px;
   --glyph-radius-sm: 4px;
   --glyph-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  --glyph-sidebar-blur: 0px;
+  --glyph-material-blur: 20px;
+  --glyph-sidebar-filter: none;
   --glyph-sidebar-bg: var(--color-surface-secondary);
   --glyph-safe-top: 0px;
   --glyph-safe-bottom: 0px;
@@ -27,7 +28,7 @@
   --glyph-radius: 8px;
   --glyph-radius-sm: 6px;
   --glyph-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-  --glyph-sidebar-blur: 20px;
+  --glyph-sidebar-filter: blur(20px) saturate(180%);
   --glyph-sidebar-bg: rgba(245, 245, 247, 0.8);
 }
 

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -15,12 +15,11 @@
   to { opacity: 1; }
 }
 
-/* Settings Modal — isolated from dynamic glyph CSS variables */
+/* Settings Modal, isolated from dynamic glyph CSS variables.
+   Background and box-shadow come from the material rules in motion.css. */
 .settings-modal {
-  background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--glyph-radius);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
   width: 640px;
   max-width: 90vw;
   height: 520px;

--- a/src/test/fixtures/sidebarLayout.ts
+++ b/src/test/fixtures/sidebarLayout.ts
@@ -11,6 +11,7 @@ export function sidebarLayoutValue(
     outlineVisible: true,
     compact: false,
     closeCompactPanels: vi.fn(),
+    drawerDismissals: new Set(),
     toggleFiles: vi.fn(),
     toggleOutline: vi.fn(),
     resetLayout: vi.fn(),

--- a/src/test/raf.ts
+++ b/src/test/raf.ts
@@ -1,5 +1,7 @@
 import { type MockInstance, vi } from "vitest";
 
+const originalRaf = globalThis.requestAnimationFrame;
+const originalCaf = globalThis.cancelAnimationFrame;
 let nowSpy: MockInstance | null = null;
 
 /**
@@ -11,14 +13,14 @@ export function stubRaf() {
   let now = 0;
   let nextId = 1;
   const pending = new Map<number, FrameRequestCallback>();
-  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => {
     const id = nextId++;
     pending.set(id, cb);
     return id;
-  });
-  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+  };
+  globalThis.cancelAnimationFrame = (id: number) => {
     pending.delete(id);
-  });
+  };
   nowSpy = vi.spyOn(performance, "now").mockImplementation(() => now);
   return {
     frame(ms = 16) {
@@ -41,7 +43,8 @@ export function stubRaf() {
 
 // Restores only what stubRaf touched, so a file's other mocks survive.
 export function restoreRaf() {
-  vi.unstubAllGlobals();
+  globalThis.requestAnimationFrame = originalRaf;
+  globalThis.cancelAnimationFrame = originalCaf;
   nowSpy?.mockRestore();
   nowSpy = null;
 }

--- a/src/test/raf.ts
+++ b/src/test/raf.ts
@@ -1,0 +1,47 @@
+import { type MockInstance, vi } from "vitest";
+
+let nowSpy: MockInstance | null = null;
+
+/**
+ * Replace requestAnimationFrame (and performance.now) with a manual pump so
+ * tests drive spring frames deterministically. Restore with `restoreRaf` in
+ * `afterEach`.
+ */
+export function stubRaf() {
+  let now = 0;
+  let nextId = 1;
+  const pending = new Map<number, FrameRequestCallback>();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    const id = nextId++;
+    pending.set(id, cb);
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    pending.delete(id);
+  });
+  nowSpy = vi.spyOn(performance, "now").mockImplementation(() => now);
+  return {
+    frame(ms = 16) {
+      now += ms;
+      const callbacks = [...pending.values()];
+      pending.clear();
+      for (const cb of callbacks) cb(now);
+    },
+    /** Pump frames until every animation settles (or the cap trips). */
+    settle(maxFrames = 600) {
+      let i = 0;
+      while (pending.size > 0 && i < maxFrames) {
+        this.frame();
+        i += 1;
+      }
+    },
+    pendingCount: () => pending.size,
+  };
+}
+
+// Restores only what stubRaf touched, so a file's other mocks survive.
+export function restoreRaf() {
+  vi.unstubAllGlobals();
+  nowSpy?.mockRestore();
+  nowSpy = null;
+}


### PR DESCRIPTION
## Summary

Builds the fluid-interaction foundation from #529: an interruptible spring layer, translucent materials for floating chrome, and instant press-state feedback, adopted first by the command palette, the settings modal, and the compact sidebar drawer (now a gesture-dismissible sheet). All motion animates `transform`/`opacity` only and respects `prefers-reduced-motion`; materials carry a `prefers-reduced-transparency` solid fallback. Documented in `docs/motion.md`.

Closes #529

## Changes

- `src/lib/spring.ts`: pure spring integrator (response + damping ratio, critically damped default, fixed substeps so background-tab rAF gaps cannot explode) plus a retargetable rAF driver with velocity handoff; snaps instantly under reduced motion.
- `src/lib/gesture.ts`: velocity tracker, momentum projection (exponential scroll decay), rubberband resistance, drawer release-target decision, and the LTR/RTL edge resolution helpers.
- `src/hooks/useSpringPresence.ts`: mount/unmount presence with a real exit phase. Writes `--presence` per frame, marks exiting surfaces `inert`, and reopening mid-close reverses from the current value without a jump.
- Command palette and settings modal open/close on the presence spring (settings opts in via `data-spring`, so the other `.settings-modal` consumers keep their keyframes until they migrate). Palette handlers additionally guard on `open` so a key repeat cannot re-run a command during the exit.
- `src/hooks/useDrawerGesture.ts`: the compact sidebar drawer springs in, tracks a horizontal drag 1:1 (vertical scroll wins via an axis threshold), rubberbands past the open edge, projects momentum at release to choose open vs dismiss, and hands the release velocity to the settle spring. Backdrop tap and open-file dismissals play the same exit spring through a registry in `useSidebarLayout`; pending dismissals are flushed if the drawer unmounts mid-close.
- Materials: `--glyph-material-*` tokens (light/dark), blur spent only where content actually passes behind the surface (overlays always; docked sidebar per platform via `--glyph-sidebar-filter`; status bar takes the tint without a filter), bright top edge, `prefers-reduced-transparency` fallback.
- Press states: `.pressable` compress for button-like controls and `:active` tints for rows, swept across the palette, settings, tabs, sidebar rows, context menu, and empty-state controls.
- Tests beside every new module plus a shared manual rAF pump in `src/test/raf.ts`; every touched source file is at 100% line coverage.

## Risk classification

- [ ] Persistence / data loss
- [x] Asynchronous ordering / races
- [x] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [x] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

- **Async ordering (INV-3 analog, stale results never win):** each surface owns exactly one spring that is retargeted in place, so no stale rAF chain can exist, and the settle callback re-checks the live `open` ref before unmounting. Covered by `useSpringPresence.test.tsx` ("reopening mid-close reverses in place without unmounting") and `CommandPalette.test.tsx` ("reopening mid-close keeps the same node and reverses").
- **Destructive lifecycle (INV-4, owners flush before they die):** a drawer dismissal interrupted by unmount (e.g. resizing out of compact mid-exit) still settles the layout state; the gesture hook flushes the pending `onDone` in its effect cleanup. Covered by `useDrawerGesture.test.tsx` ("still settles the layout state when unmounted mid-dismissal") and `useSidebarLayout.test.ts` ("defers the close to a registered drawer dismissal until it settles").
- **Accessibility:** exiting surfaces are `inert` (no pointer, focus, keyboard, or AT exposure) plus explicit `open` guards on the palette handlers, so a dismissing dialog cannot act on input (`CommandPalette.test.tsx` "does not run commands from a closing palette"). Reduced motion snaps every spring instantly (`spring.test.ts`, `useSpringPresence.test.tsx` reduced-motion cases) on top of the existing global CSS reset from #522, and `prefers-reduced-transparency` swaps every material for a solid surface in `motion.css`.

## Testing

- `pnpm typecheck`, `pnpm check`, `pnpm test` (3209 tests, 357 files) and `cargo clippy --all-targets -- -D warnings` all green.
- `pnpm test:coverage`: every source file touched by this diff reports full line coverage; spring/gesture math, presence lifecycle, drawer gestures (drag, flick, cancel, grab-mid-close, rubberband), and the reduced-motion paths are covered by deterministic tests driving a manual rAF pump.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Motion is the change, so stills add little; the visible static differences are the translucent palette/modal/drawer/status-bar materials and the press states described above.
