### PR TITLE
fix(markdown): stop the diagram lightbox blanking on flowchart labels

### DIFF
--- a/src/lib/export/rasterize.ts
+++ b/src/lib/export/rasterize.ts
@@ -4,7 +4,7 @@
 // SVG bakes in the app theme's colors). `rasterizeSvgsInHtml` is the fallback
 // for SVGs pdfmake's renderer rejects.
 
-import { decodeSvgDataUrl, ensureSvgXmlns } from "@/lib/svgDataUrl";
+import { decodeSvgDataUrl, toXmlSvg } from "@/lib/svgDataUrl";
 
 let mermaidId = 0;
 
@@ -83,7 +83,7 @@ export async function rasterizeSvgsInHtml(
   for (const el of Array.from(doc.body.querySelectorAll("svg"))) {
     try {
       const img = doc.createElement("img");
-      img.setAttribute("src", await toPng(ensureSvgXmlns(el.outerHTML)));
+      img.setAttribute("src", await toPng(toXmlSvg(el.outerHTML)));
       el.replaceWith(img);
     } catch {
       el.remove();
@@ -93,7 +93,7 @@ export async function rasterizeSvgsInHtml(
     const markup = decodeSvgDataUrl(img.getAttribute("src") ?? "");
     if (markup === null) continue;
     try {
-      img.setAttribute("src", await toPng(ensureSvgXmlns(markup)));
+      img.setAttribute("src", await toPng(toXmlSvg(markup)));
     } catch {
       img.remove();
     }

--- a/src/lib/export/svgPdfNode.ts
+++ b/src/lib/export/svgPdfNode.ts
@@ -3,7 +3,7 @@
 // HTML structure.
 
 import type { Content } from "pdfmake/interfaces";
-import { ensureSvgXmlns } from "@/lib/svgDataUrl";
+import { toXmlSvg } from "@/lib/svgDataUrl";
 
 // Page content box for an A4 page with default pdfmake margins (~40pt each).
 export const CONTENT_WIDTH = 515;
@@ -64,11 +64,11 @@ function intrinsicSize(el: Element): Size | null {
 // every descendant rule Mermaid and D2 emit (`.node rect`, `.edgePath .path`),
 // painting the shapes with default fills. An element parsed into a standalone
 // document (an SVG image decoded from a data: URL) is never laid out, so it has
-// no computed style to read and goes as markup; `ensureSvgXmlns` restores the
-// namespace the sanitizer strips.
+// no computed style to read and goes as markup; `toXmlSvg` restores the
+// namespace the sanitizer strips and hands the renderer well-formed XML.
 export function svgNode(el: Element): Content {
   const size = intrinsicSize(el);
   const scale = size ? Math.min(1, CONTENT_WIDTH / size.width, CONTENT_HEIGHT / size.height) : 1;
-  const svg = document.contains(el) ? (el as SVGElement) : ensureSvgXmlns(el.outerHTML);
+  const svg = document.contains(el) ? (el as SVGElement) : toXmlSvg(el.outerHTML);
   return { svg, width: (size?.width ?? CONTENT_WIDTH) * scale, margin: [0, 0, 0, 8] };
 }

--- a/src/lib/svgDataUrl.test.ts
+++ b/src/lib/svgDataUrl.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { decodeSvgDataUrl, ensureSvgXmlns, svgToDataUrl } from "./svgDataUrl";
+import { decodeSvgDataUrl, svgToDataUrl, toXmlSvg } from "./svgDataUrl";
+
+const decode = (url: string) => decodeURIComponent(url.slice("data:image/svg+xml,".length));
 
 describe("svgToDataUrl", () => {
   it("wraps markup in an svg data URL", () => {
     const url = svgToDataUrl('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
     expect(url.startsWith("data:image/svg+xml,")).toBe(true);
-    expect(decodeURIComponent(url.slice("data:image/svg+xml,".length))).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
-    );
+    expect(decode(url)).toBe('<svg xmlns="http://www.w3.org/2000/svg"/>');
   });
 
   it("encodes characters that would break the URL", () => {
@@ -18,33 +18,44 @@ describe("svgToDataUrl", () => {
 
   it("injects the SVG namespace when missing (so it renders as an <img>)", () => {
     // D2/Mermaid SVGs come back without xmlns; a data-URL <img> needs it.
-    const decoded = decodeURIComponent(
-      svgToDataUrl("<svg><rect/></svg>").slice("data:image/svg+xml,".length),
+    expect(decode(svgToDataUrl("<svg><rect/></svg>"))).toBe(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>',
     );
-    expect(decoded).toBe('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>');
-  });
-
-  it("leaves an existing namespace untouched", () => {
-    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>';
-    const decoded = decodeURIComponent(svgToDataUrl(svg).slice("data:image/svg+xml,".length));
-    expect(decoded).toBe(svg);
   });
 });
 
-describe("ensureSvgXmlns", () => {
-  it("adds the namespace only when absent", () => {
-    expect(ensureSvgXmlns("<svg><g/></svg>")).toBe(
-      '<svg xmlns="http://www.w3.org/2000/svg"><g/></svg>',
+describe("toXmlSvg", () => {
+  // The lightbox bug: a Mermaid flowchart label written as `A["one<br/>two"]`
+  // renders as HTML inside a `<foreignObject>`, where the break comes out as a
+  // bare `<br>`. An `<img>` parses the data URL as XML, so the unclosed tag
+  // fails the whole document and the diagram renders blank.
+  it("closes a bare <br> that would fail an XML parse", () => {
+    const xml = toXmlSvg("<svg><foreignObject><p>one<br>two</p></foreignObject></svg>");
+    expect(xml).not.toMatch(/<br(?!\s*\/)>/);
+    expect(new DOMParser().parseFromString(xml, "image/svg+xml").querySelector("parsererror")).toBe(
+      null,
     );
-    const withNs = '<svg xmlns="http://www.w3.org/2000/svg"><g/></svg>';
-    expect(ensureSvgXmlns(withNs)).toBe(withNs);
+  });
+
+  it("preserves camelCased SVG attributes", () => {
+    expect(toXmlSvg('<svg viewBox="0 0 10 10"><rect/></svg>')).toContain('viewBox="0 0 10 10"');
+  });
+
+  it("adds the SVG namespace and keeps an existing one", () => {
+    const ns = 'xmlns="http://www.w3.org/2000/svg"';
+    expect(toXmlSvg("<svg><g/></svg>")).toContain(ns);
+    expect(toXmlSvg(`<svg ${ns}><g/></svg>`)).toBe(`<svg ${ns}><g/></svg>`);
+  });
+
+  it("returns the input untouched when there is no svg root", () => {
+    expect(toXmlSvg("not markup")).toBe("not markup");
   });
 });
 
 describe("decodeSvgDataUrl", () => {
   it("round-trips a URI-encoded svg data URL", () => {
     const svg = "<svg><text>a&b #c</text></svg>";
-    expect(decodeSvgDataUrl(svgToDataUrl(svg))).toBe(ensureSvgXmlns(svg));
+    expect(decodeSvgDataUrl(svgToDataUrl(svg))).toBe(toXmlSvg(svg));
   });
 
   it("decodes a base64 svg data URL", () => {

--- a/src/lib/svgDataUrl.ts
+++ b/src/lib/svgDataUrl.ts
@@ -1,11 +1,14 @@
-const SVG_NS = "http://www.w3.org/2000/svg";
-
-// A standalone `<img>` parses SVG as XML, so the root needs an `xmlns`
-// declaration or it renders blank. Inline SVG (innerHTML) doesn't need it, and
-// renderers/sanitizers routinely drop it — D2 and Mermaid diagrams come back
-// without it — so add it back when absent.
-export function ensureSvgXmlns(svg: string): string {
-  return /<svg[^>]*\sxmlns\s*=/.test(svg) ? svg : svg.replace(/<svg\b/, `<svg xmlns="${SVG_NS}"`);
+// Serialize SVG markup as well-formed XML. Every consumer here parses it
+// strictly (an `<img>` data URL, a blob-URL image, pdfmake's SVG renderer), so
+// markup the HTML parser tolerates and XML rejects makes the whole image fail,
+// not just the offending node. Mermaid flowcharts are the case that bites: they
+// render labels as HTML inside `<foreignObject>`, and a `<br/>` in the source
+// comes out as a bare `<br>`, so the image renders blank. Parsing as HTML and
+// reserializing as XML closes those tags, and the serializer writes the `xmlns`
+// the root needs (renderers and sanitizers routinely drop it).
+export function toXmlSvg(svg: string): string {
+  const root = new DOMParser().parseFromString(svg, "text/html").body.querySelector("svg");
+  return root ? new XMLSerializer().serializeToString(root) : svg;
 }
 
 // Turn SVG markup into a `data:` URL usable as an `<img src>`. We render SVGs
@@ -14,7 +17,7 @@ export function ensureSvgXmlns(svg: string): string {
 // markup is already in hand. URL-encoding (not base64) keeps it readable and
 // handles arbitrary unicode in the SVG.
 export function svgToDataUrl(svg: string): string {
-  return `data:image/svg+xml,${encodeURIComponent(ensureSvgXmlns(svg))}`;
+  return `data:image/svg+xml,${encodeURIComponent(toXmlSvg(svg))}`;
 }
 
 // Decode a `data:image/svg+xml` URL (base64 or URI-encoded) back to its SVG


### PR DESCRIPTION
## Summary

Clicking a Mermaid flowchart whose labels contain `<br/>` opened an empty lightbox: the backdrop and toolbar appeared with no diagram.

The lightbox renders the diagram as `<img src="data:image/svg+xml,…">`, and an `<img>` parses SVG as strict XML. Mermaid draws **flowchart** labels as HTML inside `<foreignObject>`, where a `<br/>` in the source comes out as a bare `<br>`:

```
error on line 1 at column 22264: Opening and ending tag mismatch: br line 1 and p
```

One unclosed tag fails the whole document, so the image never renders. Sequence diagrams and gantt charts draw their labels as SVG `<text>`, which is why only some diagrams were affected and the bug read as random.

Reproduced against a real 4-diagram document in WebKit with mermaid 11.16.1:

| Block | Type | `<br/>` in source | Before | After |
| --- | --- | ---: | --- | --- |
| 1 | flowchart | 11 | image load failed | 145x150 |
| 2 | sequenceDiagram | 3 | 205x150 | 205x150 |
| 3 | gantt | 0 | 300x69 | 300x69 |
| 4 | flowchart | 6 | image load failed | 300x51 |

Not a regression: this path last changed in #587, so it is broken in v0.20.0 as shipped.

## Changes

- `ensureSvgXmlns` becomes `toXmlSvg`: parse as HTML, reserialize as XML. That closes tags the HTML parser tolerates, and `XMLSerializer` writes the namespace the old regex was bolting on, so the helper does strictly more with less code.
- The other two callers move with it, because both feed the same kind of strict parser: the PDF raster fallback (`svgToPng` loads a blob URL into an `Image`) and pdfmake's SVG renderer in `svgNode`.
- Tests cover the bare `<br>` (asserted both as no unclosed tag and as a clean `image/svg+xml` parse), `viewBox` surviving the round trip, namespace injection, and the no-svg-root fallback.

## Risk classification

- [x] Untrusted rendering (Markdown, plugins, links)

### Invariants at stake and evidence

**INV-5 (all external input is untrusted).** The markup passing through `toXmlSvg` is rendered from user-authored diagram source. The function is a parse and reserialize with no `innerHTML` and no execution: markup is parsed by `DOMParser` into an inert document, and `XMLSerializer` writes text back out. It neither adds nor removes a sanitization step, and every consumer's existing sanitization is untouched, so the trust boundary is where it was. Covered by the existing `rasterize.test.ts` and `d2Render.test.ts` sanitizer assertions, which still pass.

The change is strictly more conservative for the two export callers: they previously received markup that could be non-well-formed, and the PDF raster fallback dropped such an element on failure. It now parses.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

Gates: `pnpm typecheck`, `pnpm check`, `pnpm test` (3389 tests over 380 files), `cargo test --lib`, and `cargo clippy --all-targets -- -D warnings`, all via the pre-commit hook.

Verified by hand in the running app on Windows against the document in the table above: both flowcharts open in the lightbox, and the gantt and sequence diagram are unchanged. The measurements in the table come from driving real mermaid output through the same `<img>` data-URL path in WebKit.
