### PR TITLE
docs(rules): keep pull requests off the project board

### DIFF
--- a/.claude/rules/github.md
+++ b/.claude/rules/github.md
@@ -3,6 +3,7 @@
 Rules for commenting on and updating GitHub issues and PRs.
 
 - **Never merge a PR.** Open it, post the evidence, and stop; merging is always the user's call. This also rules out indirect merges: never push commits directly to `main`, including pushing a PR's head commit there (GitHub then marks the PR merged). Even if asked to land something on `main`, deliver it as a PR and let the user merge it.
+- **The project board tracks issues only.** Never add a pull request to the Glyph Roadmap board, and remove any PR that lands there (`gh project item-delete`). Issues carry the status; a PR's own state (open, merged, closed) is the only tracking it needs. Auto-add rules on the board must filter to `is:issue`.
 - **Always read the whole thread before posting.** Before adding any comment to an issue or PR, fetch and read all existing comments and the activity timeline (`gh issue view N --comments`, `gh api repos/<owner>/<repo>/issues/N/comments`, and the timeline events for label/close/reference activity). Update your understanding from what's actually there: the author may have already posted a draft themselves, another comment may have answered the question, or the state (closed, released, superseded) may have changed since your context was built.
 - **Never duplicate an existing comment.** If a drafted comment overlaps with something already posted, post only the new information.
 - **One apology per thread, maximum.** If the thread already contains an apology, don't apologize again; go straight to the update.


### PR DESCRIPTION
## Summary

Documents that the Glyph Roadmap project board tracks issues only, and that pull requests never belong on it. 42 PRs (open, merged, and closed) had accumulated on the board; they have already been removed from it.

## Changes

- `.claude/rules/github.md`: new rule stating PRs must not be added to the board, that stray PR items should be removed with `gh project item-delete`, and that the board's auto-add rule must filter to `is:issue`.

Follow-up outside this repo: the board's **Auto-add to project** workflow still matches PRs. Its filter is not editable through the API, so it needs a one-time change in the project's Workflows settings (set the filter to `is:issue`, or disable the workflow).

## Risk classification

- [x] No risk areas touched

### Invariants at stake and evidence

None. Documentation only, no runtime code paths changed.

## Testing

Docs-only change, no build or runtime surface affected.
