### PR TITLE
feat(navigation): move notes and folders by drag-and-drop in the file tree

### DIFF
--- a/src/components/layout/FileTree.create.test.tsx
+++ b/src/components/layout/FileTree.create.test.tsx
@@ -23,6 +23,7 @@ function renderFileTree(overrides: Partial<ComponentProps<typeof FileTree>> = {}
     onRename: vi.fn(async () => null),
     onDuplicate: vi.fn(async () => null),
     onMove: vi.fn(),
+    onMoveEntry: vi.fn(),
     onReveal: vi.fn(),
     onDelete: vi.fn(async () => true),
     ...overrides,

--- a/src/components/layout/FileTree.dnd.test.tsx
+++ b/src/components/layout/FileTree.dnd.test.tsx
@@ -17,6 +17,7 @@ const entries: DirEntry[] = [
 ];
 const subdirEntries: DirEntry[] = [
   { name: "deep.md", path: "/root/subdir/deep.md", isDirectory: false, modified: 0 },
+  { name: "sibling.md", path: "/root/subdir/sibling.md", isDirectory: false, modified: 0 },
   { name: "nested", path: "/root/subdir/nested", isDirectory: true, modified: 0 },
 ];
 
@@ -125,10 +126,19 @@ describe("FileTree pointer drag-and-drop move", () => {
     expect(props.onMoveEntry).not.toHaveBeenCalled();
   });
 
-  it("treats file rows as dead drop zones", () => {
+  it("drops onto a file row into that file's containing folder", () => {
     const { props } = renderTree();
     dragFromTo("/root/subdir/deep.md", row("/root/post.md"));
-    expect(rootArea().getAttribute("data-drop-target")).toBeNull();
+    expect(rootArea().getAttribute("data-drop-target")).toBe("true");
+    releaseAt();
+    expect(props.onMoveEntry).toHaveBeenCalledWith("/root/subdir/deep.md", "/root");
+  });
+
+  it("refuses a drop onto a sibling file in the same folder (no-op)", () => {
+    const { props } = renderTree();
+    dragFromTo("/root/subdir/deep.md", row("/root/subdir/sibling.md"));
+    expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
+    expect(document.body.style.cursor).toBe("no-drop");
     releaseAt();
     expect(props.onMoveEntry).not.toHaveBeenCalled();
   });

--- a/src/components/layout/FileTree.dnd.test.tsx
+++ b/src/components/layout/FileTree.dnd.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { TREE_DRAG_TYPE } from "@/hooks/useFileTreeDragMove";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DirEntry } from "@/lib/tabs";
 import { FileTree } from "./FileTree";
 
@@ -46,126 +45,125 @@ function renderTree(overrides: Partial<ComponentProps<typeof FileTree>> = {}) {
   return { ...render(<FileTree {...props} />), props };
 }
 
-const dataTransfer = () => ({
-  setData: vi.fn(),
-  effectAllowed: "",
-  dropEffect: "",
-  types: [TREE_DRAG_TYPE],
-});
 const row = (path: string) => screen.getByTitle(path);
 const rootArea = () => document.querySelector("[data-filetree-root]") as HTMLElement;
 
-describe("FileTree drag-and-drop move", () => {
-  it("marks file and folder rows draggable", () => {
-    renderTree();
-    expect(row("/root/post.md").getAttribute("draggable")).toBe("true");
-    expect(row("/root/subdir").getAttribute("draggable")).toBe("true");
+function setHit(el: Element | null) {
+  document.elementFromPoint = vi.fn(() => el) as typeof document.elementFromPoint;
+}
+
+// Press on a row, cross the drag threshold toward `target`, and hit-test it.
+function dragFromTo(fromPath: string, target: Element | null) {
+  fireEvent.pointerDown(row(fromPath), { button: 0, clientX: 0, clientY: 0 });
+  setHit(target);
+  fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
+}
+
+const releaseAt = (x = 40, y = 40) => fireEvent.pointerUp(window, { clientX: x, clientY: y });
+
+describe("FileTree pointer drag-and-drop move", () => {
+  beforeEach(() => {
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
   });
 
   it("moves a file dropped onto a folder row", () => {
     const { props } = renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/post.md"), { dataTransfer: dt });
-    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: dt });
-    fireEvent.drop(row("/root/subdir"), { dataTransfer: dt });
+    dragFromTo("/root/post.md", row("/root/subdir"));
+    expect(row("/root/subdir").getAttribute("data-drop-target")).toBe("true");
+    releaseAt();
     expect(props.onMoveEntry).toHaveBeenCalledWith("/root/post.md", "/root/subdir");
+    expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
   });
 
   it("moves a folder (with its children) dropped onto another folder", () => {
     const { props } = renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/subdir"), { dataTransfer: dt });
-    fireEvent.dragOver(row("/root/other"), { dataTransfer: dt });
-    fireEvent.drop(row("/root/other"), { dataTransfer: dt });
+    dragFromTo("/root/subdir", row("/root/other"));
+    releaseAt();
     expect(props.onMoveEntry).toHaveBeenCalledWith("/root/subdir", "/root/other");
-  });
-
-  it("highlights the hovered folder row during a valid drag", () => {
-    renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/post.md"), { dataTransfer: dt });
-    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: dt });
-    expect(row("/root/subdir").getAttribute("data-drop-target")).toBe("true");
-    fireEvent.dragEnd(row("/root/post.md"), { dataTransfer: dt });
-    expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
   });
 
   it("refuses to drop a folder onto its own descendant", () => {
     const { props } = renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/subdir"), { dataTransfer: dt });
-    fireEvent.dragOver(row("/root/subdir/nested"), { dataTransfer: dt });
+    dragFromTo("/root/subdir", row("/root/subdir/nested"));
     expect(row("/root/subdir/nested").getAttribute("data-drop-target")).toBeNull();
-    fireEvent.drop(row("/root/subdir/nested"), { dataTransfer: dt });
+    expect(document.body.style.cursor).toBe("no-drop");
+    releaseAt();
     expect(props.onMoveEntry).not.toHaveBeenCalled();
   });
 
   it("refuses to drop an entry onto its current parent folder", () => {
     const { props } = renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/subdir/deep.md"), { dataTransfer: dt });
-    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: dt });
+    dragFromTo("/root/subdir/deep.md", row("/root/subdir"));
     expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
-    fireEvent.drop(row("/root/subdir"), { dataTransfer: dt });
+    releaseAt();
     expect(props.onMoveEntry).not.toHaveBeenCalled();
   });
 
   it("moves a nested entry dropped on the empty root area to the workspace root", () => {
     const { props } = renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/subdir/deep.md"), { dataTransfer: dt });
-    fireEvent.dragOver(rootArea(), { dataTransfer: dt });
+    dragFromTo("/root/subdir/deep.md", rootArea());
     expect(rootArea().getAttribute("data-drop-target")).toBe("true");
-    fireEvent.drop(rootArea(), { dataTransfer: dt });
+    releaseAt();
     expect(props.onMoveEntry).toHaveBeenCalledWith("/root/subdir/deep.md", "/root");
   });
 
   it("rejects the root area for a top-level entry (already there)", () => {
     const { props } = renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/post.md"), { dataTransfer: dt });
-    fireEvent.dragOver(rootArea(), { dataTransfer: dt });
+    dragFromTo("/root/post.md", rootArea());
     expect(rootArea().getAttribute("data-drop-target")).toBeNull();
-    fireEvent.drop(rootArea(), { dataTransfer: dt });
+    releaseAt();
     expect(props.onMoveEntry).not.toHaveBeenCalled();
   });
 
   it("does not offer the root zone in the gaps between rows", () => {
     const { props } = renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/subdir/deep.md"), { dataTransfer: dt });
-    // Gaps hit-test the list, not the container; the root guard ignores them.
     const list = rootArea().querySelector("ul") as HTMLElement;
-    fireEvent.dragOver(list, { dataTransfer: dt });
+    dragFromTo("/root/subdir/deep.md", list);
     expect(rootArea().getAttribute("data-drop-target")).toBeNull();
-    fireEvent.drop(list, { dataTransfer: dt });
+    releaseAt();
     expect(props.onMoveEntry).not.toHaveBeenCalled();
   });
 
-  it("ignores a foreign drag without the tree payload type", () => {
+  it("treats file rows as dead drop zones", () => {
     const { props } = renderTree();
-    const foreign = { setData: vi.fn(), effectAllowed: "", dropEffect: "", types: ["text/plain"] };
-    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: foreign });
-    expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
-    fireEvent.drop(row("/root/subdir"), { dataTransfer: foreign });
+    dragFromTo("/root/subdir/deep.md", row("/root/post.md"));
+    expect(rootArea().getAttribute("data-drop-target")).toBeNull();
+    releaseAt();
     expect(props.onMoveEntry).not.toHaveBeenCalled();
   });
 
-  it("does not light up the root area while hovering a file row", () => {
-    renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/subdir/deep.md"), { dataTransfer: dt });
-    // File rows swallow dragover, so the bubbling never reaches the root zone.
-    fireEvent.dragOver(row("/root/post.md"), { dataTransfer: dt });
-    expect(rootArea().getAttribute("data-drop-target")).toBeNull();
+  it("keeps plain clicks working (open file, toggle folder)", () => {
+    const { props } = renderTree();
+    fireEvent.pointerDown(row("/root/post.md"), { button: 0, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(window, { clientX: 0, clientY: 0 });
+    fireEvent.click(row("/root/post.md"));
+    expect(props.onOpenFile).toHaveBeenCalledWith("/root/post.md");
+    fireEvent.pointerDown(row("/root/other"), { button: 0, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(window, { clientX: 0, clientY: 0 });
+    fireEvent.click(row("/root/other"));
+    expect(props.onToggle).toHaveBeenCalledWith("/root/other");
   });
 
-  it("clears the highlight when the drag leaves the hovered folder", () => {
-    renderTree();
-    const dt = dataTransfer();
-    fireEvent.dragStart(row("/root/post.md"), { dataTransfer: dt });
-    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: dt });
-    fireEvent.dragLeave(row("/root/subdir"), { dataTransfer: dt });
+  it("swallows the click synthesized after a completed drag", () => {
+    const { props } = renderTree();
+    dragFromTo("/root/post.md", row("/root/subdir"));
+    releaseAt();
+    fireEvent.click(row("/root/post.md"));
+    expect(props.onOpenFile).not.toHaveBeenCalled();
+    // The suppression is one-shot: the next real click opens as usual.
+    fireEvent.pointerDown(row("/root/post.md"), { button: 0, clientX: 0, clientY: 0 });
+    fireEvent.pointerUp(window, { clientX: 0, clientY: 0 });
+    fireEvent.click(row("/root/post.md"));
+    expect(props.onOpenFile).toHaveBeenCalledWith("/root/post.md");
+  });
+
+  it("cancels on Escape and leaves the tree untouched", () => {
+    const { props } = renderTree();
+    dragFromTo("/root/post.md", row("/root/subdir"));
+    fireEvent.keyDown(window, { key: "Escape" });
     expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
+    releaseAt();
+    expect(props.onMoveEntry).not.toHaveBeenCalled();
   });
 });

--- a/src/components/layout/FileTree.dnd.test.tsx
+++ b/src/components/layout/FileTree.dnd.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { TREE_DRAG_TYPE } from "@/hooks/useFileTreeDragMove";
 import type { DirEntry } from "@/lib/tabs";
 import { FileTree } from "./FileTree";
 
@@ -44,7 +45,12 @@ function renderTree(overrides: Partial<ComponentProps<typeof FileTree>> = {}) {
   return { ...render(<FileTree {...props} />), props };
 }
 
-const dataTransfer = () => ({ setData: vi.fn(), effectAllowed: "", dropEffect: "" });
+const dataTransfer = () => ({
+  setData: vi.fn(),
+  effectAllowed: "",
+  dropEffect: "",
+  types: [TREE_DRAG_TYPE],
+});
 const row = (path: string) => screen.getByTitle(path);
 const rootArea = () => document.querySelector("[data-filetree-root]") as HTMLElement;
 
@@ -120,6 +126,25 @@ describe("FileTree drag-and-drop move", () => {
     fireEvent.dragOver(rootArea(), { dataTransfer: dt });
     expect(rootArea().getAttribute("data-drop-target")).toBeNull();
     fireEvent.drop(rootArea(), { dataTransfer: dt });
+    expect(props.onMoveEntry).not.toHaveBeenCalled();
+  });
+
+  it("does not offer the root zone in the gaps between rows", () => {
+    renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/subdir/deep.md"), { dataTransfer: dt });
+    // Gaps hit-test the list, not the container; the root guard ignores them.
+    const list = rootArea().querySelector("ul") as HTMLElement;
+    fireEvent.dragOver(list, { dataTransfer: dt });
+    expect(rootArea().getAttribute("data-drop-target")).toBeNull();
+  });
+
+  it("ignores a foreign drag without the tree payload type", () => {
+    const { props } = renderTree();
+    const foreign = { setData: vi.fn(), effectAllowed: "", dropEffect: "", types: ["text/plain"] };
+    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: foreign });
+    expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
+    fireEvent.drop(row("/root/subdir"), { dataTransfer: foreign });
     expect(props.onMoveEntry).not.toHaveBeenCalled();
   });
 

--- a/src/components/layout/FileTree.dnd.test.tsx
+++ b/src/components/layout/FileTree.dnd.test.tsx
@@ -130,13 +130,15 @@ describe("FileTree drag-and-drop move", () => {
   });
 
   it("does not offer the root zone in the gaps between rows", () => {
-    renderTree();
+    const { props } = renderTree();
     const dt = dataTransfer();
     fireEvent.dragStart(row("/root/subdir/deep.md"), { dataTransfer: dt });
     // Gaps hit-test the list, not the container; the root guard ignores them.
     const list = rootArea().querySelector("ul") as HTMLElement;
     fireEvent.dragOver(list, { dataTransfer: dt });
     expect(rootArea().getAttribute("data-drop-target")).toBeNull();
+    fireEvent.drop(list, { dataTransfer: dt });
+    expect(props.onMoveEntry).not.toHaveBeenCalled();
   });
 
   it("ignores a foreign drag without the tree payload type", () => {

--- a/src/components/layout/FileTree.dnd.test.tsx
+++ b/src/components/layout/FileTree.dnd.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { DirEntry } from "@/lib/tabs";
+import { FileTree } from "./FileTree";
+
+// /root
+//   subdir/         (expanded)
+//     deep.md
+//     nested/
+//   other/
+//   post.md
+const entries: DirEntry[] = [
+  { name: "subdir", path: "/root/subdir", isDirectory: true, modified: 0 },
+  { name: "other", path: "/root/other", isDirectory: true, modified: 0 },
+  { name: "post.md", path: "/root/post.md", isDirectory: false, modified: 0 },
+];
+const subdirEntries: DirEntry[] = [
+  { name: "deep.md", path: "/root/subdir/deep.md", isDirectory: false, modified: 0 },
+  { name: "nested", path: "/root/subdir/nested", isDirectory: true, modified: 0 },
+];
+
+function renderTree(overrides: Partial<ComponentProps<typeof FileTree>> = {}) {
+  const props: ComponentProps<typeof FileTree> = {
+    root: "/root",
+    nodes: new Map([
+      ["/root", entries],
+      ["/root/subdir", subdirEntries],
+    ]),
+    expanded: new Set(["/root/subdir"]),
+    onToggle: vi.fn(),
+    onOpenFile: vi.fn(),
+    onCreateNote: vi.fn(async () => null),
+    onCreateCanvas: vi.fn(async () => null),
+    onCreateFolder: vi.fn(async () => null),
+    onRename: vi.fn(async () => null),
+    onDuplicate: vi.fn(async () => null),
+    onMove: vi.fn(),
+    onMoveEntry: vi.fn(),
+    onReveal: vi.fn(),
+    onDelete: vi.fn(async () => true),
+    ...overrides,
+  };
+  return { ...render(<FileTree {...props} />), props };
+}
+
+const dataTransfer = () => ({ setData: vi.fn(), effectAllowed: "", dropEffect: "" });
+const row = (path: string) => screen.getByTitle(path);
+const rootArea = () => document.querySelector("[data-filetree-root]") as HTMLElement;
+
+describe("FileTree drag-and-drop move", () => {
+  it("marks file and folder rows draggable", () => {
+    renderTree();
+    expect(row("/root/post.md").getAttribute("draggable")).toBe("true");
+    expect(row("/root/subdir").getAttribute("draggable")).toBe("true");
+  });
+
+  it("moves a file dropped onto a folder row", () => {
+    const { props } = renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/post.md"), { dataTransfer: dt });
+    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: dt });
+    fireEvent.drop(row("/root/subdir"), { dataTransfer: dt });
+    expect(props.onMoveEntry).toHaveBeenCalledWith("/root/post.md", "/root/subdir");
+  });
+
+  it("moves a folder (with its children) dropped onto another folder", () => {
+    const { props } = renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/subdir"), { dataTransfer: dt });
+    fireEvent.dragOver(row("/root/other"), { dataTransfer: dt });
+    fireEvent.drop(row("/root/other"), { dataTransfer: dt });
+    expect(props.onMoveEntry).toHaveBeenCalledWith("/root/subdir", "/root/other");
+  });
+
+  it("highlights the hovered folder row during a valid drag", () => {
+    renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/post.md"), { dataTransfer: dt });
+    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: dt });
+    expect(row("/root/subdir").getAttribute("data-drop-target")).toBe("true");
+    fireEvent.dragEnd(row("/root/post.md"), { dataTransfer: dt });
+    expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
+  });
+
+  it("refuses to drop a folder onto its own descendant", () => {
+    const { props } = renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/subdir"), { dataTransfer: dt });
+    fireEvent.dragOver(row("/root/subdir/nested"), { dataTransfer: dt });
+    expect(row("/root/subdir/nested").getAttribute("data-drop-target")).toBeNull();
+    fireEvent.drop(row("/root/subdir/nested"), { dataTransfer: dt });
+    expect(props.onMoveEntry).not.toHaveBeenCalled();
+  });
+
+  it("refuses to drop an entry onto its current parent folder", () => {
+    const { props } = renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/subdir/deep.md"), { dataTransfer: dt });
+    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: dt });
+    expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
+    fireEvent.drop(row("/root/subdir"), { dataTransfer: dt });
+    expect(props.onMoveEntry).not.toHaveBeenCalled();
+  });
+
+  it("moves a nested entry dropped on the empty root area to the workspace root", () => {
+    const { props } = renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/subdir/deep.md"), { dataTransfer: dt });
+    fireEvent.dragOver(rootArea(), { dataTransfer: dt });
+    expect(rootArea().getAttribute("data-drop-target")).toBe("true");
+    fireEvent.drop(rootArea(), { dataTransfer: dt });
+    expect(props.onMoveEntry).toHaveBeenCalledWith("/root/subdir/deep.md", "/root");
+  });
+
+  it("rejects the root area for a top-level entry (already there)", () => {
+    const { props } = renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/post.md"), { dataTransfer: dt });
+    fireEvent.dragOver(rootArea(), { dataTransfer: dt });
+    expect(rootArea().getAttribute("data-drop-target")).toBeNull();
+    fireEvent.drop(rootArea(), { dataTransfer: dt });
+    expect(props.onMoveEntry).not.toHaveBeenCalled();
+  });
+
+  it("does not light up the root area while hovering a file row", () => {
+    renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/subdir/deep.md"), { dataTransfer: dt });
+    // File rows swallow dragover, so the bubbling never reaches the root zone.
+    fireEvent.dragOver(row("/root/post.md"), { dataTransfer: dt });
+    expect(rootArea().getAttribute("data-drop-target")).toBeNull();
+  });
+
+  it("clears the highlight when the drag leaves the hovered folder", () => {
+    renderTree();
+    const dt = dataTransfer();
+    fireEvent.dragStart(row("/root/post.md"), { dataTransfer: dt });
+    fireEvent.dragOver(row("/root/subdir"), { dataTransfer: dt });
+    fireEvent.dragLeave(row("/root/subdir"), { dataTransfer: dt });
+    expect(row("/root/subdir").getAttribute("data-drop-target")).toBeNull();
+  });
+});

