### PR TITLE
fix(ci): harden the built-app smoke test after review

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -25,7 +25,7 @@ paths:
 ## Built-app smoke tests (tauri-driver)
 
 - `src/test/app/*.spec.ts` runs the built binary over WebDriver via `tauri-driver` (`pnpm test:app`, a plain `node --test` suite with a raw fetch client in `harness.ts`, no WebdriverIO). The `.spec.ts` suffix keeps Vitest out (it collects only `*.test.*`), and it lives in `src/test/app`, not `src/test/e2e`, so Playwright ignores it too.
-- This is the only test that launches the real process under the production CSP: it catches CSP/editor breakage (#390) and startup-race regressions (cold-launch, second-instance) that unit tests cannot. Needs a **release** binary (the single-instance plugin is release-only) and `tauri-driver` on PATH; keep it a handful of assertions.
+- This is the only test that launches the real process under the production CSP: it catches CSP/editor breakage (#390) and startup-race regressions (cold-launch, second-instance) that unit tests cannot. Assert layout, not just DOM content: in #390 the editor text was present in the DOM but laid out far below the fold because the CSP blocked CodeMirror's injected stylesheet. Needs a **release** binary (the single-instance plugin is release-only) and `tauri-driver` on PATH; keep it a handful of assertions.
 - CI runs it on Linux from the Build workflow via `.github/actions/app-smoke` (xvfb + `dbus-run-session`), reusing the release binary already built there; a failure flags PRs and blocks release publishing. macOS is unsupported (no WebKit WebDriver).
 
 ## Rust

--- a/.github/actions/app-smoke/action.yml
+++ b/.github/actions/app-smoke/action.yml
@@ -33,4 +33,6 @@ runs:
       shell: bash
       env:
         WEBKIT_DISABLE_COMPOSITING_MODE: "1"
-      run: dbus-run-session -- xvfb-run --auto-servernum pnpm test:app
+      # xvfb outside dbus-run-session, so DISPLAY is already set when the bus
+      # starts and bus-activated services (xdg-desktop-portal) inherit it.
+      run: xvfb-run --auto-servernum dbus-run-session -- pnpm test:app

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -96,10 +96,16 @@ jobs:
       # Flags on PRs (per-PR gating is a #502 follow-up "once stable"); hard-
       # fails on pushes to main and on release, where a broken editor must stop.
       - name: Built-app smoke test
+        id: app-smoke
         if: matrix.platform == 'ubuntu-22.04'
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         timeout-minutes: 10
         uses: ./.github/actions/app-smoke
+      # continue-on-error keeps the required check green on PRs, which hides a
+      # failure from the checks list; surface it as an annotation instead.
+      - name: Flag built-app smoke failure
+        if: matrix.platform == 'ubuntu-22.04' && steps.app-smoke.outcome == 'failure'
+        run: echo "::warning title=Built-app smoke failed::pnpm test:app failed; it hard-fails on pushes to main and at release."
 
   build-android:
     name: Android

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,30 +109,37 @@ cd src-tauri && cargo test      # Rust tests
 ### Built-app smoke test (`pnpm test:app`)
 
 Launches the built binary over WebDriver (`tauri-driver`) and asserts a
-CLI-arg document renders, the editor holds it under the production CSP, and a
-second launch reuses the running window. This is the only test that exercises
-a real process launch and the production configuration; unit tests cannot.
+CLI-arg document renders, the editor is laid out and holds the document under
+the production CSP, and a second launch reuses the running window. This is the
+only test that exercises a real process launch and the production
+configuration; unit tests cannot.
 Supported on Linux and Windows; macOS has no WebKit WebDriver and is skipped.
 
 One-time setup:
 
 ```bash
 cargo install tauri-driver --locked                 # all platforms
-sudo apt install webkit2gtk-driver dbus-x11         # Linux (WebKitWebDriver + dbus-run-session)
+sudo apt install webkit2gtk-driver xvfb             # Linux (WebKitWebDriver; xvfb only for headless runs)
 # Windows: put an msedgedriver.exe matching your installed WebView2 on PATH
 ```
 
-Then build a release binary and run the smoke:
+Then build a release binary and run the smoke (quit any running Glyph first:
+the single-instance plugin would hand the launch to that window and the
+WebDriver session would never start):
 
 ```bash
 pnpm tauri build --no-bundle                        # release binary; --debug omits the single-instance plugin
-pnpm test:app                                       # Linux: prefix with `dbus-run-session -- xvfb-run` for headless
+pnpm test:app                                       # headless Linux: xvfb-run --auto-servernum dbus-run-session -- pnpm test:app
 ```
 
-The binary is found at `src-tauri/target/release/glyph`; set `GLYPH_BIN` to
-point at another path. CI runs this on Linux from the Build workflow: it flags
-(non-blocking) on PRs and hard-fails on pushes to `main` and at release, where
-a failure blocks channel publishing (see `.github/actions/app-smoke`).
+The binary is found at `src-tauri/target/release/glyph` (`glyph.exe` on
+Windows); set `GLYPH_BIN` to point at another path. On Linux the suite runs
+the app against a throwaway profile (temp `XDG_*` dirs) so it never touches
+your real settings or session; Windows resolves its profile through
+known-folder APIs, which env vars cannot redirect. CI runs this on Linux from
+the Build workflow: it flags (non-blocking) on PRs and hard-fails on pushes to
+`main` and at release, where a failure blocks channel publishing (see
+`.github/actions/app-smoke`).
 
 ### Mobile: Android and iOS (experimental)
 

--- a/src/test/app/harness.ts
+++ b/src/test/app/harness.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -9,6 +10,31 @@ import { fileURLToPath } from "node:url";
 // client over fetch rather than a WebDriver library.
 const DRIVER_URL = "http://127.0.0.1:4444";
 const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+
+/**
+ * Environment for every process the suite launches (tauri-driver, and through
+ * it the app, plus the second instance): a throwaway profile so local runs
+ * never touch the developer's real Glyph settings or session. The XDG
+ * overrides isolate Linux; Windows resolves its dirs through known-folder
+ * APIs and ignores them. The seeded settings pin the UI language, since the
+ * "Edit mode" selector reads the aria-label and locale "system" would follow
+ * the host OS language.
+ */
+export const APP_ENV: NodeJS.ProcessEnv = (() => {
+  const profile = mkdtempSync(path.join(os.tmpdir(), "glyph-smoke-"));
+  const dataDir = path.join(profile, "data", "com.hamidfzm.glyph");
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(
+    path.join(dataDir, "settings.json"),
+    JSON.stringify({ settings: { locale: "en" } }),
+  );
+  return {
+    ...process.env,
+    XDG_CONFIG_HOME: path.join(profile, "config"),
+    XDG_DATA_HOME: path.join(profile, "data"),
+    XDG_CACHE_HOME: path.join(profile, "cache"),
+  };
+})();
 
 /** `GLYPH_BIN`, else the release build. Release-only: the single-instance plugin is release-gated (lib.rs). */
 export function resolveBinary(): string {
@@ -51,7 +77,10 @@ export async function waitFor<T>(
 
 /** Spawn `tauri-driver` (from PATH) and wait until it accepts connections. */
 export async function startDriver(): Promise<ChildProcess> {
-  const driver = spawn("tauri-driver", [], { stdio: ["ignore", "inherit", "inherit"] });
+  const driver = spawn("tauri-driver", [], {
+    stdio: ["ignore", "inherit", "inherit"],
+    env: APP_ENV,
+  });
   // tauri-driver exits immediately when its native driver is missing or the
   // ports are busy; surface that instead of a 15s "fetch failed" timeout.
   const driverStopped = new Promise<never>((_, reject) => {
@@ -74,7 +103,8 @@ export async function startDriver(): Promise<ChildProcess> {
     driverStopped,
     waitFor(
       "tauri-driver to listen",
-      () => fetch(`${DRIVER_URL}/status`).then((res) => res.ok),
+      () =>
+        fetch(`${DRIVER_URL}/status`, { signal: AbortSignal.timeout(2_000) }).then((res) => res.ok),
       15_000,
     ),
   ]);

--- a/src/test/app/smoke.spec.ts
+++ b/src/test/app/smoke.spec.ts
@@ -3,6 +3,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { after, before, test } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  APP_ENV,
   deleteSession,
   execute,
   newSession,
@@ -14,12 +15,12 @@ import {
 // Built-app smoke: launches the real binary over WebDriver (tauri-driver) and
 // checks the three things unit tests cannot see, because they need a real
 // process launch under the production CSP: a CLI-arg document renders (cold
-// start, commit 5714293 / #494), the editor holds the document under the
-// production CSP (#390), and a second launch reuses the running window
-// (#189, #494). `pnpm test:app`; CI runs it on Linux under xvfb (see
-// .github/actions/app-smoke). Needs a release binary: the single-instance
-// plugin is release-only (lib.rs), so a --debug build cannot exercise the
-// second-instance case.
+// start, commit 5714293 / #494), the editor is laid out on screen and holds
+// the document under the production CSP (#390), and a second launch reuses
+// the running window (#189, #494). `pnpm test:app`; CI runs it on Linux under
+// xvfb (see .github/actions/app-smoke). Needs a release binary: the
+// single-instance plugin is release-only (lib.rs), so a --debug build cannot
+// exercise the second-instance case.
 
 // macOS has no WebKit WebDriver, so tauri-driver cannot drive it there.
 const skip = process.platform === "darwin" ? "no WebKit WebDriver on macOS" : false;
@@ -68,13 +69,31 @@ test("edit mode shows the document in the editor", { skip }, async () => {
     );
     return text.includes("Alpha body line one.");
   });
+  // #390's failure mode: the CSP blocked CodeMirror's injected stylesheet, so
+  // the content existed in the DOM but was laid out thousands of pixels below
+  // the fold. The text check alone passes on that broken build; only layout
+  // proves the injected styles applied. Glyph's own CSS never sets display on
+  // .cm-editor, so flex can only come from CodeMirror's injected base theme.
+  const editorDisplay = await execute<string>(
+    session,
+    "return getComputedStyle(document.querySelector('.cm-editor')).display",
+  );
+  assert.equal(editorDisplay, "flex", "CodeMirror's injected stylesheet did not apply (CSP?)");
+  const [contentTop, viewportHeight] = await execute<[number, number]>(
+    session,
+    "return [document.querySelector('.cm-content').getBoundingClientRect().top, window.innerHeight]",
+  );
+  assert.ok(
+    contentTop < viewportHeight,
+    `.cm-content sits below the fold (top ${contentTop}, viewport ${viewportHeight})`,
+  );
 });
 
 test("a second instance opens its file in the running window", { skip }, async () => {
   // The single-instance plugin makes this process hand BETA to the running
   // app and exit; if it instead opened its own window, this session (attached
   // to the first window) would keep showing ALPHA with a single tab.
-  const second = spawn(resolveBinary(), [BETA], { stdio: "ignore" });
+  const second = spawn(resolveBinary(), [BETA], { stdio: "ignore", env: APP_ENV });
   const code = await new Promise<number | null>((resolve, reject) => {
     const timer = setTimeout(() => {
       second.kill();

--- a/src/test/app/smoke.spec.ts
+++ b/src/test/app/smoke.spec.ts
@@ -79,13 +79,17 @@ test("edit mode shows the document in the editor", { skip }, async () => {
     "return getComputedStyle(document.querySelector('.cm-editor')).display",
   );
   assert.equal(editorDisplay, "flex", "CodeMirror's injected stylesheet did not apply (CSP?)");
-  const [contentTop, viewportHeight] = await execute<[number, number]>(
+  // Bound against the configured window height (tauri.conf.json, 720):
+  // window.innerHeight reports 0 under xvfb for the hidden-then-revealed
+  // window, and a healthy build puts the editor right under the tab bar
+  // (top ~168 in CI) while the broken build measured ~6400.
+  const contentTop = await execute<number>(
     session,
-    "return [document.querySelector('.cm-content').getBoundingClientRect().top, window.innerHeight]",
+    "return document.querySelector('.cm-content').getBoundingClientRect().top",
   );
   assert.ok(
-    contentTop < viewportHeight,
-    `.cm-content sits below the fold (top ${contentTop}, viewport ${viewportHeight})`,
+    contentTop >= 0 && contentTop < 720,
+    `.cm-content is laid out off-screen (top ${contentTop})`,
   );
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #659 (built-app WebDriver smoke, issue #502), applying the post-merge review findings. The headline fix: the edit-mode assertion, as merged, would not actually have caught the regression the suite was built for. In that broken build the editor content was present in the DOM but laid out thousands of pixels below the fold, because the production CSP blocked CodeMirror's injected stylesheet; a `textContent` check passes on that build. The test now asserts layout as well.

## Changes

1. **Layout assertions in the edit-mode test** (`src/test/app/smoke.spec.ts`): after the existing text check, assert `getComputedStyle(.cm-editor).display === "flex"` (Glyph's own CSS never sets display on `.cm-editor`, so flex can only come from CodeMirror's injected base theme) and that `.cm-content`'s top sits inside the viewport. Also recorded the "assert layout, not just DOM content" lesson in the test-conventions rule.
2. **Isolated profile for local runs** (`src/test/app/harness.ts`): every launched process (tauri-driver, the app under it, and the second instance) now runs with throwaway `XDG_CONFIG_HOME`/`XDG_DATA_HOME`/`XDG_CACHE_HOME` dirs, so `pnpm test:app` on Linux never touches the developer's real settings or session. The seeded profile pins `locale: "en"` so the `button[aria-label="Edit mode"]` selector no longer depends on the host OS language. Windows resolves its dirs through known-folder APIs and ignores env overrides; documented as a known limitation.
3. **PR-visible failure annotation** (`.github/workflows/ci-build.yml`): `continue-on-error` keeps the required check green on PRs, hiding a smoke failure from the checks list; a follow-up step now emits a `::warning` annotation when the smoke step's outcome is failure.
4. **xvfb/dbus nesting swapped** (`.github/actions/app-smoke/action.yml`): `xvfb-run --auto-servernum dbus-run-session -- pnpm test:app`, so `DISPLAY` is set before the session bus starts and bus-activated services (xdg-desktop-portal) inherit it, removing the "cannot open display" noise seen in the first CI run.
5. **Bounded `/status` probe** (`harness.ts`): the driver-readiness fetch now carries `AbortSignal.timeout(2000)` so a stuck proxy cannot outlive the 15s wait.
6. **CONTRIBUTING accuracy**: apt line corrected to `webkit2gtk-driver xvfb` (`dbus-run-session` ships in the preinstalled `dbus` package, not `dbus-x11`), headless invocation spelled out fully, `glyph.exe` named for Windows, plus a "quit any running Glyph first" note (single-instance would swallow the launch and the session never starts).

Issue #502 is already closed by #659, so no closing keyword here.

## Risk classification

- [x] No risk areas touched

Test-harness, CI, and docs only; no application code changed, so no engineering invariants are in play.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Ran locally via the pre-commit gate: `pnpm typecheck`, Biome, full Vitest suite, `cargo test --lib`, `cargo clippy --all-targets -- -D warnings`, all green. The smoke itself runs on Linux CI (Build / ubuntu-22.04); on this PR check the "Built-app smoke test" step conclusion, since `continue-on-error` keeps the job green on PRs. No platform box is checked because the suite was not run to green on a local desktop.
