### PR TITLE
fix(release): fall back to commit subjects when the changelog is empty

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -25,9 +25,11 @@ jobs:
       - run: pnpm test:e2e
 
   release-bump:
-    # Runs the create-release version-bump script against a throwaway clone:
-    # format validation, tag-exists check, and package.json / Cargo.toml /
-    # Cargo.lock agreement. Guards create-release.yml without cutting a
+    # Runs the release scripts against throwaway repos: the version bump
+    # (format validation, tag-exists check, and package.json / Cargo.toml /
+    # Cargo.lock agreement) and the changelog resolution (previous tag from the
+    # tag's own ancestry, commit fallback when generate-notes finds no pull
+    # requests). Guards create-release.yml and release.yml without cutting a
     # release (see #504).
     name: Release bump
     runs-on: ubuntu-latest
@@ -35,3 +37,4 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/rust-setup
       - run: bash scripts/bump-version.test.sh
+      - run: bash scripts/release-changelog.test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     outputs:
-      previous_tag: ${{ steps.notes.outputs.previous_tag }}
+      changelog: ${{ steps.notes.outputs.changelog }}
     # Edits the release body and links the Announcements discussion.
     permissions:
       contents: write
@@ -155,13 +155,23 @@ jobs:
         id: notes
         env:
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
         run: |
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 --match 'v*' "${{ github.ref_name }}^" || true)
-          echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+          PREVIOUS_TAG=$(bash scripts/release-changelog.sh previous-tag "${{ github.ref_name }}")
           CHANGELOG=$(gh api repos/${{ github.repository }}/releases/generate-notes \
             -f tag_name="${{ github.ref_name }}" \
             -f previous_tag_name="$PREVIOUS_TAG" \
-            --jq .body)
+            --jq .body \
+            | bash scripts/release-changelog.sh body "${{ github.ref_name }}" "$PREVIOUS_TAG")
+
+          # Chocolatey renders the same changelog, so hand it the resolved
+          # text instead of letting that job generate a second copy.
+          {
+            echo "changelog<<NOTES_EOF"
+            printf '%s\n' "$CHANGELOG"
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
           BODY=$(cat <<'INSTALL'
           ## Install
@@ -355,6 +365,7 @@ jobs:
         shell: pwsh
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+          CHANGELOG: ${{ needs.update-release-notes.outputs.changelog }}
           GH_TOKEN: ${{ github.token }}
         run: |
           $version = "${{ steps.version.outputs.version }}"
@@ -362,18 +373,9 @@ jobs:
           $repo = "${{ github.repository }}"
           $tag = "${{ github.ref_name }}"
 
-          # Generate the version-specific changelog (same source as the GitHub
-          # release notes) so the Chocolatey package page shows what changed in
-          # this release instead of only linking to the releases list.
-          $prevTag = "${{ needs.update-release-notes.outputs.previous_tag }}"
-          # gh emits the body as multiple lines, which PowerShell captures as a
-          # string[]. Join it back with newlines so the Markdown survives (string
-          # interpolation would otherwise flatten the array with spaces and turn
-          # the whole changelog into one run-on paragraph).
-          $changelog = (gh api "repos/$repo/releases/generate-notes" `
-            -f tag_name="$tag" `
-            -f previous_tag_name="$prevTag" `
-            --jq .body) -join "`n"
+          # Reuse the changelog the release-notes job already resolved, so the
+          # Chocolatey page and the GitHub release can never disagree.
+          $changelog = $env:CHANGELOG
           # Drop the leading "<!-- Release notes generated ... -->" comment GitHub
           # prepends; Chocolatey renders raw HTML as literal text, not a comment.
           $changelog = ($changelog -replace '(?s)^\s*<!--.*?-->\s*', '').Trim()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,11 +159,20 @@ jobs:
           SERVER_URL: ${{ github.server_url }}
         run: |
           PREVIOUS_TAG=$(bash scripts/release-changelog.sh previous-tag "${{ github.ref_name }}")
+
+          # Pull request metadata for the fallback below. A release cut from
+          # main's tip never reaches it, so this is a handful of wasted calls
+          # once per release, against a decision the script owns and tests.
+          for number in $(bash scripts/release-changelog.sh pull-requests "${{ github.ref_name }}" "$PREVIOUS_TAG"); do
+            gh api "repos/${{ github.repository }}/pulls/$number" \
+              --jq '{n: .number, title: .title, author: .user.login, labels: [.labels[].name]}'
+          done | jq -s . > /tmp/pull-requests.json
+
           CHANGELOG=$(gh api repos/${{ github.repository }}/releases/generate-notes \
             -f tag_name="${{ github.ref_name }}" \
             -f previous_tag_name="$PREVIOUS_TAG" \
             --jq .body \
-            | bash scripts/release-changelog.sh body "${{ github.ref_name }}" "$PREVIOUS_TAG")
+            | bash scripts/release-changelog.sh body "${{ github.ref_name }}" "$PREVIOUS_TAG" /tmp/pull-requests.json)
 
           # Chocolatey renders the same changelog, so hand it the resolved
           # text instead of letting that job generate a second copy.

--- a/scripts/release-changelog.sh
+++ b/scripts/release-changelog.sh
@@ -20,6 +20,32 @@ previous_tag() {
   git describe --tags --abbrev=0 --match 'v*' "$1^" 2>/dev/null || true
 }
 
+# Groups commits under the headings from .github/release.yml, in that file's
+# order. Those categories key off pull request labels, which a cherry-pick
+# does not carry, so the conventional-commit type stands in for the label.
+# The catch-all keeps every commit in the output even when its type is one
+# nothing here matches.
+categorize() {
+  local remaining="$1" spec title pattern matched
+
+  for spec in \
+    '🚀 Features|^\* feat' \
+    '🐛 Bug Fixes|^\* fix' \
+    '🧪 Testing & CI|^\* (ci|test)' \
+    '📦 Dependencies|^\* (chore|build)\(deps' \
+    '📝 Documentation|^\* docs' \
+    '🔧 Other Changes|.'; do
+    title="${spec%%|*}"
+    pattern="${spec#*|}"
+
+    matched="$(printf '%s\n' "$remaining" | grep -E "$pattern" || true)"
+    [ -n "$matched" ] || continue
+
+    printf '### %s\n%s\n' "$title" "$matched"
+    remaining="$(printf '%s\n' "$remaining" | grep -Ev "$pattern" || true)"
+  done
+}
+
 body() {
   local tag="$1" previous="$2" generated commits
   generated="$(cat)"
@@ -27,11 +53,15 @@ body() {
   # generate-notes lists pull requests, and a cherry-picked commit carries no
   # PR association, so a hotfix release comes back with an empty list. Fall
   # back to commit subjects, minus the version bump the release just made.
+  # These are subjects rather than "title by @author in <pull request>",
+  # because the pull request that carried each commit is exactly what a
+  # cherry-pick loses.
   if [ -n "$previous" ] && ! printf '%s' "$generated" | grep -q '^\* '; then
     commits="$(git log --no-merges --pretty='* %s' "$previous..$tag" |
       grep -v '^\* chore: bump version to ' || true)"
-    printf "## What's Changed\n\n%s\n\n**Full Changelog**: %s/%s/compare/%s...%s\n" \
-      "$commits" "${SERVER_URL:-https://github.com}" "${REPOSITORY:?REPOSITORY is required}" \
+    printf "## What's Changed\n%s\n\n**Full Changelog**: %s/%s/compare/%s...%s\n" \
+      "$(categorize "$commits")" \
+      "${SERVER_URL:-https://github.com}" "${REPOSITORY:?REPOSITORY is required}" \
       "$previous" "$tag"
     return
   fi

--- a/scripts/release-changelog.sh
+++ b/scripts/release-changelog.sh
@@ -3,15 +3,37 @@
 # in the workflow so scripts/release-changelog.test.sh can exercise them
 # without cutting a release.
 #
-#   previous-tag <tag>          the nearest release tag in <tag>'s own ancestry
-#   body <tag> <previous-tag>   the release changelog, reading GitHub's
-#                               generated notes on stdin
+#   previous-tag <tag>                    nearest release tag in <tag>'s ancestry
+#   pull-requests <tag> <previous-tag>    pull request numbers in that range
+#   body <tag> <previous-tag> <prs.json>  the changelog, reading GitHub's
+#                                         generated notes on stdin
+#
+# GitHub generates the notes for every release cut from main's tip, and those
+# are used as-is. Only a cherry-picked release needs the fallback here:
+# generate-notes builds entries from the pull requests associated with each
+# commit, association is by commit SHA, and a cherry-pick is a new SHA. The
+# pull request survives in the "(#123)" that squash-merging leaves in the
+# subject, so the fallback resolves entries from that and renders them the way
+# GitHub would have.
 set -euo pipefail
 
 usage() {
-  echo "usage: $0 previous-tag <tag> | body <tag> <previous-tag>" >&2
+  echo "usage: $0 previous-tag <tag> | pull-requests <tag> <previous-tag> | body <tag> <previous-tag> <prs.json>" >&2
   exit 2
 }
+
+# Mirrors .github/release.yml, whose categories key off pull request labels.
+# The test fails if the two drift apart. "*" is the catch-all, matching that
+# file's own last category.
+CATEGORIES=(
+  '🚀 Features|enhancement'
+  '🐛 Bug Fixes|bug'
+  '🔒 Security|security'
+  '🧪 Testing & CI|ci testing'
+  '📦 Dependencies|dependencies'
+  '📝 Documentation|documentation'
+  '🔧 Other Changes|*'
+)
 
 # Walking the tag's ancestry, not the release list, is what makes a hotfix
 # work: a release cut from a branch off an older tag has to diff against that
@@ -20,53 +42,92 @@ previous_tag() {
   git describe --tags --abbrev=0 --match 'v*' "$1^" 2>/dev/null || true
 }
 
-# Groups commits under the headings from .github/release.yml, in that file's
-# order. Those categories key off pull request labels, which a cherry-pick
-# does not carry, so the conventional-commit type stands in for the label.
-# The catch-all keeps every commit in the output even when its type is one
-# nothing here matches.
-categorize() {
-  local remaining="$1" spec title pattern matched
+subjects() {
+  git log --no-merges --pretty='%s' "$1..$2" | grep -v '^chore: bump version to ' || true
+}
 
-  for spec in \
-    '🚀 Features|^\* feat' \
-    '🐛 Bug Fixes|^\* fix' \
-    '🧪 Testing & CI|^\* (ci|test)' \
-    '📦 Dependencies|^\* (chore|build)\(deps' \
-    '📝 Documentation|^\* docs' \
-    '🔧 Other Changes|.'; do
+pull_requests() {
+  subjects "$1" "$2" | sed -n 's/.*(#\([0-9][0-9]*\))$/\1/p'
+}
+
+# One tab-separated line per commit: the pull request's labels, then the
+# rendered entry. A commit that never went through a pull request keeps its
+# subject, since there is no author or link to attribute it to.
+entries() {
+  local previous="$1" tag="$2" meta="$3" subject number pr title author labels
+
+  while IFS= read -r subject; do
+    [ -n "$subject" ] || continue
+
+    number="$(printf '%s' "$subject" | sed -n 's/.*(#\([0-9][0-9]*\))$/\1/p')"
+    pr=""
+    [ -n "$number" ] && pr="$(jq -c --argjson n "$number" '.[] | select(.n == $n)' "$meta")"
+
+    if [ -z "$pr" ]; then
+      printf '\t* %s\n' "$subject"
+      continue
+    fi
+
+    title="$(printf '%s' "$pr" | jq -r .title)"
+    author="$(printf '%s' "$pr" | jq -r .author)"
+    labels="$(printf '%s' "$pr" | jq -r '.labels | join(" ")')"
+    printf '%s\t* %s by @%s in %s/%s/pull/%s\n' \
+      "$labels" "$title" "$author" "$SERVER_URL" "$REPOSITORY" "$number"
+  done < <(subjects "$previous" "$tag")
+}
+
+# Keeps the entries whose label field carries one of $1, or with mode "drop",
+# the ones it does not.
+filter() {
+  awk -F'\t' -v want="$1" -v mode="$2" '
+    BEGIN { n = split(want, w, " ") }
+    {
+      hit = 0
+      split($1, have, " ")
+      for (i = 1; i <= n && !hit; i++)
+        for (j in have)
+          if (have[j] == w[i]) { hit = 1; break }
+      if ((mode == "keep") == (hit == 1)) print
+    }'
+}
+
+group() {
+  local all="$1" spec title labels matched
+
+  for spec in "${CATEGORIES[@]}"; do
     title="${spec%%|*}"
-    pattern="${spec#*|}"
+    labels="${spec#*|}"
 
-    matched="$(printf '%s\n' "$remaining" | grep -E "$pattern" || true)"
-    [ -n "$matched" ] || continue
+    if [ "$labels" = '*' ]; then
+      matched="$all"
+    else
+      matched="$(printf '%s\n' "$all" | filter "$labels" keep)"
+      all="$(printf '%s\n' "$all" | filter "$labels" drop)"
+    fi
 
-    printf '### %s\n%s\n' "$title" "$matched"
-    remaining="$(printf '%s\n' "$remaining" | grep -Ev "$pattern" || true)"
+    [ -n "$(printf '%s' "$matched" | tr -d '[:space:]')" ] || continue
+    printf '### %s\n%s\n' "$title" "$(printf '%s\n' "$matched" | cut -f2-)"
   done
 }
 
 body() {
-  local tag="$1" previous="$2" generated commits
+  local tag="$1" previous="$2" meta="$3" generated
+
   generated="$(cat)"
 
-  # generate-notes lists pull requests, and a cherry-picked commit carries no
-  # PR association, so a hotfix release comes back with an empty list. Fall
-  # back to commit subjects, minus the version bump the release just made.
-  # These are subjects rather than "title by @author in <pull request>",
-  # because the pull request that carried each commit is exactly what a
-  # cherry-pick loses.
-  if [ -n "$previous" ] && ! printf '%s' "$generated" | grep -q '^\* '; then
-    commits="$(git log --no-merges --pretty='* %s' "$previous..$tag" |
-      grep -v '^\* chore: bump version to ' || true)"
-    printf "## What's Changed\n%s\n\n**Full Changelog**: %s/%s/compare/%s...%s\n" \
-      "$(categorize "$commits")" \
-      "${SERVER_URL:-https://github.com}" "${REPOSITORY:?REPOSITORY is required}" \
-      "$previous" "$tag"
+  # Anything GitHub could attribute is already right, so only an empty list
+  # falls through, which in practice means a cherry-picked release.
+  if [ -z "$previous" ] || printf '%s' "$generated" | grep -q '^\* '; then
+    printf '%s\n' "$generated"
     return
   fi
 
-  printf '%s\n' "$generated"
+  : "${REPOSITORY:?REPOSITORY is required}"
+  : "${SERVER_URL:=https://github.com}"
+
+  printf "## What's Changed\n%s\n\n**Full Changelog**: %s/%s/compare/%s...%s\n" \
+    "$(group "$(entries "$previous" "$tag" "$meta")")" \
+    "$SERVER_URL" "$REPOSITORY" "$previous" "$tag"
 }
 
 case "${1:-}" in
@@ -74,9 +135,13 @@ case "${1:-}" in
     [ $# -eq 2 ] || usage
     previous_tag "$2"
     ;;
-  body)
+  pull-requests)
     [ $# -eq 3 ] || usage
-    body "$2" "$3"
+    pull_requests "$3" "$2"
+    ;;
+  body)
+    [ $# -eq 4 ] || usage
+    body "$2" "$3" "$4"
     ;;
   *)
     usage

--- a/scripts/release-changelog.sh
+++ b/scripts/release-changelog.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Changelog helpers for release.yml. These live in a script rather than inline
+# in the workflow so scripts/release-changelog.test.sh can exercise them
+# without cutting a release.
+#
+#   previous-tag <tag>          the nearest release tag in <tag>'s own ancestry
+#   body <tag> <previous-tag>   the release changelog, reading GitHub's
+#                               generated notes on stdin
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 previous-tag <tag> | body <tag> <previous-tag>" >&2
+  exit 2
+}
+
+# Walking the tag's ancestry, not the release list, is what makes a hotfix
+# work: a release cut from a branch off an older tag has to diff against that
+# tag and not against whatever shipped most recently from main.
+previous_tag() {
+  git describe --tags --abbrev=0 --match 'v*' "$1^" 2>/dev/null || true
+}
+
+body() {
+  local tag="$1" previous="$2" generated commits
+  generated="$(cat)"
+
+  # generate-notes lists pull requests, and a cherry-picked commit carries no
+  # PR association, so a hotfix release comes back with an empty list. Fall
+  # back to commit subjects, minus the version bump the release just made.
+  if [ -n "$previous" ] && ! printf '%s' "$generated" | grep -q '^\* '; then
+    commits="$(git log --no-merges --pretty='* %s' "$previous..$tag" |
+      grep -v '^\* chore: bump version to ' || true)"
+    printf "## What's Changed\n\n%s\n\n**Full Changelog**: %s/%s/compare/%s...%s\n" \
+      "$commits" "${SERVER_URL:-https://github.com}" "${REPOSITORY:?REPOSITORY is required}" \
+      "$previous" "$tag"
+    return
+  fi
+
+  printf '%s\n' "$generated"
+}
+
+case "${1:-}" in
+  previous-tag)
+    [ $# -eq 2 ] || usage
+    previous_tag "$2"
+    ;;
+  body)
+    [ $# -eq 3 ] || usage
+    body "$2" "$3"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/scripts/release-changelog.test.sh
+++ b/scripts/release-changelog.test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Tests for scripts/release-changelog.sh against a throwaway repo whose history
+# has the shape that broke v0.22.1: a hotfix branch cut from an older tag,
+# released after a newer tag already exists on main.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+changelog="$repo_root/scripts/release-changelog.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+export REPOSITORY="owner/repo"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+commit() {
+  git commit --quiet --allow-empty -m "$1"
+}
+
+git init --quiet "$tmp/repo"
+cd "$tmp/repo"
+git config user.email test@example.com
+git config user.name Test
+
+#            v1.1.0 (main)
+#           /
+#   v1.0.0 -- fix -- bump -- v1.0.1 (hotfix branch)
+commit "feat: first"
+git tag v1.0.0
+git switch --quiet -c hotfix
+commit "fix(telemetry): stop the opener crash (#690)"
+commit "chore(deps): bump js-yaml (#686)"
+commit "chore: bump version to 1.0.1"
+git tag v1.0.1
+git switch --quiet main 2>/dev/null || git switch --quiet master
+commit "feat: something big on main"
+git tag v1.1.0
+
+# The previous tag comes from the tag's own ancestry. Resolving it by release
+# date would answer v1.1.0 here, which is what produced a nonsense range.
+got="$("$changelog" previous-tag v1.0.1)"
+[ "$got" = "v1.0.0" ] || fail "previous-tag for the hotfix is '$got', expected v1.0.0"
+
+got="$("$changelog" previous-tag v1.1.0)"
+[ "$got" = "v1.0.0" ] || fail "previous-tag for the main release is '$got', expected v1.0.0"
+
+# The very first release has no ancestor tag, and that is not an error
+got="$("$changelog" previous-tag v1.0.0)"
+[ -z "$got" ] || fail "previous-tag for the first release is '$got', expected empty"
+
+# Notes that already list pull requests are passed through untouched
+generated="## What's Changed
+* fix: something by @someone in https://github.com/owner/repo/pull/1"
+got="$(printf '%s' "$generated" | "$changelog" body v1.1.0 v1.0.0)"
+[ "$got" = "$generated" ] || fail "PR-derived notes were not passed through: $got"
+
+# An empty changelog is the hotfix case: cherry-picked commits carry no PR
+# association, so generate-notes returns a body with no entries at all
+empty="<!-- Release notes generated using configuration in .github/release.yml at v1.0.1 -->"
+got="$(printf '%s' "$empty" | "$changelog" body v1.0.1 v1.0.0)"
+
+echo "$got" | grep -q "^## What's Changed$" ||
+  fail "fallback has no What's Changed heading: $got"
+echo "$got" | grep -q '^\* fix(telemetry): stop the opener crash (#690)$' ||
+  fail "fallback dropped the fix commit: $got"
+echo "$got" | grep -q '^\* chore(deps): bump js-yaml (#686)$' ||
+  fail "fallback dropped the dependency commit: $got"
+if echo "$got" | grep -q 'bump version to'; then
+  fail "fallback listed the release's own version bump: $got"
+fi
+echo "$got" | grep -qF '**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.0.1' ||
+  fail "fallback has no compare link: $got"
+
+# Commits from the newer main-line tag are outside the hotfix's range
+if echo "$got" | grep -q 'something big on main'; then
+  fail "fallback reached past the hotfix lineage: $got"
+fi
+
+# Without a previous tag there is no range to walk, so an empty body stays empty
+got="$(printf '%s' "$empty" | "$changelog" body v1.0.0 "")"
+[ "$got" = "$empty" ] || fail "first release should pass through unchanged: $got"
+
+echo "OK: previous tag follows the tag's ancestry, and an empty changelog falls back to commits"

--- a/scripts/release-changelog.test.sh
+++ b/scripts/release-changelog.test.sh
@@ -27,12 +27,15 @@ git config user.name Test
 
 #            v1.1.0 (main)
 #           /
-#   v1.0.0 -- fix -- bump -- v1.0.1 (hotfix branch)
+#   v1.0.0 -- fixes -- bump -- v1.0.1 (hotfix branch)
 commit "feat: first"
 git tag v1.0.0
 git switch --quiet -c hotfix
 commit "fix(telemetry): stop the opener crash (#690)"
+commit "ci(release): retry the smoke test (#676)"
+commit "docs(readme): refresh the comparison tables (#677)"
 commit "chore(deps): bump js-yaml (#686)"
+commit "chore: stop tracking the generated schema (#692)"
 commit "chore: bump version to 1.0.1"
 git tag v1.0.1
 git switch --quiet main 2>/dev/null || git switch --quiet master
@@ -41,46 +44,68 @@ git tag v1.1.0
 
 # The previous tag comes from the tag's own ancestry. Resolving it by release
 # date would answer v1.1.0 here, which is what produced a nonsense range.
-got="$("$changelog" previous-tag v1.0.1)"
+got="$(bash "$changelog" previous-tag v1.0.1)"
 [ "$got" = "v1.0.0" ] || fail "previous-tag for the hotfix is '$got', expected v1.0.0"
 
-got="$("$changelog" previous-tag v1.1.0)"
+got="$(bash "$changelog" previous-tag v1.1.0)"
 [ "$got" = "v1.0.0" ] || fail "previous-tag for the main release is '$got', expected v1.0.0"
 
 # The very first release has no ancestor tag, and that is not an error
-got="$("$changelog" previous-tag v1.0.0)"
+got="$(bash "$changelog" previous-tag v1.0.0)"
 [ -z "$got" ] || fail "previous-tag for the first release is '$got', expected empty"
 
 # Notes that already list pull requests are passed through untouched
 generated="## What's Changed
+### 🐛 Bug Fixes
 * fix: something by @someone in https://github.com/owner/repo/pull/1"
-got="$(printf '%s' "$generated" | "$changelog" body v1.1.0 v1.0.0)"
+got="$(printf '%s' "$generated" | bash "$changelog" body v1.1.0 v1.0.0)"
 [ "$got" = "$generated" ] || fail "PR-derived notes were not passed through: $got"
 
 # An empty changelog is the hotfix case: cherry-picked commits carry no PR
 # association, so generate-notes returns a body with no entries at all
 empty="<!-- Release notes generated using configuration in .github/release.yml at v1.0.1 -->"
-got="$(printf '%s' "$empty" | "$changelog" body v1.0.1 v1.0.0)"
+got="$(printf '%s' "$empty" | bash "$changelog" body v1.0.1 v1.0.0)"
 
 echo "$got" | grep -q "^## What's Changed$" ||
   fail "fallback has no What's Changed heading: $got"
