### PR TITLE
ci: drop the Homebrew Linux sandbox opt-out in the smoke test

### DIFF
--- a/.github/workflows/release-smoke-test.yml
+++ b/.github/workflows/release-smoke-test.yml
@@ -139,13 +139,6 @@ jobs:
         id: check
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
-          # The formula ships no bottle, so it stages through Mktemp, which
-          # chowns the staging dir to brew's group. On the runner that group is
-          # "docker", a supplementary group of "runner"; Homebrew's Linux bwrap
-          # sandbox maps only the primary gid, so the chown fails with EINVAL
-          # (not the EPERM Mktemp rescues) and the install dies. This is the
-          # documented opt-out and only turns off build-time isolation.
-          HOMEBREW_NO_SANDBOX_LINUX: 1
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           brew tap glyph-md/tap


### PR DESCRIPTION
## Summary

The homebrew-formula smoke-test job set `HOMEBREW_NO_SANDBOX_LINUX: 1`, which made every run emit a `Sandbox unavailable: building without sandboxing!` warning annotation. The opt-out existed to dodge a bwrap-era bug: Mktemp chowns the staging dir to the group of the brew binary (`docker` on the runner), and bwrap's user namespace only mapped the primary gid, so the chown died with EINVAL. Homebrew 6.0 replaced the bwrap sandbox with Landlock, which runs without a user namespace, so that chown succeeds and the opt-out now only disables a working sandbox and produces the warning.

## Changes

- Remove `HOMEBREW_NO_SANDBOX_LINUX: 1` and its stale bwrap comment from the homebrew-formula job in `release-smoke-test.yml`; the install now runs under Homebrew's Landlock sandbox.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

CI-only change to the release smoke test; no app code touched.

## Testing

- Dispatched the smoke test from this branch for v0.22.0: https://github.com/hamidfzm/glyph/actions/runs/33338817784. All 15 jobs passed, homebrew-formula installed the formula sandboxed, and the run produced zero warning annotations.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable.