### PR TITLE
docs(rules): install instructions change in four places together

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -16,6 +16,17 @@ When a feature is worth documenting, still update in the same commit:
 
 Treat this as part of the feature's definition of done, not a follow-up.
 
+## Install instructions live in four places
+
+Install commands (Homebrew, winget, Chocolatey, Scoop, Snap, AUR, PPA, apt, dnf) are duplicated across the ecosystem. Changing any install command means updating **all four in the same delivery**, not just the one that prompted the change:
+
+1. **`README.md`** in this repo (the Install section).
+2. **`.github/workflows/release.yml`** in this repo: the generated release notes carry the install commands in **two** heredoc blocks (the initial release body and the changelog INSTALL block); patch both.
+3. **The website**: `glyph-md/glyph-md.github.io`, `src/components/Download.astro`.
+4. **The org profile**: `glyph-md/.github`, `profile/README.md`.
+
+Homebrew commands always use fully qualified names (`brew install --cask --force glyph-md/tap/glyph` on macOS, `brew install glyph-md/tap/glyph` on Linux): homebrew-core ships an unrelated `glyph` formula (an ASCII-art converter) that a plain `brew install glyph` resolves to, shadowing the app's CLI with a tool that fails with "Error: input file must be specified."
+
 ## Style
 
 - **Don't name implementation libraries in user-facing copy.** Feature bullets describe what the user gets ("Markdown editor mode: syntax highlighting, line numbers", not "Editor mode with CodeMirror 6"). Implementation details belong in `CONTRIBUTING.md`'s architecture section or PR descriptions.


### PR DESCRIPTION
## Summary

Follow-up to #671. That PR fixed the install commands in the README and in both release-notes blocks of `release.yml`, and the same change went to the website (glyph-md/glyph-md.github.io#7) and the org profile (glyph-md/.github#4). The rule capturing *why all four move together* was pushed to the #671 branch after it had already been squash-merged, so it never landed on `main`. This carries it over on its own.

## Changes

- `.claude/rules/docs.md`: new "Install instructions live in four places" section listing the four locations (README, both `release.yml` heredoc blocks, the website `Download.astro`, the org profile `README.md`) and the standing requirement that Homebrew commands use fully qualified tap names, with the homebrew-core `glyph` collision documented as the reason.

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Documentation only, no code paths touched. The four locations it describes are already consistent as of v0.22.0: the published release notes carry `brew install --cask --force glyph-md/tap/glyph`.

## Screenshots

Not applicable.