### PR TITLE
fix(markdown): let wide tables scroll instead of being clipped

### DIFF
--- a/src/components/markdown/MarkdownContent.tsx
+++ b/src/components/markdown/MarkdownContent.tsx
@@ -18,6 +18,7 @@ import { FrontmatterBlock } from "./FrontmatterBlock";
 import { useImageComponent, useSvgImageComponent } from "./ImageComponent";
 import { LinkComponent, type LinkComponentProps } from "./LinkComponent";
 import { MarkdownHeading } from "./MarkdownHeading";
+import { TableComponent } from "./TableComponent";
 import { TaskListItem } from "./TaskListItem";
 
 interface MarkdownContentProps {
@@ -135,6 +136,7 @@ export function MarkdownContent({
             pre: CodeBlockComponent,
             li: TaskListLi,
             div: DivComponent,
+            table: TableComponent,
             h1: MarkdownHeading,
             h2: MarkdownHeading,
             h3: MarkdownHeading,

--- a/src/components/markdown/TableComponent.test.tsx
+++ b/src/components/markdown/TableComponent.test.tsx
@@ -1,0 +1,33 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TableComponent } from "./TableComponent";
+
+describe("TableComponent", () => {
+  it("wraps the table in a scroller, so wide columns stay reachable", () => {
+    const { container } = render(
+      <TableComponent>
+        <tbody>
+          <tr>
+            <td>cell</td>
+          </tr>
+        </tbody>
+      </TableComponent>,
+    );
+    const wrapper = container.querySelector(".markdown-table-wrapper");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.firstElementChild?.tagName).toBe("TABLE");
+  });
+
+  it("passes table attributes through", () => {
+    const { container } = render(
+      <TableComponent data-testid="t">
+        <tbody>
+          <tr>
+            <td>cell</td>
+          </tr>
+        </tbody>
+      </TableComponent>,
+    );
+    expect(container.querySelector("table")?.getAttribute("data-testid")).toBe("t");
+  });
+});

--- a/src/components/markdown/TableComponent.tsx
+++ b/src/components/markdown/TableComponent.tsx
@@ -1,0 +1,13 @@
+// A wide table has nowhere to go: the page itself never scrolls sideways
+// (app.css sets overflow: hidden on html/body/#root), so without a scroller of
+// its own the overflowing columns are clipped and unreachable. Mirrors what
+// CsvTable already does for CSV files. No tabIndex: current WebView engines
+// make an overflow container keyboard-scrollable on their own, and adding one
+// would put a tab stop in front of every table in a document.
+export function TableComponent(props: React.ComponentProps<"table">) {
+  return (
+    <div className="markdown-table-wrapper">
+      <table {...props} />
+    </div>
+  );
+}

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -422,6 +422,26 @@
   margin-bottom: 0.5em;
 }
 
+/* The wrapper scrolls, not the page. The table sizes to its content so columns
+   keep their width instead of being crushed, but still fills the measure when
+   it is narrow enough. */
+.markdown-body .markdown-table-wrapper {
+  overflow-x: auto;
+  margin: 0 0 1em;
+  overscroll-behavior-x: contain;
+}
+
+.markdown-body .markdown-table-wrapper:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.markdown-body .markdown-table-wrapper > table {
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
+}
+
 .markdown-body table {
   width: 100%;
   margin: 0 0 1em;

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -33,7 +33,9 @@
   }
 
   [class*="overflow-y-auto"],
-  [class*="overflow-hidden"] {
+  [class*="overflow-hidden"],
+  /* The table scroller would clip columns on paper, where nothing scrolls. */
+  .markdown-table-wrapper {
     overflow: visible !important;
     height: auto !important;
     max-height: none !important;


### PR DESCRIPTION
## Summary

A markdown table only ever had `width: 100%` and no scroll container, while the page itself never scrolls sideways (`app.css` sets `overflow: hidden` on `html`, `body` and `#root`).

So a table with more columns than fit was squeezed until the text wrapped into slivers, and whatever still overflowed was **cut off at the edge with no way to reach it**. On a phone that is most tables.

The pattern already existed in the codebase: `CsvTable` has had a scroll wrapper for CSV files since it was written. Markdown tables just never got one.

## Changes

- `TableComponent` wraps each markdown table in a `.markdown-table-wrapper` scroller, registered as the `table` override alongside the existing `a`, `img`, `pre`, `li`, `div` and heading overrides.
- The table sizes to `max-content` with `min-width: 100%`, so a narrow table still fills the measure and a wide one scrolls instead of crushing its columns.
- `print.css` gets an explicit override. Paper has nothing to scroll, and the existing un-clip rule only matches Tailwind-named classes, so the wrapper would have clipped columns on export.

## On keyboard access

The wrapper deliberately has **no** `tabIndex`. Current WebView engines make an overflow container keyboard-scrollable on their own, and adding one would put a tab stop in front of every table in a document. Worth knowing that Biome's `noNoninteractiveTabindex` also rejects it, and the repo's rule is to apply the fix rather than suppress the rule.

## Export paths

Checked rather than assumed, since the repo's frontend conventions require a rendering change to work across every export:

| Path | Result |
| --- | --- |
| HTML, EPUB | Wrapper is in the DOM the exporter walks (`prepareContent.ts` reads `.markdown-body`), and `collectStyles` carries the CSS |
| PDF | `htmlToPdf`'s `CONTAINER_TAGS` includes `div`, so it recurses through the wrapper to the table |
| DOCX | `htmlToDocx` likewise recurses `div` before its `table` branch |
| Print | Explicit `overflow: visible` override added |

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [x] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

No numbered invariant applies. The component is presentational, holds no state, performs no IO, and adds no new path for untrusted input: the table element and its attributes are spread through unchanged, exactly as before.

**Accessibility** is the area because the bug was an access failure, not a cosmetic one: content was rendered but unreachable by any input method. It is now reachable by touch and pointer, and by keyboard wherever the engine focuses scrollers. Covered by `TableComponent.test.tsx` (wrapper present, attributes pass through), 100% line coverage on the new file, and the 11 existing `MarkdownContent` tests still pass unchanged.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated only. `pnpm typecheck`, `pnpm check` and `pnpm test` (378 files, 3383 tests) pass.

Worth opening a wide table on a phone build to confirm the scroll feels right, and exporting one to PDF and DOCX to confirm the wrapper changed nothing there.

## Screenshots

None. The visible change is that columns past the right edge can now be reached.
