### PR TITLE
perf(bundle): enforce bundle budgets and trim startup by 15%

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -62,6 +62,12 @@ jobs:
           CODECOV_TOKEN: ${{ matrix.bundle_analysis && secrets.CODECOV_TOKEN || '' }}
         with:
           args: ${{ github.event_name == 'pull_request' && matrix.args_pr || matrix.args_full }}
+      # Records raw/gzip sizes for startup and major lazy chunks and fails on
+      # budget regressions (bundle-budgets.json, docs/bundle-budgets.md). One
+      # deterministic leg is enough: every platform ships the same frontend.
+      - name: Check bundle budgets
+        if: matrix.platform == 'ubuntu-22.04'
+        run: node scripts/check-bundle-size.mjs
       # Boots the real webview under the production CSP and exercises the
       # grant-gated CLI export end to end; unit tests cannot enforce CSP.
       - name: Headless export smoke test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,7 @@ pnpm test                       # Run frontend tests (Vitest)
 pnpm test:watch                 # Run frontend tests in watch mode
 pnpm test:coverage              # Run frontend tests with coverage
 pnpm test:e2e                   # WebKit smoke tests (Playwright; run `pnpm exec playwright install webkit` once first)
+pnpm size:check                 # Bundle budget gate against dist/ (see docs/bundle-budgets.md)
 cd src-tauri && cargo check     # Rust type checking
 cd src-tauri && cargo clippy    # Rust linting
 cd src-tauri && cargo test      # Rust tests

--- a/bundle-budgets.json
+++ b/bundle-budgets.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "Gzip byte budgets enforced by scripts/check-bundle-size.mjs in CI. Rationale and update process: docs/bundle-budgets.md",
+  "startup": 345000,
+  "chunks": {
+    "d2": { "prefix": "d2-", "budgetGzip": 6450000 },
+    "pdfEngine": { "prefix": "pdfEngine-", "budgetGzip": 910000 },
+    "MarkdownEditor": { "prefix": "MarkdownEditor-", "budgetGzip": 297000 },
+    "mermaid": { "prefix": "mermaid.core-", "budgetGzip": 150000 },
+    "cytoscape": { "prefix": "cytoscape.esm-", "budgetGzip": 156000 },
+    "docx": { "prefix": "docx-", "budgetGzip": 116000 },
+    "katex": { "prefix": "katex-", "budgetGzip": 93000 },
+    "epub": { "prefix": "epub-", "budgetGzip": 34000 },
+    "html2canvas": { "prefix": "html2canvas.esm-", "budgetGzip": 52000 }
+  },
+  "unbudgetedChunkGzipLimit": 200000
+}