--- a/src/components/layout/FileTree.dnd.test.tsx
+++ b/src/components/layout/FileTree.dnd.test.tsx
@@ -31,6 +31,7 @@ function renderTree(overrides: Partial<ComponentProps<typeof FileTree>> = {}) {
     expanded: new Set(["/root/subdir"]),
     onToggle: vi.fn(),
     onOpenFile: vi.fn(),
+    onOpenInNewWindow: vi.fn(),
     onCreateNote: vi.fn(async () => null),
     onCreateCanvas: vi.fn(async () => null),
     onCreateFolder: vi.fn(async () => null),

--- a/src/components/layout/FileTree.menu.test.tsx
+++ b/src/components/layout/FileTree.menu.test.tsx
@@ -26,6 +26,7 @@ function renderFileTree(overrides: Partial<ComponentProps<typeof FileTree>> = {}
     onRename: vi.fn(async () => null),
     onDuplicate: vi.fn(async () => null),
     onMove: vi.fn(),
+    onMoveEntry: vi.fn(),
     onReveal: vi.fn(),
     onDelete: vi.fn(async () => true),
     ...overrides,

--- a/src/components/layout/FileTree.test.tsx
+++ b/src/components/layout/FileTree.test.tsx
@@ -23,6 +23,7 @@ function renderFileTree(overrides: Partial<ComponentProps<typeof FileTree>> = {}
     onRename: vi.fn(async () => null),
     onDuplicate: vi.fn(async () => null),
     onMove: vi.fn(),
+    onMoveEntry: vi.fn(),
     onReveal: vi.fn(),
     onDelete: vi.fn(async () => true),
     ...overrides,

--- a/src/components/layout/FileTree.tsx
+++ b/src/components/layout/FileTree.tsx
@@ -216,30 +216,20 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
     dnd,
   };
 
-  // The empty area below the entries doubles as the drop target for the
-  // workspace root. Rows stopPropagation, but the gaps between them still
-  // bubble up from the list; the target check confines the root affordance
-  // to genuinely empty space so the whole tree doesn't flash mid-crossing.
-  const rootDrop = dnd.dropHandlersFor(root);
-  const handleRootDragOver = (e: React.DragEvent) => {
-    if (e.target === e.currentTarget) rootDrop.onDragOver(e);
-  };
-  const handleRootDrop = (e: React.DragEvent) => {
-    if (e.target === e.currentTarget) rootDrop.onDrop(e);
-  };
+  // The empty area below the entries is the drop target for the workspace
+  // root; the hook's hit-testing only counts it when the pointer is over the
+  // container itself, so the gaps between rows don't flash the whole tree.
   const isRootDropTarget = dnd.dropTarget === root;
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: container only suppresses the native menu for empty-area right-clicks and accepts row drops at the root; keyboard users reach both via the menu on focusable rows
+    // biome-ignore lint/a11y/noStaticElementInteractions: container only suppresses the native menu for empty-area right-clicks; drops land here via pointer hit-testing, and keyboard users reach both actions via the menu on focusable rows
     <div
       data-filetree-root
+      data-tree-drop-dir={root}
       data-drop-target={isRootDropTarget || undefined}
       className={`min-h-full rounded-[var(--glyph-radius-sm)] ${
         isRootDropTarget ? "bg-[var(--color-surface-tertiary)]" : ""
       }`}
       onContextMenu={handleRootContextMenu}
-      onDragOver={handleRootDragOver}
-      onDragLeave={rootDrop.onDragLeave}
-      onDrop={handleRootDrop}
     >
       <ul className="space-y-0.5">
         {entries.map((entry) => (

--- a/src/components/layout/FileTree.tsx
+++ b/src/components/layout/FileTree.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useImperativeHandle, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ContextMenu, type ContextMenuModel } from "@/components/menu/ContextMenu";
+import { useFileTreeDragMove } from "@/hooks/useFileTreeDragMove";
 import { parentDir } from "@/lib/paths";
 import type { DirEntry } from "@/lib/tabs";
 import {
@@ -30,6 +31,8 @@ interface FileTreeProps {
   onDuplicate: (path: string) => Promise<string | null>;
   // Move an entry: prompt for a destination folder, then relocate it.
   onMove: (path: string) => void;
+  // Move an entry into `toDir` directly (drag-and-drop; no picker).
+  onMoveEntry: (from: string, toDir: string) => void;
   // Reveal an entry in the OS file manager.
   onReveal: (path: string) => void;
   // Delete a note/folder (confirms first); resolves true when removed.
@@ -57,6 +60,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
     onRename,
     onDuplicate,
     onMove,
+    onMoveEntry,
     onReveal,
     onDelete,
   },
@@ -67,6 +71,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
   const [contextMenu, setContextMenu] = useState<FileTreeMenuTarget | null>(null);
   const [editing, setEditing] = useState<EntryEditingState | null>(null);
   const closeMenu = useCallback(() => setContextMenu(null), []);
+  const dnd = useFileTreeDragMove(root, onMoveEntry);
 
   // Enter inline-naming for a freshly-created entry (null = creation failed).
   const beginNaming = useCallback((path: string | null, kind: EntryEditKind) => {
@@ -208,11 +213,23 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
     editing,
     onEditCommit: handleEditCommit,
     onEditCancel: handleEditCancel,
+    dnd,
   };
 
+  // The empty area below the entries doubles as the drop target for the
+  // workspace root; rows stopPropagation so only genuinely empty space counts.
+  const isRootDropTarget = dnd.dropTarget === root;
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: container only suppresses the native menu for empty-area right-clicks; keyboard users create via the menu reached from focusable rows
-    <div data-filetree-root className="min-h-full" onContextMenu={handleRootContextMenu}>
+    // biome-ignore lint/a11y/noStaticElementInteractions: container only suppresses the native menu for empty-area right-clicks and accepts row drops at the root; keyboard users reach both via the menu on focusable rows
+    <div
+      data-filetree-root
+      data-drop-target={isRootDropTarget || undefined}
+      className={`min-h-full rounded-[var(--glyph-radius-sm)] ${
+        isRootDropTarget ? "bg-[var(--color-surface-tertiary)]" : ""
+      }`}
+      onContextMenu={handleRootContextMenu}
+      {...dnd.dropHandlersFor(root)}
+    >
       <ul className="space-y-0.5">
         {entries.map((entry) => (
           <FileTreeEntry key={entry.path} {...childProps} entry={entry} depth={0} />

--- a/src/components/layout/FileTree.tsx
+++ b/src/components/layout/FileTree.tsx
@@ -217,7 +217,16 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
   };
 
   // The empty area below the entries doubles as the drop target for the
-  // workspace root; rows stopPropagation so only genuinely empty space counts.
+  // workspace root. Rows stopPropagation, but the gaps between them still
+  // bubble up from the list; the target check confines the root affordance
+  // to genuinely empty space so the whole tree doesn't flash mid-crossing.
+  const rootDrop = dnd.dropHandlersFor(root);
+  const handleRootDragOver = (e: React.DragEvent) => {
+    if (e.target === e.currentTarget) rootDrop.onDragOver(e);
+  };
+  const handleRootDrop = (e: React.DragEvent) => {
+    if (e.target === e.currentTarget) rootDrop.onDrop(e);
+  };
   const isRootDropTarget = dnd.dropTarget === root;
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: container only suppresses the native menu for empty-area right-clicks and accepts row drops at the root; keyboard users reach both via the menu on focusable rows
@@ -228,7 +237,9 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(function FileT
         isRootDropTarget ? "bg-[var(--color-surface-tertiary)]" : ""
       }`}
       onContextMenu={handleRootContextMenu}
-      {...dnd.dropHandlersFor(root)}
+      onDragOver={handleRootDragOver}
+      onDragLeave={rootDrop.onDragLeave}
+      onDrop={handleRootDrop}
     >
       <ul className="space-y-0.5">
         {entries.map((entry) => (

--- a/src/components/layout/FileTreeEntry.tsx
+++ b/src/components/layout/FileTreeEntry.tsx
@@ -5,6 +5,7 @@ import { FolderIcon } from "@/components/icons/FolderIcon";
 import { FolderOpenIcon } from "@/components/icons/FolderOpenIcon";
 import { ImageIcon } from "@/components/icons/ImageIcon";
 import { InlineRenameInput } from "@/components/layout/InlineRenameInput";
+import { blockDropHandlers, type FileTreeDragMove } from "@/hooks/useFileTreeDragMove";
 import { isCanvasFile } from "@/lib/canvasExtensions";
 import { isImageFile } from "@/lib/imageExtensions";
 import { stem } from "@/lib/paths";
@@ -37,12 +38,14 @@ export interface FileTreeEntryProps {
   editing: EntryEditingState | null;
   onEditCommit: (editing: EntryEditingState, value: string) => void;
   onEditCancel: (editing: EntryEditingState) => void;
+  dnd: FileTreeDragMove;
 }
 
 /** One row of the workspace tree: a file button, or a folder button plus its
  *  expanded children. Recurses into itself for subdirectories. */
 export function FileTreeEntry(props: FileTreeEntryProps) {
-  const { entry, depth, nodes, expanded, activeFilePath, onToggle, onOpenFile, editing } = props;
+  const { entry, depth, nodes, expanded, activeFilePath, onToggle, onOpenFile, editing, dnd } =
+    props;
   const indentStyle = { paddingLeft: `${depth * INDENT_PX + 8}px` };
 
   if (editing && editing.path === entry.path) {
@@ -63,13 +66,21 @@ export function FileTreeEntry(props: FileTreeEntryProps) {
   if (entry.isDirectory) {
     const isExpanded = expanded.has(entry.path);
     const children = nodes.get(entry.path);
+    const isDropTarget = dnd.dropTarget === entry.path;
     return (
       <li>
         <button
           type="button"
           onClick={() => onToggle(entry.path)}
           onContextMenu={(e) => props.onContextMenu(e, entry)}
-          className="w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] active:bg-[var(--color-border)] flex items-center gap-1.5"
+          {...dnd.dragHandlersFor(entry.path)}
+          {...dnd.dropHandlersFor(entry.path)}
+          data-drop-target={isDropTarget || undefined}
+          className={`w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] active:bg-[var(--color-border)] flex items-center gap-1.5 ${
+            isDropTarget
+              ? "bg-[var(--color-surface-tertiary)] ring-1 ring-inset ring-[var(--color-accent)]"
+              : ""
+          }`}
           style={indentStyle}
           title={entry.path}
         >
@@ -99,6 +110,8 @@ export function FileTreeEntry(props: FileTreeEntryProps) {
         type="button"
         onClick={() => onOpenFile(entry.path)}
         onContextMenu={(e) => props.onContextMenu(e, entry)}
+        {...dnd.dragHandlersFor(entry.path)}
+        {...blockDropHandlers}
         className={`w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors flex items-center gap-1.5 ${
           isActive
             ? "bg-[var(--color-accent)] text-white font-medium"

--- a/src/components/layout/FileTreeEntry.tsx
+++ b/src/components/layout/FileTreeEntry.tsx
@@ -5,7 +5,7 @@ import { FolderIcon } from "@/components/icons/FolderIcon";
 import { FolderOpenIcon } from "@/components/icons/FolderOpenIcon";
 import { ImageIcon } from "@/components/icons/ImageIcon";
 import { InlineRenameInput } from "@/components/layout/InlineRenameInput";
-import { blockDropHandlers, type FileTreeDragMove } from "@/hooks/useFileTreeDragMove";
+import type { FileTreeDragMove } from "@/hooks/useFileTreeDragMove";
 import { isCanvasFile } from "@/lib/canvasExtensions";
 import { isImageFile } from "@/lib/imageExtensions";
 import { stem } from "@/lib/paths";
@@ -74,7 +74,7 @@ export function FileTreeEntry(props: FileTreeEntryProps) {
           onClick={() => onToggle(entry.path)}
           onContextMenu={(e) => props.onContextMenu(e, entry)}
           {...dnd.dragHandlersFor(entry.path)}
-          {...dnd.dropHandlersFor(entry.path)}
+          data-tree-drop-dir={entry.path}
           data-drop-target={isDropTarget || undefined}
           className={`w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-tertiary)] active:bg-[var(--color-border)] flex items-center gap-1.5 ${
             isDropTarget
@@ -111,7 +111,7 @@ export function FileTreeEntry(props: FileTreeEntryProps) {
         onClick={() => onOpenFile(entry.path)}
         onContextMenu={(e) => props.onContextMenu(e, entry)}
         {...dnd.dragHandlersFor(entry.path)}
-        {...blockDropHandlers}
+        data-tree-drop-block=""
         className={`w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors flex items-center gap-1.5 ${
           isActive
             ? "bg-[var(--color-accent)] text-white font-medium"

--- a/src/components/layout/FileTreeEntry.tsx
+++ b/src/components/layout/FileTreeEntry.tsx
@@ -8,7 +8,7 @@ import { InlineRenameInput } from "@/components/layout/InlineRenameInput";
 import type { FileTreeDragMove } from "@/hooks/useFileTreeDragMove";
 import { isCanvasFile } from "@/lib/canvasExtensions";
 import { isImageFile } from "@/lib/imageExtensions";
-import { stem } from "@/lib/paths";
+import { parentDir, stem } from "@/lib/paths";
 import type { DirEntry } from "@/lib/tabs";
 
 const INDENT_PX = 12;
@@ -111,7 +111,7 @@ export function FileTreeEntry(props: FileTreeEntryProps) {
         onClick={() => onOpenFile(entry.path)}
         onContextMenu={(e) => props.onContextMenu(e, entry)}
         {...dnd.dragHandlersFor(entry.path)}
-        data-tree-drop-block=""
+        data-tree-drop-dir={parentDir(entry.path, entry.path)}
         className={`w-full text-start text-sm py-1 px-2 rounded-[var(--glyph-radius-sm)] truncate transition-colors flex items-center gap-1.5 ${
           isActive
             ? "bg-[var(--color-accent)] text-white font-medium"

--- a/src/components/layout/FilesPanel.tsx
+++ b/src/components/layout/FilesPanel.tsx
@@ -153,6 +153,7 @@ export function FilesPanel({ workspace, headerSide }: FilesPanelProps) {
             onRename={renamePath}
             onDuplicate={duplicatePath}
             onMove={handleMove}
+            onMoveEntry={movePath}
             onReveal={(path) => {
               void revealItemInDir(path);
             }}

--- a/src/hooks/useFileTreeDragMove.test.ts
+++ b/src/hooks/useFileTreeDragMove.test.ts
@@ -1,200 +1,221 @@
 import { act, renderHook } from "@testing-library/react";
-import type { DragEvent } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { blockDropHandlers, TREE_DRAG_TYPE, useFileTreeDragMove } from "./useFileTreeDragMove";
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFileTreeDragMove } from "./useFileTreeDragMove";
 
-interface MockDragEvent {
-  preventDefault: ReturnType<typeof vi.fn>;
-  stopPropagation: ReturnType<typeof vi.fn>;
-  currentTarget: { contains: (node: unknown) => boolean };
-  relatedTarget: unknown;
-  dataTransfer: {
-    setData: ReturnType<typeof vi.fn>;
-    effectAllowed: string;
-    dropEffect: string;
-    types: string[];
-  };
+function setHit(el: Element | null) {
+  document.elementFromPoint = vi.fn(() => el) as typeof document.elementFromPoint;
 }
 
-const dragEvent = (overrides: Partial<MockDragEvent> = {}) =>
-  ({
-    preventDefault: vi.fn(),
-    stopPropagation: vi.fn(),
-    currentTarget: { contains: () => false },
-    relatedTarget: null,
-    dataTransfer: { setData: vi.fn(), effectAllowed: "", dropEffect: "", types: [TREE_DRAG_TYPE] },
-    ...overrides,
-  }) as MockDragEvent & DragEvent;
+function zoneEl(attrs: Record<string, string>): HTMLElement {
+  const el = document.createElement("div");
+  for (const [name, value] of Object.entries(attrs)) el.setAttribute(name, value);
+  document.body.appendChild(el);
+  return el;
+}
 
-/** A drag that did not start in the tree: no tree payload type. */
-const foreignEvent = () =>
-  dragEvent({
-    dataTransfer: { setData: vi.fn(), effectAllowed: "", dropEffect: "", types: ["text/plain"] },
-  });
+const folderZone = (dir: string) => zoneEl({ "data-tree-drop-dir": dir });
+const fileBlock = () => zoneEl({ "data-tree-drop-block": "" });
+
+const downEvent = (overrides: Partial<ReactPointerEvent> = {}) =>
+  ({
+    button: 0,
+    pointerType: "mouse",
+    clientX: 0,
+    clientY: 0,
+    ...overrides,
+  }) as ReactPointerEvent;
+
+const clickEvent = () =>
+  ({ preventDefault: vi.fn(), stopPropagation: vi.fn() }) as unknown as ReactPointerEvent & {
+    preventDefault: ReturnType<typeof vi.fn>;
+    stopPropagation: ReturnType<typeof vi.fn>;
+  };
 
 function renderDnd(onMoveEntry = vi.fn()) {
   const { result, unmount } = renderHook(() => useFileTreeDragMove("/root", onMoveEntry));
-  const start = (path: string) => {
+  const press = (path: string, overrides: Partial<ReactPointerEvent> = {}) => {
     act(() => {
-      result.current.dragHandlersFor(path).onDragStart(dragEvent());
+      result.current.dragHandlersFor(path).onPointerDown(downEvent(overrides));
     });
   };
-  const over = (dir: string, event = dragEvent()) => {
+  const moveTo = (x = 50, y = 50) => {
     act(() => {
-      result.current.dropHandlersFor(dir).onDragOver(event);
-    });
-    return event;
-  };
-  const drop = (dir: string, event = dragEvent()) => {
-    act(() => {
-      result.current.dropHandlersFor(dir).onDrop(event);
+      window.dispatchEvent(new MouseEvent("pointermove", { clientX: x, clientY: y }));
     });
   };
-  return { result, unmount, onMoveEntry, start, over, drop };
+  const release = (x = 50, y = 50) => {
+    act(() => {
+      window.dispatchEvent(new MouseEvent("pointerup", { clientX: x, clientY: y }));
+    });
+  };
+  return { result, unmount, onMoveEntry, press, moveTo, release };
 }
 
 describe("useFileTreeDragMove", () => {
-  it("marks rows draggable and sets the tree and plain-text payloads", () => {
-    const { result } = renderDnd();
-    const handlers = result.current.dragHandlersFor("/root/a.md");
-    expect(handlers.draggable).toBe(true);
-    const event = dragEvent();
-    act(() => {
-      handlers.onDragStart(event);
-    });
-    expect(event.dataTransfer.effectAllowed).toBe("move");
-    expect(event.dataTransfer.setData).toHaveBeenCalledWith(TREE_DRAG_TYPE, "/root/a.md");
-    // WebKit refuses to start a drag with an empty text payload.
-    expect(event.dataTransfer.setData).toHaveBeenCalledWith("text/plain", "/root/a.md");
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
   });
 
-  it("accepts a valid folder target: preventDefault, move cursor, highlight", () => {
-    const { result, start, over } = renderDnd();
-    start("/root/a.md");
-    const event = over("/root/sub");
-    expect(event.preventDefault).toHaveBeenCalled();
-    expect(event.dataTransfer.dropEffect).toBe("move");
-    expect(result.current.dropTarget).toBe("/root/sub");
-    // dragover fires on every pointer move; the target stays stable.
-    over("/root/sub");
-    expect(result.current.dropTarget).toBe("/root/sub");
-  });
-
-  it("rejects the dragged entry itself, its descendants, and its current parent", () => {
-    const { result, start, over } = renderDnd();
-    start("/root/sub");
-    for (const dir of ["/root/sub", "/root/sub/nested", "/root"]) {
-      const event = over(dir);
-      expect(event.preventDefault).not.toHaveBeenCalled();
-      expect(result.current.dropTarget).toBeNull();
-    }
-  });
-
-  it("rejects every target while no drag is in progress", () => {
-    const { result, over } = renderDnd();
-    const event = over("/root/sub");
-    expect(event.preventDefault).not.toHaveBeenCalled();
+  it("ignores movement below the drag threshold, so plain clicks survive", () => {
+    const { result, onMoveEntry, press, moveTo, release } = renderDnd();
+    setHit(folderZone("/root/sub"));
+    press("/root/a.md");
+    moveTo(2, 2);
     expect(result.current.dropTarget).toBeNull();
-  });
-
-  it("ignores foreign drags even when a stale tree drag is pending", () => {
-    const { result, onMoveEntry, start, over, drop } = renderDnd();
-    // A stale ref survives when dragend never fired (source row unmounted);
-    // a later link/image drag from the document must not consume it.
-    start("/root/a.md");
-    const event = over("/root/sub", foreignEvent());
-    expect(event.preventDefault).not.toHaveBeenCalled();
-    expect(result.current.dropTarget).toBeNull();
-    drop("/root/sub", foreignEvent());
+    release(2, 2);
     expect(onMoveEntry).not.toHaveBeenCalled();
+    const click = clickEvent();
+    act(() => {
+      result.current.dragHandlersFor("/root/a.md").onClickCapture(click);
+    });
+    expect(click.preventDefault).not.toHaveBeenCalled();
   });
 
-  it("commits a valid drop through onMoveEntry exactly once and resets", () => {
-    const { result, onMoveEntry, start, over, drop } = renderDnd();
-    start("/root/a.md");
-    over("/root/sub");
-    drop("/root/sub");
+  it("highlights a valid folder target and commits the move on release", () => {
+    const { result, onMoveEntry, press, moveTo, release } = renderDnd();
+    setHit(folderZone("/root/sub"));
+    press("/root/a.md");
+    moveTo();
+    expect(result.current.dropTarget).toBe("/root/sub");
+    expect(document.body.style.userSelect).toBe("none");
+    release();
     expect(onMoveEntry).toHaveBeenCalledTimes(1);
     expect(onMoveEntry).toHaveBeenCalledWith("/root/a.md", "/root/sub");
     expect(result.current.dropTarget).toBeNull();
-    // The drag is consumed: a second drop is inert.
-    drop("/root/sub");
-    expect(onMoveEntry).toHaveBeenCalledTimes(1);
+    expect(document.body.style.userSelect).toBe("");
   });
 
-  it("re-validates on drop and refuses an invalid target", () => {
-    const { onMoveEntry, start, drop } = renderDnd();
-    start("/root/sub");
-    drop("/root/sub/nested");
+  it("suppresses exactly one click after a completed drag", () => {
+    const { result, press, moveTo, release } = renderDnd();
+    setHit(folderZone("/root/sub"));
+    press("/root/a.md");
+    moveTo();
+    release();
+    const suppressed = clickEvent();
+    act(() => {
+      result.current.dragHandlersFor("/root/a.md").onClickCapture(suppressed);
+    });
+    expect(suppressed.preventDefault).toHaveBeenCalled();
+    expect(suppressed.stopPropagation).toHaveBeenCalled();
+    const clean = clickEvent();
+    act(() => {
+      result.current.dragHandlersFor("/root/a.md").onClickCapture(clean);
+    });
+    expect(clean.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("rejects the dragged entry itself, its descendants, and its current parent", () => {
+    const { result, onMoveEntry, press, moveTo, release } = renderDnd();
+    for (const dir of ["/root/sub", "/root/sub/nested", "/root"]) {
+      setHit(folderZone(dir));
+      press("/root/sub");
+      moveTo();
+      expect(result.current.dropTarget).toBeNull();
+      expect(document.body.style.cursor).toBe("no-drop");
+      release();
+      expect(onMoveEntry).not.toHaveBeenCalled();
+      expect(document.body.style.cursor).toBe("");
+    }
+  });
+
+  it("treats file rows as dead zones via the block marker", () => {
+    const { result, onMoveEntry, press, moveTo, release } = renderDnd();
+    setHit(fileBlock());
+    press("/root/sub/deep.md");
+    moveTo();
+    expect(result.current.dropTarget).toBeNull();
+    release();
     expect(onMoveEntry).not.toHaveBeenCalled();
   });
 
-  it("clears the drag and the highlight on dragend", () => {
-    const { result, onMoveEntry, start, over, drop } = renderDnd();
-    start("/root/a.md");
-    over("/root/sub");
+  it("counts the root zone only when the pointer is over the container itself", () => {
+    const { result, onMoveEntry, press, moveTo, release } = renderDnd();
+    const container = zoneEl({ "data-filetree-root": "", "data-tree-drop-dir": "/root" });
+    const gap = document.createElement("ul");
+    container.appendChild(gap);
+
+    setHit(gap);
+    press("/root/sub/deep.md");
+    moveTo();
+    expect(result.current.dropTarget).toBeNull();
+
+    setHit(container);
+    moveTo(60, 60);
+    expect(result.current.dropTarget).toBe("/root");
+    release(60, 60);
+    expect(onMoveEntry).toHaveBeenCalledWith("/root/sub/deep.md", "/root");
+  });
+
+  it("ignores presses from touch and from non-primary buttons", () => {
+    const { result, press, moveTo } = renderDnd();
+    setHit(folderZone("/root/sub"));
+    press("/root/a.md", { pointerType: "touch" });
+    moveTo();
+    expect(result.current.dropTarget).toBeNull();
+    press("/root/a.md", { button: 2 });
+    moveTo(60, 60);
+    expect(result.current.dropTarget).toBeNull();
+  });
+
+  it("cancels on Escape without moving anything", () => {
+    const { result, onMoveEntry, press, moveTo, release } = renderDnd();
+    setHit(folderZone("/root/sub"));
+    press("/root/a.md");
+    moveTo();
     act(() => {
-      result.current.dragHandlersFor("/root/a.md").onDragEnd();
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     });
     expect(result.current.dropTarget).toBeNull();
-    drop("/root/sub");
+    release();
     expect(onMoveEntry).not.toHaveBeenCalled();
   });
 
-  it("resets via the window fallback when dragend never reaches the row", () => {
-    const { result, onMoveEntry, start, over, drop } = renderDnd();
-    start("/root/a.md");
-    over("/root/sub");
-    // Chromium skips the row's dragend when the source unmounts mid-drag.
+  it("ignores other keys mid-drag", () => {
+    const { result, press, moveTo } = renderDnd();
+    setHit(folderZone("/root/sub"));
+    press("/root/a.md");
+    moveTo();
     act(() => {
-      window.dispatchEvent(new Event("dragend"));
-    });
-    expect(result.current.dropTarget).toBeNull();
-    drop("/root/sub");
-    expect(onMoveEntry).not.toHaveBeenCalled();
-  });
-
-  it("keeps the highlight when dragleave only crosses into the row's children", () => {
-    const { result, start, over } = renderDnd();
-    start("/root/a.md");
-    over("/root/sub");
-    act(() => {
-      result.current
-        .dropHandlersFor("/root/sub")
-        .onDragLeave(dragEvent({ currentTarget: { contains: () => true } }));
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
     });
     expect(result.current.dropTarget).toBe("/root/sub");
   });
 
-  it("clears the highlight on dragleave only for the hovered target", () => {
-    const { result, start, over } = renderDnd();
-    start("/root/a.md");
-    over("/root/sub");
-    act(() => {
-      result.current.dropHandlersFor("/root/other").onDragLeave(dragEvent());
-    });
-    expect(result.current.dropTarget).toBe("/root/sub");
-    act(() => {
-      result.current.dropHandlersFor("/root/sub").onDragLeave(dragEvent());
-    });
+  it("ignores stray pointer and key events while no drag is in progress", () => {
+    const { result, onMoveEntry, moveTo, release } = renderDnd();
+    setHit(folderZone("/root/sub"));
+    moveTo();
     expect(result.current.dropTarget).toBeNull();
+    release();
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(onMoveEntry).not.toHaveBeenCalled();
   });
 
-  it("blockDropHandlers swallows dragover without marking a target", () => {
-    const event = dragEvent();
-    blockDropHandlers.onDragOver(event);
-    expect(event.stopPropagation).toHaveBeenCalled();
-    expect(event.preventDefault).not.toHaveBeenCalled();
+  it("handles a hit-test miss (pointer outside any zone)", () => {
+    const { result, onMoveEntry, press, moveTo, release } = renderDnd();
+    setHit(null);
+    press("/root/a.md");
+    moveTo();
+    expect(result.current.dropTarget).toBeNull();
+    release();
+    expect(onMoveEntry).not.toHaveBeenCalled();
   });
 
-  it("drops its window fallbacks on unmount", () => {
+  it("detaches its window listeners on unmount mid-drag", () => {
     const removeSpy = vi.spyOn(window, "removeEventListener");
-    const { start, unmount } = renderDnd();
-    start("/root/a.md");
+    const { press, unmount } = renderDnd();
+    setHit(folderZone("/root/sub"));
+    press("/root/a.md");
     unmount();
     const removed = removeSpy.mock.calls.map(([type]) => type);
-    expect(removed).toContain("dragend");
-    expect(removed).toContain("drop");
+    expect(removed).toContain("pointermove");
+    expect(removed).toContain("pointerup");
+    expect(removed).toContain("keydown");
     removeSpy.mockRestore();
   });
 });

--- a/src/hooks/useFileTreeDragMove.test.ts
+++ b/src/hooks/useFileTreeDragMove.test.ts
@@ -1,43 +1,60 @@
 import { act, renderHook } from "@testing-library/react";
 import type { DragEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { blockDropHandlers, useFileTreeDragMove } from "./useFileTreeDragMove";
+import { blockDropHandlers, TREE_DRAG_TYPE, useFileTreeDragMove } from "./useFileTreeDragMove";
 
-const dragEvent = () =>
+interface MockDragEvent {
+  preventDefault: ReturnType<typeof vi.fn>;
+  stopPropagation: ReturnType<typeof vi.fn>;
+  currentTarget: { contains: (node: unknown) => boolean };
+  relatedTarget: unknown;
+  dataTransfer: {
+    setData: ReturnType<typeof vi.fn>;
+    effectAllowed: string;
+    dropEffect: string;
+    types: string[];
+  };
+}
+
+const dragEvent = (overrides: Partial<MockDragEvent> = {}) =>
   ({
     preventDefault: vi.fn(),
     stopPropagation: vi.fn(),
-    dataTransfer: { setData: vi.fn(), effectAllowed: "", dropEffect: "" },
-  }) as unknown as DragEvent & {
-    preventDefault: ReturnType<typeof vi.fn>;
-    stopPropagation: ReturnType<typeof vi.fn>;
-    dataTransfer: { setData: ReturnType<typeof vi.fn>; effectAllowed: string; dropEffect: string };
-  };
+    currentTarget: { contains: () => false },
+    relatedTarget: null,
+    dataTransfer: { setData: vi.fn(), effectAllowed: "", dropEffect: "", types: [TREE_DRAG_TYPE] },
+    ...overrides,
+  }) as MockDragEvent & DragEvent;
+
+/** A drag that did not start in the tree: no tree payload type. */
+const foreignEvent = () =>
+  dragEvent({
+    dataTransfer: { setData: vi.fn(), effectAllowed: "", dropEffect: "", types: ["text/plain"] },
+  });
 
 function renderDnd(onMoveEntry = vi.fn()) {
-  const { result } = renderHook(() => useFileTreeDragMove("/root", onMoveEntry));
+  const { result, unmount } = renderHook(() => useFileTreeDragMove("/root", onMoveEntry));
   const start = (path: string) => {
     act(() => {
       result.current.dragHandlersFor(path).onDragStart(dragEvent());
     });
   };
-  const over = (dir: string) => {
-    const event = dragEvent();
+  const over = (dir: string, event = dragEvent()) => {
     act(() => {
       result.current.dropHandlersFor(dir).onDragOver(event);
     });
     return event;
   };
-  const drop = (dir: string) => {
+  const drop = (dir: string, event = dragEvent()) => {
     act(() => {
-      result.current.dropHandlersFor(dir).onDrop(dragEvent());
+      result.current.dropHandlersFor(dir).onDrop(event);
     });
   };
-  return { result, onMoveEntry, start, over, drop };
+  return { result, unmount, onMoveEntry, start, over, drop };
 }
 
 describe("useFileTreeDragMove", () => {
-  it("marks rows draggable and sets a drag payload (WebKit needs one)", () => {
+  it("marks rows draggable and sets the tree and plain-text payloads", () => {
     const { result } = renderDnd();
     const handlers = result.current.dragHandlersFor("/root/a.md");
     expect(handlers.draggable).toBe(true);
@@ -46,6 +63,8 @@ describe("useFileTreeDragMove", () => {
       handlers.onDragStart(event);
     });
     expect(event.dataTransfer.effectAllowed).toBe("move");
+    expect(event.dataTransfer.setData).toHaveBeenCalledWith(TREE_DRAG_TYPE, "/root/a.md");
+    // WebKit refuses to start a drag with an empty text payload.
     expect(event.dataTransfer.setData).toHaveBeenCalledWith("text/plain", "/root/a.md");
   });
 
@@ -73,6 +92,18 @@ describe("useFileTreeDragMove", () => {
     const event = over("/root/sub");
     expect(event.preventDefault).not.toHaveBeenCalled();
     expect(result.current.dropTarget).toBeNull();
+  });
+
+  it("ignores foreign drags even when a stale tree drag is pending", () => {
+    const { result, onMoveEntry, start, over, drop } = renderDnd();
+    // A stale ref survives when dragend never fired (source row unmounted);
+    // a later link/image drag from the document must not consume it.
+    start("/root/a.md");
+    const event = over("/root/sub", foreignEvent());
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(result.current.dropTarget).toBeNull();
+    drop("/root/sub", foreignEvent());
+    expect(onMoveEntry).not.toHaveBeenCalled();
   });
 
   it("commits a valid drop through onMoveEntry exactly once and resets", () => {
@@ -107,16 +138,41 @@ describe("useFileTreeDragMove", () => {
     expect(onMoveEntry).not.toHaveBeenCalled();
   });
 
+  it("resets via the window fallback when dragend never reaches the row", () => {
+    const { result, onMoveEntry, start, over, drop } = renderDnd();
+    start("/root/a.md");
+    over("/root/sub");
+    // Chromium skips the row's dragend when the source unmounts mid-drag.
+    act(() => {
+      window.dispatchEvent(new Event("dragend"));
+    });
+    expect(result.current.dropTarget).toBeNull();
+    drop("/root/sub");
+    expect(onMoveEntry).not.toHaveBeenCalled();
+  });
+
+  it("keeps the highlight when dragleave only crosses into the row's children", () => {
+    const { result, start, over } = renderDnd();
+    start("/root/a.md");
+    over("/root/sub");
+    act(() => {
+      result.current
+        .dropHandlersFor("/root/sub")
+        .onDragLeave(dragEvent({ currentTarget: { contains: () => true } }));
+    });
+    expect(result.current.dropTarget).toBe("/root/sub");
+  });
+
   it("clears the highlight on dragleave only for the hovered target", () => {
     const { result, start, over } = renderDnd();
     start("/root/a.md");
     over("/root/sub");
     act(() => {
-      result.current.dropHandlersFor("/root/other").onDragLeave();
+      result.current.dropHandlersFor("/root/other").onDragLeave(dragEvent());
     });
     expect(result.current.dropTarget).toBe("/root/sub");
     act(() => {
-      result.current.dropHandlersFor("/root/sub").onDragLeave();
+      result.current.dropHandlersFor("/root/sub").onDragLeave(dragEvent());
     });
     expect(result.current.dropTarget).toBeNull();
   });
@@ -126,5 +182,16 @@ describe("useFileTreeDragMove", () => {
     blockDropHandlers.onDragOver(event);
     expect(event.stopPropagation).toHaveBeenCalled();
     expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("drops its window fallbacks on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { start, unmount } = renderDnd();
+    start("/root/a.md");
+    unmount();
+    const removed = removeSpy.mock.calls.map(([type]) => type);
+    expect(removed).toContain("dragend");
+    expect(removed).toContain("drop");
+    removeSpy.mockRestore();
   });
 });

--- a/src/hooks/useFileTreeDragMove.test.ts
+++ b/src/hooks/useFileTreeDragMove.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import type { DragEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { blockDropHandlers, useFileTreeDragMove } from "./useFileTreeDragMove";
+
+const dragEvent = () =>
+  ({
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer: { setData: vi.fn(), effectAllowed: "", dropEffect: "" },
+  }) as unknown as DragEvent & {
+    preventDefault: ReturnType<typeof vi.fn>;
+    stopPropagation: ReturnType<typeof vi.fn>;
+    dataTransfer: { setData: ReturnType<typeof vi.fn>; effectAllowed: string; dropEffect: string };
+  };
+
+function renderDnd(onMoveEntry = vi.fn()) {
+  const { result } = renderHook(() => useFileTreeDragMove("/root", onMoveEntry));
+  const start = (path: string) => {
+    act(() => {
+      result.current.dragHandlersFor(path).onDragStart(dragEvent());
+    });
+  };
+  const over = (dir: string) => {
+    const event = dragEvent();
+    act(() => {
+      result.current.dropHandlersFor(dir).onDragOver(event);
+    });
+    return event;
+  };
+  const drop = (dir: string) => {
+    act(() => {
+      result.current.dropHandlersFor(dir).onDrop(dragEvent());
+    });
+  };
+  return { result, onMoveEntry, start, over, drop };
+}
+
+describe("useFileTreeDragMove", () => {
+  it("marks rows draggable and sets a drag payload (WebKit needs one)", () => {
+    const { result } = renderDnd();
+    const handlers = result.current.dragHandlersFor("/root/a.md");
+    expect(handlers.draggable).toBe(true);
+    const event = dragEvent();
+    act(() => {
+      handlers.onDragStart(event);
+    });
+    expect(event.dataTransfer.effectAllowed).toBe("move");
+    expect(event.dataTransfer.setData).toHaveBeenCalledWith("text/plain", "/root/a.md");
+  });
+
+  it("accepts a valid folder target: preventDefault, move cursor, highlight", () => {
+    const { result, start, over } = renderDnd();
+    start("/root/a.md");
+    const event = over("/root/sub");
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.dataTransfer.dropEffect).toBe("move");
+    expect(result.current.dropTarget).toBe("/root/sub");
+  });
+
+  it("rejects the dragged entry itself, its descendants, and its current parent", () => {
+    const { result, start, over } = renderDnd();
+    start("/root/sub");
+    for (const dir of ["/root/sub", "/root/sub/nested", "/root"]) {
+      const event = over(dir);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(result.current.dropTarget).toBeNull();
+    }
+  });
+
+  it("rejects every target while no drag is in progress", () => {
+    const { result, over } = renderDnd();
+    const event = over("/root/sub");
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(result.current.dropTarget).toBeNull();
+  });
+
+  it("commits a valid drop through onMoveEntry exactly once and resets", () => {
+    const { result, onMoveEntry, start, over, drop } = renderDnd();
+    start("/root/a.md");
+    over("/root/sub");
+    drop("/root/sub");
+    expect(onMoveEntry).toHaveBeenCalledTimes(1);
+    expect(onMoveEntry).toHaveBeenCalledWith("/root/a.md", "/root/sub");
+    expect(result.current.dropTarget).toBeNull();
+    // The drag is consumed: a second drop is inert.
+    drop("/root/sub");
+    expect(onMoveEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-validates on drop and refuses an invalid target", () => {
+    const { onMoveEntry, start, drop } = renderDnd();
+    start("/root/sub");
+    drop("/root/sub/nested");
+    expect(onMoveEntry).not.toHaveBeenCalled();
+  });
+
+  it("clears the drag and the highlight on dragend", () => {
+    const { result, onMoveEntry, start, over, drop } = renderDnd();
+    start("/root/a.md");
+    over("/root/sub");
+    act(() => {
+      result.current.dragHandlersFor("/root/a.md").onDragEnd();
+    });
+    expect(result.current.dropTarget).toBeNull();
+    drop("/root/sub");
+    expect(onMoveEntry).not.toHaveBeenCalled();
+  });
+
+  it("clears the highlight on dragleave only for the hovered target", () => {
+    const { result, start, over } = renderDnd();
+    start("/root/a.md");
+    over("/root/sub");
+    act(() => {
+      result.current.dropHandlersFor("/root/other").onDragLeave();
+    });
+    expect(result.current.dropTarget).toBe("/root/sub");
+    act(() => {
+      result.current.dropHandlersFor("/root/sub").onDragLeave();
+    });
+    expect(result.current.dropTarget).toBeNull();
+  });
+
+  it("blockDropHandlers swallows dragover without marking a target", () => {
+    const event = dragEvent();
+    blockDropHandlers.onDragOver(event);
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useFileTreeDragMove.test.ts
+++ b/src/hooks/useFileTreeDragMove.test.ts
@@ -15,7 +15,6 @@ function zoneEl(attrs: Record<string, string>): HTMLElement {
 }
 
 const folderZone = (dir: string) => zoneEl({ "data-tree-drop-dir": dir });
-const fileBlock = () => zoneEl({ "data-tree-drop-block": "" });
 
 const downEvent = (overrides: Partial<ReactPointerEvent> = {}) =>
   ({
@@ -81,11 +80,16 @@ describe("useFileTreeDragMove", () => {
     moveTo();
     expect(result.current.dropTarget).toBe("/root/sub");
     expect(document.body.style.userSelect).toBe("none");
+    expect(document.body.style.cursor).toBe("grabbing");
+    const ghost = document.querySelector("[data-tree-drag-ghost]");
+    expect(ghost?.textContent).toBe("a.md");
+    expect((ghost as HTMLElement).style.pointerEvents).toBe("none");
     release();
     expect(onMoveEntry).toHaveBeenCalledTimes(1);
     expect(onMoveEntry).toHaveBeenCalledWith("/root/a.md", "/root/sub");
     expect(result.current.dropTarget).toBeNull();
     expect(document.body.style.userSelect).toBe("");
+    expect(document.querySelector("[data-tree-drag-ghost]")).toBeNull();
   });
 
   it("suppresses exactly one click after a completed drag", () => {
@@ -121,9 +125,9 @@ describe("useFileTreeDragMove", () => {
     }
   });
 
-  it("treats file rows as dead zones via the block marker", () => {
+  it("resolves unmarked elements (document area, panels) to no target", () => {
     const { result, onMoveEntry, press, moveTo, release } = renderDnd();
-    setHit(fileBlock());
+    setHit(zoneEl({}));
     press("/root/sub/deep.md");
     moveTo();
     expect(result.current.dropTarget).toBeNull();
@@ -169,6 +173,7 @@ describe("useFileTreeDragMove", () => {
       window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     });
     expect(result.current.dropTarget).toBeNull();
+    expect(document.querySelector("[data-tree-drag-ghost]")).toBeNull();
     release();
     expect(onMoveEntry).not.toHaveBeenCalled();
   });
@@ -206,12 +211,15 @@ describe("useFileTreeDragMove", () => {
     expect(onMoveEntry).not.toHaveBeenCalled();
   });
 
-  it("detaches its window listeners on unmount mid-drag", () => {
+  it("detaches its window listeners and drops the ghost on unmount mid-drag", () => {
     const removeSpy = vi.spyOn(window, "removeEventListener");
-    const { press, unmount } = renderDnd();
+    const { press, moveTo, unmount } = renderDnd();
     setHit(folderZone("/root/sub"));
     press("/root/a.md");
+    moveTo();
+    expect(document.querySelector("[data-tree-drag-ghost]")).not.toBeNull();
     unmount();
+    expect(document.querySelector("[data-tree-drag-ghost]")).toBeNull();
     const removed = removeSpy.mock.calls.map(([type]) => type);
     expect(removed).toContain("pointermove");
     expect(removed).toContain("pointerup");

--- a/src/hooks/useFileTreeDragMove.test.ts
+++ b/src/hooks/useFileTreeDragMove.test.ts
@@ -75,6 +75,9 @@ describe("useFileTreeDragMove", () => {
     expect(event.preventDefault).toHaveBeenCalled();
     expect(event.dataTransfer.dropEffect).toBe("move");
     expect(result.current.dropTarget).toBe("/root/sub");
+    // dragover fires on every pointer move; the target stays stable.
+    over("/root/sub");
+    expect(result.current.dropTarget).toBe("/root/sub");
   });
 
   it("rejects the dragged entry itself, its descendants, and its current parent", () => {

--- a/src/hooks/useFileTreeDragMove.ts
+++ b/src/hooks/useFileTreeDragMove.ts
@@ -1,6 +1,12 @@
 import type { DragEvent } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { isPathInside, parentDir } from "@/lib/paths";
+
+/** Payload type marking an in-tree drag, so foreign HTML5 drags (links or
+ *  images dragged out of the rendered document) can never match a drop. */
+export const TREE_DRAG_TYPE = "application/x-glyph-tree-path";
+
+const isTreeDrag = (event: DragEvent) => event.dataTransfer.types.includes(TREE_DRAG_TYPE);
 
 /** Drag-source handlers for any tree row. */
 export interface TreeDragHandlers {
@@ -12,7 +18,7 @@ export interface TreeDragHandlers {
 /** Drop-target handlers for a folder row or the root area. */
 export interface TreeDropHandlers {
   onDragOver: (event: DragEvent) => void;
-  onDragLeave: () => void;
+  onDragLeave: (event: DragEvent) => void;
   onDrop: (event: DragEvent) => void;
 }
 
@@ -42,6 +48,19 @@ export function useFileTreeDragMove(
   const dragged = useRef<string | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null);
 
+  const reset = useCallback(() => {
+    dragged.current = null;
+    setDropTarget(null);
+  }, []);
+
+  useEffect(
+    () => () => {
+      window.removeEventListener("dragend", reset);
+      window.removeEventListener("drop", reset);
+    },
+    [reset],
+  );
+
   // A drop into `dir` is rejected when it targets the dragged entry itself or
   // anywhere inside it, or the directory the entry already lives in (a no-op).
   const canDrop = useCallback(
@@ -59,15 +78,19 @@ export function useFileTreeDragMove(
       onDragStart: (event) => {
         dragged.current = path;
         event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.setData(TREE_DRAG_TYPE, path);
         // WebKit refuses to start a drag with an empty payload.
         event.dataTransfer.setData("text/plain", path);
+        // Chromium skips dragend when the drag source unmounts mid-drag (a
+        // watcher refresh can delete the dragged row); window-level fallbacks
+        // still reset then. Bubble phase, so row handlers run first; the
+        // stable `reset` identity dedupes repeated registration.
+        window.addEventListener("dragend", reset, { once: true });
+        window.addEventListener("drop", reset, { once: true });
       },
-      onDragEnd: () => {
-        dragged.current = null;
-        setDropTarget(null);
-      },
+      onDragEnd: reset,
     }),
-    [],
+    [reset],
   );
 
   const dropHandlersFor = useCallback(
@@ -75,7 +98,7 @@ export function useFileTreeDragMove(
       onDragOver: (event) => {
         // Rows sit inside the root drop zone; only the innermost target counts.
         event.stopPropagation();
-        if (!canDrop(dir)) return;
+        if (!isTreeDrag(event) || !canDrop(dir)) return;
         // preventDefault marks a valid target; without it drop never fires.
         event.preventDefault();
         event.dataTransfer.dropEffect = "move";
@@ -83,14 +106,17 @@ export function useFileTreeDragMove(
         // target is unchanged so React can bail out of re-rendering.
         setDropTarget((prev) => (prev === dir ? prev : dir));
       },
-      onDragLeave: () => {
+      onDragLeave: (event) => {
+        // Entering the row's own icon/label children fires dragleave too;
+        // only a genuine exit clears the highlight.
+        if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
         setDropTarget((prev) => (prev === dir ? null : prev));
       },
       onDrop: (event) => {
         event.preventDefault();
         event.stopPropagation();
         const from = dragged.current;
-        const valid = canDrop(dir);
+        const valid = isTreeDrag(event) && canDrop(dir);
         dragged.current = null;
         setDropTarget(null);
         if (from && valid) onMoveEntry(from, dir);

--- a/src/hooks/useFileTreeDragMove.ts
+++ b/src/hooks/useFileTreeDragMove.ts
@@ -1,0 +1,103 @@
+import type { DragEvent } from "react";
+import { useCallback, useRef, useState } from "react";
+import { isPathInside, parentDir } from "@/lib/paths";
+
+/** Drag-source handlers for any tree row. */
+export interface TreeDragHandlers {
+  draggable: true;
+  onDragStart: (event: DragEvent) => void;
+  onDragEnd: () => void;
+}
+
+/** Drop-target handlers for a folder row or the root area. */
+export interface TreeDropHandlers {
+  onDragOver: (event: DragEvent) => void;
+  onDragLeave: () => void;
+  onDrop: (event: DragEvent) => void;
+}
+
+export interface FileTreeDragMove {
+  /** Directory hovered by a valid drag, for the drop-target highlight. */
+  dropTarget: string | null;
+  dragHandlersFor: (path: string) => TreeDragHandlers;
+  dropHandlersFor: (dir: string) => TreeDropHandlers;
+}
+
+/** File rows are not drop targets: swallow dragover so the root area beneath
+ *  doesn't light up while the pointer is over a file. Without preventDefault
+ *  the browser shows "no drop" and never fires drop on the row. */
+export const blockDropHandlers = {
+  onDragOver: (event: DragEvent) => event.stopPropagation(),
+};
+
+// Native HTML5 drag-and-drop for moving tree entries into folders, following
+// the useTabDragReorder pattern: no dependency, works in every WebView. The
+// dragged path lives in a ref (only the highlighted target needs renders) and
+// the move commits through `onMoveEntry(from, toDir)` on drop. The backend
+// re-validates every move; the rules here only shape the drag affordance.
+export function useFileTreeDragMove(
+  root: string,
+  onMoveEntry: (from: string, toDir: string) => void,
+): FileTreeDragMove {
+  const dragged = useRef<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<string | null>(null);
+
+  // A drop into `dir` is rejected when it targets the dragged entry itself or
+  // anywhere inside it, or the directory the entry already lives in (a no-op).
+  const canDrop = useCallback(
+    (dir: string) => {
+      const from = dragged.current;
+      if (!from || isPathInside(dir, from)) return false;
+      return parentDir(from, root) !== dir;
+    },
+    [root],
+  );
+
+  const dragHandlersFor = useCallback(
+    (path: string): TreeDragHandlers => ({
+      draggable: true,
+      onDragStart: (event) => {
+        dragged.current = path;
+        event.dataTransfer.effectAllowed = "move";
+        // WebKit refuses to start a drag with an empty payload.
+        event.dataTransfer.setData("text/plain", path);
+      },
+      onDragEnd: () => {
+        dragged.current = null;
+        setDropTarget(null);
+      },
+    }),
+    [],
+  );
+
+  const dropHandlersFor = useCallback(
+    (dir: string): TreeDropHandlers => ({
+      onDragOver: (event) => {
+        // Rows sit inside the root drop zone; only the innermost target counts.
+        event.stopPropagation();
+        if (!canDrop(dir)) return;
+        // preventDefault marks a valid target; without it drop never fires.
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+        // dragover fires on every pointer move; keep the same value while the
+        // target is unchanged so React can bail out of re-rendering.
+        setDropTarget((prev) => (prev === dir ? prev : dir));
+      },
+      onDragLeave: () => {
+        setDropTarget((prev) => (prev === dir ? null : prev));
+      },
+      onDrop: (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const from = dragged.current;
+        const valid = canDrop(dir);
+        dragged.current = null;
+        setDropTarget(null);
+        if (from && valid) onMoveEntry(from, dir);
+      },
+    }),
+    [canDrop, onMoveEntry],
+  );
+
+  return { dropTarget, dragHandlersFor, dropHandlersFor };
+}

--- a/src/hooks/useFileTreeDragMove.ts
+++ b/src/hooks/useFileTreeDragMove.ts
@@ -1,129 +1,149 @@
-import type { DragEvent } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { isPathInside, parentDir } from "@/lib/paths";
 
-/** Payload type marking an in-tree drag, so foreign HTML5 drags (links or
- *  images dragged out of the rendered document) can never match a drop. */
-export const TREE_DRAG_TYPE = "application/x-glyph-tree-path";
-
-const isTreeDrag = (event: DragEvent) => event.dataTransfer.types.includes(TREE_DRAG_TYPE);
+/** Pointer movement (px) before a press becomes a drag instead of a click. */
+const DRAG_THRESHOLD_PX = 5;
 
 /** Drag-source handlers for any tree row. */
 export interface TreeDragHandlers {
-  draggable: true;
-  onDragStart: (event: DragEvent) => void;
-  onDragEnd: () => void;
-}
-
-/** Drop-target handlers for a folder row or the root area. */
-export interface TreeDropHandlers {
-  onDragOver: (event: DragEvent) => void;
-  onDragLeave: (event: DragEvent) => void;
-  onDrop: (event: DragEvent) => void;
+  onPointerDown: (event: ReactPointerEvent) => void;
+  onClickCapture: (event: ReactPointerEvent | React.MouseEvent) => void;
 }
 
 export interface FileTreeDragMove {
   /** Directory hovered by a valid drag, for the drop-target highlight. */
   dropTarget: string | null;
   dragHandlersFor: (path: string) => TreeDragHandlers;
-  dropHandlersFor: (dir: string) => TreeDropHandlers;
 }
 
-/** File rows are not drop targets: swallow dragover so the root area beneath
- *  doesn't light up while the pointer is over a file. Without preventDefault
- *  the browser shows "no drop" and never fires drop on the row. */
-export const blockDropHandlers = {
-  onDragOver: (event: DragEvent) => event.stopPropagation(),
-};
+/** Resolve the drop directory under the pointer: the nearest marked ancestor
+ *  of the hit element. File rows carry the block marker so hovering them never
+ *  falls through to the root zone, and the root zone itself only counts when
+ *  the pointer is over genuinely empty space (not the gaps between rows). */
+function dropDirAt(x: number, y: number): string | null {
+  const hit = document.elementFromPoint(x, y);
+  if (!hit) return null;
+  const zone = hit.closest<HTMLElement>("[data-tree-drop-dir], [data-tree-drop-block]");
+  if (!zone || zone.hasAttribute("data-tree-drop-block")) return null;
+  if (zone.hasAttribute("data-filetree-root") && hit !== zone) return null;
+  return zone.getAttribute("data-tree-drop-dir");
+}
 
-// Native HTML5 drag-and-drop for moving tree entries into folders, following
-// the useTabDragReorder pattern: no dependency, works in every WebView. The
-// dragged path lives in a ref (only the highlighted target needs renders) and
-// the move commits through `onMoveEntry(from, toDir)` on drop. The backend
+// Pointer-event drag-and-drop for moving tree entries into folders. HTML5
+// drag events are NOT used on purpose: Tauri's native drag-drop handler owns
+// the OS drag loop (for dropping external files onto the window), and on
+// Windows that swallows every in-page dragover/drop, so the HTML5 API can
+// never work there. Pointer events stay inside the page. A press only becomes
+// a drag past a small movement threshold, so row clicks keep working; targets
+// are hit-tested via elementFromPoint against data-tree-drop-* markers; the
+// move commits through `onMoveEntry(from, toDir)` on release. The backend
 // re-validates every move; the rules here only shape the drag affordance.
 export function useFileTreeDragMove(
   root: string,
   onMoveEntry: (from: string, toDir: string) => void,
 ): FileTreeDragMove {
-  const dragged = useRef<string | null>(null);
-  const [dropTarget, setDropTarget] = useState<string | null>(null);
-
-  const reset = useCallback(() => {
-    dragged.current = null;
-    setDropTarget(null);
-  }, []);
-
-  useEffect(
-    () => () => {
-      window.removeEventListener("dragend", reset);
-      window.removeEventListener("drop", reset);
-    },
-    [reset],
+  const drag = useRef<{ path: string; startX: number; startY: number; active: boolean } | null>(
+    null,
   );
+  const suppressClick = useRef(false);
+  const [dropTarget, setDropTarget] = useState<string | null>(null);
 
   // A drop into `dir` is rejected when it targets the dragged entry itself or
   // anywhere inside it, or the directory the entry already lives in (a no-op).
   const canDrop = useCallback(
-    (dir: string) => {
-      const from = dragged.current;
-      if (!from || isPathInside(dir, from)) return false;
+    (dir: string, from: string) => {
+      if (isPathInside(dir, from)) return false;
       return parentDir(from, root) !== dir;
     },
     [root],
   );
 
-  const dragHandlersFor = useCallback(
-    (path: string): TreeDragHandlers => ({
-      draggable: true,
-      onDragStart: (event) => {
-        dragged.current = path;
-        event.dataTransfer.effectAllowed = "move";
-        event.dataTransfer.setData(TREE_DRAG_TYPE, path);
-        // WebKit refuses to start a drag with an empty payload.
-        event.dataTransfer.setData("text/plain", path);
-        // Chromium skips dragend when the drag source unmounts mid-drag (a
-        // watcher refresh can delete the dragged row); window-level fallbacks
-        // still reset then. Bubble phase, so row handlers run first; the
-        // stable `reset` identity dedupes repeated registration.
-        window.addEventListener("dragend", reset, { once: true });
-        window.addEventListener("drop", reset, { once: true });
-      },
-      onDragEnd: reset,
-    }),
-    [reset],
-  );
-
-  const dropHandlersFor = useCallback(
-    (dir: string): TreeDropHandlers => ({
-      onDragOver: (event) => {
-        // Rows sit inside the root drop zone; only the innermost target counts.
-        event.stopPropagation();
-        if (!isTreeDrag(event) || !canDrop(dir)) return;
-        // preventDefault marks a valid target; without it drop never fires.
-        event.preventDefault();
-        event.dataTransfer.dropEffect = "move";
-        // dragover fires on every pointer move; keep the same value while the
-        // target is unchanged so React can bail out of re-rendering.
-        setDropTarget((prev) => (prev === dir ? prev : dir));
-      },
-      onDragLeave: (event) => {
-        // Entering the row's own icon/label children fires dragleave too;
-        // only a genuine exit clears the highlight.
-        if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
-        setDropTarget((prev) => (prev === dir ? null : prev));
-      },
-      onDrop: (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        const from = dragged.current;
-        const valid = isTreeDrag(event) && canDrop(dir);
-        dragged.current = null;
-        setDropTarget(null);
-        if (from && valid) onMoveEntry(from, dir);
-      },
-    }),
+  const finishDrag = useCallback(
+    (commitAt?: { x: number; y: number }) => {
+      const dragged = drag.current;
+      if (!dragged) return;
+      drag.current = null;
+      setDropTarget(null);
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      if (!dragged.active) return;
+      // The click synthesized after a completed drag must not open/toggle.
+      suppressClick.current = true;
+      if (!commitAt) return;
+      const dir = dropDirAt(commitAt.x, commitAt.y);
+      if (dir !== null && canDrop(dir, dragged.path)) onMoveEntry(dragged.path, dir);
+    },
     [canDrop, onMoveEntry],
   );
 
-  return { dropTarget, dragHandlersFor, dropHandlersFor };
+  const handleWindowPointerMove = useCallback(
+    (event: PointerEvent) => {
+      const dragged = drag.current;
+      if (!dragged) return;
+      if (!dragged.active) {
+        const moved =
+          Math.abs(event.clientX - dragged.startX) + Math.abs(event.clientY - dragged.startY);
+        if (moved < DRAG_THRESHOLD_PX) return;
+        dragged.active = true;
+        // No text selection while dragging; the cursor signals the mode.
+        document.body.style.userSelect = "none";
+      }
+      const dir = dropDirAt(event.clientX, event.clientY);
+      const valid = dir !== null && canDrop(dir, dragged.path);
+      document.body.style.cursor = valid ? "" : "no-drop";
+      const next = valid ? dir : null;
+      setDropTarget((prev) => (prev === next ? prev : next));
+    },
+    [canDrop],
+  );
+
+  const handleWindowPointerUp = useCallback(
+    (event: PointerEvent) => {
+      finishDrag({ x: event.clientX, y: event.clientY });
+    },
+    [finishDrag],
+  );
+
+  const handleWindowKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") finishDrag();
+    },
+    [finishDrag],
+  );
+
+  // Mount-lifetime listeners: every handler early-returns while no drag is in
+  // progress, which is cheaper and simpler than attach-on-press bookkeeping.
+  useEffect(() => {
+    window.addEventListener("pointermove", handleWindowPointerMove);
+    window.addEventListener("pointerup", handleWindowPointerUp);
+    window.addEventListener("keydown", handleWindowKeyDown);
+    return () => {
+      window.removeEventListener("pointermove", handleWindowPointerMove);
+      window.removeEventListener("pointerup", handleWindowPointerUp);
+      window.removeEventListener("keydown", handleWindowKeyDown);
+    };
+  }, [handleWindowPointerMove, handleWindowPointerUp, handleWindowKeyDown]);
+
+  const dragHandlersFor = useCallback(
+    (path: string): TreeDragHandlers => ({
+      onPointerDown: (event) => {
+        // Touch keeps scrolling the tree; mobile moves files via the menu.
+        if (event.button !== 0 || event.pointerType === "touch") return;
+        // A drag that ended off-row leaves the flag set with no click to eat;
+        // a new press starts a fresh interaction.
+        suppressClick.current = false;
+        drag.current = { path, startX: event.clientX, startY: event.clientY, active: false };
+      },
+      onClickCapture: (event) => {
+        if (!suppressClick.current) return;
+        suppressClick.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+      },
+    }),
+    [],
+  );
+
+  return { dropTarget, dragHandlersFor };
 }

--- a/src/hooks/useFileTreeDragMove.ts
+++ b/src/hooks/useFileTreeDragMove.ts
@@ -1,6 +1,6 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { isPathInside, parentDir } from "@/lib/paths";
+import { basename, isPathInside, parentDir } from "@/lib/paths";
 
 /** Pointer movement (px) before a press becomes a drag instead of a click. */
 const DRAG_THRESHOLD_PX = 5;
@@ -18,14 +18,15 @@ export interface FileTreeDragMove {
 }
 
 /** Resolve the drop directory under the pointer: the nearest marked ancestor
- *  of the hit element. File rows carry the block marker so hovering them never
- *  falls through to the root zone, and the root zone itself only counts when
- *  the pointer is over genuinely empty space (not the gaps between rows). */
+ *  of the hit element. Folder rows target themselves and file rows their
+ *  containing folder (so most of the tree is a live target, as in comparable
+ *  editors); the root zone only counts when the pointer is over genuinely
+ *  empty space, not the gaps between rows. */
 function dropDirAt(x: number, y: number): string | null {
   const hit = document.elementFromPoint(x, y);
   if (!hit) return null;
-  const zone = hit.closest<HTMLElement>("[data-tree-drop-dir], [data-tree-drop-block]");
-  if (!zone || zone.hasAttribute("data-tree-drop-block")) return null;
+  const zone = hit.closest<HTMLElement>("[data-tree-drop-dir]");
+  if (!zone) return null;
   if (zone.hasAttribute("data-filetree-root") && hit !== zone) return null;
   return zone.getAttribute("data-tree-drop-dir");
 }
@@ -47,6 +48,7 @@ export function useFileTreeDragMove(
     null,
   );
   const suppressClick = useRef(false);
+  const ghost = useRef<HTMLDivElement | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null);
 
   // A drop into `dir` is rejected when it targets the dragged entry itself or
@@ -65,6 +67,8 @@ export function useFileTreeDragMove(
       if (!dragged) return;
       drag.current = null;
       setDropTarget(null);
+      ghost.current?.remove();
+      ghost.current = null;
       document.body.style.userSelect = "";
       document.body.style.cursor = "";
       if (!dragged.active) return;
@@ -88,10 +92,28 @@ export function useFileTreeDragMove(
         dragged.active = true;
         // No text selection while dragging; the cursor signals the mode.
         document.body.style.userSelect = "none";
+        // The floating name pill is the drag feedback (there is no native
+        // ghost image without the HTML5 drag API). pointer-events:none keeps
+        // it invisible to the elementFromPoint hit-testing underneath it.
+        const pill = document.createElement("div");
+        pill.dataset.treeDragGhost = "";
+        pill.style.cssText =
+          "position:fixed;left:0;top:0;z-index:9999;pointer-events:none;" +
+          "padding:2px 8px;border-radius:var(--glyph-radius-sm);font-size:12px;" +
+          "background:var(--color-surface);border:1px solid var(--color-accent);" +
+          "color:var(--color-text-primary);box-shadow:0 2px 8px rgb(0 0 0 / 0.25);" +
+          "max-width:240px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap";
+        pill.textContent = basename(dragged.path);
+        document.body.appendChild(pill);
+        ghost.current = pill;
       }
       const dir = dropDirAt(event.clientX, event.clientY);
       const valid = dir !== null && canDrop(dir, dragged.path);
-      document.body.style.cursor = valid ? "" : "no-drop";
+      ghost.current?.style.setProperty(
+        "transform",
+        `translate(${event.clientX + 14}px, ${event.clientY + 10}px)`,
+      );
+      document.body.style.cursor = valid ? "grabbing" : "no-drop";
       const next = valid ? dir : null;
       setDropTarget((prev) => (prev === next ? prev : next));
     },
@@ -122,6 +144,8 @@ export function useFileTreeDragMove(
       window.removeEventListener("pointermove", handleWindowPointerMove);
       window.removeEventListener("pointerup", handleWindowPointerUp);
       window.removeEventListener("keydown", handleWindowKeyDown);
+      ghost.current?.remove();
+      ghost.current = null;
     };
   }, [handleWindowPointerMove, handleWindowPointerUp, handleWindowKeyDown]);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,6 +95,9 @@ export default defineConfig(async ({ mode }) => ({
         path.resolve(__dirname, "src-tauri/**"),
         path.resolve(__dirname, "samples/**"),
         path.resolve(__dirname, "dist/**"),
+        // A coverage run writes thousands of HTML reports; watching them
+        // reload-storms the dev webview mid-session.
+        path.resolve(__dirname, "coverage/**"),
         path.resolve(__dirname, ".github/**"),
         path.resolve(__dirname, ".claude/**"),
         path.resolve(__dirname, "docs/**"),


### PR DESCRIPTION
## Summary

Notes and folders can be moved by dragging a file-tree row onto a folder row, onto a file row (which targets that file's containing folder), or onto the empty area below the tree (workspace root). The backend half shipped earlier with the file-tree menu work (`move_path`, listing refresh, tab and watcher re-pointing), so this is frontend-only.

The drag is **pointer-event driven, not HTML5 drag-and-drop**, and that is load-bearing: Tauri's native drag-drop handler stays enabled so dropping an external OS file onto the window keeps opening it, and on Windows that handler owns the WebView2 drag loop and swallows every in-page HTML5 dragover/drop. The HTML5 API can never work there (tab reorder has the same latent bug, tracked in #693). A press becomes a drag past a small movement threshold so row clicks keep working; targets are hit-tested under the pointer against `data-tree-drop-dir` markers; Escape cancels; the click synthesized after a completed drag is swallowed exactly once.

Closes #279

## Changes

- New `src/hooks/useFileTreeDragMove.ts`: dragged path in a ref, hovered target in state, mount-lifetime window listeners for move/up/Escape. Drop validity mirrors the backend rules (rejects the entry itself, its descendants, and its current parent), and the backend re-validates everything independently.
- Drag feedback: a floating pill with the dragged file's name follows the cursor (`pointer-events: none`, so hit-testing sees through it), the cursor shows `grabbing` over valid targets and `no-drop` over invalid ones, the hovered folder row carries a ring highlight, and the tree container tints when the drop would land at the workspace root.
- Targets: folder rows accept for themselves, file rows for their containing folder (as in comparable editors), the empty container area for the root. Gaps between rows are not the root zone, and sibling drops in the same folder stay refused as no-ops.
- `FilesPanel` passes the existing `movePath` down; the context-menu "Move to" picker is unchanged and remains the keyboard, touch, and mobile path.
- Dev-environment fix that surfaced during testing: the vite dev server no longer watches `coverage/`, whose thousands of report files used to reload-storm the dev webview.
- Tests: 13 hook unit tests and 12 `FileTree` integration tests covering the validity rules, threshold, click preservation and one-shot suppression, ghost lifecycle, Escape, root-zone guards, and unmount cleanup.

## Risk classification

- [ ] Persistence / data loss
- [x] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [x] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

- **INV-5 / INV-6 (untrusted input, backend boundary):** the source path comes only from the ref set by an in-tree press, and the destination only from `data-tree-drop-dir` attributes populated from backend listings or the workspace root. No drag payload is ever read. The backend `move_path` canonicalizes and re-validates both ends (existing `create.rs` tests: relocation, collision dedupe, self/descendant refusal, escape refusal).
- **INV-3 (stale results never win):** drop re-validates position and rules at release instead of trusting the last hover ("re-validates on drop and refuses an invalid target"); stray pointer and key events with no drag in progress are ignored; a consumed drag cannot double-commit ("commits ... exactly once and resets").
- Adversarial matrix rows covered by dedicated tests: self-drop, descendant drop, current-parent and sibling no-ops, sub-threshold movement, Escape mid-drag, stray events, hit-test miss, and unmount mid-drag (listeners and ghost torn down).

## Testing

- Full gates green locally: typecheck, Biome, 3736 frontend tests, `cargo test --lib` (471), clippy with `-D warnings`. `pnpm test:coverage`: zero uncovered lines or branches in every touched file.
- **Manually verified on Windows** against the real WebView2 build: drags commit into folder rows, file rows, and the root area; no-op and invalid targets refuse with the `no-drop` cursor; clicks and the post-drag click suppression behave. This testing is also what caught the original HTML5 dead end and the missing drag feedback.
- Not yet manually verified on macOS/Linux; pointer events avoid the engine-specific drag machinery, so the Windows-only risk from the HTML5 approach is gone.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

The dragged file's name follows the cursor as a small pill; the hovered folder row carries an accent ring; the tree container tints when the drop would land at the workspace root.
