### PR TITLE
ci(release): make the release pipeline hotfix-aware

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,6 +39,9 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: bash scripts/bump-version.sh "$VERSION"
 
+      # Pushes back to the dispatched ref, not a hardcoded main, so a hotfix
+      # release can be cut from a branch off a previous tag. Dispatch from a
+      # branch, never a tag ref.
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
@@ -48,7 +51,7 @@ jobs:
             echo "Version already at ${{ inputs.version }}, skipping commit"
           else
             git commit -m "chore: bump version to ${{ inputs.version }}"
-            git push origin main
+            git push origin "HEAD:${{ github.ref_name }}"
           fi
 
       - name: Create and push tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,18 +138,29 @@ jobs:
   update-release-notes:
     needs: build
     runs-on: ubuntu-latest
+    outputs:
+      previous_tag: ${{ steps.notes.outputs.previous_tag }}
     # Edits the release body and links the Announcements discussion.
     permissions:
       contents: write
       discussions: write
     steps:
+      # Full history and tags: the previous tag is read off this tag's own
+      # lineage, so a hotfix cut from an older tag diffs against that tag
+      # instead of against whatever happened to ship most recently.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
       - name: Generate changelog and prepend install instructions
+        id: notes
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 --match 'v*' "${{ github.ref_name }}^" || true)
+          echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
           CHANGELOG=$(gh api repos/${{ github.repository }}/releases/generate-notes \
             -f tag_name="${{ github.ref_name }}" \
-            -f previous_tag_name="$(gh release list --repo ${{ github.repository }} --limit 2 --json tagName --jq '.[1].tagName')" \
+            -f previous_tag_name="$PREVIOUS_TAG" \
             --jq .body)
 
           BODY=$(cat <<'INSTALL'
@@ -215,6 +226,22 @@ jobs:
           RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" --jq .id)
           gh api -X PATCH "repos/${{ github.repository }}/releases/$RELEASE_ID" \
             -f discussion_category_name=Announcements
+
+      # A release is created as "latest" by default. A hotfix cut from an
+      # older line is not the newest version, so hand the pointer back: the
+      # ecosystem health check and the smoke test both resolve "latest".
+      - name: Keep the latest pointer on the highest version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HIGHEST=$(gh release list --repo "${{ github.repository }}" --limit 100 \
+            --json tagName,isDraft,isPrerelease \
+            --jq '.[] | select((.isDraft or .isPrerelease) | not) | .tagName' \
+            | sort -V | tail -1)
+          if [ -n "$HIGHEST" ] && [ "$HIGHEST" != "${{ github.ref_name }}" ]; then
+            echo "$HIGHEST is newer than ${{ github.ref_name }}; leaving the latest pointer alone."
+            gh release edit "${{ github.ref_name }}" --repo "${{ github.repository }}" --latest=false
+          fi
 
   publish-homebrew:
     needs: build
@@ -305,7 +332,7 @@ jobs:
           fi
 
   publish-chocolatey:
-    needs: build
+    needs: [build, update-release-notes]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -338,7 +365,7 @@ jobs:
           # Generate the version-specific changelog (same source as the GitHub
           # release notes) so the Chocolatey package page shows what changed in
           # this release instead of only linking to the releases list.
-          $prevTag = gh release list --repo $repo --limit 2 --json tagName --jq '.[1].tagName'
+          $prevTag = "${{ needs.update-release-notes.outputs.previous_tag }}"
           # gh emits the body as multiple lines, which PowerShell captures as a
           # string[]. Join it back with newlines so the Markdown survives (string
           # interpolation would otherwise flatten the array with spaces and turn


### PR DESCRIPTION
## Summary

The release pipeline could only cut a release from `main`'s tip. Shipping a bug-fix-only release means branching off the previous tag and cherry-picking the fixes, and three separate places in the pipeline get that wrong. This makes hotfix releases work.

These two commits already ride on `fix/release-0.22.1` (the 0.22.1 hotfix branch, which is where they take effect for that release, since a tag build reads its workflows from the tag's own ref). This PR lands them on `main` so the next release from `main` keeps the fixed behaviour instead of reverting to the old logic.

## Changes

- `create-release.yml` pushed the version bump to a hardcoded `main`, so dispatching it from any other branch failed. It now pushes to `HEAD:${{ github.ref_name }}`, the ref the run was dispatched against.
- The changelog resolved its previous tag as "the release before this one by date" (`gh release list --limit 2 | .[1]`). Correct only when every release comes off `main`'s tip; a hotfix cut from an older tag would diff against whatever shipped most recently and generate a nonsense changelog. It now reads the previous tag off the tag's own lineage with `git describe --tags --abbrev=0 --match 'v*' "$TAG^"`, which needs a `fetch-depth: 0` checkout in the notes job.
- `publish-chocolatey` duplicated that same by-date lookup. It now consumes the resolved tag as a job output from `update-release-notes`, so the previous tag has one source of truth.
- A newly created release is marked latest by default. A hotfix for an older line would steal the pointer that `ecosystem-health.yml` and `release-smoke-test.yml` both resolve, and that every install channel follows. Added a guard that hands the pointer back with `--latest=false` when the tag being released is not the highest published version. No-op when releasing from `main`'s tip.

Known limitation, not addressed here: commits cherry-picked into a hotfix release still appear again in the next `main` release's notes, because `main`'s lineage continues to contain them. `generate-notes` has no way to exclude them.

## Risk classification

- [x] No risk areas touched

Workflow files only. No application code, no dependency changes.

### Invariants at stake and evidence

None. Nothing in `docs/engineering-invariants.md` covers CI configuration.

## Testing

- YAML parses; `actionlint` runs in `ci-checks`.
- `pnpm typecheck && pnpm check && pnpm test` (3607 tests) and `cargo clippy --all-targets -- -D warnings` pass on the hotfix branch carrying these commits.
- End-to-end verification only happens when a release is cut. The 0.22.1 hotfix release exercises every path here: dispatch from a non-`main` branch, lineage-derived changelog, the Chocolatey job output, and the latest-pointer guard.

## Screenshots

n/a