-echo "$got" | grep -q '^\* fix(telemetry): stop the opener crash (#690)$' ||
-  fail "fallback dropped the fix commit: $got"
-echo "$got" | grep -q '^\* chore(deps): bump js-yaml (#686)$' ||
-  fail "fallback dropped the dependency commit: $got"
+echo "$got" | grep -qF '**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.0.1' ||
+  fail "fallback has no compare link: $got"
+
 if echo "$got" | grep -q 'bump version to'; then
   fail "fallback listed the release's own version bump: $got"
 fi
-echo "$got" | grep -qF '**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.0.1' ||
-  fail "fallback has no compare link: $got"
 
 # Commits from the newer main-line tag are outside the hotfix's range
 if echo "$got" | grep -q 'something big on main'; then
   fail "fallback reached past the hotfix lineage: $got"
 fi
 
+# Commits are grouped under the same headings a labelled release uses, keyed
+# off the conventional-commit type, and every commit lands in exactly one
+expect_section() {
+  echo "$got" | awk -v heading="### $1" '
+    $0 == heading { inside = 1; next }
+    /^### / { inside = 0 }
+    inside && NF { print }
+  ' | grep -qF "$2" || fail "'$2' is not under '$1': $got"
+}
+
+expect_section "🐛 Bug Fixes" "fix(telemetry): stop the opener crash (#690)"
+expect_section "🧪 Testing & CI" "ci(release): retry the smoke test (#676)"
+expect_section "📝 Documentation" "docs(readme): refresh the comparison tables (#677)"
+expect_section "📦 Dependencies" "chore(deps): bump js-yaml (#686)"
+expect_section "🔧 Other Changes" "chore: stop tracking the generated schema (#692)"
+
+entries="$(echo "$got" | grep -c '^\* ' || true)"
+[ "$entries" = "5" ] || fail "expected 5 entries across the sections, got $entries: $got"
+
+# Headings the release has nothing for are left out rather than shown empty
+if echo "$got" | grep -q '🚀 Features'; then
+  fail "fallback printed an empty Features section: $got"
+fi
+
 # Without a previous tag there is no range to walk, so an empty body stays empty
-got="$(printf '%s' "$empty" | "$changelog" body v1.0.0 "")"
+got="$(printf '%s' "$empty" | bash "$changelog" body v1.0.0 "")"
 [ "$got" = "$empty" ] || fail "first release should pass through unchanged: $got"
 
-echo "OK: previous tag follows the tag's ancestry, and an empty changelog falls back to commits"
+echo "OK: previous tag follows the tag's ancestry, and an empty changelog falls back to categorised commits"

--- a/scripts/release-changelog.test.sh
+++ b/scripts/release-changelog.test.sh
@@ -6,10 +6,12 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 changelog="$repo_root/scripts/release-changelog.sh"
+config="$repo_root/.github/release.yml"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
 export REPOSITORY="owner/repo"
+export SERVER_URL="https://github.com"
 
 fail() {
   echo "FAIL: $1" >&2
@@ -27,20 +29,27 @@ git config user.name Test
 
 #            v1.1.0 (main)
 #           /
-#   v1.0.0 -- fixes -- bump -- v1.0.1 (hotfix branch)
+#   v1.0.0 -- cherry-picks -- bump -- v1.0.1 (hotfix branch)
 commit "feat: first"
 git tag v1.0.0
 git switch --quiet -c hotfix
 commit "fix(telemetry): stop the opener crash (#690)"
-commit "ci(release): retry the smoke test (#676)"
-commit "docs(readme): refresh the comparison tables (#677)"
 commit "chore(deps): bump js-yaml (#686)"
-commit "chore: stop tracking the generated schema (#692)"
+commit "ci(release): retry the smoke test (#676)"
+commit "ci(release): tighten the release branch by hand"
 commit "chore: bump version to 1.0.1"
 git tag v1.0.1
 git switch --quiet main 2>/dev/null || git switch --quiet master
 commit "feat: something big on main"
 git tag v1.1.0
+
+cat > "$tmp/prs.json" <<'JSON'
+[
+  {"n": 690, "title": "fix(telemetry): stop the opener crash", "author": "hamidfzm", "labels": ["bug"]},
+  {"n": 686, "title": "chore(deps): bump js-yaml", "author": "dependabot[bot]", "labels": ["dependencies", "javascript"]},
+  {"n": 676, "title": "ci(release): retry the smoke test", "author": "hamidfzm", "labels": ["ci"]}
+]
+JSON
 
 # The previous tag comes from the tag's own ancestry. Resolving it by release
 # date would answer v1.1.0 here, which is what produced a nonsense range.
@@ -54,17 +63,22 @@ got="$(bash "$changelog" previous-tag v1.1.0)"
 got="$(bash "$changelog" previous-tag v1.0.0)"
 [ -z "$got" ] || fail "previous-tag for the first release is '$got', expected empty"
 
-# Notes that already list pull requests are passed through untouched
+# The pull requests to look up come from the "(#123)" squash-merge leaves behind
+got="$(bash "$changelog" pull-requests v1.0.1 v1.0.0 | sort | tr '\n' ' ')"
+[ "$got" = "676 686 690 " ] || fail "pull-requests found '$got', expected 676 686 690"
+
+# Notes GitHub could attribute are passed through untouched, which is every
+# release cut from main's tip
 generated="## What's Changed
 ### 🐛 Bug Fixes
 * fix: something by @someone in https://github.com/owner/repo/pull/1"
-got="$(printf '%s' "$generated" | bash "$changelog" body v1.1.0 v1.0.0)"
+got="$(printf '%s' "$generated" | bash "$changelog" body v1.1.0 v1.0.0 "$tmp/prs.json")"
 [ "$got" = "$generated" ] || fail "PR-derived notes were not passed through: $got"
 
-# An empty changelog is the hotfix case: cherry-picked commits carry no PR
-# association, so generate-notes returns a body with no entries at all
+# A cherry-picked release comes back empty, because association is by commit
+# SHA and a cherry-pick is a new SHA
 empty="<!-- Release notes generated using configuration in .github/release.yml at v1.0.1 -->"
-got="$(printf '%s' "$empty" | bash "$changelog" body v1.0.1 v1.0.0)"
+got="$(printf '%s' "$empty" | bash "$changelog" body v1.0.1 v1.0.0 "$tmp/prs.json")"
 
 echo "$got" | grep -q "^## What's Changed$" ||
   fail "fallback has no What's Changed heading: $got"
@@ -80,32 +94,68 @@ if echo "$got" | grep -q 'something big on main'; then
   fail "fallback reached past the hotfix lineage: $got"
 fi
 
-# Commits are grouped under the same headings a labelled release uses, keyed
-# off the conventional-commit type, and every commit lands in exactly one
+# Entries read the way GitHub writes them, and sit under the category their
+# pull request's labels select
 expect_section() {
   echo "$got" | awk -v heading="### $1" '
     $0 == heading { inside = 1; next }
     /^### / { inside = 0 }
     inside && NF { print }
-  ' | grep -qF "$2" || fail "'$2' is not under '$1': $got"
+  ' | grep -qxF "$2" || fail "'$2' is not under '$1': $got"
 }
 
-expect_section "🐛 Bug Fixes" "fix(telemetry): stop the opener crash (#690)"
-expect_section "🧪 Testing & CI" "ci(release): retry the smoke test (#676)"
-expect_section "📝 Documentation" "docs(readme): refresh the comparison tables (#677)"
-expect_section "📦 Dependencies" "chore(deps): bump js-yaml (#686)"
-expect_section "🔧 Other Changes" "chore: stop tracking the generated schema (#692)"
+expect_section "🐛 Bug Fixes" \
+  "* fix(telemetry): stop the opener crash by @hamidfzm in https://github.com/owner/repo/pull/690"
+expect_section "🧪 Testing & CI" \
+  "* ci(release): retry the smoke test by @hamidfzm in https://github.com/owner/repo/pull/676"
+expect_section "📦 Dependencies" \
+  "* chore(deps): bump js-yaml by @dependabot[bot] in https://github.com/owner/repo/pull/686"
+
+# A commit that never went through a pull request has no author or link to
+# attribute, so it keeps its subject and lands in the catch-all
+expect_section "🔧 Other Changes" "* ci(release): tighten the release branch by hand"
 
 entries="$(echo "$got" | grep -c '^\* ' || true)"
-[ "$entries" = "5" ] || fail "expected 5 entries across the sections, got $entries: $got"
+[ "$entries" = "4" ] || fail "expected 4 entries across the sections, got $entries: $got"
 
-# Headings the release has nothing for are left out rather than shown empty
+# Categories with nothing in them are left out rather than shown empty
 if echo "$got" | grep -q '🚀 Features'; then
   fail "fallback printed an empty Features section: $got"
 fi
 
+# The script's categories mirror .github/release.yml, and drift between the two
+# would silently file entries under the wrong heading
+config_pairs="$(awk '
+  /^ *exclude:/ { done = 1 }
+  done { next }
+  /^ *- title: / {
+    if (title != "") print title "|" labels
+    title = $0
+    sub(/^ *- title: "/, "", title)
+    sub(/"$/, "", title)
+    labels = ""
+    next
+  }
+  /^ *labels:/ { next }
+  /^ *- / && title != "" {
+    label = $2
+    gsub(/"/, "", label)
+    labels = labels (labels == "" ? "" : " ") label
+  }
+  END { if (title != "") print title "|" labels }
+' "$config")"
+
+script_pairs="$(sed -n "/^CATEGORIES=(/,/^)/p" "$changelog" | sed -n "s/^  '\(.*\)'$/\1/p")"
+
+[ "$config_pairs" = "$script_pairs" ] ||
+  fail "CATEGORIES drifted from .github/release.yml:
+--- config ---
+$config_pairs
+--- script ---
+$script_pairs"
+
 # Without a previous tag there is no range to walk, so an empty body stays empty
-got="$(printf '%s' "$empty" | bash "$changelog" body v1.0.0 "")"
+got="$(printf '%s' "$empty" | bash "$changelog" body v1.0.0 "" "$tmp/prs.json")"
 [ "$got" = "$empty" ] || fail "first release should pass through unchanged: $got"
 
-echo "OK: previous tag follows the tag's ancestry, and an empty changelog falls back to categorised commits"
+echo "OK: previous tag follows the tag's ancestry, and a cherry-picked release renders its pull requests"


### PR DESCRIPTION
## Summary

`v0.22.1` shipped with an empty changelog: nothing between the install block and the compare link. [#695](https://github.com/hamidfzm/glyph/pull/695) fixed the tag *range* the notes are generated over, which was a real bug, but the range was never what emptied the list.

`generate-notes` lists **pull requests**, not commits. It maps each commit in the range to the PR that introduced it, and association is by commit SHA. A hotfix release is built by cherry-picking, and a cherry-pick is a new SHA:

```
gh api repos/hamidfzm/glyph/commits/9bb0a0e/pulls  ->  0
```

So every commit resolved to nothing, `.github/release.yml`'s label categories had nothing to sort, and the release went out saying nothing changed. This hits any cherry-picked release by construction.

Squash-merging leaves the pull request number in the commit subject, and that is the one piece of the association a cherry-pick does not destroy. The fallback resolves each `(#123)` back to its real title, author, and labels, so a hotfix release reads exactly like any other release.

The `v0.22.1` notes and its release discussion have been corrected by hand. This PR stops it happening again.

## Changes

- **`scripts/release-changelog.sh`** owns the changelog resolution: `previous-tag` walks the tag's own ancestry, `pull-requests` extracts the numbers in a range, and `body` reads GitHub's generated notes on stdin and only falls back when they list no pull requests. Entries render as `title by @author in <pull request>`, filed under the category the PR's labels select. A commit that never went through a pull request keeps its subject and lands in the catch-all, because there is no author or link to attribute it to.
- **`CATEGORIES` mirrors `.github/release.yml`**, the same file `generate-notes` reads. The test parses that config and fails if the two drift, so entries cannot silently end up under the wrong heading.
- **`release.yml`** calls the script instead of carrying the logic inline, and fetches the PR metadata the fallback needs.
- **`scripts/release-changelog.test.sh`** builds a throwaway repo with the shape that broke `v0.22.1`: a hotfix branch cut from an older tag, released after a newer tag already exists on main. It covers the ancestry walk (including a first release with no previous tag), PR number extraction, passthrough when real notes exist, entry rendering and categorisation, the unattributable-commit case, exclusion of the version bump, that the range never reaches into the newer main-line tag, and the config drift guard.
- **`ci-smoke.yml`** runs it in the existing `release-bump` job.
- **`publish-chocolatey`** generated a second copy of the same changelog and carried the same defect. It now takes the resolved text through the environment, so the package page and the GitHub release cannot disagree, and the changelog is never parsed as PowerShell.

Releases cut from main's tip are untouched: their generated notes are never empty, so the fallback never runs.

### Why CI did not catch this

The `release-bump` job could only reach `bump-version.sh`. The changelog logic lived inline in `release.yml`, and shell embedded in YAML has no test seam at all. Moving it into a script is what makes the regression test possible, which is the actual fix here.

## Risk classification

- [x] No risk areas touched

Workflow, CI config, and two shell scripts. No application code, no dependency changes.

### Invariants at stake and evidence

None. Nothing in `docs/engineering-invariants.md` covers the release pipeline.

## Testing

- `bash scripts/release-changelog.test.sh` passes.
- Mutation-checked at each stage: disabling the fallback fails the suite, and an earlier version that hardcoded its categories was caught by the drift guard once the config was consulted. The test fails for the right reasons.
- Run end to end against the real `v0.22.1` tag, exercising every step the workflow performs:

```
## What's Changed
### 🐛 Bug Fixes
* fix(ci): raise the mermaid bundle budget for 11.17.2 by @hamidfzm in https://github.com/hamidfzm/glyph/pull/688
* fix(telemetry): stop the opener and scroll-sync crashes, and report the OS on every event by @hamidfzm in https://github.com/hamidfzm/glyph/pull/690
### 📦 Dependencies
* chore(deps): bump js-yaml from 4.3.1 to 4.3.2 ... by @dependabot[bot] in https://github.com/hamidfzm/glyph/pull/686
* chore(deps): bump regex from 1.12.3 to 1.13.1 ... by @dependabot[bot] in https://github.com/hamidfzm/glyph/pull/680
* chore(deps): bump the production-dependencies group with 6 updates by @dependabot[bot] in https://github.com/hamidfzm/glyph/pull/683
### 🔧 Other Changes
* ci(release): make the release pipeline hotfix-aware
* ci(release): push the version bump to the dispatched ref
```

The two Other Changes entries are the commits I made straight onto the release branch, so their subjects carry no pull request number to resolve. On the published release I attributed them to #695 by hand.

- `pnpm typecheck && pnpm check && pnpm test` (3736 tests) and `cargo test` (505 tests) pass.
- The Chocolatey path is the one change that only runs during a real release. It substitutes an environment variable for a `gh api` call whose output fed the same variable.

## Screenshots

n/a
