### PR TITLE
feat(editor): find and replace in the markdown editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@codemirror/lang-markdown": "^6.5.2",
     "@codemirror/language": "^6.12.4",
     "@codemirror/language-data": "^6.5.2",
+    "@codemirror/search": "^6.6.0",
     "@codemirror/state": "^6.7.1",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@codemirror/language-data':
         specifier: ^6.5.2
         version: 6.5.2
+      '@codemirror/search':
+        specifier: ^6.6.0
+        version: 6.6.0
       '@codemirror/state':
         specifier: ^6.7.1
         version: 6.7.1

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -131,6 +131,8 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
             content={editorContent}
             onChange={handleEditorChange}
             workspaceFiles={workspaceFiles}
+            searchOpen={searchOpen}
+            onSearchClose={onSearchClose}
           />
         </div>
       </NoteZoomLayer>

--- a/src/components/editor/MarkdownEditor.test.tsx
+++ b/src/components/editor/MarkdownEditor.test.tsx
@@ -1,7 +1,8 @@
 import { render } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { act, type ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SettingsContext, type SettingsContextValue } from "@/contexts/SettingsContext";
+import { i18n } from "@/lib/i18n";
 import { DEFAULT_SETTINGS, type Settings } from "@/lib/settings";
 
 vi.mock("@/contexts/TabsContext", () => ({ useWorkspaceRoot: () => undefined }));
@@ -16,6 +17,10 @@ function settingsWith(spellCheck: boolean, spellCheckLanguages: string[] = ["en"
     ...DEFAULT_SETTINGS,
     editor: { ...DEFAULT_SETTINGS.editor, spellCheck, spellCheckLanguages },
   };
+}
+
+function settingsWithKeymap(keymap: Settings["editor"]["keymap"]): Settings {
+  return { ...DEFAULT_SETTINGS, editor: { ...DEFAULT_SETTINGS.editor, spellCheck: false, keymap } };
 }
 
 function wrapper(settings: Settings) {
@@ -97,5 +102,101 @@ describe("MarkdownEditor spell-check wiring", () => {
     // ...but a real set change must.
     rerender(tree(settingsWith(true, ["en", "fa"])));
     expect(buildSpellcheck).toHaveBeenCalledWith(["en", "fa"], expect.any(Function));
+  });
+});
+
+describe("MarkdownEditor find and replace", () => {
+  afterEach(async () => {
+    await act(async () => {
+      await i18n.changeLanguage("en");
+    });
+  });
+
+  function renderEditor(searchOpen: boolean, onSearchClose = vi.fn()) {
+    const tree = (open: boolean) => (
+      <MarkdownEditor
+        content="cat cat"
+        onChange={() => {}}
+        searchOpen={open}
+        onSearchClose={onSearchClose}
+      />
+    );
+    const view = render(tree(searchOpen), { wrapper: wrapper(settingsWith(false)) });
+    return { ...view, setOpen: (open: boolean) => view.rerender(tree(open)) };
+  }
+
+  const panel = (container: HTMLElement) => container.querySelector(".cm-panel.cm-search");
+
+  it("keeps the panel closed until search is opened", () => {
+    const { container } = renderEditor(false);
+    expect(panel(container)).toBeNull();
+  });
+
+  it("opens the panel with find and replace fields when search opens", () => {
+    const { container, setOpen } = renderEditor(false);
+    act(() => setOpen(true));
+
+    const found = panel(container);
+    expect(found).not.toBeNull();
+    expect(found?.querySelector("input[main-field]")).not.toBeNull();
+    expect(found?.querySelector("button[name=replace]")).not.toBeNull();
+    expect(found?.querySelector("button[name=replaceAll]")).not.toBeNull();
+  });
+
+  it("closes the panel again when search closes", () => {
+    const { container, setOpen } = renderEditor(true);
+    expect(panel(container)).not.toBeNull();
+
+    act(() => setOpen(false));
+    expect(panel(container)).toBeNull();
+  });
+
+  it("reports back when the panel is dismissed from inside", () => {
+    const onSearchClose = vi.fn();
+    const { container } = renderEditor(true, onSearchClose);
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>(".cm-panel.cm-search button[name=close]")?.click();
+    });
+    expect(onSearchClose).toHaveBeenCalled();
+  });
+
+  // A keymap change rebuilds the EditorView, which drops the panel; the parent
+  // still believes search is open, so the panel has to be restored or Find
+  // becomes a permanent no-op for that tab.
+  it("restores the panel after a keymap change rebuilds the editor", () => {
+    const tree = (settings: Settings) => (
+      <SettingsContext.Provider
+        value={{
+          settings,
+          updateSettings: vi.fn(),
+          resetSettings: vi.fn(),
+          flushSettings: async () => true,
+          loaded: true,
+        }}
+      >
+        <MarkdownEditor content="cat cat" onChange={() => {}} searchOpen onSearchClose={vi.fn()} />
+      </SettingsContext.Provider>
+    );
+    const { container, rerender } = render(tree(settingsWithKeymap("default")));
+    expect(panel(container)).not.toBeNull();
+
+    act(() => rerender(tree(settingsWithKeymap("vscode"))));
+    expect(panel(container)).not.toBeNull();
+  });
+
+  it("labels the panel in the active locale", async () => {
+    const { container } = renderEditor(true);
+    expect(container.querySelector<HTMLInputElement>("input[main-field]")?.placeholder).toBe(
+      "Find",
+    );
+
+    // Reconfigured in place: the panel is relabelled without remounting.
+    await act(async () => {
+      await i18n.changeLanguage("de");
+    });
+    expect(container.querySelector<HTMLInputElement>("input[main-field]")?.placeholder).toBe(
+      "Suchen",
+    );
   });
 });

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -1,3 +1,4 @@
+import { closeSearchPanel, openSearchPanel, searchPanelOpen } from "@codemirror/search";
 import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { useEffect, useRef } from "react";
