### PR TITLE
fix(styles): give Persian and Arabic prose a real reading face

### DIFF
--- a/docs/brand.md
+++ b/docs/brand.md
@@ -39,7 +39,15 @@ The reading face is chosen per platform, because "best for reading" is not the s
 
 Windows therefore reads in a humanist sans while Apple platforms read in a serif. That is deliberate: Palatino Linotype, the previous Windows outcome, is a print face that renders poorly at body size on Windows. Readers who want a different face set it in Settings, which overrides the platform default.
 
-All are system stacks; Glyph bundles no font files. None of the reading stack covers Han or Arabic, so Persian and Chinese prose falls through to the platform's generic `serif` (Songti, SimSun) rather than the UI face it used before.
+All are system stacks; Glyph bundles no font files.
+
+### Arabic script
+
+The Latin reading faces are not Latin-only: Calibri, and the Noto and Apple text faces, each carry their own Arabic, cramped and designed as an afterthought. Persian therefore rendered in whatever the Latin face happened to include, and appending a better face to the end of the stack would never have been reached. So `platform.css` declares an Arabic face per platform as a `@font-face` family with a `unicode-range` (Arabic blocks, presentation forms, ZWNJ) and puts it **first**, in `--glyph-arabic-font`: SF Arabic / Geeza Pro on Apple, Segoe UI on Windows, Vazirmatn / Noto Naskh Arabic elsewhere. The range keeps it off Latin, so English prose is byte-identical to before; every stack leads with it, including the ones the font setting builds in `settingsDisplay.ts` and `--glyph-font` for the interface. A reader's own custom face still wins over it: someone who names a Persian font means it.
+
+Swapping the face changes the apparent size, because Arabic body height is not the em box. `size-adjust` on the `@font-face` is the calibration knob. Measured on Windows at 100px: Calibri's own Arabic body is 52 against its 47 Latin x-height, Segoe UI's is 54, so the Windows face carries `size-adjust: 96%` and Persian keeps the size readers already have while gaining Segoe's shaping. The Apple and Noto faces are unmeasured and sit at 100%; measure the same way and set them if Persian reads off on those platforms.
+
+Han is still uncovered: Chinese prose falls through to the platform's generic `serif` (Songti, SimSun).
 
 Two export targets cannot carry the reading face: PDF (pdfmake ships Roboto only, and other faces need embedded font files) and DOCX (no default run font is set). HTML, EPUB, the site export, and print all get it. A reader's *chosen* font reaches print, which drives the live document, but no file export: `collectStyles` serialises stylesheets and the choice is written as an inline style on `<html>`, so exported files always show the default reading face. The reading face is what separates the document from the interface: prose is set in the serif while the chrome stays on the platform UI font, so the document reads as a document rather than as part of the app.
 

--- a/src/contexts/SettingsProvider.theme.test.tsx
+++ b/src/contexts/SettingsProvider.theme.test.tsx
@@ -179,7 +179,9 @@ describe("SettingsProvider appearance", () => {
         ["appearance.customFont", "Comic Sans MS"],
         ["appearance.fontFamily", "custom"],
       ]);
