### PR TITLE
fix(telemetry): stop the opener and scroll-sync crashes, and report the OS on every event

### DIFF
--- a/src/components/canvas/CanvasNodeView.test.tsx
+++ b/src/components/canvas/CanvasNodeView.test.tsx
@@ -5,7 +5,7 @@ import type { CanvasNode } from "@/lib/canvas/types";
 import { renderInWorkspace } from "@/test/renderInWorkspace";
 import { CanvasNodeView } from "./CanvasNodeView";
 
-vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn(() => Promise.resolve()) }));
 
 vi.mock("@tauri-apps/api/core", () => ({
   convertFileSrc: (path: string) => `asset://${path}`,

--- a/src/components/canvas/CanvasNodeView.tsx
+++ b/src/components/canvas/CanvasNodeView.tsx
@@ -84,7 +84,10 @@ export function CanvasNodeView({
         <button
           type="button"
           className="glyph-canvas-node-link"
-          onClick={() => void openUrl(node.url)}
+          // A board's link node carries whatever URL the document author wrote,
+          // so the opener plugin's scope can refuse it. Swallowed rather than
+          // left to escape as an unhandled rejection, which is reported as a crash.
+          onClick={() => void openUrl(node.url).catch(() => undefined)}
           title={node.url}
         >
           {label}

--- a/src/components/markdown/LinkComponent.test.tsx
+++ b/src/components/markdown/LinkComponent.test.tsx
@@ -184,6 +184,26 @@ describe("LinkComponent relative file links", () => {
     expect(openUrl).toHaveBeenCalledWith("./sibling.md");
   });
 
+  it("swallows an opener rejection instead of leaving it unhandled", async () => {
+    // The opener plugin refuses targets outside its scope (a relative link to a
+    // folder, say). React drops the handler's promise, so an escaping rejection
+    // would be reported as a crash.
+    vi.mocked(openUrl).mockRejectedValueOnce(new Error("Not allowed to open url notes/videos"));
+    const { container } = renderLink({ href: "notes/videos" }, NO_CONFIRM);
+
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    fireEvent.click(container.querySelector("a") as HTMLAnchorElement);
+    // Two macrotasks: one for the handler to settle, one for Node to decide the
+    // rejection went unhandled.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    process.off("unhandledRejection", unhandled);
+
+    expect(openUrl).toHaveBeenCalledWith("notes/videos");
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
   it("does not intercept an external URL that happens to end in .md", () => {
     vi.mocked(openUrl).mockClear();
     const onOpen = vi.fn();

--- a/src/components/markdown/LinkComponent.tsx
+++ b/src/components/markdown/LinkComponent.tsx
@@ -77,7 +77,15 @@ export function LinkComponent(props: LinkComponentProps) {
         if (!confirmed) return;
       }
 
-      await openUrl(href);
+      // The opener plugin rejects targets its scope refuses, which a relative
+      // link to something that is not an openable document (a bare folder, an
+      // extensionless file) hits. There is nothing to recover, and React drops
+      // this handler's promise, so the rejection would surface as a crash.
+      try {
+        await openUrl(href);
+      } catch {
+        // Nothing opened; the click is a no-op.
+      }
     },
     [href, onOpenRelativeFile, settings.behavior.confirmExternalLinks, t],
   );

--- a/src/hooks/useSyncedScroll.test.ts
+++ b/src/hooks/useSyncedScroll.test.ts
@@ -38,7 +38,10 @@ function fakeView(scrollDOM: HTMLElement) {
 /** Anchors at line 1 -> 0px and line 11 -> 500px, so one line is 50 preview px. */
 const ANCHOR_LINES = [1, 11];
 
-function buildSplit({ anchors = ANCHOR_LINES, previewRange = 1000 } = {}) {
+function buildSplit({
+  anchors = ANCHOR_LINES as readonly (number | string)[],
+  previewRange = 1000,
+} = {}) {
   const root = document.createElement("div");
   root.className = "split-view";
   const editorPane = document.createElement("div");
@@ -108,6 +111,19 @@ describe("useSyncedScroll", () => {
     renderHook(() => useSyncedScroll(rootRef, view, true));
 
     scroll(preview, 250);
+
+    expect(editor.scrollTop).toBe(5 * LINE_HEIGHT);
+  });
+
+  it("ignores an anchor whose data-line does not parse", () => {
+    // A plugin rehype plugin runs after the sanitizer and can stamp its own
+    // `data-line`. Kept, its NaN line would reach CodeMirror's `doc.line`.
+    const { rootRef, editor, preview, view } = buildSplit({ anchors: [1, "plugin", 11] });
+    renderHook(() => useSyncedScroll(rootRef, view, true));
+
+    // The surviving anchors are line 1 -> 0px and line 11 -> 1000px, so the
+    // midpoint is line 6.
+    scroll(preview, 500);
 
     expect(editor.scrollTop).toBe(5 * LINE_HEIGHT);
   });

--- a/src/hooks/useSyncedScroll.ts
+++ b/src/hooks/useSyncedScroll.ts
@@ -28,11 +28,14 @@ export function useSyncedScroll(
     // Measuring every anchor costs a layout pass, so the list is built once and
     // rebuilt only when the preview reflows, not on each scroll event.
     let anchors: ScrollAnchor[] = [];
+    // A plugin rehype plugin runs after the sanitizer and can stamp its own
+    // `data-line`, so the value is not guaranteed to parse. A NaN line poisons
+    // every interpolation it touches and reaches CodeMirror's `doc.line`, which
+    // walks past the end of the document rather than throwing a RangeError.
     const measureAnchors = (preview: HTMLElement) => {
-      anchors = [...preview.querySelectorAll<HTMLElement>(ANCHORS)].map((el) => ({
-        line: Number(el.dataset.line),
-        top: el.offsetTop,
-      }));
+      anchors = [...preview.querySelectorAll<HTMLElement>(ANCHORS)]
+        .map((el) => ({ line: Number(el.dataset.line), top: el.offsetTop }))
+        .filter((anchor) => Number.isFinite(anchor.line));
     };
 
     const scrollTo = (pane: HTMLElement, top: number) => {

--- a/src/lib/telemetry.test.ts
+++ b/src/lib/telemetry.test.ts
@@ -17,6 +17,12 @@ vi.mock("@sentry/react", () => ({
   captureException: vi.fn(),
 }));
 
+vi.mock("@tauri-apps/plugin-os", () => ({
+  platform: () => "linux",
+  version: () => "6.1.0",
+  arch: () => "x86_64",
+}));
+
 const mockedInvoke = vi.mocked(invoke);
 const mockedInit = vi.mocked(Sentry.init);
 const mockedGetClient = vi.mocked(Sentry.getClient);
@@ -188,6 +194,17 @@ describe("enableTelemetry", () => {
     expect(options).toMatchObject({ sendDefaultPii: false, tracesSampleRate: 0 });
     expect(options?.beforeSend).toBe(scrubEvent);
     expect(options?.beforeBreadcrumb).toBe(scrubBreadcrumb);
+  });
+
+  it("tags the platform, since the scrubber drops the request that carries it", async () => {
+    vi.stubEnv("PROD", true);
+    await enableTelemetry();
+    const scope = mockedInit.mock.calls[0][0]?.initialScope as {
+      tags: { platform: string; arch: string };
+      contexts: { os: { name: string; version: string } };
+    };
+    expect(scope.tags).toEqual({ platform: "linux", arch: "x86_64" });
+    expect(scope.contexts.os).toEqual({ name: "linux", version: "6.1.0" });
   });
 
   it("does not re-init when a client already exists", async () => {

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,5 +1,7 @@
 import type { Breadcrumb, ErrorEvent } from "@sentry/react";
 import { invoke } from "@tauri-apps/api/core";
+import { arch, version as osVersion } from "@tauri-apps/plugin-os";
+import { currentPlatform } from "@/lib/platform";
 // Single source of truth for the Sentry DSN — `src-tauri/sentry.json`. The Rust
 // build script reads the same file (see build.rs) so the frontend and backend
 // clients always target the same project. DSNs are public client identifiers,
@@ -90,6 +92,28 @@ export function scrubEvent(event: ErrorEvent): ErrorEvent {
   return event;
 }
 
+/**
+ * OS identity attached to every event. `scrubEvent` drops `event.request`, so
+ * Sentry never sees a User-Agent to infer the platform from and an issue would
+ * otherwise carry no clue which OS produced it. The version and architecture
+ * come from the OS plugin, which is absent outside a Tauri webview.
+ */
+function osScope() {
+  const name = currentPlatform();
+  let version = "";
+  let cpu = "";
+  try {
+    version = osVersion();
+    cpu = arch();
+  } catch {
+    // Plain browser or test environment: the platform tag alone still applies.
+  }
+  return {
+    tags: { platform: name, arch: cpu },
+    contexts: { os: { name, version } },
+  };
+}
+
 // Reporting only happens in production builds with a DSN present. Dev builds
 // (`pnpm tauri dev`) never initialize the SDK, so no events are sent locally.
 function reportingAllowed(): boolean {
@@ -141,6 +165,7 @@ export function enableTelemetry(): Promise<void> {
     Sentry.init({
       dsn: SENTRY_DSN,
       release: `glyph@${__APP_VERSION__}`,
+      initialScope: osScope(),
       // Hard privacy posture for a local-first viewer: no PII, no performance
       // tracing, no session replay (replay would record document contents).
       sendDefaultPii: false,


### PR DESCRIPTION
## Summary

Two crash signatures reported by users, plus the reason those reports arrived without any indication of which OS produced them.

Fixes GLYPH-4
Fixes GLYPH-5
Fixes GLYPH-6
Fixes GLYPH-9

- GLYPH-4: https://glyph-md.sentry.io/share/issue/65d244dbc8a24833b2bb11f1d53f6a23/
- GLYPH-5: https://glyph-md.sentry.io/share/issue/978f9f0c41a4488e8f427a983156abbb/
- GLYPH-6: https://glyph-md.sentry.io/share/issue/94485eedae004f9a9d14bebd8acd1a76/
- GLYPH-9: https://glyph-md.sentry.io/share/issue/ef635be0b5e64b19a8f7219947c83c3e/

## Changes

- **GLYPH-4, `UnhandledRejection: Not allowed to open url …`.** `openUrl` rejects when the opener plugin's scope refuses a target. The reported link was a relative path to a folder (`02_…/_Видео/ilyabasmanov-remonttelefonov`), which is neither markdown nor canvas, so `isOpenableRelativeHref` declined it and it fell through to `openUrl`. `LinkComponent`'s click handler is `async` and React discards the promise it returns, so the rejection escaped as an unhandled crash. It is caught now and the click is a no-op.
- **GLYPH-6, the same crash from a relative link to a local image** (`photos/photo_10@24-08-2026_19-01-49_thumb.jpg`). Same path, same fix. A board's link node in `CanvasNodeView` reaches `openUrl` with the same document-authored input through the same uncaught `void openUrl(...)`, so it is hardened alongside.
- **GLYPH-9, the same crash from a relative link to a source file** (`ParmisFramework/…/TypeContainer.cs:28`), reported from v0.21.0 after this PR was opened. Same path, same fix.
- **GLYPH-5, `TypeError: Cannot read properties of undefined (reading 'length')` in `offsetForEditorLine`.** Split-view scroll sync read `data-line` off every preview anchor without checking that it parsed. Plugin rehype plugins run after the sanitizer (`buildRehypePlugins`) and can stamp their own `data-line`, so the value is not guaranteed to be numeric. A `NaN` line propagated through the anchor interpolation into CodeMirror's `Text.line(n)`, whose `n < 1 || n > this.lines` guard is false for `NaN`, so `TextNode.lineInner` walked past the end of `children` and dereferenced `undefined`. Anchors whose line is not finite are dropped at measure time.
- **Missing platform on every frontend event.** `scrubEvent` clears `event.request`, which is where the User-Agent that Sentry infers the OS from lives, so issues carried no clue which platform they came from. `Sentry.init` now seeds `platform` and `arch` tags and an `os` context from `@tauri-apps/plugin-os` (already a dependency, already granted in `capabilities/default.json`). The Rust client needed no change: it reports `os` through the `contexts` feature it already enables.

## Risk classification

- [x] Untrusted rendering (Markdown, plugins, links)
- [x] Network

### Invariants at stake and evidence

**Untrusted rendering.** Both crashes are reached from document content: a link in the rendered markdown, and `data-line` markers stamped onto the rendered tree. Neither fix widens what is rendered or opened. `isOpenableRelativeHref` still gates in-workspace navigation, and the opener plugin's scope still decides what reaches the OS; the only change is that its refusal no longer escapes as a crash. Dropping non-finite anchors narrows the input the scroll sync trusts. Covered by `LinkComponent.test.tsx` ("swallows an opener rejection instead of leaving it unhandled") and `useSyncedScroll.test.ts` ("ignores an anchor whose data-line does not parse"); each fails without its fix. The matching `CanvasNodeView` line has no test of its own: Vitest's `mockRejectedValue` does not surface as an unhandled rejection through a bare `void` call, so the test would have passed with or without the fix, which is worse than none. It is a one-line change on the pattern `contextMenuItems.ts` and `PluginDetail.tsx` already use.

**Network.** The telemetry change alters what leaves the machine, so it is measured against the privacy posture the module already documents: no PII, no hostname, no absolute paths. The added fields are the platform name, the OS version, and the CPU architecture. None identifies a user, and all three stay inside the `os` context that `SAFE_CONTEXTS` already allows through `scrubEvent`; `event.request`, `event.user`, and `event.server_name` are still cleared. Reporting remains opt-in and production-only. Covered by `telemetry.test.ts` ("tags the platform, since the scrubber drops the request that carries it"), alongside the existing scrubber tests.

## Testing

`pnpm typecheck && pnpm check && pnpm test` and `cargo clippy --all-targets -- -D warnings` all pass (3607 frontend tests, 471 Rust tests). The three tested behaviours each have a test that fails when its fix is reverted.

Neither crash is reproducible from a synthetic document without the exact user content, so verification is the tests plus the reasoning above rather than a manual repro.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

