### PR TITLE
fix(packaging): guard the Homebrew cask against the core glyph formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
           ### macOS
           ```bash
-          brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask glyph
+          brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask --force glyph-md/tap/glyph
           ```
           Or download `Glyph_*_universal.dmg` below.
 
@@ -56,7 +56,7 @@ jobs:
           yay -S glyph-md-bin
 
           # Homebrew (Linuxbrew)
-          brew tap glyph-md/tap && brew install glyph
+          brew tap glyph-md/tap && brew install glyph-md/tap/glyph
 
           # Debian/Ubuntu (PPA)
           sudo add-apt-repository ppa:hamidfzm/glyph
@@ -157,7 +157,7 @@ jobs:
 
           ### macOS
           ```bash
-          brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask glyph
+          brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask --force glyph-md/tap/glyph
           ```
           Or download `Glyph_*_universal.dmg` below.
 
@@ -184,7 +184,7 @@ jobs:
           yay -S glyph-md-bin
 
           # Homebrew (Linuxbrew)
-          brew tap glyph-md/tap && brew install glyph
+          brew tap glyph-md/tap && brew install glyph-md/tap/glyph
 
           # Debian/Ubuntu (PPA)
           sudo add-apt-repository ppa:hamidfzm/glyph

--- a/README.md
+++ b/README.md
@@ -77,10 +77,12 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 ```bash
 brew tap glyph-md/tap
 brew trust glyph-md/tap
-brew install --cask glyph
+brew install --cask glyph-md/tap/glyph
 ```
 
 `brew trust` is required once because Glyph ships from a third-party tap; recent Homebrew refuses to load casks from untrusted taps.
+
+Use the fully qualified name: homebrew-core ships an unrelated `glyph` formula (an ASCII-art converter), so a plain `brew install glyph` installs that instead. If the `glyph` command prints `Error: input file must be specified.`, that formula is shadowing the app; remove it with `brew uninstall --formula glyph` and reinstall the cask.
 
 ### Windows (winget)
 
@@ -117,7 +119,7 @@ yay -S glyph-md-bin
 
 ```bash
 brew tap glyph-md/tap
-brew install glyph
+brew install glyph-md/tap/glyph
 ```
 
 ### Debian/Ubuntu (PPA)

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 ```bash
 brew tap glyph-md/tap
 brew trust glyph-md/tap
-brew install --cask glyph-md/tap/glyph
+brew install --cask --force glyph-md/tap/glyph
 ```
 
 `brew trust` is required once because Glyph ships from a third-party tap; recent Homebrew refuses to load casks from untrusted taps.
 
-Use the fully qualified name: homebrew-core ships an unrelated `glyph` formula (an ASCII-art converter), so a plain `brew install glyph` installs that instead. If the `glyph` command prints `Error: input file must be specified.`, that formula is shadowing the app; remove it with `brew uninstall --formula glyph` and reinstall the cask.
+Use the fully qualified name: homebrew-core ships an unrelated `glyph` formula (an ASCII-art converter), so a plain `brew install glyph` installs that instead. If the `glyph` command prints `Error: input file must be specified.`, that formula is shadowing the app; remove it with `brew uninstall --formula glyph` and reinstall the cask. `--force` also replaces an existing `/Applications/Glyph.app` left by a DMG install or an interrupted upgrade.
 
 ### Windows (winget)
 

--- a/homebrew/glyph.rb.template
+++ b/homebrew/glyph.rb.template
@@ -7,6 +7,10 @@ cask "glyph" do
   desc "Cross-platform markdown viewer"
   homepage "{{HOMEPAGE}}"
 
+  # homebrew-core ships an unrelated `glyph` formula (an ASCII-art converter)
+  # whose binary would shadow this cask's `glyph` on PATH.
+  conflicts_with formula: "glyph"
+
   livecheck do
     url :url
     strategy :github_latest

--- a/homebrew/glyph.rb.template
+++ b/homebrew/glyph.rb.template
@@ -7,10 +7,6 @@ cask "glyph" do
   desc "Cross-platform markdown viewer"
   homepage "{{HOMEPAGE}}"
 
-  # homebrew-core ships an unrelated `glyph` formula (an ASCII-art converter)
-  # whose binary would shadow this cask's `glyph` on PATH.
-  conflicts_with formula: "glyph"
-
   livecheck do
     url :url
     strategy :github_latest


### PR DESCRIPTION
## Summary

homebrew-core ships an unrelated `glyph` formula (an ASCII-art converter, formerly `asciigen`) whose binary occupies the same `/opt/homebrew/bin/glyph` path the cask links. With that formula installed, `glyph <file>` runs the wrong tool and prints `Error: input file must be specified.` This happened on a real machine where a cask upgrade had been interrupted and the core formula took over the binary name.

## Changes

- `README.md`: install commands use fully qualified names (`brew install --cask glyph-md/tap/glyph` on macOS, `brew install glyph-md/tap/glyph` on Linux) so a plain `brew install glyph` can no longer resolve to the core formula, plus a troubleshooting note describing the symptom and the fix. A cask-level `conflicts_with formula:` guard was tried first and reverted: Homebrew's cask `conflicts_with` only accepts `cask:` keys, and the `formula:` key fails cask parsing entirely.

- `.github/workflows/release.yml`: the generated release notes carried the same unqualified commands in both install blocks; they now use the qualified names with `--force` on the cask.
- The website's Download section gets the same treatment in glyph-md/glyph-md.github.io#7.

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Reproduced and fixed live on macOS: with the core formula installed, `glyph CLAUDE.md` printed the error above; after `brew uninstall --formula glyph` and `brew install --cask glyph-md/tap/glyph`, `/opt/homebrew/bin/glyph` links `Glyph.app` and `glyph --help` prints the app's usage. Windows and Linux are unaffected by the binary collision (Chocolatey, Scoop, winget, and the Linux packages own their own names); the README change for Linux Homebrew is preventive.

## Screenshots

Not applicable.

