### PR TITLE
fix(ci): raise the mermaid bundle budget for 11.17.2

### DIFF
--- a/bundle-budgets.json
+++ b/bundle-budgets.json
@@ -5,7 +5,7 @@
     "d2": { "prefix": "d2-", "budgetGzip": 6450000 },
     "pdfEngine": { "prefix": "pdfEngine-", "budgetGzip": 910000 },
     "MarkdownEditor": { "prefix": "MarkdownEditor-", "budgetGzip": 297000 },
-    "mermaid": { "prefix": "mermaid.core-", "budgetGzip": 150000 },
+    "mermaid": { "prefix": "mermaid.core-", "budgetGzip": 172000 },
     "cytoscape": { "prefix": "cytoscape.esm-", "budgetGzip": 156000 },
     "docx": { "prefix": "docx-", "budgetGzip": 116000 },
     "katex": { "prefix": "katex-", "budgetGzip": 93000 },


### PR DESCRIPTION
## Summary

Raises the mermaid chunk's gzip budget from 150,000 to 172,000 bytes. The dependabot bump to mermaid 11.17.2 (#683) grew `mermaid.core` to 152.4 kB gzip, past the 146.5 kB budget, so the `Build / ubuntu-22.04` leg now fails on `main` and on every open PR's merge build. The budget update that should have accompanied the version bump lands here: measured size plus the usual roughly 10 percent headroom, per docs/bundle-budgets.md.

## Changes

- `bundle-budgets.json`: `mermaid.budgetGzip` 150000 to 172000.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [x] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

No engineering invariants involved; this acknowledges an already-shipped dependency's size in the CI budget. The chunk stays lazy-loaded, so startup cost is unchanged; first-use cost of mermaid rendering grows by the 5.9 kB the 11.17.2 bump added.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated only: the pre-commit gate (typecheck, Biome, full frontend suite, cargo test, clippy) ran green; the budget itself is verified by the `Build / ubuntu-22.04` check on this PR.

## Screenshots

Not applicable.
