### PR TITLE
chore(review): fold three misses back into the review checklists

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -13,6 +13,8 @@ Judge the change against:
 - **Invariants** ([docs/engineering-invariants.md](../../docs/engineering-invariants.md)): for each invariant the diff touches, reconstruct the ownership and state transitions it affects and attempt a concrete counterexample (a sequence of events that violates it). Report the attempt even when it fails.
 - **Correctness**: logic errors, edge cases, and the adversarial scenario matrix from the invariants doc (stale completions, overlapping operations, lifecycle transitions).
 - **Project conventions**: the rules in `.claude/rules/` (notably `frontend.md`, `rust.md`, `tests.md`, `code-organization.md`) are authoritative; check the diff against them rather than your own style preferences.
-- **Security**: untrusted input reaching rendering or filesystem/IPC surfaces without validation (INV-5, INV-6).
+- **Security**: untrusted input reaching rendering or filesystem/IPC surfaces without validation (INV-5, INV-6). For anything written into an exported or printed file, also ask what an absolute local path or a document-supplied URL would do once the file is opened outside the app.
+- **Reach**: an element or attribute the diff adds to the rendered document reaches every DOM consumer, not just the one it was written for. Check the search walker, the AI quote locator, the export passes, print, and the website pipeline before accepting a surface-specific node.
+- **Stale descriptions**: when the diff changes behavior, the comments, docs, and five-locale strings describing the old behavior are part of it. Report each survivor as a finding.
 
 Provide specific, actionable feedback with file:line references. Rate severity: critical / warning / suggestion.

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -15,8 +15,10 @@ Worked bad-to-good examples and the correction history live in `references/examp
 2. **Build only the surface current callers use (YAGNI).** No props, type unions, overloads, or helpers with zero callers; an abstraction needs two real call sites, one call site gets inline code.
 3. **Sparse comments.** Only constraints the code cannot show (platform quirks, ordering, security guards), one line each; trim when comment lines rival code lines in the diff.
 4. **Reuse before writing.** Grep `src/lib/`, `src/hooks/`, and `src-tauri/src/` for an existing helper first; a new predicate joins the module that owns its siblings. Tool-owned manifests stay standard: no custom fields in `package.json` or other externally-owned files; derive from standard fields through existing seams and keep code-interpreted facts beside their checker.
-5. **Right altitude.** Fix the mechanism, not a symptom; special cases layered on shared infrastructure mean the fix is too shallow.
-6. **Tests assert the surface that exists.** Cover the branches the diff adds (Codecov patch must stay green); no tests for capabilities the code no longer has.
+5. **Right altitude.** Fix the mechanism, not a symptom; special cases layered on shared infrastructure mean the fix is too shallow. When a checker flags a sink, removing the sink beats guarding it: a guard the checker does not recognize costs another CI round trip and leaves the sink in place.
+6. **Tests assert the surface that exists.** Cover the branches the diff adds (Codecov patch must stay green); no tests for capabilities the code no longer has. For a new guard, break it and watch the test fail: an assertion that still passes was pinning something else.
+7. **A behavior change sweeps its descriptions.** Comments, docs, and user-visible strings in all five locales that describe the old behavior are part of the change, not a follow-up. Grep the removed behavior's vocabulary across `src/`, `.claude/`, and `samples/` before calling it done.
+8. **A node added to the rendered document joins every DOM consumer.** An element only one surface uses (print-only, export-only, hidden) still reaches the search walker (`useSearch`), the AI quote locator (`documentHighlight`), the export passes (`prepareContent`), print, and the website pipeline. Name which ones must ignore it, and make them.
 
 ## Procedure
 

--- a/.claude/skills/self-review/references/examples.md
+++ b/.claude/skills/self-review/references/examples.md
@@ -20,8 +20,16 @@ One section per checklist rule. Each entry is a real correction: what was reject
 
 ## Rule 5: right altitude
 
-- (no recorded corrections yet)
+- CodeQL flagged `js/xss-through-dom` on `link.setAttribute("href", value)` in the export fallback, where `value` came from a document attribute. Two guards were tried (a shared `exportableHref` helper, then the same regex inlined at the sink) and neither cleared the alert; each cost a push and a CI wait. Accepted shape: delete the sink. The fallback names the media instead of linking it, which is also the truer behavior, since no single-file export carries the bytes.
 
 ## Rule 6: tests assert the existing surface
 
-- (no recorded corrections yet)
+- Three assertions in the media-export work passed for reasons other than their names. `expect(JSON.stringify(blocks)).toContain("clip.mp4")` was satisfied by the poster paragraph's `alt`, never reaching the name paragraph it claimed to check; `expect(html).not.toContain("<a")` also matches `<audio`; and a test named for the hast text-child guard passed with that guard deleted, because a text node has no `tagName` either way. Accepted shape: assert the exact node (`blocks[1]`, `'<p class="markdown-media-fallback"><em>clip.mp4</em></p>'`), and prove a new guard by reverting it and watching the test fail.
+
+## Rule 7: a behavior change sweeps its descriptions
+
+- The export fallback stopped emitting links, but `print.epubMedia.description` in all five locales still promised that over-limit media "becomes a link", and six comments plus three test names described the same removed behavior. A user reading Settings was told their 40 MB clip would become a link when it becomes a name. Accepted shape: grep the old behavior's vocabulary (`link`, `href`) across `src/`, `.claude/`, and `samples/` in the same commit that changes the behavior.
+
+## Rule 8: a node added to the rendered document joins every DOM consumer
+
+- A print-only `<span>` naming a media file was added to fix an empty player printing as a black box. It is `display: none` on screen, but `useSearch` walks every text node regardless of whether it renders, so searching a note for `demo` counted a match that could never be scrolled to or highlighted. Accepted shape: add the class to the walker's existing reject list beside `script, style, .mermaid-diagram`, and check the other consumers (`documentHighlight`, `prepareContent`'s `[data-export-ignore]` strip, the website pipeline) in the same change.


### PR DESCRIPTION
## Summary

Three rules, each one paid for by a miss in the video and audio playback work (#650). No product code changes: this only sharpens the review checklists contributors and their tooling run against a diff, plus the worked-example file behind them.

The interesting one is the third. A hidden element added so that printing a note names a media file it cannot play was invisible on screen and correct in every export, but the in-document search walker takes every text node whether it renders or not. Searching a note counted a match nobody could scroll to. Both review passes looked at the new element and the surface it was written for, and neither asked which other consumers of the rendered document would now see it.

## Changes

- Two new checklist entries: a behavior change sweeps the comments, docs, and five-locale strings that describe the old behavior, and a node added to the rendered document joins every DOM consumer, with the consumers named so the check is mechanical rather than a memory test.
- Two sharpened entries: prove a new guard by reverting it and watching the test fail, and prefer deleting a sink a static checker flags over guarding it.
- Three matching worked examples recorded, including the two rules that had no recorded corrections yet.
- The reviewer agent gains the same three prompts: reach beyond the intended surface, stale descriptions as reportable findings, and what a local path or document-supplied URL does once an exported file is opened outside the app.

## Risk classification

- [x] No risk areas touched

### Invariants at stake and evidence

None. The change is review guidance in Markdown; no runtime code, tests, or configuration are affected.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

The pre-commit gates ran on Windows (Biome, typecheck, the full frontend suite, and strict clippy). There is nothing else to exercise: the diff is four Markdown files.
