### PR TITLE
docs(readme): refresh the comparison tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ cd src-tauri && cargo clippy    # Lint Rust
 
 ## Comparison with Other Markdown Apps
 
-Glyph is built around speed, native feel, and offline-first usage. The tables below compare its current capabilities against widely used markdown apps. Items marked "planned" track to issues on the [roadmap](https://github.com/hamidfzm/glyph/issues).
+Glyph is built around speed, native feel, and offline-first usage. The tables below compare its current capabilities against widely used markdown apps.
 
 ### Rendering
 
@@ -256,9 +256,10 @@ Glyph is built around speed, native feel, and offline-first usage. The tables be
 | Folder / workspace (vault) sidebar | ✅ | ✅ | ⚠️ | ✅ | ✅ | ✅ | ✅ |
 | Wikilinks & backlinks | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | plugin |
 | Graph view | ✅ | ✅ | ❌ | ❌ | ❌ | plugin | plugin |
-| Tag / metadata search | planned | ✅ | ❌ | ❌ | ✅ | ✅ | plugin |
+| Tag / metadata search | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | plugin |
 | Command palette | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | In-document search | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Workspace-wide full-text search | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Table of contents | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Live reload on disk change | ✅ | ⚠️ | n/a | n/a | ⚠️ | n/a | ✅ |
 
@@ -278,7 +279,6 @@ Glyph is built around speed, native feel, and offline-first usage. The tables be
 | Text-to-speech | ✅ | plugin | ❌ | ❌ | ❌ | ❌ | plugin |
 | Plugin / extension API | ⚠️ experimental | ✅ | ❌ | ❌ | ⚠️ | ✅ | ✅ |
 | Cloud sync | ⚠️ Git-backed | paid | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Graph view | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | plugin |
 
 ### Platform
 
@@ -292,7 +292,7 @@ Glyph is built around speed, native feel, and offline-first usage. The tables be
 | Open source | ✅ MIT | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
 | Free | ✅ | ✅ | $14.99 | ✅ | ✅ | ✅ | ✅ |
 
-Legend: ✅ supported · ⚠️ partial / inconsistent · ❌ not supported · plugin = third-party · planned = on roadmap
+Legend: ✅ supported · ⚠️ partial / inconsistent · ❌ not supported · plugin = third-party
 
 Note on "WYSIWYG / inline preview": Glyph's editor has split-view live preview and styled markdown tokens (bold/italic render as bold/italic in source), but markdown markers remain visible. Typora-style fully inline rendering is not implemented.
 


### PR DESCRIPTION
## Summary

The comparison tables had drifted behind what shipped. Tag and frontmatter metadata search still read "planned" months after it landed, the vault-wide search panel from v0.22.0 was missing entirely, and Graph view appeared in two tables with contradicting cells.

## Changes

- `Tag / metadata search` moves from `planned` to supported. It shipped as `tag:` and frontmatter filters in the command palette plus the sidebar Tags panel (#108).
- Adds a `Workspace-wide full-text search` row to the Navigation table for the panel that shipped in v0.22.0 (#210).
- Drops the duplicate `Graph view` row from Power features. It was already in Navigation, and the two rows disagreed about Joplin (`plugin` vs `not supported`). The Navigation row is the correct one.
- Removes the `planned` marker from the legend and the roadmap sentence in the intro, since no cell uses it any more.

The `## Features` list is untouched. Per the documentation rules it stays lean, and it already describes all of this.

Rows deliberately left out because they would need competitor claims I could not verify: back/forward history, static site export, find and replace, and video/audio playback. Worth a follow-up by someone who can check the other apps.

## Risk classification

- [x] No risk areas touched

### Invariants at stake and evidence

None. Documentation only, no code paths touched.

## Testing

Full pre-commit gate passed locally: typecheck, Biome, 3604 frontend tests, 471 Rust unit tests, and clippy with warnings denied. No behavior to exercise beyond that, since the diff is a single markdown file.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux
