### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

The `Cargo Audit` job in the Security workflow fails on every branch, including PRs with no Rust changes at all. The cause is RUSTSEC-2026-0258 ("h2 unbounded empty DATA frames") against `h2 0.4.15` in `src-tauri/Cargo.lock`. The advisory was published after the last green Security run on `main` (2026-08-17, 92776ed), so it started failing everything at once.

`h2` is transitive:

```
h2 v0.4.15
└── hyper v1.8.1 / reqwest v0.12.28
    ├── sentry v0.42.0
    └── tauri-plugin-http v2.5.9
```

Nothing depends on it directly, so the fix is a lockfile bump, not a manifest change.

## Changes

- Bump `h2` from 0.4.15 to 0.4.16 in `src-tauri/Cargo.lock` (2-line diff, no manifest change).

Pinned with `cargo update -p h2 --precise 0.4.16`. Worth noting: an unpinned `cargo update -p h2` produces the same `h2` bump but also re-resolves 14 unrelated `windows-sys` edges (`errno`, `rustix`, `tempfile`, `os_pipe`, and others drop from 0.61.2 to 0.45/0.52/0.59/0.60). That churn is not needed to clear the advisory, so it is left out. `cargo metadata --locked` accepts the minimal lockfile, which confirms cargo will not rewrite it during a build.

The 20 remaining `cargo audit` findings are `unmaintained` / `unsound` warnings from Tauri's GTK3 Linux stack (atk, gdk*, gtk, glib, fxhash, git2, unic-*). The job runs plain `cargo audit` with no `--deny warnings`, so those do not fail it and are left alone.

## Risk classification

- [x] Network
- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup

### Invariants at stake and evidence

Network is checked only because `h2` sits under the HTTP client used by Sentry and `tauri-plugin-http`. No Glyph code, IPC surface, or persisted format changes; the diff is two lines in a lockfile. The patch release is semver-compatible, so no call sites move and no invariants from `docs/engineering-invariants.md` are touched. The existing suite covering those paths passes unchanged (457 Rust tests, 3403 frontend tests).

## Testing

`cargo audit` in `src-tauri/` now exits 0, with no vulnerabilities and only the 20 pre-existing GTK3 warnings.

Full gates, all green:

- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (457 passed)
- `pnpm typecheck`
- `pnpm check` (898 files)
- `pnpm test` (3403 passed, 380 files)

One unrelated flake showed up on a first frontend run under heavy parallel load (`exportSite` > "inlines mermaid diagrams and restores the app theme afterwards") and passed on re-run. It is unrelated to this change, which touches no frontend code; flagging it rather than folding a fix in here.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux
