### PR TITLE
fix(lightbox): portal to body, pan viewBox-only SVGs, grab cursor, backdrop dismiss

### DIFF
--- a/src/components/markdown/Lightbox.test.tsx
+++ b/src/components/markdown/Lightbox.test.tsx
@@ -83,9 +83,46 @@ describe("Lightbox", () => {
     expect(img.style.opacity).toBe("1");
     expect(img.style.objectFit).toBe("contain");
     expect(img.style.transform).toBe("scale(1)");
+    // The stretched element's letterbox lets clicks through to the backdrop.
+    expect(img.style.pointerEvents).toBe("none");
 
     fireEvent.keyDown(window, { key: "+" });
     expect(img.style.transform).toBe("scale(1.25)");
+  });
+
+  it("recovers a layout size for an SVG data URL with only a viewBox", () => {
+    const src = `data:image/svg+xml,${encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100"></svg>',
+    )}`;
+    render(
+      <Lightbox
+        images={[{ src, alt: "diagram" }]}
+        index={0}
+        onIndexChange={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const img = screen.getByAltText("diagram") as HTMLImageElement;
+    fireEvent.load(img);
+
+    // Parsed from the markup: pixel layout (pannable when zoomed), not the
+    // transform-scale fallback.
+    expect(img.style.width).toBe("200px");
+    expect(img.style.objectFit).toBe("");
+
+    fireEvent.keyDown(window, { key: "+" });
+    expect(img.style.width).toBe("250px");
+  });
+
+  it("renders the overlay into document.body, escaping transformed ancestors", () => {
+    const { container } = render(
+      <div style={{ transform: "scale(0.5)" }}>
+        <Harness />
+      </div>,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.parentElement).toBe(document.body);
+    expect(container.contains(dialog)).toBe(false);
   });
 
   it("zooms with the keyboard", () => {

--- a/src/components/markdown/Lightbox.tsx
+++ b/src/components/markdown/Lightbox.tsx
@@ -1,4 +1,5 @@
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { ChevronLeftIcon } from "@/components/icons/ChevronLeftIcon";
 import { ChevronRightIcon } from "@/components/icons/ChevronRightIcon";
@@ -6,6 +7,8 @@ import { ModalCloseIcon } from "@/components/icons/ModalCloseIcon";
 import { useDragPan } from "@/hooks/useDragPan";
 import { useLightboxKeys } from "@/hooks/useLightboxKeys";
 import { clampScale, fitScale, type LightboxImage } from "@/lib/lightbox";
+import { decodeSvgDataUrl } from "@/lib/svgDataUrl";
+import { svgIntrinsicSize } from "@/lib/svgIntrinsicSize";
 import { LightboxToolbar } from "./LightboxToolbar";
 
 interface LightboxProps {
@@ -30,21 +33,24 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
   const [loaded, setLoaded] = useState(false);
   // Intrinsic pixel size, or null when the image has none (SVGs with only a
   // `viewBox` report naturalWidth/Height === 0). Drives the sizing model below.
+  // `naturalRef` mirrors it for the fit math, which runs inside the load
+  // handler before the state has committed.
   const [natural, setNatural] = useState<{ w: number; h: number } | null>(null);
+  const naturalRef = useRef<{ w: number; h: number } | null>(null);
 
   const hasMultiple = images.length > 1;
 
   const computeFit = useCallback(() => {
     const stage = stageRef.current;
-    const img = imgRef.current;
-    if (!stage || !img?.naturalWidth) return 1;
+    const size = naturalRef.current;
+    if (!stage || !size) return 1;
     // Subtract the overlay padding so a fitted image clears the toolbar/edges.
     const styles = getComputedStyle(stage);
     const availWidth =
       stage.clientWidth - parseFloat(styles.paddingLeft) - parseFloat(styles.paddingRight);
     const availHeight =
       stage.clientHeight - parseFloat(styles.paddingTop) - parseFloat(styles.paddingBottom);
-    return fitScale(img.naturalWidth, img.naturalHeight, availWidth, availHeight);
+    return fitScale(size.w, size.h, availWidth, availHeight);
   }, []);
 
   const applyFit = useCallback(() => {
@@ -67,6 +73,7 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
       if (next < 0 || next >= images.length) return;
       setLoaded(false);
       setNatural(null);
+      naturalRef.current = null;
       onIndexChange(next);
     },
     [images.length, onIndexChange],
@@ -75,15 +82,22 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
   const handleLoad = useCallback(() => {
     const img = imgRef.current;
     setLoaded(true);
-    // SVGs with only a viewBox report no intrinsic pixel size; fall back to a
-    // contained layout (see `imageStyle`) so they still display and zoom.
-    setNatural(
+    // SVGs with only a viewBox report no intrinsic pixel size; recover one from
+    // the markup when the source is an SVG data URL (Mermaid/D2 diagrams) so
+    // the image still lays out at natural × scale and pans when zoomed. Only a
+    // size-less non-data-URL SVG falls back to the contained layout below.
+    let size =
       img && img.naturalWidth > 0 && img.naturalHeight > 0
         ? { w: img.naturalWidth, h: img.naturalHeight }
-        : null,
-    );
+        : null;
+    if (!size && image) {
+      const svg = decodeSvgDataUrl(image.src);
+      size = svg ? svgIntrinsicSize(svg) : null;
+    }
+    naturalRef.current = size;
+    setNatural(size);
     applyFit();
-  }, [applyFit]);
+  }, [applyFit, image]);
 
   useLightboxKeys({
     hasMultiple,
@@ -119,12 +133,18 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
         objectFit: "contain",
         transform: `scale(${scale})`,
         opacity: loaded ? 1 : 0,
+        // The stretched element owns the letterbox around the visible image;
+        // letting clicks through keeps the backdrop's click-to-close working.
+        pointerEvents: "none",
       };
 
   // The dialog is the scroll container and the backdrop: clicking it directly
   // (i.e. the empty area around the image) closes. The controls below are
   // `position: fixed`, so they stay pinned while a zoomed image scrolls.
-  return (
+  // Portaled to <body>: a transformed ancestor (canvas cards render markdown
+  // inside the pan/zoom world) would otherwise become the containing block and
+  // trap the "full-screen" overlay inside the pane.
+  return createPortal(
     <div
       ref={stageRef}
       className="lightbox-overlay"
@@ -196,6 +216,7 @@ export function Lightbox({ images, index, onIndexChange, onClose }: LightboxProp
         onFit={applyFit}
         onActualSize={actualSize}
       />
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/hooks/useDragPan.test.tsx
+++ b/src/hooks/useDragPan.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
 import { useRef } from "react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { captureResizeObserver } from "@/test/scrollMetrics";
 import { useDragPan } from "./useDragPan";
 
 function Harness() {
@@ -23,6 +24,10 @@ function fire(el: HTMLElement, type: string, x: number, y: number) {
 }
 
 describe("useDragPan", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("scrolls the element when dragging overflowing content", () => {
     const { getByTestId } = render(<Harness />);
     const stage = getByTestId("stage");
@@ -100,5 +105,37 @@ describe("useDragPan", () => {
     const next = new MouseEvent("click", { bubbles: true, cancelable: true });
     stage.dispatchEvent(next);
     expect(next.defaultPrevented).toBe(false);
+  });
+
+  it("marks the element pannable when the content overflows", () => {
+    const fireResize = captureResizeObserver();
+    const { getByTestId } = render(<Harness />);
+    const stage = getByTestId("stage");
+    expect(stage.hasAttribute("data-pannable")).toBe(false);
+
+    setSize(stage, 1000, 200);
+    fireResize();
+    expect(stage.hasAttribute("data-pannable")).toBe(true);
+
+    setSize(stage, 200, 200);
+    fireResize();
+    expect(stage.hasAttribute("data-pannable")).toBe(false);
+  });
+
+  it("marks the element grabbing during a real drag and clears it on release", () => {
+    // Without ResizeObserver the release path still refreshes the affordance.
+    vi.stubGlobal("ResizeObserver", undefined);
+    const { getByTestId } = render(<Harness />);
+    const stage = getByTestId("stage");
+    setSize(stage, 1000, 200);
+
+    fire(stage, "pointerdown", 100, 100);
+    expect(stage.hasAttribute("data-grabbing")).toBe(false);
+    fire(stage, "pointermove", 60, 70);
+    expect(stage.hasAttribute("data-grabbing")).toBe(true);
+    fire(stage, "pointerup", 60, 70);
+    expect(stage.hasAttribute("data-grabbing")).toBe(false);
+    // The release also refreshes the pannable affordance.
+    expect(stage.hasAttribute("data-pannable")).toBe(true);
   });
 });

--- a/src/hooks/useDragPan.ts
+++ b/src/hooks/useDragPan.ts
@@ -9,6 +9,10 @@ const DRAG_THRESHOLD = 3;
  * overflows (nothing to pan otherwise). After a real drag it swallows the
  * trailing click so the gesture doesn't also trigger click-to-close /
  * click-to-zoom on the same element.
+ *
+ * Mirrors its state onto the element as `data-pannable` (content overflows,
+ * a drag would move it) and `data-grabbing` (a drag is in progress) so the
+ * stylesheet can show grab/grabbing cursors.
  */
 export function useDragPan(ref: RefObject<HTMLElement | null>): void {
   useEffect(() => {
@@ -23,6 +27,8 @@ export function useDragPan(ref: RefObject<HTMLElement | null>): void {
     let startTop = 0;
 
     const canPan = () => el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+
+    const syncPannable = () => el.toggleAttribute("data-pannable", canPan());
 
     const handlePointerDown = (e: PointerEvent) => {
       if (e.button !== 0 || !canPan()) return;
@@ -41,7 +47,7 @@ export function useDragPan(ref: RefObject<HTMLElement | null>): void {
       const dy = e.clientY - startY;
       if (!moved && Math.hypot(dx, dy) > DRAG_THRESHOLD) {
         moved = true;
-        el.style.cursor = "grabbing";
+        el.setAttribute("data-grabbing", "");
       }
       if (moved) {
         el.scrollLeft = startLeft - dx;
@@ -53,7 +59,8 @@ export function useDragPan(ref: RefObject<HTMLElement | null>): void {
       if (!dragging) return;
       dragging = false;
       el.releasePointerCapture?.(e.pointerId);
-      el.style.cursor = "";
+      el.removeAttribute("data-grabbing");
+      syncPannable();
       if (moved) {
         const swallow = (ev: Event) => {
           ev.stopPropagation();
@@ -63,11 +70,23 @@ export function useDragPan(ref: RefObject<HTMLElement | null>): void {
       }
     };
 
+    // Overflow changes when the content zooms or the element resizes, not on
+    // any event of its own, so watch the element and its content through a
+    // ResizeObserver (guarded: test DOMs may not implement it).
+    syncPannable();
+    let observer: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== "undefined") {
+      observer = new ResizeObserver(syncPannable);
+      observer.observe(el);
+      for (const child of el.children) observer.observe(child);
+    }
+
     el.addEventListener("pointerdown", handlePointerDown);
     el.addEventListener("pointermove", handlePointerMove);
     el.addEventListener("pointerup", handlePointerUp);
     el.addEventListener("pointercancel", handlePointerUp);
     return () => {
+      observer?.disconnect();
       el.removeEventListener("pointerdown", handlePointerDown);
       el.removeEventListener("pointermove", handlePointerMove);
       el.removeEventListener("pointerup", handlePointerUp);

--- a/src/styles/imageViewer.css
+++ b/src/styles/imageViewer.css
@@ -37,6 +37,17 @@
   transition: opacity 0.1s ease-out;
 }
 
+/* Pan affordance (set by useDragPan): open hand over a pannable image, closed
+   hand anywhere on the stage while dragging. */
+.image-viewer-stage[data-pannable] .image-viewer-img {
+  cursor: grab;
+}
+
+.image-viewer-stage[data-grabbing],
+.image-viewer-stage[data-grabbing] .image-viewer-img {
+  cursor: grabbing;
+}
+
 .image-viewer-toolbar {
   position: absolute;
   bottom: 16px;

--- a/src/styles/lightbox.css
+++ b/src/styles/lightbox.css
@@ -43,6 +43,17 @@
   transition: opacity 0.1s ease-out;
 }
 
+/* Pan affordance (set by useDragPan): open hand over a pannable image, closed
+   hand anywhere on the stage while dragging. */
+.lightbox-overlay[data-pannable] .lightbox-image {
+  cursor: grab;
+}
+
+.lightbox-overlay[data-grabbing],
+.lightbox-overlay[data-grabbing] .lightbox-image {
+  cursor: grabbing;
+}
+
 .lightbox-button {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Fixes three lightbox UX defects (#666): the overlay could render trapped inside a pane instead of covering the window, zoomed diagrams/SVGs could not be panned (and showed no hand cursor), and clicks on the dark letterbox around diagrams did not dismiss.

## Changes

- Portal the lightbox overlay to `document.body`: a transformed ancestor (canvas cards render markdown inside the pan/zoom world transform) previously became the `position: fixed` containing block and trapped the "full-screen" overlay inside the card.
- Recover a layout size for viewBox-only SVGs: when the loaded image reports no intrinsic pixels, decode the `data:image/svg+xml` source (`decodeSvgDataUrl`) and parse its size (`svgIntrinsicSize`). Mermaid/D2 diagrams now use the normal `natural x scale` layout, so zooming overflows the stage and drag-to-pan works instead of clipping.
- Let clicks pass through the residual size-less fallback image (`pointer-events: none`): the stretched element owned the letterbox around the visible image, so backdrop clicks there never reached the overlay's click-to-close.
- `useDragPan` mirrors its state onto the stage as `data-pannable` / `data-grabbing` (synced via a guarded `ResizeObserver`), and the lightbox / image-viewer stylesheets show `grab` over pannable images and `grabbing` while dragging.

Known minor limits, called out in the review: in the now-rare size-less fallback the visible image body also dismisses on click (the code cannot tell artwork from letterbox there), and its transform-scale zoom does not refresh the grab cursor until a drag ends. A lightbox opened from inside a wikilink hover preview still does not survive the preview's close-on-outside-interaction handlers; that flow was equally non-functional before this change.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

Pure view-layer change (overlay placement, cursor affordance, image sizing math). No persistence, IPC, or sanitization surface touched; the SVG markup is only parsed for numeric dimensions, never re-rendered as HTML.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated gates only: `pnpm typecheck`, `pnpm check`, full `pnpm test` (3536 tests), and `cargo clippy --all-targets -- -D warnings`. New tests cover the portal escaping a transformed ancestor, SVG data-URL size recovery and zoom, click-through on the fallback branch, and the `data-pannable` / `data-grabbing` lifecycle with and without `ResizeObserver`.

Closes #666