@@ -18,6 +19,10 @@ interface MarkdownEditorProps {
   workspaceFiles?: string[];
   /** Receives the view on mount and null on teardown, for split view scroll sync. */
   onViewReady?: (view: EditorView | null) => void;
+  /** Drives CodeMirror's find/replace panel. Closing it from inside (Escape or
+   *  its close button) reports back through `onSearchClose`. */
+  searchOpen?: boolean;
+  onSearchClose?: () => void;
 }
 
 export function MarkdownEditor({
@@ -25,6 +30,8 @@ export function MarkdownEditor({
   onChange,
   workspaceFiles,
   onViewReady,
+  searchOpen = false,
+  onSearchClose,
 }: MarkdownEditorProps) {
   const workspaceRoot = useWorkspaceRoot();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -33,6 +40,10 @@ export function MarkdownEditor({
   onChangeRef.current = onChange;
   const onViewReadyRef = useRef(onViewReady);
   onViewReadyRef.current = onViewReady;
+  const onSearchCloseRef = useRef(onSearchClose);
+  onSearchCloseRef.current = onSearchClose;
+  const searchOpenRef = useRef(searchOpen);
+  searchOpenRef.current = searchOpen;
 
   // Read workspace state through refs so the completion source — installed
   // once at mount — picks up updates without reconfiguring the editor. The
@@ -44,7 +55,7 @@ export function MarkdownEditor({
   workspaceFilesRef.current = workspaceFiles ?? [];
   workspaceRootRef.current = workspaceRoot;
 
-  const { t } = useTranslation("settings");
+  const { t, i18n } = useTranslation("settings");
   const { settings } = useSettings();
   const platform = usePlatform();
   const keymapPreset = settings.editor.keymap;
@@ -108,6 +119,28 @@ export function MarkdownEditor({
   const spellcheckExtension = (enabled: boolean, languages: readonly string[]) =>
     enabled ? buildSpellcheck(languages, () => spellLabelsRef.current) : [];
 
+  // CodeMirror builds the find/replace panel from these phrases when it opens,
+  // so they can't be read through a ref like the menus above. A Compartment
+  // lets a locale change reconfigure them without discarding undo history.
+  const searchPhrasesCompartment = useRef(new Compartment()).current;
+  const searchPhrases = EditorState.phrases.of({
+    Find: t("editor.search.find"),
+    Replace: t("editor.search.replace"),
+    next: t("editor.search.next"),
+    previous: t("editor.search.previous"),
+    all: t("editor.search.all"),
+    "match case": t("editor.search.matchCase"),
+    regexp: t("editor.search.regexp"),
+    "by word": t("editor.search.byWord"),
+    replace: t("editor.search.replaceOne"),
+    "replace all": t("editor.search.replaceAll"),
+    close: t("editor.search.close"),
+    "current match": t("editor.search.currentMatch"),
+    "on line": t("editor.search.onLine"),
+    "replaced match on line $": t("editor.search.replacedOnLine"),
+    "replaced $ matches": t("editor.search.replacedMatches"),
+  });
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: content is synced via separate effect below to avoid destroying the editor on every keystroke
   useEffect(() => {
     if (!containerRef.current) return;
@@ -124,7 +157,10 @@ export function MarkdownEditor({
           pasteHtmlRef,
           spellcheckCompartment,
           spellcheckExtension: spellcheckExtension(spellCheck, spellCheckLanguages),
+          searchPhrasesCompartment,
+          searchPhrases,
           onDocChange: (doc: string) => onChangeRef.current(doc),
+          onSearchPanelClose: () => onSearchCloseRef.current?.(),
         }),
       }),
       parent: containerRef.current,
@@ -132,6 +168,10 @@ export function MarkdownEditor({
 
     viewRef.current = view;
     onViewReadyRef.current?.(view);
+    // A keymap change rebuilds the view, dropping any open panel while the
+    // caller still believes search is open. Restore it with the rest of the
+    // state this effect owns.
+    if (searchOpenRef.current) openSearchPanel(view);
 
     return () => {
       view.destroy();
@@ -164,6 +204,26 @@ export function MarkdownEditor({
       ),
     });
   }, [spellCheck, spellCheckLanguagesKey]);
+
+  // Re-translate the panel in place when the locale changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: searchPhrasesCompartment is a stable ref, and searchPhrases is rebuilt on every render, so keying on the language is what actually marks a real change
+  useEffect(() => {
+    viewRef.current?.dispatch({
+      effects: searchPhrasesCompartment.reconfigure(searchPhrases),
+    });
+  }, [i18n.language]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    if (searchOpen) {
+      // Re-opening an open panel just refocuses the find field, which is what
+      // pressing the shortcut again should do.
+      openSearchPanel(view);
+    } else if (searchPanelOpen(view.state)) {
+      closeSearchPanel(view);
+    }
+  }, [searchOpen]);
 
   return <div ref={containerRef} className="editor-container" />;
 }

--- a/src/components/editor/SplitView.test.tsx
+++ b/src/components/editor/SplitView.test.tsx
@@ -7,6 +7,10 @@ import { captureResizeObserver, sizeScroller, stubOffsetTop } from "@/test/scrol
 
 const LINE_HEIGHT = 20;
 
+// Whether the stand-in editor claims focus, so the focus-routed Find shortcut
+// can be tested without a real CodeMirror instance.
+let editorHasFocus = false;
+
 // The stand-ins reproduce the markup and the view handoff the sync hook needs,
 // so these tests exercise the real wiring rather than the hook's own behaviour,
 // which useSyncedScroll.test.ts covers against the same fake geometry.
@@ -15,10 +19,12 @@ vi.mock("./MarkdownEditor", () => ({
     content,
     onChange,
     onViewReady,
+    searchOpen,
   }: {
     content: string;
     onChange: (v: string) => void;
     onViewReady?: (view: unknown) => void;
+    searchOpen?: boolean;
   }) => {
     const scrollerRef = useRef<HTMLDivElement>(null);
     useEffect(() => {
@@ -31,6 +37,9 @@ vi.mock("./MarkdownEditor", () => ({
       });
       onViewReady({
         scrollDOM,
+        get hasFocus() {
+          return editorHasFocus;
+        },
         get documentTop() {
           return -scrollDOM.scrollTop;
         },
@@ -47,7 +56,12 @@ vi.mock("./MarkdownEditor", () => ({
       return () => onViewReady(null);
     }, [onViewReady]);
     return (
-      <div ref={scrollerRef} className="cm-scroller" data-testid="editor-scroller">
+      <div
+        ref={scrollerRef}
+        className="cm-scroller"
+        data-testid="editor-scroller"
+        data-search-open={String(Boolean(searchOpen))}
+      >
         <div className="cm-content">
           <textarea
             data-testid="editor"
@@ -61,8 +75,21 @@ vi.mock("./MarkdownEditor", () => ({
 }));
 
 vi.mock("@/components/markdown/MarkdownViewer", () => ({
-  MarkdownViewer: ({ content, sourceLines }: { content: string; sourceLines?: boolean }) => (
-    <div data-scroll-container="" data-testid="preview" data-source-lines={String(sourceLines)}>
+  MarkdownViewer: ({
+    content,
+    sourceLines,
+    searchOpen,
+  }: {
+    content: string;
+    sourceLines?: boolean;
+    searchOpen?: boolean;
+  }) => (
+    <div
+      data-scroll-container=""
+      data-testid="preview"
+      data-source-lines={String(sourceLines)}
+      data-search-open={String(Boolean(searchOpen))}
+    >
       <div className="markdown-body">
         <p data-line="1">{content}</p>
         <p data-line="11" data-testid="last-anchor" />
@@ -103,6 +130,7 @@ function renderSplit(syncScroll: boolean) {
 describe("SplitView", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    editorHasFocus = false;
   });
 
   afterEach(() => {
@@ -198,5 +226,55 @@ describe("SplitView", () => {
 
   it("skips source-line markers when the panes are independent", () => {
     expect(renderSplit(false).preview.dataset.sourceLines).toBe("false");
+  });
+});
+
+// One Find shortcut, two panes: the caret decides which one answers it, so
+// editing text does not send the search to the preview and vice versa.
+describe("SplitView find routing", () => {
+  function renderWithSearch(searchOpen: boolean) {
+    const tree = (open: boolean) => (
+      <SplitView content="hello" onChange={() => {}} searchOpen={open} onSearchClose={() => {}} />
+    );
+    const view = render(tree(searchOpen));
+    return { ...view, setOpen: (open: boolean) => view.rerender(tree(open)) };
+  }
+
+  const openOn = (view: ReturnType<typeof render>) => ({
+    editor: view.getByTestId("editor-scroller").dataset.searchOpen,
+    preview: view.getByTestId("preview").dataset.searchOpen,
+  });
+
+  afterEach(() => {
+    editorHasFocus = false;
+  });
+
+  it("routes Find to the editor when the caret is there", () => {
+    editorHasFocus = true;
+    const view = renderWithSearch(false);
+    act(() => view.setOpen(true));
+    expect(openOn(view)).toEqual({ editor: "true", preview: "false" });
+  });
+
+  it("routes Find to the preview when the editor is not focused", () => {
+    const view = renderWithSearch(false);
+    act(() => view.setOpen(true));
+    expect(openOn(view)).toEqual({ editor: "false", preview: "true" });
+  });
+
+  it("re-decides the target on the next Find rather than sticking to the last pane", () => {
+    const view = renderWithSearch(false);
+    act(() => view.setOpen(true));
+    expect(openOn(view)).toEqual({ editor: "false", preview: "true" });
+
+    act(() => view.setOpen(false));
+    editorHasFocus = true;
+    act(() => view.setOpen(true));
+    expect(openOn(view)).toEqual({ editor: "true", preview: "false" });
+  });
+
+  it("leaves both panes closed while search is not open", () => {
+    const view = renderWithSearch(false);
+    expect(openOn(view)).toEqual({ editor: "false", preview: "false" });
   });
 });

--- a/src/components/editor/SplitView.tsx
+++ b/src/components/editor/SplitView.tsx
@@ -31,6 +31,8 @@ export function SplitView({
   onTaskToggle,
 }: SplitViewProps) {
   const [previewContent, setPreviewContent] = useState(content);
+  // One Find shortcut, two panes: the focused one answers it.
+  const [searchTarget, setSearchTarget] = useState<"editor" | "preview">("preview");
   const [editorView, setEditorView] = useState<EditorView | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -38,6 +40,10 @@ export function SplitView({
   const syncScroll = settings.editor.syncScroll;
 
   useSyncedScroll(rootRef, editorView, syncScroll);
+
+  useEffect(() => {
+    if (searchOpen) setSearchTarget(editorView?.hasFocus ? "editor" : "preview");
+  }, [searchOpen, editorView]);
 
   const handleChange = (newContent: string) => {
     onChange(newContent);
@@ -73,6 +79,8 @@ export function SplitView({
           onChange={handleChange}
           workspaceFiles={workspaceFiles}
           onViewReady={setEditorView}
+          searchOpen={searchOpen && searchTarget === "editor"}
+          onSearchClose={onSearchClose}
         />
       </div>
       <div
@@ -82,7 +90,7 @@ export function SplitView({
         <MarkdownViewer
           content={previewContent}
           filePath={filePath}
-          searchOpen={searchOpen}
+          searchOpen={searchOpen && searchTarget === "preview"}
           onSearchClose={onSearchClose}
           workspaceFiles={workspaceFiles}
           onOpenWikilink={onOpenWikilink}

--- a/src/lib/editorExtensions.test.ts
+++ b/src/lib/editorExtensions.test.ts
@@ -1,3 +1,4 @@
+import { openSearchPanel, replaceAll, SearchQuery, setSearchQuery } from "@codemirror/search";
 import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -18,6 +19,7 @@ const LABELS = {
 // extensions actually resolve; each extension has its own unit test alongside.
 function mount(doc: string) {
   const onDocChange = vi.fn();
+  const onSearchPanelClose = vi.fn();
   const parent = document.createElement("div");
   document.body.appendChild(parent);
   const view = new EditorView({
@@ -35,12 +37,15 @@ function mount(doc: string) {
         pasteHtmlRef: { current: true },
         spellcheckCompartment: new Compartment(),
         spellcheckExtension: [],
+        searchPhrasesCompartment: new Compartment(),
+        searchPhrases: EditorState.phrases.of({ Find: "Buscar", "replace all": "Reemplazar todo" }),
         onDocChange,
+        onSearchPanelClose,
       }),
     }),
     parent,
   });
-  return { view, onDocChange };
+  return { view, onDocChange, onSearchPanelClose };
 }
 
 afterEach(() => {
@@ -77,6 +82,52 @@ describe("buildEditorExtensions", () => {
     });
     view.contentDOM.dispatchEvent(event);
     expect(view.state.doc.toString()).toBe("*hi*");
+  });
+
+  it("labels the search panel from the configured phrases", () => {
+    const { view } = mount("hello");
+    openSearchPanel(view);
+    const panel = view.dom.querySelector(".cm-panel.cm-search");
+    expect(panel?.querySelector("input")?.getAttribute("placeholder")).toBe("Buscar");
+    expect(panel?.querySelector("button[name=replaceAll]")?.textContent).toBe("Reemplazar todo");
+  });
+
+  it("offers replace controls for a writable document", () => {
+    const { view } = mount("hello");
+    openSearchPanel(view);
+    expect(view.dom.querySelector(".cm-panel.cm-search button[name=replace]")).not.toBeNull();
+  });
+
+  it("replaces every match and reports the new document once", () => {
+    const { view, onDocChange } = mount("cat cat cat");
+    view.dispatch({
+      effects: setSearchQuery.of(new SearchQuery({ search: "cat", replace: "dog" })),
+    });
+    replaceAll(view);
+    expect(view.state.doc.toString()).toBe("dog dog dog");
+    expect(onDocChange).toHaveBeenCalledWith("dog dog dog");
+  });
+
+  it("undoes a replace-all in one step", () => {
+    const { view } = mount("cat cat cat");
+    view.dispatch({
+      effects: setSearchQuery.of(new SearchQuery({ search: "cat", replace: "dog" })),
+    });
+    replaceAll(view);
+    view.contentDOM.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "z", code: "KeyZ", ctrlKey: true, bubbles: true }),
+    );
+    expect(view.state.doc.toString()).toBe("cat cat cat");
+  });
+
+  it("reports back when the panel is closed from inside", () => {
+    const { view, onSearchPanelClose } = mount("hello");
+    openSearchPanel(view);
+    expect(onSearchPanelClose).not.toHaveBeenCalled();
+    view.dom
+      .querySelector<HTMLButtonElement>(".cm-panel.cm-search button[name=close]")
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onSearchPanelClose).toHaveBeenCalled();
   });
 
   it("opens the editor menu on right-click", () => {

--- a/src/lib/editorExtensions.ts
+++ b/src/lib/editorExtensions.ts
@@ -9,6 +9,7 @@ import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { syntaxHighlighting } from "@codemirror/language";
 import { languages } from "@codemirror/language-data";
+import { search, searchKeymap, searchPanelOpen } from "@codemirror/search";
 import type { Compartment, Extension } from "@codemirror/state";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import type { RefObject } from "react";
@@ -37,7 +38,12 @@ interface EditorExtensionOptions {
   /** Holds the spell-check extension so it can be reconfigured in place. */
   spellcheckCompartment: Compartment;
   spellcheckExtension: Extension;
+  /** Holds the search panel's translated labels, reconfigured on locale change. */
+  searchPhrasesCompartment: Compartment;
+  searchPhrases: Extension;
   onDocChange: (doc: string) => void;
+  /** Fires when the panel closes from inside (Escape or its close button). */
+  onSearchPanelClose: () => void;
 }
 
 /** The full extension list for a markdown editor instance, in the order the
@@ -51,7 +57,10 @@ export function buildEditorExtensions({
   pasteHtmlRef,
   spellcheckCompartment,
   spellcheckExtension,
+  searchPhrasesCompartment,
+  searchPhrases,
   onDocChange,
+  onSearchPanelClose,
 }: EditorExtensionOptions): Extension[] {
   const { leading, extraKeys } = editorKeymapExtensions(keymapPreset);
   return [
@@ -74,6 +83,9 @@ export function buildEditorExtensions({
       // VSCode preset bindings (empty for other presets) take precedence
       // over the CodeMirror defaults below.
       ...extraKeys,
+      // Ahead of defaultKeymap so Escape closes the search panel rather than
+      // collapsing the selection; the rest of searchKeymap is unclaimed.
+      ...searchKeymap,
       ...defaultKeymap,
       ...historyKeymap,
     ]),
@@ -89,6 +101,11 @@ export function buildEditorExtensions({
       // updates that re-render React siblings) — Esc still closes.
       closeOnBlur: false,
     }),
+    // The panel adds its own replace row whenever the document is writable, so
+    // find and replace need no separate UI. Phrases must precede it: they are
+    // read when the panel is built.
+    searchPhrasesCompartment.of(searchPhrases),
+    search({ top: true }),
     markdown({ base: markdownLanguage, codeLanguages: languages }),
     pasteHtmlExtension(() => pasteHtmlRef.current),
     wrapSelectionExtension,
@@ -102,6 +119,9 @@ export function buildEditorExtensions({
     EditorView.updateListener.of((update) => {
       if (update.docChanged) {
         onDocChange(update.state.doc.toString());
+      }
+      if (searchPanelOpen(update.startState) && !searchPanelOpen(update.state)) {
+        onSearchPanelClose();
       }
     }),
     glyphEditorTheme,

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -206,6 +206,23 @@
       "copy": "Kopieren",
       "paste": "Einfügen",
       "selectAll": "Alles auswählen"
+    },
+    "search": {
+      "find": "Suchen",
+      "replace": "Ersetzen",
+      "next": "Weiter",
+      "previous": "Zurück",
+      "all": "Alle",
+      "matchCase": "Groß-/Kleinschreibung",
+      "regexp": "Regex",
+      "byWord": "Ganzes Wort",
+      "replaceOne": "Ersetzen",
+      "replaceAll": "Alle ersetzen",
+      "close": "Schließen",
+      "currentMatch": "Aktueller Treffer",
+      "onLine": "in Zeile",
+      "replacedOnLine": "Treffer in Zeile $ ersetzt",
+      "replacedMatches": "$ Treffer ersetzt"
     }
   },
   "ai": {

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -206,6 +206,23 @@
       "copy": "Copy",
       "paste": "Paste",
       "selectAll": "Select all"
+    },
+    "search": {
+      "find": "Find",
+      "replace": "Replace",
+      "next": "next",
+      "previous": "previous",
+      "all": "all",
+      "matchCase": "match case",
+      "regexp": "regexp",
+      "byWord": "by word",
+      "replaceOne": "replace",
+      "replaceAll": "replace all",
+      "close": "close",
+      "currentMatch": "current match",
+      "onLine": "on line",
+      "replacedOnLine": "replaced match on line $",
+      "replacedMatches": "replaced $ matches"
     }
   },
   "ai": {

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -206,6 +206,23 @@
       "copy": "Copiar",
       "paste": "Pegar",
       "selectAll": "Seleccionar todo"
+    },
+    "search": {
+      "find": "Buscar",
+      "replace": "Reemplazar",
+      "next": "Siguiente",
+      "previous": "Anterior",
+      "all": "Todo",
+      "matchCase": "Coincidir mayúsculas",
+      "regexp": "Regex",
+      "byWord": "Palabra completa",
+      "replaceOne": "Reemplazar",
+      "replaceAll": "Reemplazar todo",
+      "close": "Cerrar",
+      "currentMatch": "Coincidencia actual",
+      "onLine": "en la línea",
+      "replacedOnLine": "coincidencia reemplazada en la línea $",
+      "replacedMatches": "$ coincidencias reemplazadas"
     }
   },
   "ai": {

--- a/src/locales/fa/settings.json
+++ b/src/locales/fa/settings.json
@@ -206,6 +206,23 @@
       "copy": "رونوشت",
       "paste": "چسباندن",
       "selectAll": "انتخاب همه"
+    },
+    "search": {
+      "find": "جست‌وجو",
+      "replace": "جایگزینی",
+      "next": "بعدی",
+      "previous": "قبلی",
+      "all": "همه",
+      "matchCase": "حساس به بزرگی حروف",
+      "regexp": "عبارت باقاعده",
+      "byWord": "واژهٔ کامل",
+      "replaceOne": "جایگزینی",
+      "replaceAll": "جایگزینی همه",
+      "close": "بستن",
+      "currentMatch": "مورد فعلی",
+      "onLine": "در خط",
+      "replacedOnLine": "مورد خط $ جایگزین شد",
+      "replacedMatches": "$ مورد جایگزین شد"
     }
   },
   "ai": {

--- a/src/locales/zh/settings.json
+++ b/src/locales/zh/settings.json
@@ -206,6 +206,23 @@
       "copy": "复制",
       "paste": "粘贴",
       "selectAll": "全选"
+    },
+    "search": {
+      "find": "查找",
+      "replace": "替换",
+      "next": "下一个",
+      "previous": "上一个",
+      "all": "全部",
+      "matchCase": "区分大小写",
+      "regexp": "正则",
+      "byWord": "全字匹配",
+      "replaceOne": "替换",
+      "replaceAll": "全部替换",
+      "close": "关闭",
+      "currentMatch": "当前匹配",
+      "onLine": "位于行",
+      "replacedOnLine": "已替换第 $ 行的匹配项",
+      "replacedMatches": "已替换 $ 处匹配"
     }
   },
   "ai": {

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -284,3 +284,109 @@
   margin: 4px 0;
   background: var(--color-border);
 }
+
+/* CodeMirror's find/replace panel, dressed to match the preview's .search-bar.
+   It docks across the top of the editor rather than floating, because the
+   replace row makes it too tall to overlay the text comfortably. */
+.cm-panels.cm-panels-top {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+}
+
+.cm-panel.cm-search {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding-block: 6px;
+  /* Room on the end for the absolutely positioned close button. */
+  padding-inline: 8px 32px;
+  font-size: 13px;
+  /* The editor theme sets a monospace face on `&`; the panel is chrome. */
+  font-family: var(--glyph-font, system-ui, -apple-system, sans-serif);
+}
+
+.cm-panel.cm-search br {
+  flex-basis: 100%;
+  height: 0;
+}
+
+.cm-panel.cm-search input,
+.cm-panel.cm-search button,
+.cm-panel.cm-search label {
+  margin: 0;
+}
+
+.cm-panel.cm-search .cm-textfield {
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--glyph-radius-sm);
+  padding: 4px 8px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--color-text-primary);
+  width: 200px;
+  outline: none;
+}
+
+.cm-panel.cm-search .cm-textfield:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 25%, transparent);
+}
+
+.cm-panel.cm-search label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  /* The base theme sets `pre`, which lets a translated multi-word label
+     overflow the panel instead of wrapping with it. */
+  white-space: normal;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.cm-panel.cm-search button:not([name="close"]) {
+  appearance: none;
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--glyph-radius-sm);
+  padding: 4px 10px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.cm-panel.cm-search button:not([name="close"]):hover {
+  background: var(--color-surface-tertiary);
+}
+
+.cm-panel.cm-search [name="close"] {
+  /* The base theme pins this with `right`, which lands on the wrong side in
+     RTL. Re-anchor it on the logical edge. */
+  right: auto;
+  inset-inline-end: 6px;
+  top: 6px;
+  padding: 0 4px;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.cm-panel.cm-search [name="close"]:hover {
+  color: var(--color-text-primary);
+}
+
+/* Match the preview's highlight colours so find looks the same in both panes. */
+.cm-editor .cm-searchMatch {
+  background: color-mix(in srgb, var(--color-accent) 25%, transparent);
+}
+
+.cm-editor .cm-searchMatch.cm-searchMatch-selected {
+  background: var(--color-accent);
+  color: #ffffff;
+}
+

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -15,6 +15,7 @@
   .settings-overlay,
   .command-palette-overlay,
   .search-bar,
+  .cm-panel.cm-search,
   .ai-chat-panel {
     display: none !important;
   }


### PR DESCRIPTION
## Summary

`Cmd/Ctrl+F` reached only the rendered preview: edit mode ignored it entirely, split mode always sent it to the preview pane, and nothing anywhere could replace text.

This wires CodeMirror's own `@codemirror/search` into the markdown editor. It was already resolved in `pnpm-lock.yaml` at 6.6.0 as a transitive dependency of `codemirror` and `@replit/codemirror-vim`, so promoting it to a direct dependency downloads nothing new and adds **1.6 KB raw** to the `MarkdownEditor` chunk (800,451 to 802,058 bytes), because the module was already being shipped.

Its panel adds the replace row itself whenever the document is writable, so find and replace share one piece of UI and no new menu item or accelerator was needed (`Mod-Alt-F` opens it focused on replace).

Closes #652

## Changes

- Add `@codemirror/search` as a direct dependency at the version already in the lock
- Wire `search({ top: true })` and `searchKeymap` into `buildEditorExtensions`, with `searchKeymap` ahead of `defaultKeymap` so Escape closes the panel instead of collapsing the selection
- Feed every panel label through `EditorState.phrases`, from a new `editor.search` block in all five locales, held in a Compartment so a locale change relabels the panel in place without discarding undo history
- Style `.cm-panel.cm-search` to match the preview's `.search-bar`, with the close button re-anchored on the logical edge for RTL, and hide the panel in print alongside `.search-bar`
- Route `menu-find` by mode: the CodeMirror panel in edit mode, and in split mode whichever pane holds focus, defaulting to the preview so view mode is unchanged
- Report a panel closed from inside (Escape or its close button) back to React, so the shortcut does not go dead after the first dismissal

## Risk classification

- [x] Accessibility
- [x] Bundle size / startup

### Invariants at stake and evidence

Neither area touches an invariant in `docs/engineering-invariants.md`; no persistence, IPC, or lifecycle surface changes.

**Accessibility**: the panel's `aria-label`s and placeholders are the same phrases as its visible labels, so they translate with the rest of the UI (`MarkdownEditor.test.tsx` asserts the placeholder flips from `Find` to `Suchen` on a locale change without a remount). Escape and the close button both dismiss the panel and hand focus back to the editor. `localeParity.test.ts` fails the suite if any of the 15 new keys is missing from `de`, `es`, `fa`, or `zh`.

**Bundle size**: measured by building `HEAD~1` and `HEAD`, +1,607 bytes raw on the lazily loaded `MarkdownEditor` chunk. No change to the entry chunk.

Two bugs were found and fixed during self-review, each with a regression test:

- The field styling targeted `input[type="text"]`, but `@codemirror/search` builds both inputs with `class="cm-textfield"` and no `type` attribute, so the rules were inert and the fields rendered unstyled. Now targets `.cm-textfield`.
- Changing the keymap preset rebuilds the `EditorView` and dropped the open panel while React still believed search was open, leaving `Cmd/Ctrl+F` permanently dead for that tab. The mount effect now restores the panel it destroyed; `MarkdownEditor.test.tsx` "restores the panel after a keymap change rebuilds the editor" fails without the fix.

## Testing

Gates, all green: `pnpm typecheck`, `pnpm check`, `pnpm test` (3418 tests, 380 files), `pnpm build`, and `cargo clippy --all-targets -- -D warnings`.

19 new tests cover the panel opening and closing on the shortcut, the replace controls being present for a writable document, replace-all editing the document and undoing in one step, the close-from-inside callback, in-place relabelling on a locale change, panel survival across a keymap rebuild, and split-mode routing following focus in both directions.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Not yet exercised in the running app on any platform, so the panel's rendered appearance is unverified by eye; the CSS was checked against the DOM `@codemirror/search` actually builds (which is how the `type` attribute bug above surfaced), but a look at it in light, dark, and RTL before merge would be worth it.

## Screenshots

None; see the note above.
