### PR TITLE
feat(sidebar): keep the tags and backlinks blocks in place

### DIFF
--- a/src/components/layout/BacklinksBlock.tsx
+++ b/src/components/layout/BacklinksBlock.tsx
@@ -11,13 +11,12 @@ interface BacklinksBlockProps {
 }
 
 /** Backlinks pinned to the bottom of the Files panel, resizable against the
- *  tree above. Renders nothing without backlinks. */
+ *  tree above. */
 export function BacklinksBlock({ workspaceRoot, onOpen }: BacklinksBlockProps) {
   const { t } = useTranslation("common");
   const { backlinks } = useTabsContext();
-  const { backlinksHeight, setBacklinksHeight } = useSidebarLayoutContext();
-
-  if (backlinks.length === 0) return null;
+  const { backlinksHeight, setBacklinksHeight, backlinksCollapsed, setBacklinksCollapsed } =
+    useSidebarLayoutContext();
 
   return (
     <ResizableBlock
@@ -25,8 +24,15 @@ export function BacklinksBlock({ workspaceRoot, onOpen }: BacklinksBlockProps) {
       min={BACKLINKS_HEIGHT_MIN}
       height={backlinksHeight}
       onHeightCommit={setBacklinksHeight}
+      collapsed={backlinksCollapsed}
     >
-      <BacklinksSection backlinks={backlinks} workspaceRoot={workspaceRoot} onOpen={onOpen} />
+      <BacklinksSection
+        backlinks={backlinks}
+        workspaceRoot={workspaceRoot}
+        collapsed={backlinksCollapsed}
+        onToggleCollapsed={() => setBacklinksCollapsed(!backlinksCollapsed)}
+        onOpen={onOpen}
+      />
     </ResizableBlock>
   );
 }

--- a/src/components/layout/BacklinksSection.test.tsx
+++ b/src/components/layout/BacklinksSection.test.tsx
@@ -9,16 +9,24 @@ const backlinks: Backlink[] = [
   { source: "/workspace/Notes/Travel.md", line: 12, snippet: "ref to [[Cooking]] here" },
 ];
 
+const defaultProps = {
+  backlinks,
+  workspaceRoot: root,
+  collapsed: false,
+  onToggleCollapsed: vi.fn(),
+  onOpen: vi.fn(),
+};
+
 describe("BacklinksSection", () => {
-  it("renders nothing when there are no backlinks", () => {
-    const { container } = render(
-      <BacklinksSection backlinks={[]} workspaceRoot={root} onOpen={vi.fn()} />,
-    );
-    expect(container.firstChild).toBeNull();
+  it("keeps the heading and shows an empty message without backlinks", () => {
+    render(<BacklinksSection {...defaultProps} backlinks={[]} />);
+    expect(screen.getByText("Backlinks")).toBeTruthy();
+    expect(screen.getByText("0")).toBeTruthy();
+    expect(screen.getByText("No backlinks")).toBeTruthy();
   });
 
   it("shows the count and one row per backlink", () => {
-    render(<BacklinksSection backlinks={backlinks} workspaceRoot={root} onOpen={vi.fn()} />);
+    render(<BacklinksSection {...defaultProps} />);
     expect(screen.getByText("Backlinks")).toBeTruthy();
     expect(screen.getByText("2")).toBeTruthy();
     expect(screen.getByText("Index.md")).toBeTruthy();
@@ -26,22 +34,28 @@ describe("BacklinksSection", () => {
   });
 
   it("renders snippets for each entry", () => {
-    render(<BacklinksSection backlinks={backlinks} workspaceRoot={root} onOpen={vi.fn()} />);
+    render(<BacklinksSection {...defaultProps} />);
     expect(screen.getByText("see [[Cooking]]")).toBeTruthy();
     expect(screen.getByText("ref to [[Cooking]] here")).toBeTruthy();
   });
 
   it("invokes onOpen with source and line on click", () => {
     const onOpen = vi.fn();
-    render(<BacklinksSection backlinks={backlinks} workspaceRoot={root} onOpen={onOpen} />);
+    render(<BacklinksSection {...defaultProps} onOpen={onOpen} />);
     fireEvent.click(screen.getByText("Index.md"));
     expect(onOpen).toHaveBeenCalledWith("/workspace/Index.md", 4);
   });
 
-  it("collapses on header click", () => {
-    render(<BacklinksSection backlinks={backlinks} workspaceRoot={root} onOpen={vi.fn()} />);
-    const header = screen.getByRole("button", { name: /backlinks/i });
-    fireEvent.click(header);
+  it("reports a header click instead of collapsing itself", () => {
+    const onToggleCollapsed = vi.fn();
+    render(<BacklinksSection {...defaultProps} onToggleCollapsed={onToggleCollapsed} />);
+    fireEvent.click(screen.getByRole("button", { name: /backlinks/i }));
+    expect(onToggleCollapsed).toHaveBeenCalledOnce();
+    expect(screen.getByText("Index.md")).toBeTruthy();
+  });
+
+  it("hides the rows when collapsed", () => {
+    render(<BacklinksSection {...defaultProps} collapsed={true} />);
     expect(screen.queryByText("Index.md")).toBeNull();
   });
 });

--- a/src/components/layout/BacklinksSection.tsx
+++ b/src/components/layout/BacklinksSection.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Backlink } from "@/lib/backlinks";
 import { relativeToRoot } from "@/lib/paths";
@@ -6,20 +5,27 @@ import { relativeToRoot } from "@/lib/paths";
 interface BacklinksSectionProps {
   backlinks: Backlink[];
   workspaceRoot: string;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
   onOpen: (path: string, line?: number) => void;
 }
 
-export function BacklinksSection({ backlinks, workspaceRoot, onOpen }: BacklinksSectionProps) {
+// Always rendered, empty included: a note without backlinks would otherwise
+// pull the block out of the panel and shift everything above it.
+export function BacklinksSection({
+  backlinks,
+  workspaceRoot,
+  collapsed,
+  onToggleCollapsed,
+  onOpen,
+}: BacklinksSectionProps) {
   const { t } = useTranslation("common");
-  const [collapsed, setCollapsed] = useState(false);
-
-  if (backlinks.length === 0) return null;
 
   return (
     <section className="backlinks-section">
       <button
         type="button"
-        onClick={() => setCollapsed((c) => !c)}
+        onClick={onToggleCollapsed}
         className="flex items-center gap-1 w-full text-start text-xs font-semibold text-[var(--color-text-tertiary)] uppercase tracking-wider mb-2 hover:text-[var(--color-text-secondary)] transition-colors"
         aria-expanded={!collapsed}
       >
@@ -31,7 +37,10 @@ export function BacklinksSection({ backlinks, workspaceRoot, onOpen }: Backlinks
           {backlinks.length}
         </span>
       </button>
-      {!collapsed && (
+      {!collapsed && backlinks.length === 0 && (
+        <p className="px-2 text-xs text-[var(--color-text-tertiary)]">{t("backlinks.empty")}</p>
+      )}
+      {!collapsed && backlinks.length > 0 && (
         <ul className="space-y-1">
           {backlinks.map((b) => (
             <li key={`${b.source}:${b.line}`}>

--- a/src/components/layout/ResizableBlock.tsx
+++ b/src/components/layout/ResizableBlock.tsx
@@ -14,6 +14,8 @@ interface ResizableBlockProps {
   onHeightCommit: (height: number | null) => void;
   /** Cap for the natural height, applied only while no height is persisted. */
   naturalMax?: number;
+  /** A collapsed block is only its heading, so it isn't resizable. */
+  collapsed?: boolean;
   children: ReactNode;
 }
 
@@ -25,6 +27,7 @@ export function ResizableBlock({
   height,
   onHeightCommit,
   naturalMax,
+  collapsed = false,
   children,
 }: ResizableBlockProps) {
   const blockRef = useRef<HTMLDivElement>(null);
@@ -51,19 +54,27 @@ export function ResizableBlock({
 
   return (
     <>
-      <ResizeHandle
-        axis="y"
-        label={label}
-        value={size ?? measure()}
-        min={min}
-        max={maxHeight()}
-        className="mt-3 -mx-3 h-1.5 shrink-0"
-        {...resize.handleProps}
-      />
+      {collapsed ? (
+        <div className="mt-3 h-1.5 shrink-0" />
+      ) : (
+        <ResizeHandle
+          axis="y"
+          label={label}
+          value={size ?? measure()}
+          min={min}
+          max={maxHeight()}
+          className="mt-3 -mx-3 h-1.5 shrink-0"
+          {...resize.handleProps}
+        />
+      )}
       <div
         ref={blockRef}
         className="pt-2 border-t border-[var(--color-border)] shrink-0 overflow-y-auto"
-        style={{ height: size ?? undefined, maxHeight: size === null ? naturalMax : undefined }}
+        style={
+          collapsed
+            ? undefined
+            : { height: size ?? undefined, maxHeight: size === null ? naturalMax : undefined }
+        }
       >
         {children}
       </div>

--- a/src/components/layout/Sidebar.files.test.tsx
+++ b/src/components/layout/Sidebar.files.test.tsx
@@ -124,9 +124,18 @@ describe("Sidebar files panel", () => {
       expect(screen.getByTitle("Filter by #personal")).toBeInTheDocument();
     });
 
-    it("has no tags block when the workspace carries no metadata", () => {
+    // The block stays put so the panel doesn't reflow as tags come and go.
+    it("keeps the tags block when the workspace carries no metadata", () => {
       renderSidebar({ workspace: makeWorkspace() });
-      expect(screen.queryByText("Tags")).not.toBeInTheDocument();
+      expect(screen.getByText("Tags")).toBeInTheDocument();
+      expect(screen.getByText("No tags")).toBeInTheDocument();
+    });
+
+    it("persists the collapsed state instead of holding it locally", () => {
+      const setTagsCollapsed = vi.fn();
+      renderSidebar({ workspace: makeWorkspace(), tabs: { metadata }, setTagsCollapsed });
+      fireEvent.click(screen.getByRole("button", { name: /^Tags/ }));
+      expect(setTagsCollapsed).toHaveBeenCalledExactlyOnceWith(true);
     });
 
     // The filtered list replaces the tree: matches can live in folders the

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -160,7 +160,7 @@ describe("Sidebar placement", () => {
 
   it("renders resize handles on both panels", () => {
     renderBothSides({ workspace: makeWorkspace(), sidebarLayout: "split" });
-    expect(screen.getAllByRole("separator").length).toBe(2);
+    expect(screen.getAllByRole("separator", { name: "Resize sidebar" }).length).toBe(2);
   });
 
   it("commits a dragged files-panel width once on release", () => {
@@ -171,7 +171,7 @@ describe("Sidebar placement", () => {
       setFilesSidebarWidth,
     });
     const nav = container.querySelector('nav[data-sidebar="left"]') as HTMLElement;
-    const handle = within(nav).getByRole("separator");
+    const handle = within(nav).getByRole("separator", { name: "Resize sidebar" });
     fireEvent.pointerDown(handle, { button: 0, clientX: 200 });
     // Left-side panel in LTR: dragging right grows it.
     fireEvent.pointerMove(handle, { clientX: 250 });
@@ -190,7 +190,7 @@ describe("Sidebar placement", () => {
         setFilesSidebarWidth,
       });
       const nav = container.querySelector('nav[data-sidebar="left"]') as HTMLElement;
-      const handle = within(nav).getByRole("separator");
+      const handle = within(nav).getByRole("separator", { name: "Resize sidebar" });
       fireEvent.pointerDown(handle, { button: 0, clientX: 200 });
       // Mirrored layout: dragging left grows the panel.
       fireEvent.pointerMove(handle, { clientX: 150 });
@@ -209,7 +209,7 @@ describe("Sidebar placement", () => {
       setFilesSidebarWidth,
     });
     const nav = container.querySelector('nav[data-sidebar="left"]') as HTMLElement;
-    fireEvent.doubleClick(within(nav).getByRole("separator"));
+    fireEvent.doubleClick(within(nav).getByRole("separator", { name: "Resize sidebar" }));
     expect(setFilesSidebarWidth).toHaveBeenCalledExactlyOnceWith(SIDEBAR_WIDTH_DEFAULT);
   });
 
@@ -256,6 +256,27 @@ describe("Sidebar placement", () => {
     });
     fireEvent.doubleClick(screen.getByRole("separator", { name: "Resize backlinks" }));
     expect(setBacklinksHeight).toHaveBeenCalledExactlyOnceWith(null);
+  });
+
+  // The block stays put so opening a note without backlinks doesn't reflow the
+  // panel around it.
+  it("keeps the backlinks block when the active note has none", () => {
+    renderSidebar({ workspace: makeWorkspace(), tabs: { backlinks: [] } });
+    expect(screen.getByText("Backlinks")).toBeInTheDocument();
+    expect(screen.getByText("No backlinks")).toBeInTheDocument();
+  });
+
+  it("persists the backlinks collapsed state instead of holding it locally", () => {
+    const setBacklinksCollapsed = vi.fn();
+    renderSidebar({ workspace: makeWorkspace(), setBacklinksCollapsed });
+    fireEvent.click(screen.getByRole("button", { name: /backlinks/i }));
+    expect(setBacklinksCollapsed).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  // Nothing left to resize once the block is just its heading.
+  it("drops the backlinks divider while the block is collapsed", () => {
+    renderSidebar({ workspace: makeWorkspace(), backlinksCollapsed: true });
+    expect(screen.queryByRole("separator", { name: "Resize backlinks" })).not.toBeInTheDocument();
   });
 
   it("drags the tags divider and persists the height", () => {

--- a/src/components/layout/TagsBlock.tsx
+++ b/src/components/layout/TagsBlock.tsx
@@ -17,12 +17,10 @@ interface TagsBlockProps {
 }
 
 /** The workspace tag cloud in the Files panel, resizable against the tree
- *  above. Renders nothing without tags. */
+ *  above. */
 export function TagsBlock({ tags, selected, onSelect }: TagsBlockProps) {
   const { t } = useTranslation("common");
-  const { tagsHeight, setTagsHeight } = useSidebarLayoutContext();
-
-  if (tags.length === 0) return null;
+  const { tagsHeight, setTagsHeight, tagsCollapsed, setTagsCollapsed } = useSidebarLayoutContext();
 
   return (
     <ResizableBlock
@@ -31,8 +29,15 @@ export function TagsBlock({ tags, selected, onSelect }: TagsBlockProps) {
       height={tagsHeight}
       onHeightCommit={setTagsHeight}
       naturalMax={TAGS_HEIGHT_NATURAL_MAX}
+      collapsed={tagsCollapsed}
     >
-      <TagsSection tags={tags} selected={selected} onSelect={onSelect} />
+      <TagsSection
+        tags={tags}
+        selected={selected}
+        collapsed={tagsCollapsed}
+        onToggleCollapsed={() => setTagsCollapsed(!tagsCollapsed)}
+        onSelect={onSelect}
+      />
     </ResizableBlock>
   );
 }

--- a/src/components/layout/TagsSection.test.tsx
+++ b/src/components/layout/TagsSection.test.tsx
@@ -13,7 +13,13 @@ const nested: TagCount[] = [
   { tag: "project/glyph", count: 1 },
 ];
 
-const defaultProps = { tags, selected: null, onSelect: vi.fn() };
+const defaultProps = {
+  tags,
+  selected: null,
+  collapsed: false,
+  onToggleCollapsed: vi.fn(),
+  onSelect: vi.fn(),
+};
 
 /** Chip text in render order, which is what the sort toggle changes. */
 function chipLabels() {
@@ -21,9 +27,11 @@ function chipLabels() {
 }
 
 describe("TagsSection", () => {
-  it("renders nothing without tags", () => {
-    const { container } = render(<TagsSection {...defaultProps} tags={[]} />);
-    expect(container.firstChild).toBeNull();
+  it("keeps the heading and shows an empty message without tags", () => {
+    render(<TagsSection {...defaultProps} tags={[]} />);
+    expect(screen.getByText("Tags")).toBeTruthy();
+    expect(screen.getByText("No tags")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Sort tags by count" })).toBeNull();
   });
 
   it("shows one chip per tag with its count", () => {
@@ -49,9 +57,16 @@ describe("TagsSection", () => {
     expect(onSelect).toHaveBeenCalledWith(null);
   });
 
-  it("collapses on header click, hiding the chips and the sort toggle", () => {
-    render(<TagsSection {...defaultProps} />);
+  it("reports a header click instead of collapsing itself", () => {
+    const onToggleCollapsed = vi.fn();
+    render(<TagsSection {...defaultProps} onToggleCollapsed={onToggleCollapsed} />);
     fireEvent.click(screen.getByRole("button", { name: /^Tags/ }));
+    expect(onToggleCollapsed).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Filter by #work" })).toBeTruthy();
+  });
+
+  it("hides the chips and the sort toggle when collapsed", () => {
+    render(<TagsSection {...defaultProps} collapsed={true} />);
     expect(screen.queryByRole("button", { name: "Filter by #work" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Sort tags by count" })).toBeNull();
   });

--- a/src/components/layout/TagsSection.tsx
+++ b/src/components/layout/TagsSection.tsx
@@ -10,26 +10,32 @@ interface TagsSectionProps {
   tags: TagCount[];
   /** The tag currently filtering the file list, if any. */
   selected: string | null;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
   onSelect: (tag: string | null) => void;
 }
 
 // Workspace tags, alphabetical until the user toggles frequency. Selecting one
 // filters the Files panel to the documents carrying it (or any tag nested under
-// it); selecting it again clears the filter.
-export function TagsSection({ tags, selected, onSelect }: TagsSectionProps) {
+// it); selecting it again clears the filter. Stays rendered while empty so the
+// panel below the tree keeps a stable height.
+export function TagsSection({
+  tags,
+  selected,
+  collapsed,
+  onToggleCollapsed,
+  onSelect,
+}: TagsSectionProps) {
   const { t } = useTranslation("common");
-  const [collapsed, setCollapsed] = useState(false);
   const [sort, setSort] = useState<TagSort>("name");
   const tree = useMemo(() => buildTagTree(tags, sort), [tags, sort]);
-
-  if (tags.length === 0) return null;
 
   return (
     <section>
       <div className="flex items-center gap-1 mb-2">
         <button
           type="button"
-          onClick={() => setCollapsed((c) => !c)}
+          onClick={onToggleCollapsed}
           className="flex items-center gap-1 flex-1 min-w-0 text-start text-xs font-semibold text-[var(--color-text-tertiary)] uppercase tracking-wider hover:text-[var(--color-text-secondary)] transition-colors"
           aria-expanded={!collapsed}
         >
@@ -41,7 +47,7 @@ export function TagsSection({ tags, selected, onSelect }: TagsSectionProps) {
             {tags.length}
           </span>
         </button>
-        {!collapsed && (
+        {!collapsed && tags.length > 0 && (
           <ToolbarButton
             title={t("tags.sortByCount")}
             pressed={sort === "count"}
@@ -51,7 +57,12 @@ export function TagsSection({ tags, selected, onSelect }: TagsSectionProps) {
           </ToolbarButton>
         )}
       </div>
-      {!collapsed && <TagTree nodes={tree} selected={selected} onSelect={onSelect} />}
+      {!collapsed && tags.length === 0 && (
+        <p className="px-2 text-xs text-[var(--color-text-tertiary)]">{t("tags.empty")}</p>
+      )}
+      {!collapsed && tags.length > 0 && (
+        <TagTree nodes={tree} selected={selected} onSelect={onSelect} />
+      )}
     </section>
   );
 }

--- a/src/contexts/SidebarLayoutContext.ts
+++ b/src/contexts/SidebarLayoutContext.ts
@@ -16,6 +16,8 @@ export interface SidebarLayoutContextValue extends SidebarLayoutApi {
   outlineSidebarWidth: number;
   backlinksHeight: number | null;
   tagsHeight: number | null;
+  backlinksCollapsed: boolean;
+  tagsCollapsed: boolean;
 }
 
 export const SidebarLayoutContext = createContext<SidebarLayoutContextValue | null>(null);

--- a/src/contexts/SidebarLayoutProvider.tsx
+++ b/src/contexts/SidebarLayoutProvider.tsx
@@ -20,6 +20,8 @@ export function SidebarLayoutProvider({ children }: { children: ReactNode }) {
       outlineSidebarWidth: settings.layout.outlineSidebarWidth,
       backlinksHeight: settings.layout.backlinksHeight,
       tagsHeight: settings.layout.tagsHeight,
+      backlinksCollapsed: settings.layout.backlinksCollapsed,
+      tagsCollapsed: settings.layout.tagsCollapsed,
     }),
     [
       layout,
@@ -29,6 +31,8 @@ export function SidebarLayoutProvider({ children }: { children: ReactNode }) {
       settings.layout.outlineSidebarWidth,
       settings.layout.backlinksHeight,
       settings.layout.tagsHeight,
+      settings.layout.backlinksCollapsed,
+      settings.layout.tagsCollapsed,
     ],
   );
 

--- a/src/hooks/useSidebarLayout.test.ts
+++ b/src/hooks/useSidebarLayout.test.ts
@@ -71,9 +71,13 @@ describe("useSidebarLayout", () => {
       result.current.setOutlineSidebarWidth(280);
       result.current.setBacklinksHeight(150);
       result.current.setTagsHeight(120);
+      result.current.setBacklinksCollapsed(true);
+      result.current.setTagsCollapsed(true);
       result.current.setBacklinksHeight(null);
     });
     expect(updateSettings).toHaveBeenCalledWith("layout.tagsHeight", 120);
+    expect(updateSettings).toHaveBeenCalledWith("layout.backlinksCollapsed", true);
+    expect(updateSettings).toHaveBeenCalledWith("layout.tagsCollapsed", true);
     expect(updateSettings).toHaveBeenCalledWith("layout.filesSidebarWidth", 300);
     expect(updateSettings).toHaveBeenCalledWith("layout.outlineSidebarWidth", 280);
     expect(updateSettings).toHaveBeenCalledWith("layout.backlinksHeight", 150);
@@ -101,6 +105,8 @@ describe("useSidebarLayout", () => {
     expect(updateSettings).toHaveBeenCalledWith("layout.aiPanelWidth", 340);
     expect(updateSettings).toHaveBeenCalledWith("layout.backlinksHeight", null);
     expect(updateSettings).toHaveBeenCalledWith("layout.tagsHeight", null);
+    expect(updateSettings).toHaveBeenCalledWith("layout.backlinksCollapsed", false);
+    expect(updateSettings).toHaveBeenCalledWith("layout.tagsCollapsed", false);
   });
 });
 

--- a/src/hooks/useSidebarLayout.ts
+++ b/src/hooks/useSidebarLayout.ts
@@ -97,6 +97,16 @@ export function useSidebarLayout({
     [updateSettings],
   );
 
+  const setBacklinksCollapsed = useCallback(
+    (collapsed: boolean) => updateSettings("layout.backlinksCollapsed", collapsed),
+    [updateSettings],
+  );
+
+  const setTagsCollapsed = useCallback(
+    (collapsed: boolean) => updateSettings("layout.tagsCollapsed", collapsed),
+    [updateSettings],
+  );
+
   const resetLayout = useCallback(() => {
     updateSettings("layout.filesSidebarVisible", true);
     updateSettings("layout.outlineSidebarVisible", true);
@@ -107,6 +117,8 @@ export function useSidebarLayout({
     updateSettings("layout.aiPanelWidth", AI_PANEL_WIDTH_DEFAULT);
     updateSettings("layout.backlinksHeight", null);
     updateSettings("layout.tagsHeight", null);
+    updateSettings("layout.backlinksCollapsed", false);
+    updateSettings("layout.tagsCollapsed", false);
   }, [updateSettings]);
 
   return {
@@ -123,6 +135,8 @@ export function useSidebarLayout({
     setOutlineSidebarWidth,
     setBacklinksHeight,
     setTagsHeight,
+    setBacklinksCollapsed,
+    setTagsCollapsed,
     resetLayout,
   };
 }

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -33,6 +33,8 @@ describe("DEFAULT_SETTINGS", () => {
     expect(DEFAULT_SETTINGS.layout.aiPanelWidth).toBe(AI_PANEL_WIDTH_DEFAULT);
     expect(DEFAULT_SETTINGS.layout.backlinksHeight).toBeNull();
     expect(DEFAULT_SETTINGS.layout.tagsHeight).toBeNull();
+    expect(DEFAULT_SETTINGS.layout.backlinksCollapsed).toBe(false);
+    expect(DEFAULT_SETTINGS.layout.tagsCollapsed).toBe(false);
   });
 
   it("keeps resize bounds ordered around the defaults", () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -32,6 +32,10 @@ export interface LayoutSettings {
   backlinksHeight: number | null;
   // Same, for the tag cloud block.
   tagsHeight: number | null;
+  // Collapsed state of the two blocks, kept workspace-wide so switching files
+  // doesn't reshuffle the panel.
+  backlinksCollapsed: boolean;
+  tagsCollapsed: boolean;
   sidebarLayout: SidebarLayout;
   // Mirrors the sidebar layout. Default Files-left / Outline-right; when true
   // it becomes Files-right / Outline-left. Affects all layout modes.
@@ -240,6 +244,8 @@ export const DEFAULT_SETTINGS: Settings = {
     aiPanelWidth: AI_PANEL_WIDTH_DEFAULT,
     backlinksHeight: null,
     tagsHeight: null,
+    backlinksCollapsed: false,
+    tagsCollapsed: false,
     sidebarLayout: "beside",
     swapSidebarSides: false,
   },

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -42,14 +42,16 @@
     "indexIncomplete": "Index unvollständig"
   },
   "backlinks": {
-    "heading": "Rückverweise"
+    "heading": "Rückverweise",
+    "empty": "Keine Rückverweise"
   },
   "tags": {
     "heading": "Tags",
     "filterBy": "Nach #{{tag}} filtern",
     "filtered": "#{{tag}} ({{total}})",
     "clearFilter": "Tag-Filter aufheben",
-    "sortByCount": "Tags nach Anzahl sortieren"
+    "sortByCount": "Tags nach Anzahl sortieren",
+    "empty": "Keine Tags"
   },
   "tabBar": {
     "graphLabel": "Graph: {{name}}",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -42,14 +42,16 @@
     "indexIncomplete": "Index incomplete"
   },
   "backlinks": {
-    "heading": "Backlinks"
+    "heading": "Backlinks",
+    "empty": "No backlinks"
   },
   "tags": {
     "heading": "Tags",
     "filterBy": "Filter by #{{tag}}",
     "filtered": "#{{tag}} ({{total}})",
     "clearFilter": "Clear tag filter",
-    "sortByCount": "Sort tags by count"
+    "sortByCount": "Sort tags by count",
+    "empty": "No tags"
   },
   "tabBar": {
     "graphLabel": "Graph: {{name}}",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -42,14 +42,16 @@
     "indexIncomplete": "Índice incompleto"
   },
   "backlinks": {
-    "heading": "Enlaces entrantes"
+    "heading": "Enlaces entrantes",
+    "empty": "Sin enlaces entrantes"
   },
   "tags": {
     "heading": "Etiquetas",
     "filterBy": "Filtrar por #{{tag}}",
     "filtered": "#{{tag}} ({{total}})",
     "clearFilter": "Quitar el filtro de etiqueta",
-    "sortByCount": "Ordenar etiquetas por cantidad"
+    "sortByCount": "Ordenar etiquetas por cantidad",
+    "empty": "Sin etiquetas"
   },
   "tabBar": {
     "graphLabel": "Grafo: {{name}}",

--- a/src/locales/fa/common.json
+++ b/src/locales/fa/common.json
@@ -42,14 +42,16 @@
     "indexIncomplete": "نمایه ناقص"
   },
   "backlinks": {
-    "heading": "پیوندهای ورودی"
+    "heading": "پیوندهای ورودی",
+    "empty": "پیوندی وجود ندارد"
   },
   "tags": {
     "heading": "برچسب‌ها",
     "filterBy": "فیلتر بر پایهٔ #{{tag}}",
     "filtered": "#{{tag}} ({{total}})",
     "clearFilter": "پاک کردن فیلتر برچسب",
-    "sortByCount": "مرتب‌سازی برچسب‌ها بر پایهٔ شمار"
+    "sortByCount": "مرتب‌سازی برچسب‌ها بر پایهٔ شمار",
+    "empty": "برچسبی وجود ندارد"
   },
   "tabBar": {
     "graphLabel": "گراف: {{name}}",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -42,14 +42,16 @@
     "indexIncomplete": "索引不完整"
   },
   "backlinks": {
-    "heading": "反向链接"
+    "heading": "反向链接",
+    "empty": "没有反向链接"
   },
   "tags": {
     "heading": "标签",
     "filterBy": "按 #{{tag}} 筛选",
     "filtered": "#{{tag}}（{{total}}）",
     "clearFilter": "清除标签筛选",
-    "sortByCount": "按数量排序标签"
+    "sortByCount": "按数量排序标签",
+    "empty": "没有标签"
   },
   "tabBar": {
     "graphLabel": "图谱：{{name}}",

--- a/src/test/fixtures/sidebar.tsx
+++ b/src/test/fixtures/sidebar.tsx
@@ -72,6 +72,10 @@ export interface RenderOpts {
   backlinksHeight?: number | null;
   setTagsHeight?: (height: number | null) => void;
   tagsHeight?: number | null;
+  backlinksCollapsed?: boolean;
+  tagsCollapsed?: boolean;
+  setBacklinksCollapsed?: (collapsed: boolean) => void;
+  setTagsCollapsed?: (collapsed: boolean) => void;
   tabs?: Partial<TabsContextValue>;
 }
 
@@ -103,6 +107,10 @@ function buildSidebarContext(opts: RenderOpts): SidebarLayoutContextValue {
     setOutlineSidebarWidth: opts.setOutlineSidebarWidth ?? vi.fn(),
     setBacklinksHeight: opts.setBacklinksHeight ?? vi.fn(),
     setTagsHeight: opts.setTagsHeight ?? vi.fn(),
+    backlinksCollapsed: opts.backlinksCollapsed ?? false,
+    tagsCollapsed: opts.tagsCollapsed ?? false,
+    setBacklinksCollapsed: opts.setBacklinksCollapsed ?? vi.fn(),
+    setTagsCollapsed: opts.setTagsCollapsed ?? vi.fn(),
   });
 }
 

--- a/src/test/fixtures/sidebarLayout.ts
+++ b/src/test/fixtures/sidebarLayout.ts
@@ -21,10 +21,14 @@ export function sidebarLayoutValue(
     outlineSidebarWidth: 260,
     backlinksHeight: null,
     tagsHeight: null,
+    backlinksCollapsed: false,
+    tagsCollapsed: false,
     setFilesSidebarWidth: vi.fn(),
     setOutlineSidebarWidth: vi.fn(),
     setBacklinksHeight: vi.fn(),
     setTagsHeight: vi.fn(),
+    setBacklinksCollapsed: vi.fn(),
+    setTagsCollapsed: vi.fn(),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

The Tags and Backlinks blocks at the bottom of the Files panel used to vanish when they had nothing to show. Backlinks are per-document, so opening a note nobody links to removed the whole block and the file tree jumped down to fill the gap, then jumped back on the next linked note. Both blocks also kept their collapsed flag in local component state, which the unmount threw away, while the heights right next to it were already persisted in settings.

Both blocks now stay mounted at every count, with a short empty message in place of the list, and their collapsed flag lives in settings alongside those heights.

Closes #645

## Changes

- `LayoutSettings` gains `backlinksCollapsed` and `tagsCollapsed` (both `false` by default), with setters on `useSidebarLayout` and both flags surfaced on `SidebarLayoutContext`
- `BacklinksSection` and `TagsSection` drop their local `useState` and their empty-list early returns, taking `collapsed` / `onToggleCollapsed` as props and rendering `backlinks.empty` / `tags.empty` at zero
- `BacklinksBlock` and `TagsBlock` no longer return `null` when empty
- `ResizableBlock` takes a `collapsed` prop: a collapsed block is only its heading, so it skips its resize divider and its height style
- "Reset View" resets both flags with the rest of the layout
- `backlinks.empty` and `tags.empty` added to `en`, `de`, `es`, `fa`, `zh`
- The tag sort toggle stays local: it is a view option, not layout state

## Risk classification

- [x] Migrations / persisted-format changes
- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Accessibility
- [ ] Bundle size / startup

### Invariants at stake and evidence

Two additive `layout.*` booleans, both defaulting to `false`. Settings are deep-merged over `DEFAULT_SETTINGS`, so a store written by an older version simply reads the defaults; no migration is needed and no existing key changes meaning. `settings.test.ts` asserts both defaults.

## Testing

`pnpm typecheck && pnpm check && pnpm test` (3400 passing) and `cargo clippy --all-targets -- -D warnings` all clean, run on Windows. Not yet exercised in the running app on any platform.

New coverage:

- `BacklinksSection.test.tsx` / `TagsSection.test.tsx`: heading and empty message at zero entries, the header click reported to the parent rather than self-collapsing, and the collapsed render
- `Sidebar.test.tsx`: the backlinks block survives a note with no backlinks, the toggle calls `setBacklinksCollapsed(true)`, and a collapsed block exposes no resize handle
- `Sidebar.files.test.tsx`: same for tags on a workspace with no metadata
- `useSidebarLayout.test.ts`: both setters write their `layout.*` keys, and `resetLayout` writes both back to `false`

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
