### PR TITLE
ci: harden the ecosystem health check after review

### DIFF
--- a/.github/workflows/ecosystem-health.yml
+++ b/.github/workflows/ecosystem-health.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Install check-jsonschema
-        run: pipx install check-jsonschema
+        run: pipx install check-jsonschema==0.38.0
       - name: Resolve latest release
         id: release
         env:
@@ -38,4 +38,6 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Checking endpoints against release **$VERSION**." >> "$GITHUB_STEP_SUMMARY"
       - name: Check endpoints
-        run: bash scripts/ecosystem-health-check.sh "${{ steps.release.outputs.version }}"
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: bash scripts/ecosystem-health-check.sh "$VERSION"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,7 +283,7 @@ The **Release Smoke Test** workflow (`release-smoke-test.yml`) installs Glyph fr
 
 ### Ecosystem health check
 
-The **Ecosystem Health** workflow (`ecosystem-health.yml`) runs weekly and probes the endpoints a release publishes to without installing anything: the apt and dnf repos (metadata reachable, signed by the release key, advertising the latest release), the website and its locale pages, and the plugin marketplace index (valid against its schema, every package URL downloadable). A failed run emails the maintainer. It can be dispatched manually, and runs on PRs that edit it. Locally, with `curl`, `gpg`, `jq`, `python3`, and [`check-jsonschema`](https://pypi.org/project/check-jsonschema/) on PATH:
+The **Ecosystem Health** workflow (`ecosystem-health.yml`) runs weekly and probes the endpoints a release publishes to without installing anything: the apt and dnf repos (metadata reachable, signed by the release key, advertising the latest release), the website and its locale pages, and the plugin marketplace index (valid against its schema, every package downloadable and matching its checksum). A failed run emails the maintainer. It can be dispatched manually, and runs on PRs that edit it. Locally, with `curl`, `gpg`, `jq`, `python3`, and [`check-jsonschema`](https://pypi.org/project/check-jsonschema/) on PATH:
 
 ```bash
 bash scripts/ecosystem-health-check.sh 0.21.0   # the latest released version

--- a/scripts/ecosystem-health-check.sh
+++ b/scripts/ecosystem-health-check.sh
@@ -14,6 +14,13 @@ if ! echo "$expected" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   exit 2
 fi
 
+# A missing tool must not read as a broken endpoint. The python3 probe also
+# catches the Windows Store stub that sits on PATH but cannot run anything.
+for tool in curl gpg jq gzip sha256sum python3 check-jsonschema; do
+  command -v "$tool" >/dev/null || { echo "missing on PATH: $tool" >&2; exit 2; }
+done
+python3 -c 'import xml.etree.ElementTree' 2>/dev/null || { echo "python3 on PATH does not run" >&2; exit 2; }
+
 APT_REPO="https://glyph-md.github.io/apt-repo"
 RPM_REPO="https://glyph-md.github.io/rpm-repo"
 WEBSITE="https://glyph-md.github.io"
@@ -36,12 +43,16 @@ failed=0
 fail() { echo "::error::$*"; failed=1; }
 ok() { echo "ok: $*"; }
 
+# Bounded timeouts so one blackholed host cannot eat the job timeout and hide
+# the sections after it; https only, including across redirects.
+CURL=(curl -fsSL --retry 3 --retry-all-errors --connect-timeout 20 --max-time 120 --proto =https --proto-redir =https)
+
 fetch() { # fetch <url> <out>
-  curl -fsSL --retry 3 --retry-all-errors -o "$2" "$1" || { fail "$1: download failed"; return 1; }
+  "${CURL[@]}" -o "$2" "$1" || { fail "$1: download failed"; return 1; }
 }
 
 reachable() { # reachable <url>
-  curl -fsSIL --retry 3 --retry-all-errors -o /dev/null "$1" || { fail "$1: unreachable"; return 1; }
+  "${CURL[@]}" -I -o /dev/null "$1" || { fail "$1: unreachable"; return 1; }
 }
 
 import_signing_key() { # import_signing_key <url>
@@ -107,7 +118,7 @@ root = ET.parse(sys.argv[1]).getroot()
 print(root.findtext(ns + "revision", ""))
 loc = root.find(ns + "data[@type=\"primary\"]/" + ns + "location")
 print("" if loc is None else loc.get("href", ""))
-' "$d/repomd.xml" 2>/dev/null | tr -d '\r') || true
+' "$d/repomd.xml" | tr -d '\r') || true
   if [ "$revision" = "$expected" ]; then
     ok "dnf repomd.xml revision $revision"
   else
@@ -117,7 +128,8 @@ print("" if loc is None else loc.get("href", ""))
   # sees a valid repo with nothing to install.
   [ -n "$primary" ] || { fail "dnf repomd.xml: no primary location"; return 0; }
   fetch "$RPM_REPO/$primary" "$d/primary.xml.gz" || return 0
-  if gzip -dc "$d/primary.xml.gz" | grep -q "ver=\"$expected\""; then
+  gzip -dc "$d/primary.xml.gz" > "$d/primary.xml" || { fail "dnf primary.xml.gz: not gzip"; return 0; }
+  if grep -q "ver=\"$expected\"" "$d/primary.xml"; then
     ok "dnf primary.xml lists $expected"
   else
     fail "dnf primary.xml: does not list $expected"
@@ -131,7 +143,8 @@ check_website() {
   for path in / /de/ /es/ /fa/ /zh/ /plugins/; do
     reachable "$WEBSITE$path" && ok "website $path"
   done
-  if curl -fsSL --retry 3 --retry-all-errors "$WEBSITE/" | grep -q 'id="download"'; then
+  fetch "$WEBSITE/" "$tmp/home.html" || return 0
+  if grep -q 'id="download"' "$tmp/home.html"; then
     ok "website homepage has the #download section"
   else
     fail "website homepage: no #download section"
@@ -148,11 +161,19 @@ check_marketplace() {
   else
     fail "marketplace index: schema validation failed"
   fi
-  # Every listed package must download, or the Install button is a dead end.
-  local url
-  while IFS= read -r url; do
-    reachable "$url" && ok "marketplace package $url"
-  done < <(jq -r '.plugins[].packageUrl' "$d/index.json" | tr -d '\r')
+  # Every listed package must download and match the index checksum the app
+  # verifies on install, or the Install button ends in a dead link or a
+  # checksum-mismatch error.
+  local url sha n=0
+  while read -r url sha; do
+    n=$((n + 1))
+    fetch "$url" "$d/package-$n.zip" || continue
+    if echo "$sha  $d/package-$n.zip" | sha256sum -c --quiet >/dev/null 2>&1; then
+      ok "marketplace package $url"
+    else
+      fail "marketplace package $url: sha256 does not match the index"
+    fi
+  done < <(jq -r '.plugins[] | "\(.packageUrl) \(.sha256)"' "$d/index.json" | tr -d '\r')
 }
 
 check_apt


### PR DESCRIPTION
## Summary

Follow-up to #660: hardens the ecosystem health check with the fixes from its code review. The review landed after #660 was merged, so this carries them separately. Relates to #506.

## Changes

- Bounded curl everywhere (`--connect-timeout 20 --max-time 120`, shared flag array), so one blackholed host fails its own assertion with a named URL instead of eating the job timeout and hiding every section after it; `--proto =https --proto-redir =https` enforces https across redirects.
- Preflight for required tools (curl, gpg, jq, gzip, sha256sum, python3, check-jsonschema), exiting 2 with the missing name instead of blaming a healthy endpoint; the python3 probe also catches the Windows Store PATH stub.
- Marketplace packages are now downloaded and verified against the index sha256 (the same checksum the app enforces on install), instead of a HEAD probe; a re-uploaded asset at the same URL now fails the run.
- Fetched files are grepped on disk instead of piping curl/gzip into `grep -q` under `pipefail` (EPIPE false-failure class), and the repomd python parse no longer swallows stderr.
- Workflow: version passed via `env:`, `check-jsonschema` pinned to 0.38.0, script marked executable; CONTRIBUTING wording updated.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [x] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

Network: outbound GETs to our own published endpoints from a `contents: read` workflow, now https-only and time-bounded. No app code touched, no engineering invariants in scope.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [x] Tested on Linux

Local Git Bash runs: `0.21.0` passes all assertions including the two package sha256 checks; `0.20.0` fails with version drift and exit 1; a stripped PATH exits 2 with `missing on PATH: curl`. The Linux proof is this PR's own Ecosystem Health run (the workflow triggers on PRs that edit the script).

## Screenshots

Not applicable.
