### PR TITLE
ci: built-app e2e smoke via tauri-driver

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -22,6 +22,12 @@ paths:
 - `src/test/e2e/*.spec.ts` runs in Playwright's WebKit only (`pnpm test:e2e`, CI job `Smoke / WebKit` in `ci-smoke.yml`); Vitest ignores it (it only collects `*.test.*`). This suite exists for behavior that differs by engine, like CSP enforcement inside blob workers (the D2 renderer); a Chromium run would pass even when the app is broken on Linux/macOS.
 - Keep it a smoke suite: a handful of engine-level checks, not app E2E coverage. It drives the bundled libraries directly, not the Tauri app.
 
+## Built-app smoke tests (tauri-driver)
+
+- `src/test/app/*.spec.ts` runs the built binary over WebDriver via `tauri-driver` (`pnpm test:app`, a plain `node --test` suite with a raw fetch client in `harness.ts`, no WebdriverIO). The `.spec.ts` suffix keeps Vitest out (it collects only `*.test.*`), and it lives in `src/test/app`, not `src/test/e2e`, so Playwright ignores it too.
+- This is the only test that launches the real process under the production CSP: it catches CSP/editor breakage (#390) and startup-race regressions (cold-launch, second-instance) that unit tests cannot. Needs a **release** binary (the single-instance plugin is release-only) and `tauri-driver` on PATH; keep it a handful of assertions.
+- CI runs it on Linux from the Build workflow via `.github/actions/app-smoke` (xvfb + `dbus-run-session`), reusing the release binary already built there; a failure flags PRs and blocks release publishing. macOS is unsupported (no WebKit WebDriver).
+
 ## Rust
 
 - Unit tests live in `#[cfg(test)]` modules in the same file as the code under test.

--- a/.github/actions/app-smoke/action.yml
+++ b/.github/actions/app-smoke/action.yml
@@ -1,0 +1,36 @@
+name: Built-app smoke test
+description: >-
+  Run the WebDriver smoke suite (pnpm test:app) against an already-built Glyph
+  binary on Linux, via tauri-driver under xvfb. Assumes the release binary is
+  at src-tauri/target/release/glyph and pnpm dependencies are installed.
+runs:
+  using: composite
+  steps:
+    # webkit2gtk-driver is WebKitWebDriver (the native driver tauri-driver
+    # proxies to); xvfb gives the hidden window a display; dbus provides
+    # dbus-run-session, since the single-instance plugin hands the second
+    # launch over the D-Bus session bus.
+    - name: Install WebDriver dependencies
+      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y webkit2gtk-driver xvfb dbus
+    # tauri-driver is a cargo binary; cache it so the ~30s build only runs when
+    # the version changes.
+    - name: Cache tauri-driver
+      id: cache-tauri-driver
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ~/.cargo/bin/tauri-driver
+        key: tauri-driver-2.0.6-${{ runner.os }}-${{ runner.arch }}
+    - name: Install tauri-driver
+      if: steps.cache-tauri-driver.outputs.cache-hit != 'true'
+      shell: bash
+      run: cargo install tauri-driver --version 2.0.6 --locked
+    - name: Run built-app smoke
+      shell: bash
+      env:
+        WEBKIT_DISABLE_COMPOSITING_MODE: "1"
+      run: dbus-run-session -- xvfb-run --auto-servernum pnpm test:app

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -90,6 +90,16 @@ jobs:
             echo "expected a usage error for a folder given to --export pdf" >&2
             exit 1
           fi
+      # Drives the built binary over WebDriver (launch, render, edit, second
+      # instance) against the same release build the export smoke used. A
+      # release binary is required: the single-instance plugin is release-only.
+      # Flags on PRs (per-PR gating is a #502 follow-up "once stable"); hard-
+      # fails on pushes to main and on release, where a broken editor must stop.
+      - name: Built-app smoke test
+        if: matrix.platform == 'ubuntu-22.04'
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        timeout-minutes: 10
+        uses: ./.github/actions/app-smoke
 
   build-android:
     name: Android

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -4,9 +4,10 @@ on:
   workflow_call:
 
 # CI-time smoke tests: fast checks that drive real engines or binaries, as
-# opposed to unit tests. Future smoke jobs (e.g. the built-app tauri-driver
-# smoke from #502) belong here. Post-release channel smoke tests live in
-# release-smoke-test.yml instead.
+# opposed to unit tests. The built-app tauri-driver smoke (#502) instead rides
+# the Build workflow's ubuntu-22.04 leg (.github/actions/app-smoke), reusing
+# the release binary already built there rather than building a second one.
+# Post-release channel smoke tests live in release-smoke-test.yml instead.
 jobs:
   webkit:
     # Renders a real D2 diagram and probes every CSP-dependent render surface

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,14 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           args: ${{ matrix.args }}
+      # Gate channel publishing on the built-app smoke: a failure fails this
+      # build leg, and every publish-* job needs: build, so nothing is pushed
+      # to a package channel (the GitHub release and its assets are already
+      # uploaded by this point). One x64 Linux leg is enough (WebKitWebDriver).
+      - name: Built-app smoke test
+        if: matrix.platform == 'ubuntu-22.04'
+        timeout-minutes: 10
+        uses: ./.github/actions/app-smoke
 
   update-release-notes:
     needs: build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,40 @@ pnpm test                       # Run frontend tests (Vitest)
 pnpm test:watch                 # Run frontend tests in watch mode
 pnpm test:coverage              # Run frontend tests with coverage
 pnpm test:e2e                   # WebKit smoke tests (Playwright; run `pnpm exec playwright install webkit` once first)
+pnpm test:app                   # Built-app smoke: drives the real binary over WebDriver (setup below)
 pnpm size:check                 # Bundle budget gate against dist/ (see docs/bundle-budgets.md)
 cd src-tauri && cargo check     # Rust type checking
 cd src-tauri && cargo clippy    # Rust linting
 cd src-tauri && cargo test      # Rust tests
 ```
+
+### Built-app smoke test (`pnpm test:app`)
+
+Launches the built binary over WebDriver (`tauri-driver`) and asserts a
+CLI-arg document renders, the editor holds it under the production CSP, and a
+second launch reuses the running window. This is the only test that exercises
+a real process launch and the production configuration; unit tests cannot.
+Supported on Linux and Windows; macOS has no WebKit WebDriver and is skipped.
+
+One-time setup:
+
+```bash
+cargo install tauri-driver --locked                 # all platforms
+sudo apt install webkit2gtk-driver dbus-x11         # Linux (WebKitWebDriver + dbus-run-session)
+# Windows: put an msedgedriver.exe matching your installed WebView2 on PATH
+```
+
+Then build a release binary and run the smoke:
+
+```bash
+pnpm tauri build --no-bundle                        # release binary; --debug omits the single-instance plugin
+pnpm test:app                                       # Linux: prefix with `dbus-run-session -- xvfb-run` for headless
+```
+
+The binary is found at `src-tauri/target/release/glyph`; set `GLYPH_BIN` to
+point at another path. CI runs this on Linux from the Build workflow: it flags
+(non-blocking) on PRs and hard-fails on pushes to `main` and at release, where
+a failure blocks channel publishing (see `.github/actions/app-smoke`).
 
 ### Mobile: Android and iOS (experimental)
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:app": "node --test --test-timeout=120000 src/test/app/smoke.spec.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "size:check": "node scripts/check-bundle-size.mjs",

--- a/src/test/app/fixtures/alpha.md
+++ b/src/test/app/fixtures/alpha.md
@@ -1,0 +1,3 @@
+# Alpha smoke document
+
+Alpha body line one.

--- a/src/test/app/fixtures/beta.md
+++ b/src/test/app/fixtures/beta.md
@@ -1,0 +1,3 @@
+# Beta smoke document
+
+Beta body line one.

--- a/src/test/app/harness.ts
+++ b/src/test/app/harness.ts
@@ -1,0 +1,121 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// tauri-driver proxies the W3C WebDriver protocol to the platform's native
+// driver (WebKitWebDriver on Linux, msedgedriver on Windows), which launches
+// the binary itself. Three endpoints are all the smoke needs, so this is a raw
+// client over fetch rather than a WebDriver library.
+const DRIVER_URL = "http://127.0.0.1:4444";
+const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/** `GLYPH_BIN`, else the release build. Release-only: the single-instance plugin is release-gated (lib.rs). */
+export function resolveBinary(): string {
+  const exe = process.platform === "win32" ? ".exe" : "";
+  const candidates = [
+    process.env.GLYPH_BIN,
+    path.join(REPO_ROOT, "src-tauri", "target", "release", `glyph${exe}`),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      `No Glyph release binary found; run \`pnpm tauri build --no-bundle\` or set GLYPH_BIN. Looked in:\n${candidates.join("\n")}`,
+    );
+  }
+  return found;
+}
+
+/** Poll `probe` until it resolves truthy; throws with the last result on timeout. */
+export async function waitFor<T>(
+  what: string,
+  probe: () => Promise<T>,
+  timeoutMs = 30_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const value = await probe();
+      if (value) return value;
+      last = value;
+    } catch (error) {
+      last = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for ${what}; last result: ${String(last)}`,
+  );
+}
+
+/** Spawn `tauri-driver` (from PATH) and wait until it accepts connections. */
+export async function startDriver(): Promise<ChildProcess> {
+  const driver = spawn("tauri-driver", [], { stdio: ["ignore", "inherit", "inherit"] });
+  // tauri-driver exits immediately when its native driver is missing or the
+  // ports are busy; surface that instead of a 15s "fetch failed" timeout.
+  const driverStopped = new Promise<never>((_, reject) => {
+    driver.once("error", (error) =>
+      reject(
+        new Error(
+          `Could not start tauri-driver (cargo install tauri-driver --locked): ${error.message}`,
+        ),
+      ),
+    );
+    driver.once("exit", (code, signal) =>
+      reject(
+        new Error(
+          `tauri-driver exited (${code ?? signal}) before listening; is WebKitWebDriver/msedgedriver installed and are ports 4444/4445 free?`,
+        ),
+      ),
+    );
+  });
+  await Promise.race([
+    driverStopped,
+    waitFor(
+      "tauri-driver to listen",
+      () => fetch(`${DRIVER_URL}/status`).then((res) => res.ok),
+      15_000,
+    ),
+  ]);
+  return driver;
+}
+
+async function request<T>(method: string, route: string, body?: unknown): Promise<T> {
+  const response = await fetch(`${DRIVER_URL}${route}`, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const text = await response.text();
+  let value: unknown = text;
+  try {
+    value = JSON.parse(text).value;
+  } catch {
+    // Non-JSON error body (e.g. a driver stack trace); keep the raw text.
+  }
+  if (!response.ok) {
+    const detail = typeof value === "string" ? value : JSON.stringify(value);
+    throw new Error(`${method} ${route} -> ${response.status}: ${detail}`);
+  }
+  return value as T;
+}
+
+/** Launch `application` with `args` through the driver; resolves to the session id. */
+export async function newSession(application: string, args: string[]): Promise<string> {
+  const { sessionId } = await request<{ sessionId: string }>("POST", "/session", {
+    capabilities: { alwaysMatch: { "tauri:options": { application, args } } },
+  });
+  return sessionId;
+}
+
+/** Run `script` (a function body; use `return`) in the app's webview. */
+export function execute<T>(sessionId: string, script: string): Promise<T> {
+  return request<T>("POST", `/session/${sessionId}/execute/sync`, { script, args: [] });
+}
+
+/** Close the session, which also quits the app the driver launched. */
+export function deleteSession(sessionId: string): Promise<void> {
+  return request<void>("DELETE", `/session/${sessionId}`);
+}

--- a/src/test/app/smoke.spec.ts
+++ b/src/test/app/smoke.spec.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { type ChildProcess, spawn } from "node:child_process";
+import { after, before, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  deleteSession,
+  execute,
+  newSession,
+  resolveBinary,
+  startDriver,
+  waitFor,
+} from "./harness.ts";
+
+// Built-app smoke: launches the real binary over WebDriver (tauri-driver) and
+// checks the three things unit tests cannot see, because they need a real
+// process launch under the production CSP: a CLI-arg document renders (cold
+// start, commit 5714293 / #494), the editor holds the document under the
+// production CSP (#390), and a second launch reuses the running window
+// (#189, #494). `pnpm test:app`; CI runs it on Linux under xvfb (see
+// .github/actions/app-smoke). Needs a release binary: the single-instance
+// plugin is release-only (lib.rs), so a --debug build cannot exercise the
+// second-instance case.
+
+// macOS has no WebKit WebDriver, so tauri-driver cannot drive it there.
+const skip = process.platform === "darwin" ? "no WebKit WebDriver on macOS" : false;
+
+const ALPHA = fileURLToPath(new URL("./fixtures/alpha.md", import.meta.url));
+const BETA = fileURLToPath(new URL("./fixtures/beta.md", import.meta.url));
+
+let driver: ChildProcess;
+let session: string;
+
+const renderedHeading = () =>
+  execute<string>(session, "return document.querySelector('.markdown-body h1')?.textContent ?? ''");
+
+before(
+  async () => {
+    if (skip) return;
+    driver = await startDriver();
+    session = await newSession(resolveBinary(), [ALPHA]);
+  },
+  { timeout: 60_000 },
+);
+
+after(async () => {
+  try {
+    if (session) await deleteSession(session);
+  } finally {
+    driver?.kill();
+  }
+});
+
+test("renders the markdown file passed as a CLI argument", { skip }, async () => {
+  await waitFor("the alpha heading to render", async () => {
+    return (await renderedHeading()).trim() === "Alpha smoke document";
+  });
+});
+
+test("edit mode shows the document in the editor", { skip }, async () => {
+  // Click the toggle rather than sending Ctrl+E: on Linux that accelerator
+  // belongs to the native GTK menu, which synthesized WebDriver key events
+  // may never reach.
+  await execute(session, "document.querySelector('button[aria-label=\"Edit mode\"]').click()");
+  await waitFor("the editor to show the alpha body", async () => {
+    const text = await execute<string>(
+      session,
+      "return document.querySelector('.cm-content')?.textContent ?? ''",
+    );
+    return text.includes("Alpha body line one.");
+  });
+});
+
+test("a second instance opens its file in the running window", { skip }, async () => {
+  // The single-instance plugin makes this process hand BETA to the running
+  // app and exit; if it instead opened its own window, this session (attached
+  // to the first window) would keep showing ALPHA with a single tab.
+  const second = spawn(resolveBinary(), [BETA], { stdio: "ignore" });
+  const code = await new Promise<number | null>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      second.kill();
+      reject(new Error("second instance did not exit within 10s"));
+    }, 10_000);
+    second.on("error", reject);
+    second.on("exit", (exitCode) => {
+      clearTimeout(timer);
+      resolve(exitCode);
+    });
+  });
+  assert.equal(code, 0);
+
+  await waitFor("the beta heading to render in the same window", async () => {
+    return (await renderedHeading()).trim() === "Beta smoke document";
+  });
+  const tabCount = await execute<number>(
+    session,
+    "return document.querySelectorAll('.tab-label').length",
+  );
+  assert.equal(tabCount, 2, "the handed-over file should open as a second tab in the same window");
+});


### PR DESCRIPTION
## Summary

Adds a built-app WebDriver smoke test that launches the real Glyph binary (via `tauri-driver`) and asserts the behaviour that unit tests structurally cannot see, because it only reproduces on a real process launch under the production configuration. This is the class of regression that shipped invisibly before: a production CSP that broke the editor in every release build, and the recurring cold-launch / second-instance startup races.

The suite is a plain `node --test` spec driving a raw WebDriver client over `fetch` (no WebdriverIO, zero new npm dependencies). CI runs it on Linux from the Build workflow, reusing the release binary already built there, so it adds no extra build.

Closes #502

## Changes

- **`src/test/app/smoke.spec.ts`** + **`harness.ts`** + fixtures: three assertions against the running binary:
  1. a document passed as a CLI arg renders (`.markdown-body h1`); cold start
  2. edit mode shows the document in the editor (`.cm-content`), the exact assertion that would have caught the release-only CSP editor breakage
  3. a second launch reuses the running window (same session shows the new file, two tabs); single-instance handover
- **`package.json`**: `pnpm test:app` script (`test:e2e` already means the Playwright WebKit suite, so a distinct, unambiguous name). Runs `node --test` with a 120s per-test timeout.
- **`.github/actions/app-smoke/action.yml`**: one shared composite action (installs `webkit2gtk-driver`, `xvfb`, `dbus`; caches `tauri-driver`; runs the suite under `dbus-run-session -- xvfb-run`), called from both workflows so the install-and-run block is not duplicated.
- **Build workflow** (`ci-build.yml`): runs the smoke on the `ubuntu-22.04` leg right after the existing headless export smoke, reusing that binary. `continue-on-error` on PRs (per-PR gating is the issue's stated follow-up "once stable"); hard-fails on pushes to `main`.
- **Release workflow** (`release.yml`): runs the smoke on the `ubuntu-22.04` build leg after `tauri-action`; every `publish-*` job `needs: build`, so a failure blocks channel publishing.
- **Smoke workflow** comment and the test-conventions rule updated to point at where the built-app smoke actually lives.
- **CONTRIBUTING.md**: `pnpm test:app` in Development Commands with the one-time setup and the release-build prerequisite.

Notes for the reviewer:
- **Linux only.** macOS has no WebKit WebDriver (out of scope, skipped in the spec). Windows is supported in principle but not wired into CI.
- **A release binary is required.** The single-instance plugin is compiled only into release builds, so `resolveBinary` targets `target/release/glyph` (override with `GLYPH_BIN`); a `--debug` build cannot exercise the second-instance assertion.
- The smoke could not be validated locally on Windows (WebView2 automation attaches to an error page, a known `tauri-driver`/msedgedriver limitation, and the local `--debug` build lacks single-instance). **Linux CI on this PR is the authoritative proof**, so please confirm the "Built-app smoke test" step is green on the `Build / ubuntu-22.04` leg (it is `continue-on-error` on PRs, so check the step conclusion, not just the job).

## Risk classification

- [x] No risk areas touched

Test-only and CI-only change: no application code, state, persistence, IPC, rendering, or network paths are modified, so no engineering invariants are in play. The new suite reads existing selectors and drives the binary read-only.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Ran locally: `pnpm typecheck`, `pnpm check`, `pnpm test` (3482 frontend tests), `cargo test --lib` (457 Rust tests) and `cargo clippy --all-targets -- -D warnings` all green via the pre-commit gate. The built-app smoke itself runs on Linux in CI (see the note above); it was not run to green on a local desktop, so no platform box is checked.
