### PR TITLE
ci: guard release workflows with actionlint and a bump-flow test

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           xvfb-run --auto-servernum ./src-tauri/target/release/glyph "$PWD/samples" --export site --out /tmp/csp-smoke
           test -f /tmp/csp-smoke/index.html
-          test "$(ls /tmp/csp-smoke/*.html | wc -l)" -ge 3
+          test "$(find /tmp/csp-smoke -maxdepth 1 -name '*.html' | wc -l)" -ge 3
           # A document export renders the live DOM, so it exercises the
           # render-readiness gate the site export never touches.
           xvfb-run --auto-servernum ./src-tauri/target/release/glyph "$PWD/samples/Index.md" --export html --out /tmp/doc-smoke.html

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -33,6 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        with:
+          # The action downloads the actionlint binary at runtime; pin it so
+          # the executed tool is as immutable as the SHA-pinned wrapper.
+          version: 1.7.12
 
   typecheck:
     name: Typecheck

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -25,6 +25,15 @@ jobs:
       - name: Biome format check
         run: npx @biomejs/biome format --error-on-warnings --reporter=github src/
 
+  actionlint:
+    # Catches workflow syntax/expression errors per PR instead of live in a
+    # release run (see #504).
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -22,3 +22,15 @@ jobs:
       - name: Install Playwright WebKit
         run: pnpm exec playwright install --with-deps webkit
       - run: pnpm test:e2e
+
+  release-bump:
+    # Runs the create-release version-bump script against a throwaway clone:
+    # format validation, tag-exists check, and package.json / Cargo.toml /
+    # Cargo.lock agreement. Guards create-release.yml without cutting a
+    # release (see #504).
+    name: Release bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: ./.github/actions/rust-setup
+      - run: bash scripts/bump-version.test.sh

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,33 +30,14 @@ jobs:
           git remote set-url --push origin "git@github.com:${{ github.repository }}.git"
           echo "GIT_SSH_COMMAND=ssh -i ~/.ssh/release_key -o IdentitiesOnly=yes" >> "$GITHUB_ENV"
 
-      - name: Validate version format
-        run: |
-          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Invalid version format '${{ inputs.version }}'. Expected semver (e.g. 1.2.3)"
-            exit 1
-          fi
-
-      - name: Check tag does not already exist
-        run: |
-          if git ls-remote --tags origin | grep -q "refs/tags/v${{ inputs.version }}$"; then
-            echo "::error::Tag v${{ inputs.version }} already exists"
-            exit 1
-          fi
-
       - uses: ./.github/actions/rust-setup
 
-      - name: Bump version in package.json
-        run: |
-          jq --arg v "${{ inputs.version }}" '.version = $v' package.json > package.json.tmp
-          mv package.json.tmp package.json
-
-      - name: Bump version in Cargo.toml
-        run: |
-          sed -i 's/^version = ".*"/version = "${{ inputs.version }}"/' src-tauri/Cargo.toml
-
-      - name: Update Cargo.lock
-        run: cargo update --manifest-path src-tauri/Cargo.toml -p glyph
+      # Validation and the three-file bump live in the script so the
+      # release-bump CI job can exercise them without cutting a release.
+      - name: Bump version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: bash scripts/bump-version.sh "$VERSION"
 
       - name: Commit version bump
         run: |

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -12,14 +12,24 @@ if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   exit 1
 fi
 
-if git ls-remote --tags origin | grep -q "refs/tags/v$version\$"; then
+# --exit-code: 0 = ref exists, 2 = no matching ref, anything else = the query
+# itself failed. Fail closed on a failed query instead of assuming the tag is
+# free; grepping ls-remote output would proceed on a network error.
+status=0
+git ls-remote --exit-code origin "refs/tags/v$version" >/dev/null || status=$?
+if [ "$status" -eq 0 ]; then
   echo "::error::Tag v$version already exists"
+  exit 1
+elif [ "$status" -ne 2 ]; then
+  echo "::error::Could not query origin tags (git ls-remote exit $status)"
   exit 1
 fi
 
 jq --arg v "$version" '.version = $v' package.json > package.json.tmp
 mv package.json.tmp package.json
 
-sed -i "s/^version = \".*\"/version = \"$version\"/" src-tauri/Cargo.toml
+# First match only, so a future [dependencies.foo] table with a bare
+# version line cannot be clobbered.
+sed -i "0,/^version = /s/^version = \".*\"/version = \"$version\"/" src-tauri/Cargo.toml
 
 cargo update --manifest-path src-tauri/Cargo.toml -p glyph

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Shared version-bump flow for create-release.yml and scripts/bump-version.test.sh.
+# Validates the version, checks the tag is unused on origin, then bumps
+# package.json, src-tauri/Cargo.toml, and src-tauri/Cargo.lock in the working
+# tree. Committing, tagging, and pushing stay in the workflow.
+set -euo pipefail
+
+version="${1:-}"
+
+if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "::error::Invalid version format '$version'. Expected semver (e.g. 1.2.3)"
+  exit 1
+fi
+
+if git ls-remote --tags origin | grep -q "refs/tags/v$version\$"; then
+  echo "::error::Tag v$version already exists"
+  exit 1
+fi
+
+jq --arg v "$version" '.version = $v' package.json > package.json.tmp
+mv package.json.tmp package.json
+
+sed -i "s/^version = \".*\"/version = \"$version\"/" src-tauri/Cargo.toml
+
+cargo update --manifest-path src-tauri/Cargo.toml -p glyph