--- a/docs/bundle-budgets.md
+++ b/docs/bundle-budgets.md
@@ -1,0 +1,76 @@
+# Bundle Budgets
+
+CI enforces gzip size budgets on the frontend bundle so size regressions fail a
+PR instead of shipping silently. The gate is `scripts/check-bundle-size.mjs`,
+run by the `Check bundle budgets` step of the `ubuntu-22.04` build leg after
+the frontend is built; budgets live in [`bundle-budgets.json`](../bundle-budgets.json).
+
+Run it locally against a fresh production build:
+
+```bash
+pnpm build && pnpm size:check
+```
+
+## What is measured
+
+- **startup**: every asset referenced from `dist/index.html` (the entry script,
+  stylesheets, and any modulepreloads). This is what every launch parses.
+- **Named lazy chunks**: each `chunks` entry in `bundle-budgets.json` matches
+  `dist/assets/` files by filename prefix and sums them. These load on first
+  use of their feature, so their cost is first-use latency plus installer size.
+- **Unbudgeted assets**: any other asset (chunk, stylesheet, font) above
+  `unbudgetedChunkGzipLimit` fails the check. A new heavyweight dependency must
+  get a stable chunk name (via `manualChunks` in `vite.config.ts` or its
+  natural file name) and an explicit budget before it can merge.
+
+Budgets are gzip bytes (gzip is what matters for install/transfer size; raw
+sizes are recorded in the CI step summary for parse-cost context). Each budget
+is the measured size plus roughly 10% headroom, so dependency bumps pass while
+a feature accidentally landing in the wrong chunk does not.
+
+## What keeps startup small
+
+The startup chunk is the markdown viewer shell: React, the remark/rehype
+pipeline, the Tauri API glue, i18n, and the app shell components. Everything
+optional loads on first use:
+
+- Editor (CodeMirror), notebook, canvas, graph view, and the settings modals
+  are `lazy()` components (`lazyEditor`, `lazyNotebook`, `lazyCanvas`,
+  `lazyGraph`, `lazySettings`, `lazyWorkspaceSettings`).
+- The AI chat panel (`lazyAIChatPanel`) and plugin marketplace modal
+  (`lazyPluginsModal`) load on first open.
+- Syntax highlighting, KaTeX, and the gemoji table load when a document first
+  needs them (`lazyHighlight`, `lazyKatex`, `lazyGemoji`).
+- The Sentry SDK loads only after the production telemetry opt-in
+  (`src/lib/telemetry.ts`); error reporting before that is a no-op by design.
+- The export pipeline (`src/lib/export/*`) is reached only through dynamic
+  imports in `useExport`, `usePrint`, `useCliExport`, `useExportSite`, and the
+  plugin exporter runner, which keeps docx/epub/pdfmake/html2canvas out of
+  startup entirely.
+
+When adding a feature, put its heavy dependencies behind one of these seams
+(or a new `lazy()` wrapper following the same pattern). If startup legitimately
+needs to grow, raise `startup` in `bundle-budgets.json` in the same PR and
+explain why in the PR description.
+
+## D2 delivery decision
+
+`@terrastruct/d2` ships as a single 8 MB browser file with the WASM compiler
+inlined as base64 (gzip ~5.9 MB); as of the latest upstream release (0.1.33)
+there is no split `.wasm` asset or slimmer browser build. Repackaging the WASM
+ourselves would mean patching upstream's blob-worker bootstrap, which is
+CSP-sensitive (see the WebKit smoke suite) and would break on every upgrade.
+
+Accepted tradeoff: the chunk stays lazy behind `d2Render.ts`, so it is parsed
+only on the first D2 diagram render and never touches startup; the cost that
+remains is installer size. Revisit if upstream publishes a separable WASM
+artifact; the budget pins today's size so an upstream regression is visible.
+
+## Updating budgets
+
+1. Build and measure: `pnpm build && pnpm size:check`.
+2. If a group legitimately grew (new feature, dependency bump), set its budget
+   to the new measured size plus ~10% and note the reason in the PR.
+3. If a budgeted chunk disappeared or was renamed, update its `prefix`; the
+   check fails loudly on prefixes that match nothing, so stale entries cannot
+   linger.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "playwright test",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "size:check": "node scripts/check-bundle-size.mjs",
     "sync:tauri-npm": "node scripts/sync-tauri-npm-versions.mjs",
     "sync:tauri-npm:check": "node scripts/sync-tauri-npm-versions.mjs --check",
     "prepare": "husky"

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,0 +1,138 @@
+// Bundle size gate: records raw + gzip sizes for the startup assets and the
+// major lazy chunks, and fails when a gzip budget in bundle-budgets.json is
+// exceeded. Budgets and the process for updating them are documented in
+// docs/bundle-budgets.md.
+//
+// Usage: node scripts/check-bundle-size.mjs [distDir]
+import { appendFileSync, existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { gzipSync } from "node:zlib";
+
+/** Asset paths referenced from index.html: the startup download set. */
+export function startupAssets(html) {
+  const refs = [];
+  for (const m of html.matchAll(/<script[^>]+src="([^"]+)"/g)) refs.push(m[1]);
+  for (const m of html.matchAll(/<link[^>]+rel="(?:stylesheet|modulepreload)"[^>]+href="([^"]+)"/g))
+    refs.push(m[1]);
+  return refs.map((r) => r.replace(/^\//, ""));
+}
+
+/** Group dist files into budget groups. Returns rows + hard failures. */
+export function evaluateBudgets({ startupFiles, assetFiles, budgets, sizeOf }) {
+  const rows = [];
+  const failures = [];
+  const claimed = new Set();
+
+  const measure = (name, files, budgetGzip) => {
+    let raw = 0;
+    let gzip = 0;
+    for (const f of files) {
+      const s = sizeOf(f);
+      raw += s.raw;
+      gzip += s.gzip;
+    }
+    const over = budgetGzip != null && gzip > budgetGzip;
+    rows.push({ name, files: files.length, raw, gzip, budgetGzip, over });
+    if (over) {
+      failures.push(
+        `${name}: ${kb(gzip)} gzip exceeds the ${kb(budgetGzip)} budget. ` +
+          `If the growth is intentional, update bundle-budgets.json and docs/bundle-budgets.md.`,
+      );
+    }
+  };
+
+  // An empty startup set means index.html parsing broke (attribute order,
+  // quoting); it must fail loudly, not pass a 0-byte budget forever.
+  if (startupFiles.length === 0) {
+    failures.push(
+      "startup: no assets found in dist/index.html. " +
+        "The startupAssets() regexes no longer match Vite's output; fix scripts/check-bundle-size.mjs.",
+    );
+  }
+  measure("startup", startupFiles, budgets.startup);
+  for (const [name, entry] of Object.entries(budgets.chunks)) {
+    const files = assetFiles.filter((f) => path.basename(f).startsWith(entry.prefix));
+    for (const f of files) claimed.add(f);
+    if (files.length === 0) {
+      failures.push(
+        `${name}: no dist/assets file matches prefix "${entry.prefix}". ` +
+          `The chunk was renamed or removed; update bundle-budgets.json to match.`,
+      );
+      continue;
+    }
+    measure(name, files, entry.budgetGzip);
+  }
+
+  // A new heavyweight asset without a budget must not slip in unnoticed.
+  for (const f of assetFiles) {
+    if (claimed.has(f) || startupFiles.includes(f)) continue;
+    const { gzip } = sizeOf(f);
+    if (gzip > budgets.unbudgetedChunkGzipLimit) {
+      failures.push(
+        `${path.basename(f)}: ${kb(gzip)} gzip has no budget entry ` +
+          `(limit for unbudgeted chunks is ${kb(budgets.unbudgetedChunkGzipLimit)}). ` +
+          `Give it a stable name and a budget in bundle-budgets.json.`,
+      );
+    }
+  }
+
+  return { rows, failures };
+}
+
+export function kb(bytes) {
+  return `${(bytes / 1024).toFixed(1)} kB`;
+}
+
+export function markdownTable(rows) {
+  const lines = [
+    "| Group | Files | Raw | Gzip | Budget (gzip) | Status |",
+    "|---|---:|---:|---:|---:|---|",
+  ];
+  for (const r of rows) {
+    const budget = r.budgetGzip == null ? "" : kb(r.budgetGzip);
+    lines.push(
+      `| ${r.name} | ${r.files} | ${kb(r.raw)} | ${kb(r.gzip)} | ${budget} | ${r.over ? "OVER" : "ok"} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+  const distDir = path.resolve(process.argv[2] ?? path.join(root, "dist"));
+  if (!existsSync(path.join(distDir, "index.html"))) {
+    console.error(`No build found at ${distDir}. Run \`pnpm build\` first.`);
+    process.exit(1);
+  }
+  const budgets = JSON.parse(readFileSync(path.join(root, "bundle-budgets.json"), "utf8"));
+  const html = readFileSync(path.join(distDir, "index.html"), "utf8");
+
+  const startupFiles = startupAssets(html);
+  // Forward-slash relative paths so they compare equal to index.html refs on
+  // Windows. Sourcemaps never ship to users, so they are not measured.
+  const assetFiles = readdirSync(path.join(distDir, "assets"))
+    .filter((f) => !f.endsWith(".map"))
+    .map((f) => `assets/${f}`);
+  const sizeOf = (rel) => {
+    const abs = path.join(distDir, rel);
+    const raw = statSync(abs).size;
+    const gzip = gzipSync(readFileSync(abs), { level: 9 }).length;
+    return { raw, gzip };
+  };
+
+  const { rows, failures } = evaluateBudgets({ startupFiles, assetFiles, budgets, sizeOf });
+  const table = markdownTable(rows);
+  console.log(table);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## Bundle sizes\n\n${table}\n`);
+  }
+  if (failures.length > 0) {
+    for (const f of failures) console.error(`ERROR: ${f}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/check-bundle-size.test.mjs
+++ b/scripts/check-bundle-size.test.mjs
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { evaluateBudgets, kb, markdownTable, startupAssets } from "./check-bundle-size.mjs";
+
+const HTML = `<!doctype html><html><head>
+<script>/* inline theme bootstrap has no src and is not an asset */</script>
+<script type="module" crossorigin src="/assets/index-BmciaJVA.js"></script>
+<link rel="stylesheet" crossorigin href="/assets/index-CduMu0bs.css">
+<link rel="modulepreload" crossorigin href="/assets/vendor-abc.js">
+<link rel="icon" href="/favicon.png" />
+</head><body></body></html>`;
+
+describe("startupAssets", () => {
+  it("collects entry scripts, stylesheets, and modulepreloads without the leading slash", () => {
+    expect(startupAssets(HTML)).toEqual([
+      "assets/index-BmciaJVA.js",
+      "assets/index-CduMu0bs.css",
+      "assets/vendor-abc.js",
+    ]);
+  });
+
+  it("ignores inline scripts and icons", () => {
+    expect(startupAssets(HTML)).not.toContain("favicon.png");
+  });
+});
+
+// Sizes keyed by file path; gzip modeled as half the raw size.
+function sizerFor(sizes) {
+  return (f) => {
+    if (!(f in sizes)) throw new Error(`unexpected file measured: ${f}`);
+    return { raw: sizes[f], gzip: sizes[f] / 2 };
+  };
+}
+
+const budgets = {
+  startup: 100,
+  chunks: {
+    d2: { prefix: "d2-", budgetGzip: 500 },
+    pdf: { prefix: "pdfEngine-", budgetGzip: 50 },
+  },
+  unbudgetedChunkGzipLimit: 40,
+};
+
+describe("evaluateBudgets", () => {
+  it("passes when every group is at or under budget", () => {
+    const { rows, failures } = evaluateBudgets({
+      startupFiles: ["assets/index-a.js"],
+      assetFiles: ["assets/index-a.js", "assets/d2-x.js", "assets/pdfEngine-x.js"],
+      budgets,
+      sizeOf: sizerFor({ "assets/index-a.js": 200, "assets/d2-x.js": 1000, "assets/pdfEngine-x.js": 100 }),
+    });
+    expect(failures).toEqual([]);
+    expect(rows.map((r) => r.name)).toEqual(["startup", "d2", "pdf"]);
+    expect(rows[0]).toMatchObject({ raw: 200, gzip: 100, over: false });
+  });
+
+  it("fails a group whose gzip total exceeds its budget", () => {
+    const { rows, failures } = evaluateBudgets({
+      startupFiles: ["assets/index-a.js"],
+      assetFiles: ["assets/index-a.js", "assets/d2-x.js", "assets/pdfEngine-x.js"],
+      budgets,
+      sizeOf: sizerFor({ "assets/index-a.js": 300, "assets/d2-x.js": 1000, "assets/pdfEngine-x.js": 100 }),
+    });
+    expect(rows[0].over).toBe(true);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("startup");
+  });
+
+  it("sums multiple files matching one prefix", () => {
+    const { rows } = evaluateBudgets({
+      startupFiles: [],
+      assetFiles: ["assets/d2-x.js", "assets/d2-y.js", "assets/pdfEngine-x.js"],
+      budgets,
+      sizeOf: sizerFor({ "assets/d2-x.js": 400, "assets/d2-y.js": 600, "assets/pdfEngine-x.js": 100 }),
+    });
+    const d2 = rows.find((r) => r.name === "d2");
+    expect(d2).toMatchObject({ files: 2, raw: 1000, gzip: 500, over: false });
+  });
+
+  it("fails when a budgeted prefix matches no file", () => {
+    const { failures } = evaluateBudgets({
+      startupFiles: [],
+      assetFiles: ["assets/d2-x.js"],
+      budgets,
+      sizeOf: sizerFor({ "assets/d2-x.js": 400 }),
+    });
+    expect(failures.some((f) => f.includes('prefix "pdfEngine-"'))).toBe(true);
+  });
+
+  it("fails an unbudgeted asset above the limit and allows one below it", () => {
+    const { failures } = evaluateBudgets({
+      startupFiles: [],
+      assetFiles: [
+        "assets/d2-x.js",
+        "assets/pdfEngine-x.js",
+        "assets/huge-new.js",
+        "assets/small-new.js",
+        "assets/huge-style.css",
+        "assets/small-font.woff2",
+      ],
+      budgets,
+      sizeOf: sizerFor({
+        "assets/d2-x.js": 400,
+        "assets/pdfEngine-x.js": 100,
+        "assets/huge-new.js": 100,
+        "assets/small-new.js": 60,
+        "assets/huge-style.css": 100,
+        "assets/small-font.woff2": 60,
+      }),
+    });
+    expect(failures.some((f) => f.includes("huge-new.js"))).toBe(true);
+    expect(failures.some((f) => f.includes("huge-style.css"))).toBe(true);
+    expect(failures.some((f) => f.includes("small-new.js"))).toBe(false);
+    expect(failures.some((f) => f.includes("small-font.woff2"))).toBe(false);
+  });
+
+  it("fails when index.html yields no startup assets", () => {
+    const { failures } = evaluateBudgets({
+      startupFiles: [],
+      assetFiles: ["assets/d2-x.js", "assets/pdfEngine-x.js"],
+      budgets,
+      sizeOf: sizerFor({ "assets/d2-x.js": 100, "assets/pdfEngine-x.js": 50 }),
+    });
+    expect(failures.some((f) => f.includes("no assets found in dist/index.html"))).toBe(true);
+  });
+});
+
+describe("markdownTable", () => {
+  it("renders a row per group with OVER marking", () => {
+    const table = markdownTable([
+      { name: "startup", files: 2, raw: 2048, gzip: 1024, budgetGzip: 512, over: true },
+      { name: "d2", files: 1, raw: 1024, gzip: 512, budgetGzip: null, over: false },
+    ]);
+    expect(table).toContain("| startup | 2 | 2.0 kB | 1.0 kB | 0.5 kB | OVER |");
+    expect(table).toContain("| d2 | 1 | 1.0 kB | 0.5 kB |  | ok |");
+  });
+});
+
+describe("kb", () => {
+  it("formats bytes as kB with one decimal", () => {
+    expect(kb(1536)).toBe("1.5 kB");
+  });
+});

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SettingsContext, type SettingsContextValue } from "@/contexts/SettingsContext";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
+import { CHUNK_LOAD_TIMEOUT_MS } from "@/test/chunkLoadTimeout";
 
 vi.mock("./editor/lazyEditor", () => ({
   MarkdownEditor: () => <div data-testid="lazy-editor" />,
@@ -180,7 +181,14 @@ describe("App", () => {
     await act(async () => {
       listeners["menu-workspace-settings"]?.({ payload: undefined });
     });
-    expect(await findByRole("dialog", { name: /workspace settings/i })).toBeInTheDocument();
+    // The modal is a lazy chunk now; give its first import the chunk timeout.
+    expect(
+      await findByRole(
+        "dialog",
+        { name: /workspace settings/i },
+        { timeout: CHUNK_LOAD_TIMEOUT_MS },
+      ),
+    ).toBeInTheDocument();
 
     await act(async () => {
       (await findByRole("button", { name: /close/i })).click();
@@ -198,7 +206,8 @@ describe("App", () => {
     await act(async () => {
       listeners["menu-manage-plugins"]?.({ payload: undefined });
     });
-    expect(await findByRole("dialog")).toBeInTheDocument();
+    // The modal is a lazy chunk now; give its first import the chunk timeout.
+    expect(await findByRole("dialog", {}, { timeout: CHUNK_LOAD_TIMEOUT_MS })).toBeInTheDocument();
   });
 
   it("renders EmptyState with a working Open Folder button (covers inline arrow)", async () => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -22,7 +22,7 @@ import { useTabReorderShortcuts } from "@/hooks/useTabReorderShortcuts";
 import { useWindowClose } from "@/hooks/useWindowClose";
 import { useWindowReveal } from "@/hooks/useWindowReveal";
 import { isImageFile } from "@/lib/imageExtensions";
-import { AIChatPanel } from "./ai/AIChatPanel";
+import { AIChatPanel } from "./ai/lazyAIChatPanel";
 import { AppBanners } from "./layout/AppBanners";
 import { AppModals } from "./layout/AppModals";
 import { EmptyState } from "./layout/EmptyState";

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureException } from "@/lib/telemetry";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+vi.mock("@/lib/telemetry", () => ({ captureException: vi.fn() }));
+
+function Bomb(): never {
+  throw new Error("render exploded");
+}
+
+describe("ErrorBoundary", () => {
+  beforeEach(() => {
+    // React logs caught render errors to console.error; keep test output clean.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders its children when nothing throws", () => {
+    render(
+      <ErrorBoundary fallback={<div>fallback</div>}>
+        <div>content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("content")).toBeInTheDocument();
+    expect(screen.queryByText("fallback")).not.toBeInTheDocument();
+  });
+
+  it("renders the fallback and reports the error when a child throws", () => {
+    render(
+      <ErrorBoundary fallback={<div>fallback</div>}>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("fallback")).toBeInTheDocument();
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "render exploded" }),
+      expect.objectContaining({
+        contexts: expect.objectContaining({ react: expect.anything() }),
+      }),
+    );
+  });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { captureException } from "@/lib/telemetry";
+
+interface ErrorBoundaryProps {
+  fallback: ReactNode;
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+// Top-level render-error boundary. Reports through the telemetry facade
+// instead of Sentry's own boundary component so the SDK stays out of the
+// startup bundle (it loads only after the production opt-in).
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
+    // Keep the component trail Sentry.ErrorBoundary used to attach.
+    captureException(error, {
+      contexts: { react: { componentStack: errorInfo.componentStack } },
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/ai/lazyAIChatPanel.test.tsx
+++ b/src/components/ai/lazyAIChatPanel.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CHUNK_LOAD_TIMEOUT_MS } from "@/test/chunkLoadTimeout";
+import { AIChatPanel } from "./lazyAIChatPanel";
+
+// The underlying panel pulls in the whole AI feature; these tests only
+// exercise the first-open latch and the lazy() + Suspense plumbing.
+vi.mock("./AIChatPanel", () => ({
+  AIChatPanel: ({ open }: { open: boolean }) => (
+    <div data-testid="ai-chat-panel">{open ? "open" : "closed"}</div>
+  ),
+}));
+
+const defaultProps = {
+  onClose: vi.fn(),
+  turns: [],
+  streaming: false,
+  error: null,
+  configured: true,
+  hasDocument: false,
+  onSend: vi.fn(),
+  onStop: vi.fn(),
+  onClear: vi.fn(),
+  onQuickAction: vi.fn(),
+};
+
+describe("lazyAIChatPanel", { timeout: CHUNK_LOAD_TIMEOUT_MS }, () => {
+  it("renders nothing while the panel has never been opened", () => {
+    render(<AIChatPanel {...defaultProps} open={false} />);
+    expect(screen.queryByTestId("ai-chat-panel")).not.toBeInTheDocument();
+  });
+
+  it("loads the panel on first open", async () => {
+    render(<AIChatPanel {...defaultProps} open />);
+    await waitFor(() => expect(screen.getByTestId("ai-chat-panel")).toHaveTextContent("open"), {
+      timeout: CHUNK_LOAD_TIMEOUT_MS,
+    });
+  });
+
+  it("keeps the panel mounted after it closes so composer draft and scroll survive", async () => {
+    const { rerender } = render(<AIChatPanel {...defaultProps} open />);
+    await waitFor(() => expect(screen.getByTestId("ai-chat-panel")).toBeInTheDocument(), {
+      timeout: CHUNK_LOAD_TIMEOUT_MS,
+    });
+    rerender(<AIChatPanel {...defaultProps} open={false} />);
+    expect(screen.getByTestId("ai-chat-panel")).toHaveTextContent("closed");
+  });
+});

--- a/src/components/ai/lazyAIChatPanel.tsx
+++ b/src/components/ai/lazyAIChatPanel.tsx
@@ -1,0 +1,26 @@
+import { type ComponentProps, lazy, Suspense, useState } from "react";
+
+// The AI panel (chat history, composer, quick actions, provider glue) is
+// optional: most sessions never open it, so it stays out of the startup
+// bundle. The panel is always-mounted UI (CSS shows/hides it via data-open,
+// and it holds the composer draft and scroll position), so it cannot simply
+// be unmounted while closed. Instead the chunk loads on the first open and
+// the panel stays mounted afterwards.
+const AIChatPanelLazy = lazy(() =>
+  import("./AIChatPanel").then((m) => ({ default: m.AIChatPanel })),
+);
+
+export function AIChatPanel(props: ComponentProps<typeof AIChatPanelLazy>) {
+  const [everOpened, setEverOpened] = useState(false);
+  if (props.open && !everOpened) {
+    setEverOpened(true);
+  }
+  if (!everOpened && !props.open) {
+    return null;
+  }
+  return (
+    <Suspense fallback={null}>
+      <AIChatPanelLazy {...props} />
+    </Suspense>
+  );
+}

--- a/src/components/layout/AppModals.test.tsx
+++ b/src/components/layout/AppModals.test.tsx
@@ -7,10 +7,10 @@ import { AppModals } from "./AppModals";
 vi.mock("@/components/modals/settings/lazySettings", () => ({
   SettingsModal: () => <div>settings modal</div>,
 }));
-vi.mock("@/components/modals/workspace/WorkspaceSettingsModal", () => ({
+vi.mock("@/components/modals/workspace/lazyWorkspaceSettings", () => ({
   WorkspaceSettingsModal: () => <div>workspace modal</div>,
 }));
-vi.mock("@/components/plugins/PluginsModal", () => ({
+vi.mock("@/components/plugins/lazyPluginsModal", () => ({
   PluginsModal: () => <div>plugins modal</div>,
 }));
 

--- a/src/components/layout/AppModals.tsx
+++ b/src/components/layout/AppModals.tsx
@@ -1,6 +1,6 @@
 import { SettingsModal } from "@/components/modals/settings/lazySettings";
-import { WorkspaceSettingsModal } from "@/components/modals/workspace/WorkspaceSettingsModal";
-import { PluginsModal } from "@/components/plugins/PluginsModal";
+import { WorkspaceSettingsModal } from "@/components/modals/workspace/lazyWorkspaceSettings";
+import { PluginsModal } from "@/components/plugins/lazyPluginsModal";
 import type { AppModals as AppModalsState } from "@/hooks/useAppModals";
 import { useSpringPresence } from "@/hooks/useSpringPresence";
 

--- a/src/components/markdown/MarkdownContent.tsx
+++ b/src/components/markdown/MarkdownContent.tsx
@@ -4,6 +4,7 @@ import { EmbedContext, type EmbedContextValue, useEmbedContext } from "@/context
 import { LightboxProvider } from "@/contexts/LightboxProvider";
 import { usePluginsOptional } from "@/contexts/PluginsContext";
 import { useWorkspaceRoot } from "@/contexts/TabsContext";
+import { useGemojiPlugin } from "@/hooks/useGemojiPlugin";
 import { useHighlightPlugin } from "@/hooks/useHighlightPlugin";
 import { useKatexPlugin } from "@/hooks/useKatexPlugin";
 import { useRegistryEntries } from "@/hooks/usePluginRegistry";
@@ -59,6 +60,8 @@ export function MarkdownContent({
   // With math off, skip the KaTeX lazy-load entirely (remark-math is also
   // dropped from the pipeline, so $…$ stays literal text).
   const katexPlugin = useKatexPlugin(features.math ? content : "");
+  // Same deal for emoji: with the toggle off, the gemoji table never loads.
+  const gemojiPlugin = useGemojiPlugin(features.emoji ? content : "");
   const highlightPlugin = useHighlightPlugin(content);
   // Plugin-contributed remark/rehype plugins, appended to the built-in pipeline.
   const plugins = usePluginsOptional();
@@ -92,8 +95,9 @@ export function MarkdownContent({
   );
 
   const remarkPlugins = useMemo(
-    () => buildRemarkPlugins({ workspaceFiles, filePath, features, extra: pluginRemark }),
-    [workspaceFiles, filePath, features, pluginRemark],
+    () =>
+      buildRemarkPlugins({ workspaceFiles, filePath, features, gemojiPlugin, extra: pluginRemark }),
+    [workspaceFiles, filePath, features, gemojiPlugin, pluginRemark],
   );
 
   const LinkWithWikilink = useCallback(

--- a/src/components/markdown/lazyGemoji.test.ts
+++ b/src/components/markdown/lazyGemoji.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { hasEmojiShortcode, loadGemoji } from "./lazyGemoji";
+
+describe("hasEmojiShortcode", () => {
+  it("matches word shortcodes", () => {
+    expect(hasEmojiShortcode("hello :smile: world")).toBe(true);
+  });
+
+  it("matches plus and minus shortcodes", () => {
+    expect(hasEmojiShortcode("nice :+1:")).toBe(true);
+    expect(hasEmojiShortcode("nope :-1:")).toBe(true);
+  });
+
+  it("returns false for plain prose", () => {
+    expect(hasEmojiShortcode("just words, no codes")).toBe(false);
+  });
+
+  it("returns false for a lone colon pair with a space between", () => {
+    expect(hasEmojiShortcode("a : b : c")).toBe(false);
+  });
+});
+
+describe("loadGemoji", () => {
+  it("caches the returned plugin between calls", async () => {
+    const a = await loadGemoji();
+    const b = await loadGemoji();
+    expect(a).toBe(b);
+    expect(typeof a).toBe("function");
+  });
+});

--- a/src/components/markdown/lazyGemoji.ts
+++ b/src/components/markdown/lazyGemoji.ts
@@ -1,4 +1,5 @@
 import type { Options } from "react-markdown";
+import { trackPluginLoad } from "@/lib/markdown/pluginLoads";
 
 type RemarkPlugin = NonNullable<Options["remarkPlugins"]>[number];
 
@@ -17,7 +18,9 @@ export function hasEmojiShortcode(content: string): boolean {
 // it stays out of the startup chunk and loads on first sight of a shortcode.
 export function loadGemoji(): Promise<RemarkPlugin> {
   if (!gemojiPromise) {
-    gemojiPromise = import("remark-gemoji").then((mod) => mod.default as RemarkPlugin);
+    gemojiPromise = trackPluginLoad(
+      import("remark-gemoji").then((mod) => mod.default as RemarkPlugin),
+    );
   }
   return gemojiPromise;
 }

--- a/src/components/markdown/lazyGemoji.ts
+++ b/src/components/markdown/lazyGemoji.ts
@@ -1,0 +1,23 @@
+import type { Options } from "react-markdown";
+
+type RemarkPlugin = NonNullable<Options["remarkPlugins"]>[number];
+
+// Cheap detector: a false positive (e.g. "10:30:45") just means the gemoji
+// data loads when it didn't have to, not a correctness problem. The shortcode
+// alphabet is letters, digits, underscore, plus, and minus (:+1:, :-1:).
+const EMOJI_SHORTCODE_PATTERN = /:[-+\w]+:/;
+
+let gemojiPromise: Promise<RemarkPlugin> | null = null;
+
+export function hasEmojiShortcode(content: string): boolean {
+  return EMOJI_SHORTCODE_PATTERN.test(content);
+}
+
+// remark-gemoji bundles the full shortcode-to-emoji table, which is heavy, so
+// it stays out of the startup chunk and loads on first sight of a shortcode.
+export function loadGemoji(): Promise<RemarkPlugin> {
+  if (!gemojiPromise) {
+    gemojiPromise = import("remark-gemoji").then((mod) => mod.default as RemarkPlugin);
+  }
+  return gemojiPromise;
+}

--- a/src/components/markdown/lazyHighlight.ts
+++ b/src/components/markdown/lazyHighlight.ts
@@ -1,4 +1,5 @@
 import type { Options } from "react-markdown";
+import { trackPluginLoad } from "@/lib/markdown/pluginLoads";
 
 type RehypePlugin = NonNullable<Options["rehypePlugins"]>[number];
 
@@ -19,7 +20,9 @@ export function hasCodeBlock(content: string): boolean {
 
 export function loadHighlight(): Promise<RehypePlugin> {
   if (!highlightPromise) {
-    highlightPromise = import("rehype-highlight").then((mod) => mod.default as RehypePlugin);
+    highlightPromise = trackPluginLoad(
+      import("rehype-highlight").then((mod) => mod.default as RehypePlugin),
+    );
   }
   return highlightPromise;
 }

--- a/src/components/markdown/lazyKatex.ts
+++ b/src/components/markdown/lazyKatex.ts
@@ -1,4 +1,5 @@
 import type { Options } from "react-markdown";
+import { trackPluginLoad } from "@/lib/markdown/pluginLoads";
 
 type RehypePlugin = NonNullable<Options["rehypePlugins"]>[number];
 
@@ -14,8 +15,10 @@ export function hasMath(content: string): boolean {
 
 export function loadKatex(): Promise<RehypePlugin> {
   if (!katexPromise) {
-    katexPromise = Promise.all([import("rehype-katex"), import("katex/dist/katex.min.css")]).then(
-      ([mod]) => mod.default as RehypePlugin,
+    katexPromise = trackPluginLoad(
+      Promise.all([import("rehype-katex"), import("katex/dist/katex.min.css")]).then(
+        ([mod]) => mod.default as RehypePlugin,
+      ),
     );
   }
   return katexPromise;

--- a/src/components/modals/workspace/lazyWorkspaceSettings.test.tsx
+++ b/src/components/modals/workspace/lazyWorkspaceSettings.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CHUNK_LOAD_TIMEOUT_MS } from "@/test/chunkLoadTimeout";
+import { WorkspaceSettingsModal } from "./lazyWorkspaceSettings";
+
+// The real modal drags in sync + site-export configuration; this test only
+// exercises the lazy() + Suspense wrapper, i.e. that the chunk resolves.
+vi.mock("./WorkspaceSettingsModal", () => ({
+  WorkspaceSettingsModal: () => <div data-testid="workspace-settings-modal" />,
+}));
+
+describe("lazyWorkspaceSettings", { timeout: CHUNK_LOAD_TIMEOUT_MS }, () => {
+  it("lazily renders the WorkspaceSettingsModal", async () => {
+    render(<WorkspaceSettingsModal open onClose={() => {}} tab="website" onTabChange={() => {}} />);
+    await waitFor(
+      () => expect(screen.getByTestId("workspace-settings-modal")).toBeInTheDocument(),
+      {
+        timeout: CHUNK_LOAD_TIMEOUT_MS,
+      },
+    );
+  });
+});

--- a/src/components/modals/workspace/lazyWorkspaceSettings.tsx
+++ b/src/components/modals/workspace/lazyWorkspaceSettings.tsx
@@ -1,0 +1,17 @@
+import { type ComponentProps, lazy, Suspense } from "react";
+
+// Workspace settings (sync configuration, site export options) is occasional
+// UI, so its code loads on first open instead of at startup. AppModals only
+// mounts this while the modal is open. Suspense is wrapped here so callers use
+// it as a drop-in replacement, matching lazySettings.
+const WorkspaceSettingsModalLazy = lazy(() =>
+  import("./WorkspaceSettingsModal").then((m) => ({ default: m.WorkspaceSettingsModal })),
+);
+
+export function WorkspaceSettingsModal(props: ComponentProps<typeof WorkspaceSettingsModalLazy>) {
+  return (
+    <Suspense fallback={null}>
+      <WorkspaceSettingsModalLazy {...props} />
+    </Suspense>
+  );
+}

--- a/src/components/plugins/lazyPluginsModal.test.tsx
+++ b/src/components/plugins/lazyPluginsModal.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CHUNK_LOAD_TIMEOUT_MS } from "@/test/chunkLoadTimeout";
+import { PluginsModal } from "./lazyPluginsModal";
+
+// The real modal drags in the whole marketplace; this test only exercises the
+// lazy() + Suspense wrapper, i.e. that the chunk resolves and props flow.
+vi.mock("./PluginsModal", () => ({
+  PluginsModal: () => <div data-testid="plugins-modal" />,
+}));
+
+describe("lazyPluginsModal", { timeout: CHUNK_LOAD_TIMEOUT_MS }, () => {
+  it("lazily renders the PluginsModal", async () => {
+    render(<PluginsModal onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByTestId("plugins-modal")).toBeInTheDocument(), {
+      timeout: CHUNK_LOAD_TIMEOUT_MS,
+    });
+  });
+});

--- a/src/components/plugins/lazyPluginsModal.tsx
+++ b/src/components/plugins/lazyPluginsModal.tsx
@@ -1,0 +1,17 @@
+import { type ComponentProps, lazy, Suspense } from "react";
+
+// The plugin marketplace (browse, detail, install flows) is opt-in UI, so its
+// code loads on first open instead of at startup. AppModals only mounts this
+// while the modal is open. Suspense is wrapped here so callers use it as a
+// drop-in replacement, matching lazySettings.
+const PluginsModalLazy = lazy(() =>
+  import("./PluginsModal").then((m) => ({ default: m.PluginsModal })),
+);
+
+export function PluginsModal(props: ComponentProps<typeof PluginsModalLazy>) {
+  return (
+    <Suspense fallback={null}>
+      <PluginsModalLazy {...props} />
+    </Suspense>
+  );
+}

--- a/src/hooks/useErrorReporting.ts
+++ b/src/hooks/useErrorReporting.ts
@@ -11,7 +11,7 @@ export function useErrorReporting(enabled: boolean, loaded: boolean): void {
   useEffect(() => {
     if (!loaded) return;
     if (enabled) {
-      enableTelemetry();
+      void enableTelemetry();
     } else {
       disableTelemetry();
     }

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -53,13 +53,19 @@ export function useExport({
         // The export pipeline is loaded on first use so none of it (nor its
         // docx/epub/pdf dependencies) weighs down startup; a failed chunk load
         // lands in the same catch as a failed export.
-        const [{ exportCanvas }, { exportDocument }, { deriveExportMeta }, { EXPORT_EXT }] =
-          await Promise.all([
-            import("@/lib/export/exportCanvas"),
-            import("@/lib/export/exportDocument"),
-            import("@/lib/export/meta"),
-            import("@/lib/export/writeExport"),
-          ]);
+        const [
+          { exportCanvas },
+          { exportDocument },
+          { deriveExportMeta },
+          { EXPORT_EXT },
+          { EXPORTABLE_ROOT_SELECTOR, waitForRenderIdle },
+        ] = await Promise.all([
+          import("@/lib/export/exportCanvas"),
+          import("@/lib/export/exportDocument"),
+          import("@/lib/export/meta"),
+          import("@/lib/export/writeExport"),
+          import("@/lib/export/renderReady"),
+        ]);
 
         const meta = deriveExportMeta(filePath, content);
         const ext = EXPORT_EXT[format];
@@ -69,6 +75,14 @@ export function useExport({
         // Show the indicator only for the real work, after the (blocking)
         // native dialog: image inlining and the build/write.
         setExporting(format);
+        // The document can be closed while the native dialog sits open. There
+        // is nothing to wait for then, and waiting would stall until the
+        // gate's deadline instead of aborting.
+        if (!document.querySelector(EXPORTABLE_ROOT_SELECTOR)) return;
+        // Export reads the live DOM, so a diagram still compiling or a lazy
+        // plugin chunk still in flight would be snapshotted half-rendered.
+        // Same gate the CLI export uses; normally settles in one quiet window.
+        await waitForRenderIdle();
         if (canvas) await exportCanvas(format, path, meta);
         else await exportDocument(format, path, meta, { entries, includeToc });
       } catch (err) {

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -1,9 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { exportCanvas } from "@/lib/export/exportCanvas";
-import { exportDocument } from "@/lib/export/exportDocument";
-import { deriveExportMeta } from "@/lib/export/meta";
-import { EXPORT_EXT, type ExportFormat } from "@/lib/export/writeExport";
+import type { ExportFormat } from "@/lib/export/writeExport";
 import { pickSave } from "@/lib/pickers";
 import type { PrintSettings } from "@/lib/settings";
 import type { TocEntry } from "./useTableOfContents";
@@ -52,15 +49,26 @@ export function useExport({
       // Cheap guard so we don't pop a save dialog with nothing to export.
       if (!canvas && !document.querySelector(".markdown-body")) return;
 
-      const meta = deriveExportMeta(filePath, content);
-      const ext = EXPORT_EXT[format];
-      const path = await pickSave(`${meta.baseName}.${ext}`, t(`exportFilter.${format}`), [ext]);
-      if (!path) return; // user cancelled
-
-      // Show the indicator only for the real work — after the (blocking) native
-      // dialog, covering image inlining and the build/write.
-      setExporting(format);
       try {
+        // The export pipeline is loaded on first use so none of it (nor its
+        // docx/epub/pdf dependencies) weighs down startup; a failed chunk load
+        // lands in the same catch as a failed export.
+        const [{ exportCanvas }, { exportDocument }, { deriveExportMeta }, { EXPORT_EXT }] =
+          await Promise.all([
+            import("@/lib/export/exportCanvas"),
+            import("@/lib/export/exportDocument"),
+            import("@/lib/export/meta"),
+            import("@/lib/export/writeExport"),
+          ]);
+
+        const meta = deriveExportMeta(filePath, content);
+        const ext = EXPORT_EXT[format];
+        const path = await pickSave(`${meta.baseName}.${ext}`, t(`exportFilter.${format}`), [ext]);
+        if (!path) return; // user cancelled
+
+        // Show the indicator only for the real work, after the (blocking)
+        // native dialog: image inlining and the build/write.
+        setExporting(format);
         if (canvas) await exportCanvas(format, path, meta);
         else await exportDocument(format, path, meta, { entries, includeToc });
       } catch (err) {

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -28,8 +28,8 @@ export interface ExportHandlers {
 /**
  * Export the active document to HTML/DOCX/EPUB/PDF. Reuses the rendered
  * `.markdown-body` DOM for fidelity, shows a native save dialog, and writes a
- * file via Rust commands (text for HTML, bytes for DOCX/EPUB/PDF) — no print
- * dialog. The separate File > Print item is the print-dialog path.
+ * file via Rust commands (text for HTML, bytes for DOCX/EPUB/PDF), with no
+ * print dialog. The separate File > Print item is the print-dialog path.
  */
 export function useExport({
   entries,

--- a/src/hooks/useGemojiPlugin.test.ts
+++ b/src/hooks/useGemojiPlugin.test.ts
@@ -1,11 +1,38 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useGemojiPlugin } from "./useGemojiPlugin";
+
+// Only the loader is stubbed; the shortcode detector stays real. Holding the
+// chunk in flight is what lets a test land a load after the content moved on.
+const { loadGemojiMock } = vi.hoisted(() => ({ loadGemojiMock: vi.fn() }));
+vi.mock("@/components/markdown/lazyGemoji", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/components/markdown/lazyGemoji")>()),
+  loadGemoji: () => loadGemojiMock(),
+}));
+
+const gemojiPlugin = () => {};
+
+/** Hold the next load open; the returned function lets it finish. */
+function deferLoad(): () => void {
+  let settle = () => {};
+  loadGemojiMock.mockReturnValue(
+    new Promise((resolve) => {
+      settle = () => resolve(gemojiPlugin);
+    }),
+  );
+  return settle;
+}
+
+beforeEach(() => {
+  loadGemojiMock.mockReset();
+  loadGemojiMock.mockResolvedValue(gemojiPlugin);
+});
 
 describe("useGemojiPlugin", () => {
   it("returns null for content without shortcodes and never loads", () => {
     const { result } = renderHook(() => useGemojiPlugin("plain text"));
     expect(result.current).toBeNull();
+    expect(loadGemojiMock).not.toHaveBeenCalled();
   });
 
   it("resolves the plugin once content contains a shortcode", async () => {
@@ -13,7 +40,7 @@ describe("useGemojiPlugin", () => {
       initialProps: { content: "hello :smile:" },
     });
     await waitFor(() => {
-      expect(typeof result.current).toBe("function");
+      expect(result.current).toBe(gemojiPlugin);
     });
   });
 
@@ -26,5 +53,25 @@ describe("useGemojiPlugin", () => {
     });
     rerender({ content: "plain" });
     expect(result.current).toBeNull();
+  });
+
+  it("drops a load that lands after the content stopped needing it", async () => {
+    const settle = deferLoad();
+    const { result, rerender } = renderHook(({ content }) => useGemojiPlugin(content), {
+      initialProps: { content: "hello :smile:" },
+    });
+
+    // The chunk is still in flight when the document loses its shortcodes.
+    rerender({ content: "plain prose" });
+    await act(async () => {
+      settle();
+    });
+    expect(result.current).toBeNull();
+
+    // The dropped load left nothing broken: a later shortcode still resolves.
+    rerender({ content: "back :tada:" });
+    await waitFor(() => {
+      expect(result.current).toBe(gemojiPlugin);
+    });
   });
 });

--- a/src/hooks/useGemojiPlugin.test.ts
+++ b/src/hooks/useGemojiPlugin.test.ts
@@ -1,0 +1,30 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useGemojiPlugin } from "./useGemojiPlugin";
+
+describe("useGemojiPlugin", () => {
+  it("returns null for content without shortcodes and never loads", () => {
+    const { result } = renderHook(() => useGemojiPlugin("plain text"));
+    expect(result.current).toBeNull();
+  });
+
+  it("resolves the plugin once content contains a shortcode", async () => {
+    const { result } = renderHook(({ content }) => useGemojiPlugin(content), {
+      initialProps: { content: "hello :smile:" },
+    });
+    await waitFor(() => {
+      expect(typeof result.current).toBe("function");
+    });
+  });
+
+  it("goes back to null when the shortcode disappears", async () => {
+    const { result, rerender } = renderHook(({ content }) => useGemojiPlugin(content), {
+      initialProps: { content: "hello :smile:" },
+    });
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+    });
+    rerender({ content: "plain" });
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/hooks/useGemojiPlugin.ts
+++ b/src/hooks/useGemojiPlugin.ts
@@ -14,13 +14,7 @@ export function useGemojiPlugin(content: string): RemarkPlugin | null {
 
   useEffect(() => {
     if (!contentHasShortcode) return;
-    let cancelled = false;
-    loadGemoji().then((p) => {
-      if (!cancelled) setPlugin(() => p);
-    });
-    return () => {
-      cancelled = true;
-    };
+    loadGemoji().then((p) => setPlugin(() => p));
   }, [contentHasShortcode]);
 
   return contentHasShortcode ? plugin : null;

--- a/src/hooks/useGemojiPlugin.ts
+++ b/src/hooks/useGemojiPlugin.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import type { Options } from "react-markdown";
+import { hasEmojiShortcode, loadGemoji } from "@/components/markdown/lazyGemoji";
+
+type RemarkPlugin = NonNullable<Options["remarkPlugins"]>[number];
+
+/**
+ * Lazily loads `remark-gemoji` the first time `content` contains an emoji
+ * shortcode. Returns `null` until the plugin is ready or if none is present.
+ */
+export function useGemojiPlugin(content: string): RemarkPlugin | null {
+  const contentHasShortcode = hasEmojiShortcode(content);
+  const [plugin, setPlugin] = useState<RemarkPlugin | null>(null);
+
+  useEffect(() => {
+    if (!contentHasShortcode) return;
+    let cancelled = false;
+    loadGemoji().then((p) => {
+      if (!cancelled) setPlugin(() => p);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [contentHasShortcode]);
+
+  return contentHasShortcode ? plugin : null;
+}

--- a/src/hooks/useHighlightPlugin.ts
+++ b/src/hooks/useHighlightPlugin.ts
@@ -18,13 +18,7 @@ export function useHighlightPlugin(content: string): RehypePlugin | null {
 
   useEffect(() => {
     if (!contentHasCode) return;
-    let cancelled = false;
-    loadHighlight().then((p) => {
-      if (!cancelled) setPlugin(() => [p, HIGHLIGHT_OPTIONS] as RehypePlugin);
-    });
-    return () => {
-      cancelled = true;
-    };
+    loadHighlight().then((p) => setPlugin(() => [p, HIGHLIGHT_OPTIONS] as RehypePlugin));
   }, [contentHasCode]);
 
   return contentHasCode ? plugin : null;

--- a/src/hooks/useKatexPlugin.ts
+++ b/src/hooks/useKatexPlugin.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { Options } from "react-markdown";
-import { hasMath, loadKatex } from "../components/markdown/lazyKatex";
+import { hasMath, loadKatex } from "@/components/markdown/lazyKatex";
 
 type RehypePlugin = NonNullable<Options["rehypePlugins"]>[number];
 
@@ -14,13 +14,7 @@ export function useKatexPlugin(content: string): RehypePlugin | null {
 
   useEffect(() => {
     if (!contentHasMath) return;
-    let cancelled = false;
-    loadKatex().then((p) => {
-      if (!cancelled) setPlugin(() => p);
-    });
-    return () => {
-      cancelled = true;
-    };
+    loadKatex().then((p) => setPlugin(() => p));
   }, [contentHasMath]);
 
   return contentHasMath ? plugin : null;

--- a/src/hooks/usePrint.test.ts
+++ b/src/hooks/usePrint.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PrintSettings } from "../lib/settings";
+import type { PrintSettings } from "@/lib/settings";
 import { usePrint } from "./usePrint";
 import type { TocEntry } from "./useTableOfContents";
 

--- a/src/hooks/usePrint.test.ts
+++ b/src/hooks/usePrint.test.ts
@@ -11,9 +11,12 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 const restoreDiagramsMock = vi.fn();
 const swapDiagramsLightMock = vi.fn(async () => restoreDiagramsMock);
-vi.mock("@/lib/export/lightDiagrams", () => ({
-  swapDiagramsLight: () => swapDiagramsLightMock(),
-}));
+// The factory can be told to fail so the chunk-load error path is testable.
+let lightDiagramsLoadError: Error | null = null;
+vi.mock("@/lib/export/lightDiagrams", () => {
+  if (lightDiagramsLoadError) throw lightDiagramsLoadError;
+  return { swapDiagramsLight: () => swapDiagramsLightMock() };
+});
 
 const DEFAULT_PRINT: PrintSettings = {
   pageBreakLevel: "none",
@@ -44,14 +47,32 @@ describe("usePrint", () => {
     restoreDiagramsMock.mockClear();
   });
 
-  it("no-ops when no .markdown-body is present", () => {
+  // First in the file: the mock factory only throws on its first evaluation
+  // (a failed factory is not cached, so later tests re-evaluate it clean),
+  // which only lines up while no other test has imported the module yet.
+  it("aborts printing with a log when the helper chunk fails to load", async () => {
+    lightDiagramsLoadError = new Error("chunk load failed");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { result } = renderHook(() => usePrint({ entries: ENTRIES, settings: DEFAULT_PRINT }));
+      await result.current();
+      expect(errorSpy).toHaveBeenCalledWith("Print helpers failed to load:", expect.any(Error));
+      expect(invokeMock).not.toHaveBeenCalled();
+      expect(document.documentElement.hasAttribute("data-print-breaks")).toBe(false);
+    } finally {
+      lightDiagramsLoadError = null;
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("no-ops when no .markdown-body is present", async () => {
     document.body.innerHTML = "";
     const { result } = renderHook(() => usePrint({ entries: ENTRIES, settings: DEFAULT_PRINT }));
-    result.current();
+    await result.current();
     expect(invokeMock).not.toHaveBeenCalled();
   });
 
-  it("no-ops when the only markdown body belongs to a canvas card", () => {
+  it("no-ops when the only markdown body belongs to a canvas card", async () => {
     document.body.innerHTML = "";
     const board = document.createElement("div");
     board.className = "glyph-canvas";
@@ -61,32 +82,32 @@ describe("usePrint", () => {
     document.body.appendChild(board);
 
     const { result } = renderHook(() => usePrint({ entries: ENTRIES, settings: DEFAULT_PRINT }));
-    result.current();
+    await result.current();
     expect(invokeMock).not.toHaveBeenCalled();
     expect(document.documentElement.hasAttribute("data-print-breaks")).toBe(false);
   });
 
-  it("sets html data attributes from settings before printing", () => {
+  it("sets html data attributes from settings before printing", async () => {
     const { result } = renderHook(() =>
       usePrint({
         entries: ENTRIES,
         settings: { pageBreakLevel: "h2", includeToc: false, includeBackground: true },
       }),
     );
-    result.current();
+    await result.current();
     expect(document.documentElement.getAttribute("data-print-breaks")).toBe("h2");
     expect(document.documentElement.getAttribute("data-print-bg")).toBe("true");
     expect(invokeMock).toHaveBeenCalledWith("print_document");
   });
 
-  it("injects a print-toc when includeToc is true and entries exist", () => {
+  it("injects a print-toc when includeToc is true and entries exist", async () => {
     const { result } = renderHook(() =>
       usePrint({
         entries: ENTRIES,
         settings: { ...DEFAULT_PRINT, includeToc: true },
       }),
     );
-    result.current();
+    await result.current();
     const toc = document.querySelector(".print-toc");
     expect(toc).toBeTruthy();
     const links = toc?.querySelectorAll("a") ?? [];
@@ -95,14 +116,14 @@ describe("usePrint", () => {
     expect(links[1].textContent).toBe("Details");
   });
 
-  it("does not inject a print-toc when includeToc is true but entries are empty", () => {
+  it("does not inject a print-toc when includeToc is true but entries are empty", async () => {
     const { result } = renderHook(() =>
       usePrint({
         entries: [],
         settings: { ...DEFAULT_PRINT, includeToc: true },
       }),
     );
-    result.current();
+    await result.current();
     expect(document.querySelector(".print-toc")).toBeNull();
   });
 
@@ -112,7 +133,7 @@ describe("usePrint", () => {
     window.print = printSpy;
 
     const { result } = renderHook(() => usePrint({ entries: ENTRIES, settings: DEFAULT_PRINT }));
-    result.current();
+    await result.current();
 
     await vi.waitFor(() => expect(printSpy).toHaveBeenCalledTimes(1));
   });
@@ -135,14 +156,14 @@ describe("usePrint", () => {
     expect(swapDiagramsLightMock).not.toHaveBeenCalled();
   });
 
-  it("cleans up attributes and toc on afterprint", () => {
+  it("cleans up attributes and toc on afterprint", async () => {
     const { result } = renderHook(() =>
       usePrint({
         entries: ENTRIES,
         settings: { pageBreakLevel: "h1", includeToc: true, includeBackground: false },
       }),
     );
-    result.current();
+    await result.current();
     expect(document.querySelector(".print-toc")).toBeTruthy();
 
     window.dispatchEvent(new Event("afterprint"));

--- a/src/hooks/usePrint.ts
+++ b/src/hooks/usePrint.ts
@@ -1,8 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback } from "react";
-import { swapDiagramsLight } from "@/lib/export/lightDiagrams";
-import { buildTocElement } from "@/lib/export/toc";
-import type { PrintSettings } from "../lib/settings";
+import type { PrintSettings } from "@/lib/settings";
 import type { TocEntry } from "./useTableOfContents";
 
 interface UsePrintOptions {
@@ -16,6 +14,21 @@ export function usePrint({ entries, settings }: UsePrintOptions) {
     // Canvas cards carry their own small markdown bodies; printing one of
     // those is never what the user wants. Export the board as PNG instead.
     if (!body || body.closest(".glyph-canvas")) return;
+
+    // Loaded on first print so the diagram-relight/TOC helpers (and their
+    // rasterize dependencies) stay out of the startup bundle. A failed chunk
+    // load (corrupted install) aborts with a log, not an unhandled rejection.
+    let helpers: [typeof import("@/lib/export/lightDiagrams"), typeof import("@/lib/export/toc")];
+    try {
+      helpers = await Promise.all([
+        import("@/lib/export/lightDiagrams"),
+        import("@/lib/export/toc"),
+      ]);
+    } catch (err) {
+      console.error("Print helpers failed to load:", err);
+      return;
+    }
+    const [{ swapDiagramsLight }, { buildTocElement }] = helpers;
 
     const root = document.documentElement;
     root.setAttribute("data-print-breaks", settings.pageBreakLevel);

--- a/src/hooks/usePrint.ts
+++ b/src/hooks/usePrint.ts
@@ -18,17 +18,27 @@ export function usePrint({ entries, settings }: UsePrintOptions) {
     // Loaded on first print so the diagram-relight/TOC helpers (and their
     // rasterize dependencies) stay out of the startup bundle. A failed chunk
     // load (corrupted install) aborts with a log, not an unhandled rejection.
-    let helpers: [typeof import("@/lib/export/lightDiagrams"), typeof import("@/lib/export/toc")];
+    let helpers: [
+      typeof import("@/lib/export/lightDiagrams"),
+      typeof import("@/lib/export/toc"),
+      typeof import("@/lib/export/renderReady"),
+    ];
     try {
       helpers = await Promise.all([
         import("@/lib/export/lightDiagrams"),
         import("@/lib/export/toc"),
+        import("@/lib/export/renderReady"),
       ]);
     } catch (err) {
       console.error("Print helpers failed to load:", err);
       return;
     }
-    const [{ swapDiagramsLight }, { buildTocElement }] = helpers;
+    const [{ swapDiagramsLight }, { buildTocElement }, { waitForRenderIdle }] = helpers;
+
+    // Print renders the live DOM, so wait out any diagram still compiling or
+    // lazy plugin chunk still in flight before touching it. Runs before the
+    // TOC injection below so our own mutations aren't what we wait on.
+    await waitForRenderIdle();
 
     const root = document.documentElement;
     root.setAttribute("data-print-breaks", settings.pageBreakLevel);

--- a/src/hooks/useWindowClose.test.ts
+++ b/src/hooks/useWindowClose.test.ts
@@ -1,9 +1,9 @@
-import { captureException } from "@sentry/react";
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureException } from "@/lib/telemetry";
 import { useWindowClose } from "./useWindowClose";
 
-vi.mock("@sentry/react", () => ({ captureException: vi.fn() }));
+vi.mock("@/lib/telemetry", () => ({ captureException: vi.fn() }));
 
 // Mock the Tauri window API. `onCloseRequested` captures the handler the hook
 // registers so tests can fire a synthetic close request; `close` is asserted on.

--- a/src/hooks/useWindowClose.ts
+++ b/src/hooks/useWindowClose.ts
@@ -1,6 +1,6 @@
-import * as Sentry from "@sentry/react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useRef } from "react";
+import { captureException } from "@/lib/telemetry";
 
 /**
  * Intercept the native window-close request (title-bar close, Close Window
@@ -40,7 +40,7 @@ export function useWindowClose(flush: () => Promise<boolean>) {
         } catch (err) {
           // Don't trap the window closed when the flush fails (#530).
           console.error("Close flush failed; closing anyway:", err);
-          Sentry.captureException(err);
+          captureException(err);
           proceed = true;
         }
         if (proceed) {

--- a/src/lib/d2Render.ts
+++ b/src/lib/d2Render.ts
@@ -5,7 +5,6 @@
 // self-contained and makes no network request — the diagram renders offline.
 
 import type { CompileOptions, Diagram, RenderOptions } from "@terrastruct/d2";
-import DOMPurify from "dompurify";
 
 // The shipped `D2` class types `compile`'s second argument as
 // `Omit<CompileRequest, "fs">` ({ inputPath?, options }), but the runtime treats
@@ -46,7 +45,11 @@ const cache = new Map<string, Promise<string>>();
 // <foreignObject>, the SVG-embedded-HTML XSS vector. Note: this also strips D2's
 // foreignObject-based markdown/code blocks, an accepted trade-off — the XSS
 // guard outweighs those rare embeds.
-function sanitizeSvg(svg: string): string {
+// DOMPurify is imported on demand (matching the export-path call sites) so it
+// stays out of the startup bundle; a D2 render already awaits the multi-MB
+// compiler, so the extra dynamic import is noise.
+async function sanitizeSvg(svg: string): Promise<string> {
+  const { default: DOMPurify } = await import("dompurify");
   return DOMPurify.sanitize(svg, { FORBID_TAGS: ["foreignObject"] });
 }
 

--- a/src/lib/export/renderReady.test.ts
+++ b/src/lib/export/renderReady.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { trackPluginLoad } from "@/lib/markdown/pluginLoads";
 import { waitForRenderIdle } from "./renderReady";
 
 function setBody(html: string): HTMLElement {
@@ -36,6 +37,40 @@ describe("waitForRenderIdle", () => {
 
     body.querySelector(".mermaid-diagram")!.innerHTML = "<svg></svg>";
     await expect(pending).resolves.toEqual({ settled: true });
+  });
+
+  // A document waiting on a lazy chunk mutates nothing, so the quiet check
+  // alone would call it finished and export the unrendered shortcode.
+  it("waits for a lazy plugin chunk that is still loading", async () => {
+    setBody("<p>shipped :tada:</p>");
+    let settle = () => {};
+    void trackPluginLoad(
+      new Promise<void>((resolve) => {
+        settle = resolve;
+      }),
+    );
+    const pending = waitForRenderIdle(document, 3000);
+
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    let done = false;
+    void pending.then(() => {
+      done = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(done).toBe(false);
+
+    settle();
+    await expect(pending).resolves.toEqual({ settled: true });
+  });
+
+  // A board is an exportable root in its own right; treating only the document
+  // bodies as one made every canvas export wait out the deadline.
+  it("settles on a canvas board", async () => {
+    const board = document.createElement("div");
+    board.className = "glyph-canvas";
+    board.innerHTML = '<div class="markdown-body"><p>card</p></div>';
+    document.body.appendChild(board);
+    await expect(waitForRenderIdle(document, 2000)).resolves.toEqual({ settled: true });
   });
 
   it("gives up at the deadline so one stuck diagram cannot hang the process", async () => {

--- a/src/lib/export/renderReady.ts
+++ b/src/lib/export/renderReady.ts
@@ -1,14 +1,19 @@
+import { pendingPluginLoads } from "@/lib/markdown/pluginLoads";
+
 // Diagrams and math render asynchronously after the document mounts (Mermaid
-// and D2 compile in a worker, KaTeX loads lazily), so a CLI export that fired
-// on mount would write a document with empty diagram slots. Wait for the
-// rendered body to appear and then settle.
+// and D2 compile in a worker, highlighting/KaTeX/gemoji load lazily), so an
+// export that fired on mount would write a document with empty diagram slots
+// and unrendered shortcodes. Wait for the rendered body to appear and settle.
 
 // How long the body must go unchanged before it counts as settled. Long enough
 // to bridge the gap between one diagram finishing and the next starting, short
 // enough not to pad every export.
 const QUIET_MS = 250;
 
-const BODY_SELECTOR = ".markdown-body, .notebook-body";
+// Every root an export can snapshot. A canvas board is included because its
+// cards hold their own markdown bodies, so it has the same lazy content to
+// wait on; leaving it out made a board export sit here until the deadline.
+export const EXPORTABLE_ROOT_SELECTOR = ".markdown-body, .notebook-body, .glyph-canvas";
 
 /** Diagram containers still waiting for their SVG (or their error message). */
 function pendingDiagrams(root: ParentNode): number {
@@ -19,7 +24,10 @@ function pendingDiagrams(root: ParentNode): number {
 
 /**
  * Resolve once the rendered document has appeared and stopped changing with no
- * diagram left empty, or when `timeoutMs` elapses. The timeout is the CI guard:
+ * diagram left empty and no lazy plugin still loading, or when `timeoutMs`
+ * elapses. The plugin check matters on its own: a document waiting for the
+ * gemoji or KaTeX chunk mutates nothing, so quiet alone would mean "finished"
+ * while the swap is still coming. The timeout is the CI guard:
  * one diagram that never resolves must not hang the process forever, so the
  * export proceeds with whatever rendered. A diagram missing from the output is
  * visible; a hung job is not.
@@ -46,10 +54,10 @@ export function waitForRenderIdle(
     function armQuietTimer() {
       window.clearTimeout(quietTimer);
       quietTimer = window.setTimeout(() => {
-        const body = doc.querySelector(BODY_SELECTOR);
+        const body = doc.querySelector(EXPORTABLE_ROOT_SELECTOR);
         // Quiet but incomplete means the document is still loading, or a
         // diagram is between frames; keep waiting for the deadline to decide.
-        if (body && pendingDiagrams(body) === 0) finish(true);
+        if (body && pendingDiagrams(body) === 0 && pendingPluginLoads() === 0) finish(true);
         else armQuietTimer();
       }, QUIET_MS);
     }

--- a/src/lib/export/site/renderPage.test.ts
+++ b/src/lib/export/site/renderPage.test.ts
@@ -26,6 +26,11 @@ describe("renderPageHtml", () => {
     expect(html).toContain("katex");
   });
 
+  it("renders emoji shortcodes through gemoji", async () => {
+    const html = await render("shipped :tada:");
+    expect(html).toContain("🎉");
+  });
+
   it("renders GitHub blockquote alerts", async () => {
     const html = await render("> [!NOTE]\n> Heads up");
     expect(html).toContain("markdown-alert");

--- a/src/lib/export/site/renderPage.ts
+++ b/src/lib/export/site/renderPage.ts
@@ -2,6 +2,7 @@ import rehypeStringify from "rehype-stringify";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { type PluggableList, unified } from "unified";
+import { hasEmojiShortcode, loadGemoji } from "@/components/markdown/lazyGemoji";
 import {
   HIGHLIGHT_OPTIONS,
   hasCodeBlock,
@@ -40,10 +41,18 @@ export async function renderPageHtml({
     ? ([await loadHighlight(), HIGHLIGHT_OPTIONS] as MarkdownPlugin)
     : null;
   const katexPlugin = hasMath(content) ? await loadKatex() : null;
+  const gemojiPlugin = hasEmojiShortcode(content) ? await loadGemoji() : null;
 
   const file = await unified()
     .use(remarkParse)
-    .use(buildRemarkPlugins({ workspaceFiles, filePath, extra: extraRemark }) as PluggableList)
+    .use(
+      buildRemarkPlugins({
+        workspaceFiles,
+        filePath,
+        gemojiPlugin,
+        extra: extraRemark,
+      }) as PluggableList,
+    )
     // Raw HTML must survive into the hast tree so rehype-raw can parse it and
     // rehype-sanitize can clean it, exactly as react-markdown does internally.
     .use(remarkRehype, { allowDangerousHtml: true })

--- a/src/lib/markdown/pipeline.test.ts
+++ b/src/lib/markdown/pipeline.test.ts
@@ -23,7 +23,15 @@ describe("buildRemarkPlugins", () => {
   });
 
   it("works with no extras", () => {
-    expect(buildRemarkPlugins({}).length).toBeGreaterThanOrEqual(6);
+    expect(buildRemarkPlugins({}).length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("includes the gemoji plugin only when the caller provides it resolved", () => {
+    const gemoji = vi.fn();
+    const withGemoji = buildRemarkPlugins({ gemojiPlugin: gemoji });
+    expect(withGemoji.map(ref)).toContain(gemoji);
+    expect(withGemoji.length).toBe(buildRemarkPlugins({}).length + 1);
+    expect(buildRemarkPlugins({ gemojiPlugin: null }).map(ref)).not.toContain(gemoji);
   });
 
   it("drops a feature's plugin when its toggle is off", () => {

--- a/src/lib/markdown/pipeline.ts
+++ b/src/lib/markdown/pipeline.ts
@@ -3,7 +3,6 @@ import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
 import rehypeSlug from "rehype-slug";
 import remarkFrontmatter from "remark-frontmatter";
-import remarkGemoji from "remark-gemoji";
 import remarkGfm from "remark-gfm";
 import { remarkAlert } from "remark-github-blockquote-alert";
 import remarkMath from "remark-math";
@@ -31,6 +30,11 @@ export interface RemarkPipelineOptions {
    * block is a document property, not a syntax extension.
    */
   features?: Partial<MarkdownSettings>;
+  /**
+   * Emoji-shortcode plugin, lazily loaded only when the document contains a
+   * `:name:` code (and the emoji toggle is on; callers gate the load).
+   */
+  gemojiPlugin?: MarkdownPlugin | null;
   /** Plugin-contributed remark plugins, appended after the built-ins. */
   extra?: readonly MarkdownPlugin[];
 }
@@ -39,12 +43,13 @@ export function buildRemarkPlugins({
   workspaceFiles,
   filePath,
   features = {},
+  gemojiPlugin,
   extra = [],
 }: RemarkPipelineOptions): RemarkPlugins {
   const plugins: RemarkPlugins = [remarkFrontmatter];
   if (features.gfm !== false) plugins.push(remarkGfm);
   if (features.math !== false) plugins.push(remarkMath);
-  if (features.emoji !== false) plugins.push(remarkGemoji);
+  if (gemojiPlugin) plugins.push(gemojiPlugin);
   if (features.alerts !== false) plugins.push(remarkAlert);
   if (features.wikilinks !== false) {
     plugins.push([remarkWikilink, { workspaceFiles, currentFilePath: filePath }]);

--- a/src/lib/markdown/pluginLoads.test.ts
+++ b/src/lib/markdown/pluginLoads.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { pendingPluginLoads, trackPluginLoad } from "./pluginLoads";
+
+describe("trackPluginLoad", () => {
+  it("counts a load while it is in flight and stops counting when it lands", async () => {
+    let settle = (_: string) => {};
+    const tracked = trackPluginLoad(
+      new Promise<string>((resolve) => {
+        settle = resolve;
+      }),
+    );
+    expect(pendingPluginLoads()).toBe(1);
+
+    settle("plugin");
+    await expect(tracked).resolves.toBe("plugin");
+    expect(pendingPluginLoads()).toBe(0);
+  });
+
+  it("stops counting a load that fails, and still rejects", async () => {
+    const tracked = trackPluginLoad(Promise.reject(new Error("chunk load failed")));
+    await expect(tracked).rejects.toThrow("chunk load failed");
+    expect(pendingPluginLoads()).toBe(0);
+  });
+
+  it("counts concurrent loads independently", async () => {
+    let settleFirst = () => {};
+    const first = trackPluginLoad(
+      new Promise<void>((resolve) => {
+        settleFirst = resolve;
+      }),
+    );
+    const second = trackPluginLoad(Promise.resolve());
+    expect(pendingPluginLoads()).toBe(2);
+
+    await second;
+    expect(pendingPluginLoads()).toBe(1);
+
+    settleFirst();
+    await first;
+    expect(pendingPluginLoads()).toBe(0);
+  });
+});

--- a/src/lib/markdown/pluginLoads.ts
+++ b/src/lib/markdown/pluginLoads.ts
@@ -1,0 +1,19 @@
+// Lazy markdown plugins (syntax highlighting, KaTeX, gemoji) swap into an
+// already-painted document when their chunk arrives. Exports read the live DOM,
+// and a document waiting on a chunk mutates nothing, so a quiet-DOM check alone
+// would call it finished and snapshot `:tada:` instead of the emoji. Counting
+// the loads in flight gives the export gate the missing signal.
+
+let inFlight = 0;
+
+/** Count `load` while it runs. Returns it unchanged, rejection included. */
+export function trackPluginLoad<T>(load: Promise<T>): Promise<T> {
+  inFlight++;
+  return load.finally(() => {
+    inFlight--;
+  });
+}
+
+export function pendingPluginLoads(): number {
+  return inFlight;
+}

--- a/src/lib/plugins/runExporter.ts
+++ b/src/lib/plugins/runExporter.ts
@@ -1,7 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { TocEntry } from "@/hooks/useTableOfContents";
-import { deriveExportMeta } from "@/lib/export/meta";
-import { prepareContent } from "@/lib/export/prepareContent";
 import { pickSave } from "@/lib/pickers";
 import type { ExporterContribution } from "./types";
 
@@ -24,6 +22,12 @@ export async function runExporter({
   filePath,
   content,
 }: RunExporterOptions): Promise<void> {
+  // Loaded on first use so the export pipeline stays out of the startup bundle.
+  const [{ prepareContent }, { deriveExportMeta }] = await Promise.all([
+    import("@/lib/export/prepareContent"),
+    import("@/lib/export/meta"),
+  ]);
+
   const prepared = await prepareContent({ entries, includeToc: false });
   if (prepared == null) return; // nothing rendered to export
 

--- a/src/lib/plugins/runExporter.ts
+++ b/src/lib/plugins/runExporter.ts
@@ -23,11 +23,20 @@ export async function runExporter({
   content,
 }: RunExporterOptions): Promise<void> {
   // Loaded on first use so the export pipeline stays out of the startup bundle.
-  const [{ prepareContent }, { deriveExportMeta }] = await Promise.all([
+  const [
+    { prepareContent },
+    { deriveExportMeta },
+    { EXPORTABLE_ROOT_SELECTOR, waitForRenderIdle },
+  ] = await Promise.all([
     import("@/lib/export/prepareContent"),
     import("@/lib/export/meta"),
+    import("@/lib/export/renderReady"),
   ]);
 
+  // The plugin gets the same fully-rendered DOM the built-in exporters do.
+  // Skipped when nothing is rendered: `prepareContent` bails just below, and
+  // waiting would stall until the gate's deadline first.
+  if (document.querySelector(EXPORTABLE_ROOT_SELECTOR)) await waitForRenderIdle();
   const prepared = await prepareContent({ entries, includeToc: false });
   if (prepared == null) return; // nothing rendered to export
 

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/react";
 import { invoke } from "@tauri-apps/api/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  captureException,
   disableTelemetry,
   enableTelemetry,
   redactPaths,
@@ -13,11 +14,13 @@ import {
 vi.mock("@sentry/react", () => ({
   init: vi.fn(),
   getClient: vi.fn(() => undefined),
+  captureException: vi.fn(),
 }));
 
 const mockedInvoke = vi.mocked(invoke);
 const mockedInit = vi.mocked(Sentry.init);
 const mockedGetClient = vi.mocked(Sentry.getClient);
+const mockedCapture = vi.mocked(Sentry.captureException);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -151,17 +154,35 @@ describe("scrubEvent", () => {
   });
 });
 
+describe("captureException", () => {
+  it("is a no-op before the telemetry opt-in has loaded the SDK", async () => {
+    // A fresh module instance guarantees the lazy SDK slot is still empty.
+    vi.resetModules();
+    const fresh = await import("./telemetry");
+    expect(() => fresh.captureException(new Error("boom"))).not.toThrow();
+    expect(mockedCapture).not.toHaveBeenCalled();
+  });
+
+  it("delegates to the SDK once the opt-in has loaded it", async () => {
+    vi.stubEnv("PROD", true);
+    await enableTelemetry();
+    const error = new Error("boom");
+    captureException(error);
+    expect(mockedCapture).toHaveBeenCalledWith(error, undefined);
+  });
+});
+
 describe("enableTelemetry", () => {
-  it("mirrors state to the backend but does not init Sentry in dev", () => {
+  it("mirrors state to the backend but does not init Sentry in dev", async () => {
     vi.stubEnv("PROD", false);
-    enableTelemetry();
+    await enableTelemetry();
     expect(mockedInvoke).toHaveBeenCalledWith("set_error_reporting", { enabled: true });
     expect(mockedInit).not.toHaveBeenCalled();
   });
 
-  it("initializes Sentry in production when no client exists", () => {
+  it("initializes Sentry in production when no client exists", async () => {
     vi.stubEnv("PROD", true);
-    enableTelemetry();
+    await enableTelemetry();
     expect(mockedInit).toHaveBeenCalledTimes(1);
     const options = mockedInit.mock.calls[0][0];
     expect(options).toMatchObject({ sendDefaultPii: false, tracesSampleRate: 0 });
@@ -169,16 +190,38 @@ describe("enableTelemetry", () => {
     expect(options?.beforeBreadcrumb).toBe(scrubBreadcrumb);
   });
 
-  it("does not re-init when a client already exists", () => {
+  it("does not re-init when a client already exists", async () => {
     vi.stubEnv("PROD", true);
     mockedGetClient.mockReturnValue({} as ReturnType<typeof Sentry.getClient>);
-    enableTelemetry();
+    await enableTelemetry();
     expect(mockedInit).not.toHaveBeenCalled();
+  });
+
+  it("does not init when the user opts out while the SDK is still loading", async () => {
+    vi.stubEnv("PROD", true);
+    const pending = enableTelemetry();
+    disableTelemetry();
+    await pending;
+    expect(mockedInit).not.toHaveBeenCalled();
+  });
+
+  it("re-initializes when re-enabled after an opt-out closed the client", async () => {
+    vi.stubEnv("PROD", true);
+    await enableTelemetry();
+    const close = vi.fn();
+    mockedGetClient.mockReturnValue({ close } as unknown as ReturnType<typeof Sentry.getClient>);
+    disableTelemetry();
+    mockedInit.mockClear();
+
+    await enableTelemetry();
+    expect(mockedInit).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("disableTelemetry", () => {
-  it("mirrors state to the backend and closes an existing client", () => {
+  it("mirrors state to the backend and closes an existing client", async () => {
+    vi.stubEnv("PROD", true);
+    await enableTelemetry();
     const close = vi.fn();
     mockedGetClient.mockReturnValue({ close } as unknown as ReturnType<typeof Sentry.getClient>);
     disableTelemetry();
@@ -186,7 +229,7 @@ describe("disableTelemetry", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
-  it("is a no-op on the client when none exists", () => {
+  it("is a no-op on the client when none is bound", () => {
     mockedGetClient.mockReturnValue(undefined);
     expect(() => disableTelemetry()).not.toThrow();
   });

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,5 +1,4 @@
 import type { Breadcrumb, ErrorEvent } from "@sentry/react";
-import * as Sentry from "@sentry/react";
 import { invoke } from "@tauri-apps/api/core";
 // Single source of truth for the Sentry DSN — `src-tauri/sentry.json`. The Rust
 // build script reads the same file (see build.rs) so the frontend and backend
@@ -97,27 +96,58 @@ function reportingAllowed(): boolean {
   return import.meta.env.PROD && SENTRY_DSN.length > 0;
 }
 
+type SentrySdk = typeof import("@sentry/react");
+
+// The SDK is heavy and only useful in production after the user opts in, so it
+// is imported on demand: startup never downloads it, and `captureException`
+// stays a no-op until the opt-in has loaded it (uninitialized-SDK semantics).
+let sdkPromise: Promise<SentrySdk> | null = null;
+let sdk: SentrySdk | null = null;
+// Desired state, tracked separately because loading is async: an opt-out that
+// lands while the SDK is still downloading must win over the pending init.
+let telemetryWanted = false;
+// A closed client stays bound in the SDK, so `getClient()` alone cannot tell
+// "running" from "opted out"; without this flag a re-enable would be skipped
+// and every later capture silently dropped by the closed client.
+let clientClosed = false;
+
+function loadSdk(): Promise<SentrySdk> {
+  sdkPromise ??= import("@sentry/react").then((mod) => {
+    sdk = mod;
+    return mod;
+  });
+  return sdkPromise;
+}
+
 /**
  * Turn error reporting on. Mirrors the choice into the Rust backend (which has
- * its own prod gate) and lazily initializes the JS SDK. No-op in dev or if the
- * client is already running.
+ * its own prod gate) and lazily loads + initializes the JS SDK. No-op in dev
+ * or if the client is already running. The returned promise resolves once the
+ * SDK is ready (or immediately when reporting is off); callers may ignore it.
  */
-export function enableTelemetry(): void {
+export function enableTelemetry(): Promise<void> {
+  telemetryWanted = true;
   void invoke("set_error_reporting", { enabled: true }).catch(() => {});
 
-  if (!reportingAllowed() || Sentry.getClient()) {
-    return;
+  if (!reportingAllowed()) {
+    return Promise.resolve();
   }
 
-  Sentry.init({
-    dsn: SENTRY_DSN,
-    release: `glyph@${__APP_VERSION__}`,
-    // Hard privacy posture for a local-first viewer: no PII, no performance
-    // tracing, no session replay (replay would record document contents).
-    sendDefaultPii: false,
-    tracesSampleRate: 0,
-    beforeSend: scrubEvent,
-    beforeBreadcrumb: scrubBreadcrumb,
+  return loadSdk().then((Sentry) => {
+    if (!telemetryWanted || (Sentry.getClient() && !clientClosed)) {
+      return;
+    }
+    clientClosed = false;
+    Sentry.init({
+      dsn: SENTRY_DSN,
+      release: `glyph@${__APP_VERSION__}`,
+      // Hard privacy posture for a local-first viewer: no PII, no performance
+      // tracing, no session replay (replay would record document contents).
+      sendDefaultPii: false,
+      tracesSampleRate: 0,
+      beforeSend: scrubEvent,
+      beforeBreadcrumb: scrubBreadcrumb,
+    });
   });
 }
 
@@ -126,6 +156,23 @@ export function enableTelemetry(): void {
  * tells the Rust backend to drop its Sentry guard.
  */
 export function disableTelemetry(): void {
+  telemetryWanted = false;
   void invoke("set_error_reporting", { enabled: false }).catch(() => {});
-  void Sentry.getClient()?.close();
+  const client = sdk?.getClient();
+  if (client) {
+    void client.close();
+    clientClosed = true;
+  }
+}
+
+/**
+ * Report an error to Sentry if the telemetry opt-in has loaded the SDK.
+ * Callers use this instead of importing `@sentry/react`, which would drag the
+ * SDK into the startup bundle.
+ */
+export function captureException(
+  error: unknown,
+  hint?: Parameters<SentrySdk["captureException"]>[1],
+): void {
+  sdk?.captureException(error, hint);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,19 +1,19 @@
-import * as Sentry from "@sentry/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./components/App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ErrorFallback } from "./components/ErrorFallback";
 import { SettingsProvider } from "./contexts/SettingsProvider";
 import "./styles/app.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    {/* Captures React render errors. No-op until telemetry is initialized
-        (production + opted in); see src/lib/telemetry.ts. */}
-    <Sentry.ErrorBoundary fallback={<ErrorFallback />}>
+    {/* Captures React render errors. Reporting is a no-op until telemetry is
+        initialized (production + opted in); see src/lib/telemetry.ts. */}
+    <ErrorBoundary fallback={<ErrorFallback />}>
       <SettingsProvider>
         <App />
       </SettingsProvider>
-    </Sentry.ErrorBoundary>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     environment: "happy-dom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}", "scripts/**/*.test.mjs"],
     reporters: process.env.CI
       ? ["default", ["junit", { outputFile: "junit-frontend.xml" }]]
       : ["default"],


### PR DESCRIPTION
## Summary

Adds a CI-enforced bundle budget gate and trims the startup chunk by 15% gzip. CI now records raw and gzip sizes for the startup assets and every major lazy chunk and fails the build when a documented budget is exceeded. The startup bundle drops from 381 kB to 323 kB gzip by making the Sentry SDK, the gemoji table, the AI chat panel, the plugin marketplace, workspace settings, and the export pipeline load on first use. The D2 delivery tradeoff is investigated and documented.

Closes #437

## Changes

- `scripts/check-bundle-size.mjs` + `bundle-budgets.json`: gzip budget gate over `dist/` (startup set parsed from `index.html`, lazy chunks matched by filename prefix, unbudgeted assets over 195 kB gzip rejected, loud failure on renamed/missing budgeted chunks or an empty startup set), with unit tests and a `pnpm size:check` script.
- `.github/workflows/ci-build.yml`: "Check bundle budgets" step on the `ubuntu-22.04` leg after the Tauri build, writing the size table to the step summary. No job renames, so the pinned required checks are untouched.
- `docs/bundle-budgets.md`: budgets rationale, update process, and the D2 delivery decision (upstream 0.1.33 ships a single 8 MB browser file with inlined WASM and no slimmer alternative; the chunk stays lazy behind `d2Render.ts` and its budget pins today's size).
- Sentry SDK is now loaded only after the production telemetry opt-in: `src/lib/telemetry.ts` imports `@sentry/react` on demand and exposes a `captureException` facade; a local `ErrorBoundary` (forwarding the React component stack) replaces `Sentry.ErrorBoundary` in `main.tsx`. Opt-out during the SDK download wins over the pending init, and re-enabling after an opt-out re-initializes the closed client.
- `remark-gemoji` loads lazily on the first `:shortcode:` sighting (`lazyGemoji` + `useGemojiPlugin`, mirroring the katex/highlight pattern); the pipeline takes a resolved `gemojiPlugin` and the site export sniffs content the same way.
- Lazy `lazy()` wrappers for the AI chat panel (first-open latch, panel stays mounted afterwards so composer draft and scroll survive), the plugins modal, and the workspace settings modal.
- `src/lib/export/*` is now reached only through dynamic imports (`useExport`, `usePrint`, plugin exporter runner); `d2Render.ts` imports DOMPurify on demand. Chunk-load failures land in the existing error logging instead of unhandled rejections.

## Risk classification

- [ ] Persistence / data loss
- [x] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [x] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [x] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

- **INV-3 (stale results never win), async ordering**: the telemetry opt-in is now async. An opt-out that lands while the SDK is still downloading wins over the pending init (`telemetry.test.ts` "does not init when the user opts out while the SDK is still loading"), and re-enabling after an opt-out re-initializes the closed client instead of silently dropping every later capture ("re-initializes when re-enabled after an opt-out closed the client"). The gemoji hook blocks stale completions: a plugin resolution that lands after the content stopped containing shortcodes cannot overwrite newer state (`useGemojiPlugin.test.ts` "goes back to null when the shortcode disappears").
- **INV-5 (all external input is untrusted)**: `sanitizeSvg` in `d2Render.ts` became async (DOMPurify imported on demand), but every render path still resolves through it before any SVG can reach `innerHTML`; if the DOMPurify import fails, the cached promise rejects and is evicted, so an unsanitized string is never observable. Covered by `d2Render.test.ts` (sanitizer wiring, `FORBID_TAGS: ["foreignObject"]`).
- **Bundle size / startup**: the point of the PR. The budget gate itself is the regression guard (`scripts/check-bundle-size.test.mjs` covers over-budget, missing-prefix, empty-startup, and unbudgeted-asset failures), and CI fails on any meaningful regression from here on.

## Measurements (before / after)

Production Vite build, measured by `scripts/check-bundle-size.mjs` (gzip level 9; raw in parentheses):

| Group | Before | After |
|---|---:|---:|
| **startup (entry JS + CSS)** | **381.0 kB (1228.4 kB)** | **323.0 kB (1057.5 kB)** |
| d2 (lazy) | 5849.0 kB (7997.1 kB) | unchanged |
| pdfEngine (lazy) | 807.5 kB (1825.0 kB) | unchanged |
| MarkdownEditor (lazy) | 263.3 kB (781.5 kB) | unchanged |
| mermaid (lazy) | 133.3 kB (576.5 kB) | unchanged |
| AI chat panel | in startup | 2.4 kB (6.4 kB), loads on first open |
| Plugins modal | in startup | 2.0 kB (6.8 kB), loads on first open |
| Workspace settings | in startup | 3.4 kB (13.3 kB), loads on first open |

Startup is 58 kB gzip (171 kB raw JS parse) lighter; that raw delta is the removed Sentry SDK, gemoji table, and AI/marketplace/export code every launch used to parse. First-use costs are the lazy-chunk sizes above; loading uses the same `Suspense fallback={null}` pattern as the existing lazy features, and a failed chunk load logs and aborts recoverably instead of rejecting unhandled. No wall-clock startup benchmark was run; the measured quantity is bundle size.

A full production `pnpm tauri build --no-bundle` on this branch passes with zero Cargo warnings, measures startup at 312.3 kB gzip against the 336.9 kB budget (about 7% headroom), and produces a 30.3 MiB release binary (`glyph.exe`).

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated gates on the development machine (Windows): `pnpm typecheck`, `pnpm check`, `pnpm test` (3307 tests), `cargo clippy --all-targets -- -D warnings`, `pnpm test:coverage` (100% line coverage on every changed file), `pnpm build && pnpm size:check` (gate passes with the new budgets), and a production `pnpm tauri build --no-bundle` (success, zero Cargo warnings).

## Screenshots

Not applicable; the user-visible surface is unchanged (first-use loading follows the existing lazy-feature pattern).
