### PR TITLE
ci: retry release smoke tests until a release passes

### DIFF
--- a/.github/workflows/release-smoke-test.yml
+++ b/.github/workflows/release-smoke-test.yml
@@ -14,9 +14,9 @@ on:
         required: false
         type: string
   schedule:
-    # Daily; the resolve job only dispatches the testing run when the
-    # latest release is 2-3 days old, so each release gets exactly one
-    # automatic check.
+    # Daily; the resolve job decides whether the latest release still needs
+    # a check, so each release is tested once and retried only while it has
+    # no green run.
     - cron: "23 6 * * *"
 
 permissions:
@@ -56,11 +56,21 @@ jobs:
           MATURE=false
           [ "$AGE" -ge 172800 ] && MATURE=true
 
+          # Two to seven days after publishing, a scheduled run re-dispatches
+          # daily until one titled run comes back green, then stops. Testing
+          # once and never again left v0.21.0 unverified when its only run
+          # timed out fetching apt indexes on the runner.
           RUN=true
           if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-            if [ "$AGE" -lt 172800 ] || [ "$AGE" -ge 259200 ]; then
+            if [ "$AGE" -lt 172800 ] || [ "$AGE" -ge 604800 ]; then
               RUN=false
-              echo "::notice::Skipping: latest release $TAG is outside the 2-3 day window"
+              echo "::notice::Skipping: latest release $TAG is outside the 2-7 day retry window"
+            elif gh run list --repo "$GITHUB_REPOSITORY" \
+                --workflow release-smoke-test.yml --event workflow_dispatch \
+                --status success --limit 100 --json displayTitle \
+                --jq '.[].displayTitle' | grep -qxF "Release Smoke Test $TAG"; then
+              RUN=false
+              echo "::notice::Skipping: $TAG already passed a smoke test"
             fi
           fi
 
@@ -155,7 +165,7 @@ jobs:
           # The tap ships both a formula and a cask named glyph, so --formula
           # is what keeps brew from warning about the ambiguous name.
           brew install --formula glyph-md/tap/glyph
-          sudo apt-get update && sudo apt-get install -y xvfb libwebkit2gtk-4.1-0 libgtk-3-0
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update && sudo apt-get install -y xvfb libwebkit2gtk-4.1-0 libgtk-3-0
           [ "$("$(brew --prefix)/bin/glyph" --version)" = "glyph $VERSION" ]
 
           set +e
@@ -180,7 +190,7 @@ jobs:
         run: |
           curl -fsSL --retry 5 --retry-all-errors https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
           echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
-          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update
 
           CANDIDATE=$(apt-cache policy glyph | awk '/Candidate:/ {print $2}')
           if [ "$CANDIDATE" != "$VERSION" ]; then
@@ -218,7 +228,7 @@ jobs:
           SERIES: jammy
         run: |
           sudo add-apt-repository -y ppa:hamidfzm/glyph
-          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update
 
           CANDIDATE=$(apt-cache policy glyph | awk '/Candidate:/ {print $2}')
           case "$CANDIDATE" in
@@ -258,7 +268,7 @@ jobs:
           SERIES: noble
         run: |
           sudo add-apt-repository -y ppa:hamidfzm/glyph
-          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update
 
           CANDIDATE=$(apt-cache policy glyph | awk '/Candidate:/ {print $2}')
           case "$CANDIDATE" in
@@ -307,7 +317,7 @@ jobs:
           INSTALLED=$(snap list glyph | awk 'NR==2 {print $2}')
           [ "$INSTALLED" = "$VERSION" ]
           [ "$(snap run glyph --version)" = "glyph $VERSION" ]
-          sudo apt-get update && sudo apt-get install -y xvfb
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update && sudo apt-get install -y xvfb
 
           set +e
           WEBKIT_DISABLE_COMPOSITING_MODE=1 xvfb-run -a timeout 15 snap run glyph
@@ -543,7 +553,7 @@ jobs:
 
           # Runners have no FUSE, so extract rather than mount.
           "./$APPIMAGE" --appimage-extract >/dev/null
-          sudo apt-get update && sudo apt-get install -y xvfb libwebkit2gtk-4.1-0 libgtk-3-0
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update && sudo apt-get install -y xvfb libwebkit2gtk-4.1-0 libgtk-3-0
           [ "$(squashfs-root/AppRun --version)" = "glyph $VERSION" ]
 
           set +e


### PR DESCRIPTION
## Summary

The Release Smoke Test gave each release exactly one automatic run, dispatched in a 2-3 day window after publishing. When that single run flaked, coverage silently ended.

That is what happened to v0.21.0. Its only titled run, [32226657060](https://github.com/hamidfzm/glyph/actions/runs/32226657060), was **cancelled**: the `appimage` and `apt` jobs both hit `timeout-minutes: 15` stuck in `apt-get update`, after the Azure mirror `Ign`'d every index and the fallback to `archive.ubuntu.com` stalled for 14 minutes on `noble-security InRelease`. Thirteen channels passed, those two were never verified, and no later run retried them: every subsequent scheduled run logged `Skipping: latest release v0.21.0 is outside the 2-3 day window` and exited green with all jobs skipped.

## Changes

- `resolve` now decides on **state, not just age**: the daily dispatch fires when the release is at least two days old and no titled run for that tag has already succeeded, checked with `gh run list --status success`. A release that passes is still tested exactly once; one that flakes gets retried the next day.
- The upper bound moves from 3 days to 7, so a flake has five daily attempts to land a green run before the workflow stops asking.
- Every `sudo apt-get update` in the workflow now runs with `-o Acquire::Retries=3 -o Acquire::http::Timeout=20`, so a stalled mirror errors after 20 seconds and is retried, instead of hanging until the job timeout. (`Acquire::https::Timeout` inherits from the http value on apt 2.x, so it is not set separately.)

## Risk classification

- [x] No risk areas touched

CI workflow only. No application code, no persisted formats, no runtime surface.

### Invariants at stake and evidence

None. The change is confined to `.github/workflows/release-smoke-test.yml`.

## Testing

Verified locally, since the logic cannot be exercised without publishing a release:

- Parsed the workflow as YAML (16 jobs) and ran `bash -n` over all 12 bash `run` blocks; the 4 PowerShell blocks were skipped.
- Ran the `gh run list` query against the live repo. It returns the titles of the smoke runs that actually went green (`v0.20.0`, `v0.18.0`, `v0.17.2`) and does **not** match `v0.21.0`, which is the correct answer.
- Drove the new decision through its branches with the real query behind it:

  | tag | age | run? | reason |
  |---|---|---|---|
  | v0.21.0 | 10 days | no | outside 2-7 day window |
  | v0.21.0 | 3 days | **yes** | never went green, so retry (old logic said no) |
  | v0.20.0 | 3 days | no | already passed |
  | v0.22.0 | 3 days | **yes** | needs a check |
  | v0.22.0 | 1 day | no | too early |

- Full gates green via the pre-commit hook: typecheck, Biome, 3604 frontend tests, `cargo test`, strict clippy.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

N/A