-      expect(root().getPropertyValue("--glyph-reading-font")).toBe("Comic Sans MS");
+      expect(root().getPropertyValue("--glyph-reading-font")).toBe(
+        "Comic Sans MS, var(--glyph-arabic-font)",
+      );
     });
 
     it("clears the override for system, leaving the stylesheet reading serif", async () => {

--- a/src/lib/settingsDisplay.test.ts
+++ b/src/lib/settingsDisplay.test.ts
@@ -26,6 +26,12 @@ describe("FONT_FAMILY_MAP", () => {
   it("has mono font stack", () => {
     expect(FONT_FAMILY_MAP.mono).toContain("monospace");
   });
+
+  it("leads every stack with the Arabic face, which the Latin faces would beat", () => {
+    for (const key of ["serif", "sans", "mono"]) {
+      expect(FONT_FAMILY_MAP[key], key).toMatch(/^var\(--glyph-arabic-font\), /);
+    }
+  });
 });
 
 describe("LINE_HEIGHT_MAP", () => {
@@ -81,20 +87,53 @@ describe("reading face", () => {
   // The default is per platform, so the guard is coverage rather than equality:
   // a platform without its own face silently falls back to the generic serif.
   const css = readFileSync("src/styles/platform.css", "utf8");
+  const blockAfter = (marker: string) => {
+    const start = css.indexOf(marker);
+    return css.slice(start, css.indexOf("}", start));
+  };
+  const platforms = ["macos", "windows", "linux", "ios", "android"];
 
   it("declares a reading face for every platform the app targets", () => {
-    for (const platform of ["macos", "windows", "linux", "ios", "android"]) {
-      const block = css.slice(css.indexOf(`[data-platform="${platform}"]`));
-      const decl = block.slice(0, block.indexOf("}")).includes("--glyph-reading-font");
-      expect(decl, `${platform} has no --glyph-reading-font`).toBe(true);
+    for (const platform of platforms) {
+      const decl = blockAfter(`[data-platform="${platform}"]`);
+      expect(decl, `${platform} has no --glyph-reading-font`).toContain("--glyph-reading-font");
+    }
+  });
+
+  it("leads every reading stack with the Arabic face", () => {
+    // Trailing it does nothing: Calibri and the Noto/Apple text faces carry
+    // their own cramped Arabic, so they would claim Persian first.
+    for (const platform of platforms) {
+      const decl = blockAfter(`[data-platform="${platform}"]`);
+      expect(decl, `${platform} has no --glyph-arabic-font`).toContain("--glyph-arabic-font:");
+      expect(decl, `${platform} reading stack does not lead with Arabic`).toContain(
+        "--glyph-reading-font: var(--glyph-arabic-font)",
+      );
+    }
+  });
+
+  it("backs every named Arabic family with a unicode-ranged @font-face", () => {
+    // Without the range the face would claim Latin too, changing English prose.
+    const named = new Set(
+      [...css.matchAll(/--glyph-arabic-font:\s*([^;]+);/g)].flatMap((m) =>
+        m[1].split(",").map((name) => name.trim()),
+      ),
+    );
+    expect(named.size).toBeGreaterThan(0);
+    for (const family of named) {
+      const rule = blockAfter(`font-family: ${family};`);
+      expect(rule, `${family} has no @font-face rule`).toContain("src: local(");
+      expect(rule, `${family} has no unicode-range`).toContain("unicode-range:");
     }
   });
 
   it("keeps a generic fallback for an unknown platform", () => {
-    const root = css.slice(css.indexOf(":root"), css.indexOf("}"));
+    const root = blockAfter(":root");
     expect(root).toContain("--glyph-reading-font");
+    expect(root).toContain("--glyph-arabic-font");
   });
 });
+
 describe("resolveReadingFont", () => {
   const base = DEFAULT_SETTINGS.appearance;
 
@@ -106,9 +145,9 @@ describe("resolveReadingFont", () => {
     expect(resolveReadingFont({ ...base, fontFamily: "mono" })).toContain("monospace");
   });
 
-  it("uses the custom font when one is named", () => {
+  it("uses the custom font when one is named, with the Arabic face behind it", () => {
     expect(resolveReadingFont({ ...base, fontFamily: "custom", customFont: "Comic Sans MS" })).toBe(
-      "Comic Sans MS",
+      "Comic Sans MS, var(--glyph-arabic-font)",
     );
   });
 

--- a/src/lib/settingsDisplay.ts
+++ b/src/lib/settingsDisplay.ts
@@ -7,11 +7,17 @@ import type { AISettings } from "@/lib/settings";
 
 export const ZOOM_DEFAULT = 16;
 
+// Arabic-script face, declared per platform in platform.css and unicode-ranged
+// there so it only claims Persian/Arabic runs. It leads each stack because the
+// Latin faces below carry their own cramped Arabic, which a trailing fallback
+// would never displace.
+const ARABIC = "var(--glyph-arabic-font)";
+
 export const FONT_FAMILY_MAP: Record<string, string> = {
   system: "",
-  serif: "'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, ui-serif, serif",
-  sans: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-  mono: "'SF Mono', 'Fira Code', 'Cascadia Code', monospace",
+  serif: `${ARABIC}, 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, ui-serif, serif`,
+  sans: `${ARABIC}, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`,
+  mono: `${ARABIC}, 'SF Mono', 'Fira Code', 'Cascadia Code', monospace`,
 };
 
 export const LINE_HEIGHT_MAP: Record<string, string> = {
@@ -41,6 +47,11 @@ export const MODEL_SUGGESTIONS: Record<AISettings["provider"], string[]> = {
 export function resolveReadingFont(appearance: AppearanceSettings): string {
   // Trimmed: a blank custom name would set an empty custom property, which
   // makes font-family invalid and drops prose to the interface font.
-  if (appearance.fontFamily === "custom") return appearance.customFont.trim();
+  if (appearance.fontFamily === "custom") {
+    // A named face wins over the Arabic default: someone who types a Persian
+    // font wants it used for Persian. The default only catches what it misses.
+    const custom = appearance.customFont.trim();
+    return custom ? `${custom}, ${ARABIC}` : "";
+  }
   return FONT_FAMILY_MAP[appearance.fontFamily] ?? "";
 }

--- a/src/styles/platform.css
+++ b/src/styles/platform.css
@@ -1,9 +1,44 @@
+/* Arabic-script faces, one @font-face family per platform. They lead every
+   stack rather than trailing it: Calibri and the Noto/Apple text faces carry
+   their own cramped Arabic, so a fallback appended at the end never runs. The
+   unicode-range keeps them off Latin, which still resolves to the platform
+   face behind them (Persian digits, Arabic-Indic digits and ZWNJ are inside
+   the ranges, so a Persian paragraph shapes in one face).
+   size-adjust is the calibration knob: Arabic body height is not the em box,
+   so an Arabic face swapped in at the same font-size reads a different size
+   than the Latin it replaced. Measured on Windows at 100px: Calibri's own
+   Arabic body is 52 against a 47 Latin x-height, Segoe UI's is 54, so 96%
+   holds Persian at the size readers see today while gaining Segoe's shaping.
+   The Apple and Noto faces are unmeasured (no macOS/Linux box here), so they
+   stay at 100%; measure and set them the same way if Persian reads off there. */
+@font-face {
+  font-family: GlyphArabic;
+  src: local("Segoe UI");
+  size-adjust: 96%;
+  unicode-range: U+0600-06FF, U+0750-077F, U+0870-08FF, U+FB50-FDFF, U+FE70-FEFF, U+200C;
+}
+
+@font-face {
+  font-family: GlyphArabicApple;
+  src: local("SF Arabic"), local("Geeza Pro");
+  unicode-range: U+0600-06FF, U+0750-077F, U+0870-08FF, U+FB50-FDFF, U+FE70-FEFF, U+200C;
+}
+
+@font-face {
+  font-family: GlyphArabicNoto;
+  src: local("Vazirmatn"), local("Noto Naskh Arabic"), local("Noto Sans Arabic");
+  unicode-range: U+0600-06FF, U+0750-077F, U+0870-08FF, U+FB50-FDFF, U+FE70-FEFF, U+200C;
+}
+
 :root {
-  --glyph-font: system-ui, -apple-system, sans-serif;
+  /* Which Arabic family this platform uses. Leads --glyph-font and every
+     reading stack, including the ones built in settingsDisplay.ts. */
+  --glyph-arabic-font: GlyphArabicNoto;
+  --glyph-font: var(--glyph-arabic-font), system-ui, -apple-system, sans-serif;
   /* Long-form reading face, per platform: whichever face that OS ships that
      is designed for reading at body size, not the UI face. Overridden by the
      document-font setting; see docs/brand.md. */
-  --glyph-reading-font: Georgia, serif;
+  --glyph-reading-font: var(--glyph-arabic-font), Georgia, serif;
   --glyph-radius: 6px;
   --glyph-radius-sm: 4px;
   --glyph-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -20,7 +55,9 @@
    the notch, home indicator, and (in landscape) the side cutout/status bar. */
 [data-platform="ios"],
 [data-platform="android"] {
-  --glyph-reading-font: "New York", ui-serif, "Noto Serif", Georgia, serif;
+  --glyph-arabic-font: GlyphArabicApple, GlyphArabicNoto;
+  --glyph-reading-font: var(--glyph-arabic-font), "New York", ui-serif,
+    "Noto Serif", Georgia, serif;
   --glyph-safe-top: env(safe-area-inset-top);
   --glyph-safe-bottom: env(safe-area-inset-bottom);
   --glyph-safe-left: env(safe-area-inset-left);
@@ -28,10 +65,11 @@
 }
 
 [data-platform="macos"] {
-  --glyph-font: "SF Pro", -apple-system, BlinkMacSystemFont, system-ui,
-    sans-serif;
-  --glyph-reading-font: "New York", ui-serif, "Iowan Old Style", Charter,
-    Palatino, serif;
+  --glyph-arabic-font: GlyphArabicApple;
+  --glyph-font: var(--glyph-arabic-font), "SF Pro", -apple-system,
+    BlinkMacSystemFont, system-ui, sans-serif;
+  --glyph-reading-font: var(--glyph-arabic-font), "New York", ui-serif,
+    "Iowan Old Style", Charter, Palatino, serif;
   --glyph-radius: 8px;
   --glyph-radius-sm: 6px;
   --glyph-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
@@ -44,16 +82,22 @@
 }
 
 [data-platform="windows"] {
-  --glyph-font: "Segoe UI Variable", "Segoe UI", system-ui, sans-serif;
-  --glyph-reading-font: Calibri, Constantia, Cambria, Georgia, sans-serif;
+  --glyph-arabic-font: GlyphArabic;
+  --glyph-font: var(--glyph-arabic-font), "Segoe UI Variable", "Segoe UI",
+    system-ui, sans-serif;
+  --glyph-reading-font: var(--glyph-arabic-font), Calibri, Constantia, Cambria,
+    Georgia, sans-serif;
   --glyph-radius: 4px;
   --glyph-radius-sm: 2px;
   --glyph-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
 [data-platform="linux"] {
-  --glyph-font: system-ui, "Ubuntu", "Cantarell", sans-serif;
-  --glyph-reading-font: "Noto Serif", "DejaVu Serif", "Liberation Serif", serif;
+  --glyph-arabic-font: GlyphArabicNoto;
+  --glyph-font: var(--glyph-arabic-font), system-ui, "Ubuntu", "Cantarell",
+    sans-serif;
+  --glyph-reading-font: var(--glyph-arabic-font), "Noto Serif", "DejaVu Serif",
+    "Liberation Serif", serif;
   --glyph-radius: 6px;
   --glyph-radius-sm: 4px;
   --glyph-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary

Persian and Arabic prose rendered in whatever Arabic the Latin reading face happened to include. That is not a missing-glyph fallback: Calibri, and the Noto and Apple text faces, each ship their own cramped Arabic, so they claim the run first and any better face appended to the end of the stack is never reached.

This declares the Arabic face per platform as a `@font-face` family with a `unicode-range`, puts it first in every stack, and calibrates its size with `size-adjust` so the swap does not change how large Persian reads.

## Changes

- `src/styles/platform.css`: three `@font-face` families (`GlyphArabic` for Segoe UI on Windows, `GlyphArabicApple` for SF Arabic / Geeza Pro, `GlyphArabicNoto` for Vazirmatn / Noto Naskh Arabic), each ranged to the Arabic blocks, presentation forms and ZWNJ. `--glyph-arabic-font` picks one per platform and now leads `--glyph-reading-font` and `--glyph-font`.
- `size-adjust: 96%` on the Windows face, from measurement (below). Apple and Noto faces stay at 100%, unmeasured.
- `src/lib/settingsDisplay.ts`: the serif/sans/mono stacks the document-font setting builds also lead with the Arabic face. A custom font named by the reader keeps priority over it, since naming a Persian font means it.
- `docs/brand.md`: documents the mechanism, the measured numbers, and that Han is still uncovered (#648).
- Tests: every platform block declares the face and leads its reading stack with it, every named family has a unicode-ranged `@font-face` behind it, and the setting-built stacks lead with it too.

## Risk classification

- [x] No risk areas touched

### Invariants at stake and evidence

None. Presentation only; no state, IPC, or persisted format is involved.

## Testing

`pnpm typecheck && pnpm check && pnpm test` green (380 files, 3397 tests). No Rust touched.

Measured in Chromium 151 on Windows 11 against `src/styles/platform.css` as shipped, at 16px, comparing the old stack with the new one:

| | before | after |
| --- | --- | --- |
| Persian line width | 413.8px | 476.7px |
| Latin `Hamburgefonstiv` width | 110.1px | 110.1px |

Latin is unchanged to the pixel, which is what the `unicode-range` is there to guarantee. Persian moves off Calibri's Arabic onto Segoe UI, with the ZWNJ in `می‌دهد` shaping correctly.

Size calibration, measured at 100px on the same box: Calibri Latin x-height 47, Calibri Arabic body 52, Segoe UI Arabic body 54. `size-adjust: 96%` puts the new face back at body height 52, so Persian keeps the size readers have today and only gains the shaping.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

macOS and Linux are unverified: the Apple and Noto factors need the same measurement on those platforms, which `docs/brand.md` spells out.
