### PR TITLE
fix(styles): read in SF Pro Text on macOS instead of the New York serif

### DIFF
--- a/docs/brand.md
+++ b/docs/brand.md
@@ -32,12 +32,13 @@ The reading face is chosen per platform, because "best for reading" is not the s
 
 | Platform | Reading face |
 | --- | --- |
-| macOS, iOS | New York, then Iowan Old Style / Charter |
+| macOS | SF Pro Text (the system face) |
+| iOS | New York, then Iowan Old Style / Charter |
 | Windows | Calibri, then Constantia / Cambria |
 | Linux | Noto Serif, then DejaVu / Liberation |
 | Unknown | Georgia |
 
-Windows therefore reads in a humanist sans while Apple platforms read in a serif. That is deliberate: Palatino Linotype, the previous Windows outcome, is a print face that renders poorly at body size on Windows. Readers who want a different face set it in Settings, which overrides the platform default.
+macOS reads in the system face: next to native apps the New York serif read as foreign, so desktop Mac prose uses SF Pro Text while iOS keeps the serif. Windows likewise reads in a humanist sans. That is deliberate: Palatino Linotype, the previous Windows outcome, is a print face that renders poorly at body size on Windows. Readers who want a different face set it in Settings, which overrides the platform default.
 
 All are system stacks; Glyph bundles no font files.
 

--- a/src/styles/platform.css
+++ b/src/styles/platform.css
@@ -68,8 +68,8 @@
   --glyph-arabic-font: GlyphArabicApple;
   --glyph-font: var(--glyph-arabic-font), "SF Pro", -apple-system,
     BlinkMacSystemFont, system-ui, sans-serif;
-  --glyph-reading-font: var(--glyph-arabic-font), "New York", ui-serif,
-    "Iowan Old Style", Charter, Palatino, serif;
+  --glyph-reading-font: var(--glyph-arabic-font), -apple-system,
+    BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
   --glyph-radius: 8px;
   --glyph-radius-sm: 6px;
   --glyph-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
## Summary

On macOS, document prose rendered in the New York serif (via `ui-serif`, with Iowan Old Style / Charter / Palatino fallbacks). Next to native macOS apps, which set body text in the system face, the serif read as foreign rather than editorial. Desktop Mac prose now uses SF Pro Text, the platform's own reading face.

## Changes

- `src/styles/platform.css`: the `[data-platform="macos"]` `--glyph-reading-font` stack becomes `-apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif`, still led by the Arabic face (`GlyphArabicApple`) so Persian and Arabic prose keep SF Arabic / Geeza Pro shaping.
- `docs/brand.md`: the reading-face table splits the macOS and iOS rows (iOS keeps New York) and the prose explains the choice.

The font setting is untouched: readers who pick Serif still get the Iowan / Palatino stack, and a custom face still wins over everything.

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

`settingsDisplay.test.ts` (the reading-face contract suite: every platform declares a face, every stack leads with the Arabic face) passes, 25/25. Windows and Linux stacks are untouched.

## Screenshots

Not applicable (font stack change; verify by opening any document on macOS).
