### PR TITLE
feat(markdown): cache rendered Mermaid SVG and bound both diagram caches

### DIFF
--- a/src/components/markdown/MermaidDiagram.test.tsx
+++ b/src/components/markdown/MermaidDiagram.test.tsx
@@ -2,14 +2,14 @@ import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MermaidDiagram } from "./MermaidDiagram";
 
-const initialize = vi.fn();
+// The component delegates rendering (and caching) to the mermaidRender lib;
+// its own contract is what gets asked for and what happens with the result,
+// so the lib is mocked here. Cache/id/theme-config behavior is covered in
+// mermaidRender.test.ts.
 const renderMermaid = vi.fn();
 
-vi.mock("mermaid", () => ({
-  default: {
-    initialize: (...args: unknown[]) => initialize(...args),
-    render: (...args: unknown[]) => renderMermaid(...args),
-  },
+vi.mock("@/lib/mermaidRender", () => ({
+  renderMermaid: (...args: unknown[]) => renderMermaid(...args),
 }));
 
 // Controllable lightbox: null by default (no provider in scope), set per-test to
@@ -22,7 +22,6 @@ vi.mock("@/contexts/LightboxContext", () => ({
 
 describe("MermaidDiagram", () => {
   beforeEach(() => {
-    initialize.mockReset();
     renderMermaid.mockReset();
     mockLightbox = null;
     document.documentElement.classList.remove("dark");
@@ -38,7 +37,7 @@ describe("MermaidDiagram", () => {
   });
 
   it("renders the diagram SVG into the container on mount", async () => {
-    renderMermaid.mockResolvedValue({ svg: "<svg data-test='m'>x</svg>" });
+    renderMermaid.mockResolvedValue("<svg data-test='m'>x</svg>");
     const { container } = render(<MermaidDiagram code="graph TD; A-->B" />);
 
     await waitFor(() => {
@@ -46,18 +45,16 @@ describe("MermaidDiagram", () => {
       expect(svg).not.toBeNull();
       expect(svg?.getAttribute("data-test")).toBe("m");
     });
-    expect(initialize).toHaveBeenCalledWith(
-      expect.objectContaining({ theme: "default", startOnLoad: false }),
-    );
+    expect(renderMermaid).toHaveBeenCalledWith("graph TD; A-->B", false);
   });
 
-  it("uses the dark theme when the document is in dark mode", async () => {
-    renderMermaid.mockResolvedValue({ svg: "<svg/>" });
+  it("requests the dark theme when the document is in dark mode", async () => {
+    renderMermaid.mockResolvedValue("<svg/>");
     document.documentElement.classList.add("dark");
     render(<MermaidDiagram code="graph TD; A-->B" />);
 
     await waitFor(() => {
-      expect(initialize).toHaveBeenCalledWith(expect.objectContaining({ theme: "dark" }));
+      expect(renderMermaid).toHaveBeenCalledWith("graph TD; A-->B", true);
     });
   });
 
@@ -89,8 +86,8 @@ describe("MermaidDiagram", () => {
     );
   });
 
-  it("flags empty/whitespace-only diagram source without calling mermaid.render", async () => {
-    renderMermaid.mockResolvedValue({ svg: "<svg/>" });
+  it("flags empty/whitespace-only diagram source without rendering", async () => {
+    renderMermaid.mockResolvedValue("<svg/>");
     // JSX string-attribute values don't process backslash escapes, so wrap
     // in `{...}` to actually pass a tab+newline-bearing string.
     const { container } = render(<MermaidDiagram code={"   \n\t  "} />);
@@ -102,7 +99,7 @@ describe("MermaidDiagram", () => {
   });
 
   it("re-renders when the html class list changes (theme toggle)", async () => {
-    renderMermaid.mockResolvedValue({ svg: "<svg/>" });
+    renderMermaid.mockResolvedValue("<svg/>");
     render(<MermaidDiagram code="graph TD; A-->B" />);
     await waitFor(() => {
       expect(renderMermaid).toHaveBeenCalled();
@@ -117,25 +114,6 @@ describe("MermaidDiagram", () => {
     });
   });
 
-  // Regression: Mermaid v11 keeps internal state keyed by the id passed to
-  // `render`. If we pass the same id twice (which happens whenever the
-  // render callback fires more than once for the same component instance,
-  // e.g. React 19 double-effect + the MutationObserver), the second call
-  // returns a tiny stub SVG and the diagram silently blanks out. Pass a
-  // fresh id every time.
-  it("passes a fresh id to mermaid.render on every call", async () => {
-    renderMermaid.mockResolvedValue({ svg: "<svg/>" });
-    render(<MermaidDiagram code="graph TD; A-->B" />);
-    await act(async () => {
-      document.documentElement.classList.add("dark");
-    });
-    await waitFor(() => {
-      expect(renderMermaid.mock.calls.length).toBeGreaterThanOrEqual(2);
-    });
-    const ids = renderMermaid.mock.calls.map((c) => c[0]);
-    expect(new Set(ids).size).toBe(ids.length);
-  });
-
   // Regression: when two renders are in flight concurrently, only the
   // newest one is allowed to write into the DOM. Otherwise a stale
   // (smaller, broken) SVG can overwrite a freshly-rendered good one.
@@ -143,15 +121,15 @@ describe("MermaidDiagram", () => {
     // The first render hangs until we resolve it manually; the second
     // resolves immediately with a known SVG. The hung first call must
     // NOT overwrite the second's output once it eventually settles.
-    type Resolver = (value: { svg: string }) => void;
+    type Resolver = (svg: string) => void;
     const firstRender: { resolve: Resolver } = { resolve: () => {} };
     renderMermaid.mockImplementationOnce(
       () =>
-        new Promise<{ svg: string }>((resolve) => {
+        new Promise<string>((resolve) => {
           firstRender.resolve = resolve;
         }),
     );
-    renderMermaid.mockResolvedValueOnce({ svg: "<svg id='winner'/>" });
+    renderMermaid.mockResolvedValueOnce("<svg id='winner'/>");
 
     const { container } = render(<MermaidDiagram code="graph TD; A-->B" />);
     // Trigger a second render via the theme MutationObserver path.
@@ -163,9 +141,9 @@ describe("MermaidDiagram", () => {
       expect(container.querySelector("svg#winner")).not.toBeNull();
     });
 
-    // Now let the stale first render finally resolve — it must NOT
+    // Now let the stale first render finally resolve; it must NOT
     // overwrite the winner.
-    firstRender.resolve({ svg: "<svg id='stale'/>" });
+    firstRender.resolve("<svg id='stale'/>");
     await new Promise((r) => setTimeout(r, 10));
     expect(container.querySelector("svg#stale")).toBeNull();
     expect(container.querySelector("svg#winner")).not.toBeNull();
@@ -175,25 +153,25 @@ describe("MermaidDiagram", () => {
   // flight, `containerRef.current` is null by the time the await resolves
   // and we must not try to write into it.
   it("skips the DOM write when the container ref is null at resolution time", async () => {
-    type Resolver = (value: { svg: string }) => void;
+    type Resolver = (svg: string) => void;
     const pending: { resolve: Resolver } = { resolve: () => {} };
     renderMermaid.mockImplementationOnce(
       () =>
-        new Promise<{ svg: string }>((resolve) => {
+        new Promise<string>((resolve) => {
           pending.resolve = resolve;
         }),
     );
 
     const { unmount } = render(<MermaidDiagram code="graph TD; A-->B" />);
-    // Make sure renderDiagram actually reached the awaited `mermaid.render`
-    // before we tear down — otherwise unmount could happen before the
-    // function captures the (then-still-non-null) ref into its closure.
+    // Make sure renderDiagram actually reached the awaited render before we
+    // tear down; otherwise unmount could happen before the function
+    // captures the (then-still-non-null) ref into its closure.
     await waitFor(() => expect(renderMermaid).toHaveBeenCalled());
     unmount();
     // Now resolve. The awaited continuation runs as a microtask AFTER
     // unmount, so `containerRef.current` is null and the false branch of
     // the nil-check fires (skipping the DOM write).
-    pending.resolve({ svg: "<svg id='post-unmount'/>" });
+    pending.resolve("<svg id='post-unmount'/>");
     await new Promise((r) => setTimeout(r, 10));
     expect(document.querySelector("svg#post-unmount")).toBeNull();
   });
@@ -206,11 +184,11 @@ describe("MermaidDiagram", () => {
     const firstRender: { reject: Rejecter } = { reject: () => {} };
     renderMermaid.mockImplementationOnce(
       () =>
-        new Promise<{ svg: string }>((_resolve, reject) => {
+        new Promise<string>((_resolve, reject) => {
           firstRender.reject = reject;
         }),
     );
-    renderMermaid.mockResolvedValueOnce({ svg: "<svg id='winner'/>" });
+    renderMermaid.mockResolvedValueOnce("<svg id='winner'/>");
 
     const { container } = render(<MermaidDiagram code="graph TD; A-->B" />);
     await act(async () => {
@@ -235,7 +213,7 @@ describe("MermaidDiagram", () => {
     });
 
     it("is a zoomable button and opens the rendered SVG in the lightbox on click", async () => {
-      renderMermaid.mockResolvedValue({ svg: "<svg id='zoomed'/>" });
+      renderMermaid.mockResolvedValue("<svg id='zoomed'/>");
       const { container } = render(<MermaidDiagram code="graph TD; A-->B" />);
 
       const diagram = await waitFor(() => {
@@ -250,7 +228,7 @@ describe("MermaidDiagram", () => {
     });
 
     it("opens the lightbox on Enter and Space but not other keys", async () => {
-      renderMermaid.mockResolvedValue({ svg: "<svg/>" });
+      renderMermaid.mockResolvedValue("<svg/>");
       const { container } = render(<MermaidDiagram code="graph TD; A-->B" />);
       const diagram = await waitFor(
         () => container.querySelector(".mermaid-diagram") as HTMLElement,
@@ -265,7 +243,7 @@ describe("MermaidDiagram", () => {
 
     it("is not a button when no lightbox provider is in scope", async () => {
       mockLightbox = null;
-      renderMermaid.mockResolvedValue({ svg: "<svg/>" });
+      renderMermaid.mockResolvedValue("<svg/>");
       const { container } = render(<MermaidDiagram code="graph TD; A-->B" />);
       const diagram = await waitFor(
         () => container.querySelector(".mermaid-diagram") as HTMLElement,

--- a/src/components/markdown/MermaidDiagram.tsx
+++ b/src/components/markdown/MermaidDiagram.tsx
@@ -2,17 +2,8 @@ import { type KeyboardEvent, useCallback, useEffect, useRef, useState } from "re
 import { useTranslation } from "react-i18next";
 import { useLightbox } from "@/contexts/LightboxContext";
 import { useIsDarkMode } from "@/hooks/useIsDarkMode";
+import { renderMermaid } from "@/lib/mermaidRender";
 import { svgToDataUrl } from "@/lib/svgDataUrl";
-
-let idCounter = 0;
-let mermaidPromise: Promise<typeof import("mermaid").default> | null = null;
-
-function loadMermaid() {
-  if (!mermaidPromise) {
-    mermaidPromise = import("mermaid").then((m) => m.default);
-  }
-  return mermaidPromise;
-}
 
 interface MermaidDiagramProps {
   code: string;
@@ -37,18 +28,8 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
       setError(t("mermaid.empty"));
       return;
     }
-    // Always pass a fresh id to `mermaid.render`. Mermaid v11 keeps internal
-    // state keyed by id, and calling render twice with the same id (React
-    // double-mount, theme flip, parent re-render) makes the second call
-    // return a tiny ~5KB stub SVG that paints as a blank preview.
-    const id = `mermaid-diagram-${idCounter++}`;
     try {
-      const mermaid = await loadMermaid();
-      mermaid.initialize({
-        startOnLoad: false,
-        theme: isDark ? "dark" : "default",
-      });
-      const { svg } = await mermaid.render(id, code);
+      const svg = await renderMermaid(code, isDark);
       if (renderSeqRef.current !== mySeq) return;
       svgRef.current = svg;
       if (containerRef.current) {

--- a/src/lib/d2Render.test.ts
+++ b/src/lib/d2Render.test.ts
@@ -23,6 +23,7 @@ vi.mock("dompurify", () => ({
 }));
 
 import { renderD2 } from "./d2Render";
+import { DIAGRAM_RENDER_CACHE_LIMIT } from "./lruCache";
 
 describe("renderD2", () => {
   beforeEach(() => {
@@ -61,5 +62,20 @@ describe("renderD2", () => {
     await expect(renderD2("retry-key", false)).rejects.toThrow("boom");
     await expect(renderD2("retry-key", false)).resolves.toBe("CLEAN:<svg></svg>");
     expect(compile).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least recently used entry past the cache limit", async () => {
+    renderSvg.mockResolvedValue("<svg></svg>");
+    for (let i = 0; i < DIAGRAM_RENDER_CACHE_LIMIT; i++) {
+      await renderD2(`evict-${i}`, false);
+    }
+    const cold = compile.mock.calls.length;
+    // evict-0 is the oldest; one more distinct source pushes it out, so
+    // re-requesting it recompiles while a fresher entry still hits.
+    await renderD2("evict-overflow", false);
+    await renderD2("evict-overflow", false);
+    expect(compile).toHaveBeenCalledTimes(cold + 1);
+    await renderD2("evict-0", false);
+    expect(compile).toHaveBeenCalledTimes(cold + 2);
   });
 });

--- a/src/lib/d2Render.test.ts
+++ b/src/lib/d2Render.test.ts
@@ -64,6 +64,33 @@ describe("renderD2", () => {
     expect(compile).toHaveBeenCalledTimes(2);
   });
 
+  it("a failed render evicted from the LRU does not delete a newer promise under its key", async () => {
+    renderSvg.mockResolvedValue("<svg></svg>");
+    let rejectFirst: (reason: unknown) => void = () => {};
+    compile.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+    );
+    const first = renderD2("dup-key", false);
+    await vi.waitFor(() => expect(compile).toHaveBeenCalledTimes(1));
+    // These synchronous cache.set calls push "dup-key" out of the LRU while
+    // its render is still in flight.
+    for (let i = 0; i < DIAGRAM_RENDER_CACHE_LIMIT; i++) {
+      await renderD2(`dup-fill-${i}`, false);
+    }
+    // Miss (the key was evicted): a second, healthy promise is cached.
+    const second = renderD2("dup-key", false);
+    rejectFirst(new Error("stale failure"));
+    await expect(first).rejects.toThrow("stale failure");
+    await expect(second).resolves.toBe("CLEAN:<svg></svg>");
+    const settled = compile.mock.calls.length;
+    // The healthy promise must have survived the failed one's eviction.
+    await renderD2("dup-key", false);
+    expect(compile).toHaveBeenCalledTimes(settled);
+  });
+
   it("evicts the least recently used entry past the cache limit", async () => {
     renderSvg.mockResolvedValue("<svg></svg>");
     for (let i = 0; i < DIAGRAM_RENDER_CACHE_LIMIT; i++) {

--- a/src/lib/d2Render.ts
+++ b/src/lib/d2Render.ts
@@ -5,6 +5,7 @@
 // self-contained and makes no network request — the diagram renders offline.
 
 import type { CompileOptions, Diagram, RenderOptions } from "@terrastruct/d2";
+import { DIAGRAM_RENDER_CACHE_LIMIT, LruCache } from "@/lib/lruCache";
 
 // The shipped `D2` class types `compile`'s second argument as
 // `Omit<CompileRequest, "fs">` ({ inputPath?, options }), but the runtime treats
@@ -36,7 +37,9 @@ const DARK_THEME_ID = 200;
 // tab switch, parent re-render, reopening an unchanged doc) skip the expensive
 // WASM layout. Promises are cached (not strings) so concurrent renders of the
 // same diagram share one compile; failures are evicted so they can be retried.
-const cache = new Map<string, Promise<string>>();
+// LRU-bounded so a long session with many distinct diagrams cannot grow it
+// without limit (rationale on the shared constant).
+const cache = new LruCache<Promise<string>>(DIAGRAM_RENDER_CACHE_LIMIT);
 
 // The rendered SVG is untrusted (it derives from arbitrary D2 source) and is
 // injected via innerHTML, so sanitize before it reaches the DOM. DOMPurify's

--- a/src/lib/d2Render.ts
+++ b/src/lib/d2Render.ts
@@ -69,8 +69,12 @@ export function renderD2(source: string, dark: boolean): Promise<string> {
     const svg = await d2.render(result.diagram, { ...result.renderOptions, noXMLTag: true });
     return sanitizeSvg(svg);
   })();
-  // Don't cache a failed render, so a transient error can be retried.
-  pending.catch(() => cache.delete(key));
+  // Don't cache a failed render, so a transient error can be retried. Evict
+  // only the promise that actually failed: past the LRU bound the key may
+  // have been evicted and re-inserted with a newer, healthy promise.
+  pending.catch(() => {
+    if (cache.peek(key) === pending) cache.delete(key);
+  });
   cache.set(key, pending);
   return pending;
 }

--- a/src/lib/export/rasterize.ts
+++ b/src/lib/export/rasterize.ts
@@ -4,6 +4,7 @@
 // SVG bakes in the app theme's colors). `rasterizeSvgsInHtml` is the fallback
 // for SVGs pdfmake's renderer rejects.
 
+import { enqueueMermaid } from "@/lib/mermaidRender";
 import { decodeSvgDataUrl, toXmlSvg } from "@/lib/svgDataUrl";
 
 let mermaidId = 0;
@@ -20,16 +21,22 @@ export async function rasterizeElement(el: HTMLElement, backgroundColor: string)
 // taint a canvas in the raster fallback). Returns the SVG markup. Always
 // light, regardless of the app theme.
 export async function renderMermaidLightSvg(source: string): Promise<string> {
-  const { default: mermaid } = await import("mermaid");
-  // Both flags are needed: with only the flowchart one, Mermaid v11 still wraps
-  // every node label in a `<foreignObject>` and the labels vanish from the PDF.
-  mermaid.initialize({
-    startOnLoad: false,
-    theme: "default",
-    htmlLabels: false,
-    flowchart: { htmlLabels: false },
+  // Queued so this export-config pair cannot steal the theme from a viewer
+  // render mid-flight (which the viewer would then cache).
+  const svg = await enqueueMermaid(async () => {
+    const { default: mermaid } = await import("mermaid");
+    // Both flags are needed: with only the flowchart one, Mermaid v11 still
+    // wraps every node label in a `<foreignObject>` and the labels vanish from
+    // the PDF.
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: "default",
+      htmlLabels: false,
+      flowchart: { htmlLabels: false },
+    });
+    const { svg } = await mermaid.render(`glyph-export-mermaid-${mermaidId++}`, source);
+    return svg;
   });
-  const { svg } = await mermaid.render(`glyph-export-mermaid-${mermaidId++}`, source);
   return sanitizeDiagramSvg(svg);
 }
 
@@ -59,12 +66,14 @@ async function sanitizeDiagramSvg(svg: string): Promise<string> {
 // Restore Mermaid's (global) config to the app theme after export-time renders,
 // so on-screen diagrams keep their theme and HTML labels.
 export async function restoreMermaidTheme(dark: boolean): Promise<void> {
-  const { default: mermaid } = await import("mermaid");
-  mermaid.initialize({
-    startOnLoad: false,
-    theme: dark ? "dark" : "default",
-    htmlLabels: true,
-    flowchart: { htmlLabels: true },
+  await enqueueMermaid(async () => {
+    const { default: mermaid } = await import("mermaid");
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: dark ? "dark" : "default",
+      htmlLabels: true,
+      flowchart: { htmlLabels: true },
+    });
   });
 }
 

--- a/src/lib/lruCache.test.ts
+++ b/src/lib/lruCache.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { LruCache } from "./lruCache";
+
+describe("LruCache", () => {
+  it("stores and retrieves values", () => {
+    const cache = new LruCache<string>(2);
+    cache.set("a", "1");
+    expect(cache.get("a")).toBe("1");
+    expect(cache.get("missing")).toBeUndefined();
+  });
+
+  it("evicts the oldest entry past the limit", () => {
+    const cache = new LruCache<string>(2);
+    cache.set("a", "1");
+    cache.set("b", "2");
+    cache.set("c", "3");
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBe("2");
+    expect(cache.get("c")).toBe("3");
+    expect(cache.size).toBe(2);
+  });
+
+  it("get refreshes recency, protecting the entry from eviction", () => {
+    const cache = new LruCache<string>(2);
+    cache.set("a", "1");
+    cache.set("b", "2");
+    cache.get("a");
+    cache.set("c", "3");
+    expect(cache.get("a")).toBe("1");
+    expect(cache.get("b")).toBeUndefined();
+  });
+
+  it("set on an existing key updates the value without evicting", () => {
+    const cache = new LruCache<string>(2);
+    cache.set("a", "1");
+    cache.set("b", "2");
+    cache.set("a", "updated");
+    expect(cache.get("a")).toBe("updated");
+    expect(cache.get("b")).toBe("2");
+    expect(cache.size).toBe(2);
+  });
+
+  it("delete removes an entry", () => {
+    const cache = new LruCache<string>(1);
+    cache.set("a", "1");
+    cache.delete("a");
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+});

--- a/src/lib/lruCache.test.ts
+++ b/src/lib/lruCache.test.ts
@@ -30,6 +30,16 @@ describe("LruCache", () => {
     expect(cache.get("b")).toBeUndefined();
   });
 
+  it("peek reads without refreshing recency", () => {
+    const cache = new LruCache<string>(2);
+    cache.set("a", "1");
+    cache.set("b", "2");
+    expect(cache.peek("a")).toBe("1");
+    cache.set("c", "3");
+    expect(cache.peek("a")).toBeUndefined();
+    expect(cache.peek("b")).toBe("2");
+  });
+
   it("set on an existing key updates the value without evicting", () => {
     const cache = new LruCache<string>(2);
     cache.set("a", "1");

--- a/src/lib/lruCache.ts
+++ b/src/lib/lruCache.ts
@@ -34,10 +34,10 @@ export class LruCache<V> {
     this.map.delete(key);
     this.map.set(key, value);
     if (this.map.size > this.limit) {
-      const oldest = this.map.keys().next().value;
-      if (oldest !== undefined) {
-        this.map.delete(oldest);
-      }
+      // size > limit means the map is non-empty, so a first (least recently
+      // used) key always exists.
+      const oldest = this.map.keys().next().value as string;
+      this.map.delete(oldest);
     }
   }
 

--- a/src/lib/lruCache.ts
+++ b/src/lib/lruCache.ts
@@ -24,6 +24,12 @@ export class LruCache<V> {
     return hit;
   }
 
+  /** Read without refreshing recency. For identity checks (does the cache
+   *  still hold this exact value?) that must not disturb eviction order. */
+  peek(key: string): V | undefined {
+    return this.map.get(key);
+  }
+
   set(key: string, value: V): void {
     this.map.delete(key);
     this.map.set(key, value);

--- a/src/lib/lruCache.ts
+++ b/src/lib/lruCache.ts
@@ -1,0 +1,45 @@
+// Minimal LRU used by the diagram render caches: a Map whose insertion order
+// doubles as recency (get re-inserts). Deliberately tiny, not a general cache
+// abstraction.
+
+// Shared bound for the Mermaid and D2 render caches. A rendered+sanitized
+// diagram SVG is typically 10-100KB, so 50 entries keeps each cache under a
+// few MB worst case while still covering every diagram in the handful of
+// documents a session flips between. Evicting an entry never breaks a diagram
+// already on screen: components hold their own copy of the SVG, the cache only
+// decides whether a future mount re-renders.
+export const DIAGRAM_RENDER_CACHE_LIMIT = 50;
+
+export class LruCache<V> {
+  private map = new Map<string, V>();
+
+  constructor(private readonly limit: number) {}
+
+  get(key: string): V | undefined {
+    const hit = this.map.get(key);
+    if (hit !== undefined) {
+      this.map.delete(key);
+      this.map.set(key, hit);
+    }
+    return hit;
+  }
+
+  set(key: string, value: V): void {
+    this.map.delete(key);
+    this.map.set(key, value);
+    if (this.map.size > this.limit) {
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) {
+        this.map.delete(oldest);
+      }
+    }
+  }
+
+  delete(key: string): void {
+    this.map.delete(key);
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}

--- a/src/lib/mermaidRender.test.ts
+++ b/src/lib/mermaidRender.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DIAGRAM_RENDER_CACHE_LIMIT } from "./lruCache";
+
+const initialize = vi.fn();
+const renderSvg = vi.fn();
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: (...args: unknown[]) => initialize(...args),
+    render: (...args: unknown[]) => renderSvg(...args),
+  },
+}));
+
+import { renderMermaid } from "./mermaidRender";
+
+// The module-level cache survives across tests in this file, so every test
+// uses its own distinct source strings (same convention as d2Render.test.ts).
+describe("renderMermaid", () => {
+  beforeEach(() => {
+    initialize.mockClear();
+    renderSvg.mockReset();
+    renderSvg.mockResolvedValue({ svg: "<svg/>" });
+  });
+
+  it("serves an unchanged (source, theme) from cache without re-rendering", async () => {
+    await renderMermaid("cache-hit", false);
+    await renderMermaid("cache-hit", false);
+    expect(renderSvg).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-renders when the theme changes for the same source", async () => {
+    await renderMermaid("theme-key", false);
+    await renderMermaid("theme-key", true);
+    expect(renderSvg).toHaveBeenCalledTimes(2);
+    expect(initialize).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ theme: "default", startOnLoad: false }),
+    );
+    expect(initialize).toHaveBeenNthCalledWith(2, expect.objectContaining({ theme: "dark" }));
+  });
+
+  it("re-renders when the source changes", async () => {
+    await renderMermaid("source-a", false);
+    await renderMermaid("source-b", false);
+    expect(renderSvg).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes a fresh id to mermaid.render on every real render", async () => {
+    await renderMermaid("fresh-id-a", false);
+    await renderMermaid("fresh-id-b", false);
+    const ids = renderSvg.mock.calls.map((c) => c[0]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("does not cache a failed render, so the next call retries it", async () => {
+    renderSvg.mockRejectedValueOnce(new Error("boom"));
+    renderSvg.mockResolvedValueOnce({ svg: "<svg id='retried'/>" });
+    await expect(renderMermaid("retry-key", false)).rejects.toThrow("boom");
+    await expect(renderMermaid("retry-key", false)).resolves.toBe("<svg id='retried'/>");
+    expect(renderSvg).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares one render pass between concurrent calls for the same diagram", async () => {
+    let resolveRender: (v: { svg: string }) => void = () => {};
+    renderSvg.mockImplementationOnce(
+      () =>
+        new Promise<{ svg: string }>((resolve) => {
+          resolveRender = resolve;
+        }),
+    );
+    const first = renderMermaid("concurrent-key", false);
+    const second = renderMermaid("concurrent-key", false);
+    // The render starts asynchronously (behind the serialization queue), so
+    // wait for it before resolving, or the resolver is still the no-op.
+    await vi.waitFor(() => expect(renderSvg).toHaveBeenCalledTimes(1));
+    resolveRender({ svg: "<svg id='shared'/>" });
+    await expect(first).resolves.toBe("<svg id='shared'/>");
+    await expect(second).resolves.toBe("<svg id='shared'/>");
+    expect(renderSvg).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes initialize+render pairs so themes cannot interleave", async () => {
+    let resolveFirst: (v: { svg: string }) => void = () => {};
+    renderSvg.mockImplementationOnce(
+      () =>
+        new Promise<{ svg: string }>((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    const first = renderMermaid("serial-a", false);
+    const second = renderMermaid("serial-b", true);
+    await vi.waitFor(() => expect(renderSvg).toHaveBeenCalledTimes(1));
+    // The second pair must not start (no initialize, no render) while the
+    // first render is still in flight, no matter how many microtasks pass.
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+    expect(renderSvg).toHaveBeenCalledTimes(1);
+    expect(initialize).toHaveBeenCalledTimes(1);
+    resolveFirst({ svg: "<svg/>" });
+    await first;
+    await second;
+    expect(renderSvg).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least recently used entry past the cache limit", async () => {
+    for (let i = 0; i < DIAGRAM_RENDER_CACHE_LIMIT; i++) {
+      await renderMermaid(`evict-${i}`, false);
+    }
+    expect(renderSvg).toHaveBeenCalledTimes(DIAGRAM_RENDER_CACHE_LIMIT);
+    // Touch evict-0 so it is the most recently used, then push one past the
+    // limit: evict-1 (now oldest) falls out, evict-0 survives.
+    await renderMermaid("evict-0", false);
+    expect(renderSvg).toHaveBeenCalledTimes(DIAGRAM_RENDER_CACHE_LIMIT);
+    await renderMermaid("evict-overflow", false);
+    await renderMermaid("evict-0", false);
+    expect(renderSvg).toHaveBeenCalledTimes(DIAGRAM_RENDER_CACHE_LIMIT + 1);
+    await renderMermaid("evict-1", false);
+    expect(renderSvg).toHaveBeenCalledTimes(DIAGRAM_RENDER_CACHE_LIMIT + 2);
+  });
+});

--- a/src/lib/mermaidRender.test.ts
+++ b/src/lib/mermaidRender.test.ts
@@ -103,6 +103,34 @@ describe("renderMermaid", () => {
     expect(renderSvg).toHaveBeenCalledTimes(2);
   });
 
+  it("a failed render evicted from the LRU does not delete a newer promise under its key", async () => {
+    let rejectFirst: (reason: unknown) => void = () => {};
+    renderSvg.mockImplementationOnce(
+      () =>
+        new Promise<{ svg: string }>((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+    );
+    const first = renderMermaid("w1-dup", false);
+    // These synchronous cache.set calls push "w1-dup" out of the LRU while its
+    // render is still queued.
+    const fillers: Promise<string>[] = [];
+    for (let i = 0; i < DIAGRAM_RENDER_CACHE_LIMIT; i++) {
+      fillers.push(renderMermaid(`w1-fill-${i}`, false));
+    }
+    // Miss (the key was evicted): a second, healthy promise is cached.
+    const second = renderMermaid("w1-dup", false);
+    await vi.waitFor(() => expect(renderSvg).toHaveBeenCalledTimes(1));
+    rejectFirst(new Error("stale failure"));
+    await expect(first).rejects.toThrow("stale failure");
+    await Promise.all(fillers);
+    await expect(second).resolves.toBe("<svg/>");
+    const settled = renderSvg.mock.calls.length;
+    // The healthy promise must have survived the failed one's eviction.
+    await renderMermaid("w1-dup", false);
+    expect(renderSvg).toHaveBeenCalledTimes(settled);
+  });
+
   it("evicts the least recently used entry past the cache limit", async () => {
     for (let i = 0; i < DIAGRAM_RENDER_CACHE_LIMIT; i++) {
       await renderMermaid(`evict-${i}`, false);

--- a/src/lib/mermaidRender.ts
+++ b/src/lib/mermaidRender.ts
@@ -22,11 +22,23 @@ function loadMermaid() {
 const cache = new LruCache<Promise<string>>(DIAGRAM_RENDER_CACHE_LIMIT);
 
 // `mermaid.initialize()` sets global config; the theme is not a per-render
-// argument the way D2's `themeID` is, so two renders at different themes could
-// interleave and steal each other's theme. Chaining every initialize+render
-// pair on this queue makes that impossible. Failures are absorbed so one
-// broken diagram cannot stall the queue.
+// argument the way D2's `themeID` is, so two initialize+render pairs could
+// interleave and steal each other's theme. Chaining every pair on this queue
+// makes that impossible, as long as everything that touches `initialize` goes
+// through `enqueueMermaid` (the export path does). Rejections are absorbed so
+// one broken diagram cannot stall the queue; a render that never settles would
+// stall later diagrams, accepted because Mermaid's layout is CPU-bound (a real
+// hang freezes the main thread regardless of any queue).
 let queue: Promise<unknown> = Promise.resolve();
+
+/** Run a Mermaid initialize+render pair after every previously queued pair.
+ *  Mermaid's config is global, so an unqueued pair can steal the theme out
+ *  from under a queued one mid-render. */
+export function enqueueMermaid<T>(work: () => Promise<T>): Promise<T> {
+  const pending = queue.then(work);
+  queue = pending.catch(() => {});
+  return pending;
+}
 
 /** Render a Mermaid source to SVG, served from cache when the same source has
  *  already been rendered for the same theme. */
@@ -35,7 +47,7 @@ export function renderMermaid(source: string, dark: boolean): Promise<string> {
   const cached = cache.get(key);
   if (cached) return cached;
 
-  const pending = queue.then(async () => {
+  const pending = enqueueMermaid(async () => {
     const mermaid = await loadMermaid();
     mermaid.initialize({
       startOnLoad: false,
@@ -46,9 +58,12 @@ export function renderMermaid(source: string, dark: boolean): Promise<string> {
     const { svg } = await mermaid.render(`mermaid-diagram-${idCounter++}`, source);
     return svg;
   });
-  queue = pending.catch(() => {});
-  // Don't cache a failed render, so a transient error can be retried.
-  pending.catch(() => cache.delete(key));
+  // Don't cache a failed render, so a transient error can be retried. Evict
+  // only the promise that actually failed: past the LRU bound the key may
+  // have been evicted and re-inserted with a newer, healthy promise.
+  pending.catch(() => {
+    if (cache.peek(key) === pending) cache.delete(key);
+  });
   cache.set(key, pending);
   return pending;
 }

--- a/src/lib/mermaidRender.ts
+++ b/src/lib/mermaidRender.ts
@@ -1,0 +1,54 @@
+// Lazy Mermaid loader + render cache, mirroring d2Render. Pure logic (no JSX)
+// so the on-screen `MermaidDiagram` component and tests share it. The export
+// path (`renderMermaidLightSvg`) deliberately stays separate: it re-renders
+// with different options once per export, off the hot path.
+
+import { DIAGRAM_RENDER_CACHE_LIMIT, LruCache } from "@/lib/lruCache";
+
+let idCounter = 0;
+let mermaidPromise: Promise<typeof import("mermaid").default> | null = null;
+
+function loadMermaid() {
+  if (!mermaidPromise) {
+    mermaidPromise = import("mermaid").then((m) => m.default);
+  }
+  return mermaidPromise;
+}
+
+// Rendered SVG keyed by `${theme}:${source}` so re-renders (scroll, tab
+// switch, parent re-render, reopening an unchanged doc) skip Mermaid's parse
+// and layout. Promises are cached (not strings) so concurrent mounts of the
+// same diagram share one render; failures are evicted so they can be retried.
+const cache = new LruCache<Promise<string>>(DIAGRAM_RENDER_CACHE_LIMIT);
+
+// `mermaid.initialize()` sets global config; the theme is not a per-render
+// argument the way D2's `themeID` is, so two renders at different themes could
+// interleave and steal each other's theme. Chaining every initialize+render
+// pair on this queue makes that impossible. Failures are absorbed so one
+// broken diagram cannot stall the queue.
+let queue: Promise<unknown> = Promise.resolve();
+
+/** Render a Mermaid source to SVG, served from cache when the same source has
+ *  already been rendered for the same theme. */
+export function renderMermaid(source: string, dark: boolean): Promise<string> {
+  const key = `${dark ? "dark" : "light"}:${source}`;
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const pending = queue.then(async () => {
+    const mermaid = await loadMermaid();
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: dark ? "dark" : "default",
+    });
+    // Always pass a fresh id. Mermaid v11 keeps internal state keyed by id,
+    // and a reused id returns a tiny stub SVG that paints as a blank preview.
+    const { svg } = await mermaid.render(`mermaid-diagram-${idCounter++}`, source);
+    return svg;
+  });
+  queue = pending.catch(() => {});
+  // Don't cache a failed render, so a transient error can be retried.
+  pending.catch(() => cache.delete(key));
+  cache.set(key, pending);
+  return pending;
+}


### PR DESCRIPTION
## Summary

Mermaid diagrams now render once per unique (theme, source) pair instead of once per mount: `renderMermaid` mirrors the existing `renderD2` promise cache, and both caches gain a shared LRU bound. Reopening a Mermaid-heavy document or switching back to its tab repaints from cache.

Closes #644

## Changes

- `src/lib/mermaidRender.ts` (new): lazy Mermaid loader plus render cache keyed `${theme}:${source}`. Promises are cached so concurrent mounts of the same diagram share one render; failures are evicted for retry; the fresh-id workaround for Mermaid v11's id-keyed state lives here now. The initialize+render pair is chained on a module-level queue, closing the issue's noted hazard: `mermaid.initialize()` is global config, so two renders at different themes could previously interleave and steal each other's theme.
- `src/lib/lruCache.ts` (new): minimal Map-based LRU (get refreshes recency). Shared `DIAGRAM_RENDER_CACHE_LIMIT = 50` with the rationale documented on the constant: rendered SVGs run 10-100KB, so each cache stays under a few MB worst case while covering every diagram in the documents a session flips between.
- `src/lib/d2Render.ts`: its unbounded Map becomes the same LRU.
- `MermaidDiagram.tsx`: delegates to `renderMermaid`; keeps its stale-result guard, error UI, and lightbox behavior. Eviction cannot break an on-screen diagram: components hold their own copy of the SVG, the cache only decides whether a future mount re-renders.
- Review follow-up (second commit): the failure eviction is identity-guarded (`LruCache.peek`) so a failed render whose key was LRU-evicted and re-inserted cannot delete the newer healthy promise, and the export path's `initialize`+`render` pairs go through the shared queue via `enqueueMermaid`, fixing a pre-existing viewer/export theme race that the cache would otherwise have made sticky.
- Tests: new `mermaidRender.test.ts` (hit, theme miss, source miss, fresh ids, failure retry, concurrent share, serialization, LRU eviction), new `lruCache.test.ts`, an LRU eviction case for `renderD2`, and `MermaidDiagram.test.tsx` re-targeted at the lib boundary (cache/id/theme assertions moved to the lib tests).

Not done: the issue's before/after tab-switch measurement. Real Mermaid does not render under the test DOM (its SVG geometry calls fail with "Could not find a suitable point for the given distance"), so an honest wall-clock number needs the running app. The tests prove the render-call elimination (a second request for a cached diagram performs zero Mermaid work); the two measurement checkboxes on the issue are left unticked for a run in the real app.

Out of scope, unchanged: `renderMermaidLightSvg` in the export path, per the issue.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [x] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

The sanitization posture is unchanged: D2 output is still sanitized before caching (`d2Render.test.ts` asserts the DOMPurify routing), and Mermaid output was already injected as returned by Mermaid's own strict security level; caching memoizes the same string a mount would have produced. The stale-render and unmount guards in `MermaidDiagram` are unchanged and still covered by their regression tests.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

30 tests across the four affected files pass locally plus the full pre-commit gate (typecheck, Biome, full Vitest suite, cargo test, clippy).

## Screenshots

Not applicable.
