### PR TITLE
chore(bundle): stamp publisher, copyright, license and category on bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -642,7 +642,11 @@ jobs:
           sed "s|{{HOMEPAGE}}|$HOMEPAGE|g" ppa/debian/control > /tmp/glyph-${VERSION}/debian/control
           cp ppa/debian/rules ppa/debian/install /tmp/glyph-${VERSION}/debian/
 
-          # Generate debian/copyright from repo LICENSE file
+          # Generate debian/copyright from repo LICENSE file. The holder and
+          # the license id come from tauri.conf.json's bundle metadata, the
+          # same values every other bundle format is stamped with.
+          COPYRIGHT=$(jq -r '.bundle.copyright' src-tauri/tauri.conf.json | sed 's/^Copyright (c) //')
+          LICENSE_ID=$(jq -r '.bundle.license' src-tauri/tauri.conf.json)
           {
             echo "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/"
             echo "Upstream-Name: glyph"
@@ -650,10 +654,10 @@ jobs:
             echo "Source: https://github.com/hamidfzm/glyph"
             echo ""
             echo "Files: *"
-            echo "Copyright: 2026 hamidfzm"
-            echo "License: MIT"
+            echo "Copyright: $COPYRIGHT"
+            echo "License: $LICENSE_ID"
             echo ""
-            echo "License: MIT"
+            echo "License: $LICENSE_ID"
             awk 'NR>3{if(/^$/)print " .";else print " "$0}' LICENSE
           } > /tmp/glyph-${VERSION}/debian/copyright
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,6 +36,12 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "publisher": "hamidfzm",
+    "copyright": "Copyright (c) 2026 hamidfzm",
+    "license": "MIT",
+    "licenseFile": "../LICENSE",
+    "category": "Productivity",
+    "longDescription": "A modern markdown viewer and editor with GFM support, syntax highlighting, Mermaid and D2 diagrams, live file watching, table of contents sidebar, cloud sync, JavaScript plugins, and platform-native styling.",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

The `bundle` block in `tauri.conf.json` carried no packaging metadata beyond the icons and targets, so every artifact the release workflow builds shipped with fields blank that the format has a slot for:

- Windows installer: no Manufacturer
- rpm and deb: no License field
- macOS: no `LSApplicationCategoryType`
- Linux desktop entry: no Categories

Separately, the PPA job hardcoded `Copyright: 2026 hamidfzm` and `License: MIT` when generating `debian/copyright`, a second copy of values that belong with the rest of the packaging metadata. It now reads both from `tauri.conf.json`.

Split out of #699, which is a security change and should not carry unrelated packaging edits.

## Changes

- Add `publisher`, `copyright`, `license`, `licenseFile`, `category` (`Productivity`), and `longDescription` to `bundle` in `src-tauri/tauri.conf.json`
- Read the copyright holder and license id in the PPA job from `tauri.conf.json` instead of hardcoding them

Two fields were deliberately left out:

- `shortDescription`, because Tauri already falls back to `description` in `Cargo.toml`
- `homepage`, because `package.json`'s `homepage` is the canonical install and docs URL, and the release workflow already injects it into the deb control file. Adding it here would create a second source.

One duplicate is knowingly left in place: the long description also lives in `ppa/debian/control`. Deduping it means generating debian's continuation-line format inside the Launchpad-critical source-package step, which is not worth the blast radius for a description string.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

None. No runtime code path changes: this is bundler input and one workflow step. The app binary behaves identically, only the metadata stamped onto the installers differs.

## Testing

`pnpm typecheck`, `pnpm check`, `pnpm test`, `cargo test --lib`, and `cargo clippy --all-targets -- -D warnings` all pass, though none of them exercise the bundler.

What is genuinely unverified: no packaged artifact has been built from this config. `category` is checked against the value list in the Tauri config schema and `licenseFile` resolves relative to `src-tauri/`, but the first real proof is a release build. Worth watching the next `tauri build` for a bundler warning on these fields.

The PPA change is also unexercised until a release runs. `jq -r '.bundle.copyright'` and `.bundle.license` both resolve against the committed config, and the step already uses `jq` on `package.json` two lines above, so the tool and the working directory are known good.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