--- a/scripts/bump-version.test.sh
+++ b/scripts/bump-version.test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# End-to-end test for scripts/bump-version.sh on a throwaway checkout.
+# The clone's origin is a local bare copy of this repo, so the tag-exists
+# check runs for real while nothing can reach the actual remote.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+bump="$repo_root/scripts/bump-version.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+git clone --quiet --bare "$repo_root" "$tmp/origin.git"
+git -C "$tmp/origin.git" tag -f v9.9.8
+git clone --quiet "$tmp/origin.git" "$tmp/repo"
+cd "$tmp/repo"
+
+# Malformed versions are rejected before anything is touched
+for bad in "1.2" "v1.2.3" "1.2.3-rc1" ""; do
+  if bash "$bump" "$bad" >/dev/null 2>&1; then
+    fail "accepted invalid version '$bad'"
+  fi
+done
+git diff --quiet || fail "rejected version still modified the working tree"
+
+# A version whose tag already exists on origin is rejected
+out=$(bash "$bump" 9.9.8 2>&1) && fail "accepted already-tagged version 9.9.8"
+echo "$out" | grep -q "already exists" || fail "wrong error for existing tag: $out"
+
+# Happy path: package.json, Cargo.toml, and Cargo.lock all agree
+bash "$bump" 9.9.9
+
+pkg="$(jq -r .version package.json)"
+toml="$(grep -m1 '^version = ' src-tauri/Cargo.toml | cut -d'"' -f2)"
+lock="$(awk '/^name = "glyph"$/ { getline; print }' src-tauri/Cargo.lock | cut -d'"' -f2)"
+
+[ "$pkg" = "9.9.9" ] || fail "package.json version is '$pkg', expected 9.9.9"
+[ "$toml" = "9.9.9" ] || fail "Cargo.toml version is '$toml', expected 9.9.9"
+[ "$lock" = "9.9.9" ] || fail "Cargo.lock glyph version is '$lock', expected 9.9.9"
+
+echo "OK: bump flow validates, rejects existing tags, and keeps all three files in sync"

--- a/scripts/bump-version.test.sh
+++ b/scripts/bump-version.test.sh
@@ -25,11 +25,17 @@ for bad in "1.2" "v1.2.3" "1.2.3-rc1" ""; do
     fail "accepted invalid version '$bad'"
   fi
 done
-git diff --quiet || fail "rejected version still modified the working tree"
+[ -z "$(git status --porcelain)" ] || fail "rejected version still modified the working tree"
 
 # A version whose tag already exists on origin is rejected
 out=$(bash "$bump" 9.9.8 2>&1) && fail "accepted already-tagged version 9.9.8"
 echo "$out" | grep -q "already exists" || fail "wrong error for existing tag: $out"
+
+# An unreachable origin aborts the bump instead of failing open
+git remote set-url origin "$tmp/missing.git"
+out=$(bash "$bump" 9.9.7 2>&1) && fail "proceeded when origin tags could not be queried"
+echo "$out" | grep -q "Could not query" || fail "wrong error for unreachable origin: $out"
+git remote set-url origin "$tmp/origin.git"
 
 # Happy path: package.json, Cargo.toml, and Cargo.lock all agree
 bash "$bump" 9.9.9


### PR DESCRIPTION
## Summary

Release workflow logic was only exercised by real releases, so errors surfaced live (#495, #409, #385, #169) and a create-release failure burns a version number. This adds two cheap per-PR guards: actionlint over all workflows, and an end-to-end test of the create-release version-bump flow that runs against a throwaway clone, so nothing can touch the real remote or cut a release.

Closes #504

## Changes

- `scripts/bump-version.sh` (new): the create-release bump flow in one place, shared by the workflow and the test. Validates semver format, checks `v<version>` is unused on origin via `git ls-remote --exit-code` (a failed query aborts instead of failing open), bumps `package.json` (jq) and the first `version` line of `src-tauri/Cargo.toml` (sed), and refreshes `Cargo.lock` (`cargo update -p glyph`). Commit, tag, and push stay in the workflow.
- `scripts/bump-version.test.sh` (new): clones the repo into a temp bare "origin" plus a working clone, then asserts malformed versions are rejected without touching the tree, an already-tagged version is rejected, an unreachable origin aborts the bump, and the happy path leaves `package.json`, `Cargo.toml`, and `Cargo.lock` agreeing.
- `create-release.yml`: the four inline bump steps are replaced by one call to the script, with the version passed via env instead of interpolated into the shell.
- `ci-checks.yml`: new `actionlint` job. The action is pinned to a commit SHA and the downloaded actionlint binary is pinned to 1.7.12, so neither floats.
- `ci-smoke.yml`: new `release-bump` job running the bump-flow test per PR.
- `ci-build.yml`: fixed the one pre-existing actionlint finding (SC2012, `ls` piped to `wc` replaced with `find`).

Both jobs ride the reusable workflows `ci.yml` already calls on every PR. Note for the merge queue: the new contexts (`Checks / actionlint`, `Smoke / Release bump`) are not in the required-checks ruleset; adding them is a repo-settings change if they should gate merges.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

CI workflows and release scripts only; no app code ships in this diff. The release-flow property the scripts must uphold (a malformed version, existing tag, or failed tag query aborts before anything is written) is asserted directly by `scripts/bump-version.test.sh`, which runs per PR in the `Release bump` job.

## Testing

- `scripts/bump-version.test.sh` passes locally (all four scenarios, real jq/sed/cargo against a throwaway clone) and runs per PR in `ci-smoke.yml`
- actionlint 1.7.12 with shellcheck integration is clean over all 12 workflows; shellcheck is clean over both new scripts
- `pnpm typecheck && pnpm check && pnpm test` (3275 tests) and `cargo clippy --all-targets -- -D warnings` are green
- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable (CI-only change).
