### PR TITLE
fix(tabs): reorder tabs with pointer events instead of HTML5 drag

### DIFF
--- a/src/components/layout/FileTree.dnd.test.tsx
+++ b/src/components/layout/FileTree.dnd.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DirEntry } from "@/lib/tabs";
-import { dragFromTo as dragElementTo, releaseAt } from "@/test/pointerDrag";
+import { dragFromTo as dragElementTo, releaseAt, setHit } from "@/test/pointerDrag";
 import { FileTree } from "./FileTree";
 
 // /root
@@ -55,6 +55,7 @@ const dragFromTo = (fromPath: string, target: Element | null) =>
 
 describe("FileTree pointer drag-and-drop move", () => {
   beforeEach(() => {
+    setHit(null);
     document.body.style.cursor = "";
     document.body.style.userSelect = "";
   });

--- a/src/components/layout/FileTree.dnd.test.tsx
+++ b/src/components/layout/FileTree.dnd.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DirEntry } from "@/lib/tabs";
+import { dragFromTo as dragElementTo, releaseAt } from "@/test/pointerDrag";
 import { FileTree } from "./FileTree";
 
 // /root
@@ -49,18 +50,8 @@ function renderTree(overrides: Partial<ComponentProps<typeof FileTree>> = {}) {
 const row = (path: string) => screen.getByTitle(path);
 const rootArea = () => document.querySelector("[data-filetree-root]") as HTMLElement;
 
-function setHit(el: Element | null) {
-  document.elementFromPoint = vi.fn(() => el) as typeof document.elementFromPoint;
-}
-
-// Press on a row, cross the drag threshold toward `target`, and hit-test it.
-function dragFromTo(fromPath: string, target: Element | null) {
-  fireEvent.pointerDown(row(fromPath), { button: 0, clientX: 0, clientY: 0 });
-  setHit(target);
-  fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
-}
-
-const releaseAt = (x = 40, y = 40) => fireEvent.pointerUp(window, { clientX: x, clientY: y });
+const dragFromTo = (fromPath: string, target: Element | null) =>
+  dragElementTo(row(fromPath), target);
 
 describe("FileTree pointer drag-and-drop move", () => {
   beforeEach(() => {

--- a/src/components/layout/TabBar.dnd.test.tsx
+++ b/src/components/layout/TabBar.dnd.test.tsx
@@ -5,7 +5,7 @@ import type { TabsContextValue } from "@/contexts/TabsContext";
 import type { FileTab, Tab } from "@/lib/tabs";
 import { sidebarLayoutValue } from "@/test/fixtures/sidebarLayout";
 import { TabsWrapper, tabsContextValue } from "@/test/fixtures/tabsContext";
-import { dragFromTo, ghostEl, releaseAt, setHit } from "@/test/pointerDrag";
+import { dragFromTo, ghostEl, moveTo, releaseAt, setHit } from "@/test/pointerDrag";
 import { TabBar } from "./TabBar";
 
 const makeFileTab = (i: number): FileTab => ({
@@ -47,6 +47,7 @@ describe("pointer drag reordering", () => {
     fireEvent.pointerDown(tabEl(name), { button: 0, clientX: 0, clientY: 0, ...init });
 
   beforeEach(() => {
+    setHit(null);
     document.body.style.cursor = "";
     document.body.style.userSelect = "";
   });
@@ -56,7 +57,7 @@ describe("pointer drag reordering", () => {
     const moveTab = vi.fn();
     renderTabBar({ setActiveTab, moveTab });
     press("file1.md");
-    fireEvent.pointerMove(window, { clientX: 2, clientY: 2 });
+    moveTo(2, 2);
     expect(ghostEl()).toBeNull();
     releaseAt(2, 2);
     fireEvent.click(activateButton("file1.md"));
@@ -87,19 +88,49 @@ describe("pointer drag reordering", () => {
     expect(moveTab).toHaveBeenCalledWith("tab-0", 2);
   });
 
-  it("captures the pointer on press so a release outside the window still ends the drag", () => {
+  it("captures the pointer on the pressed element, not on the wrapper carrying the handlers", () => {
     renderTabBar();
-    const setPointerCapture = vi.fn();
-    Object.assign(tabEl("file0.md"), { setPointerCapture });
-    press("file0.md", { pointerId: 7 });
-    expect(setPointerCapture).toHaveBeenCalledWith(7);
+    const onLabel = vi.fn();
+    const onWrapper = vi.fn();
+    Object.assign(labelEl("file0.md"), { setPointerCapture: onLabel });
+    Object.assign(tabEl("file0.md"), { setPointerCapture: onWrapper });
+    fireEvent.pointerDown(labelEl("file0.md"), { button: 0, pointerId: 7 });
+    // Capturing on the wrapper would retarget the click away from the inner
+    // activate / close buttons.
+    expect(onLabel).toHaveBeenCalledWith(7);
+    expect(onWrapper).not.toHaveBeenCalled();
+  });
+
+  it("ignores another pointer's release or cancel mid-drag", () => {
+    const moveTab = vi.fn();
+    renderTabBar({ moveTab });
+    dragFromTo(tabEl("file0.md"), tabEl("file1.md"));
+    // A stray touch during a mouse drag.
+    fireEvent.pointerUp(window, { clientX: 40, clientY: 40, pointerId: 9 });
+    fireEvent.pointerCancel(window, { pointerId: 9 });
+    expect(tabEl("file1.md").getAttribute("data-drop")).toBe("after");
+    expect(moveTab).not.toHaveBeenCalled();
+    releaseAt();
+    expect(moveTab).toHaveBeenCalledWith("tab-0", 1);
+  });
+
+  it("ends the drag when a move arrives with the button already released", () => {
+    const moveTab = vi.fn();
+    renderTabBar({ moveTab });
+    dragFromTo(tabEl("file0.md"), tabEl("file1.md"));
+    // Focus stolen mid-press (Alt+Tab): the release never reached the page.
+    fireEvent.pointerMove(window, { clientX: 45, clientY: 40, buttons: 0 });
+    expect(ghostEl()).toBeNull();
+    expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
+    releaseAt();
+    expect(moveTab).not.toHaveBeenCalled();
   });
 
   it("shows the trailing-edge indicator and the label ghost when dragging right", () => {
     renderTabBar({ tabs: makeTabs(3) });
     dragFromTo(tabEl("file0.md"), tabEl("file2.md"));
-    // pointermove fires continuously over the same target; the indicator is stable.
-    fireEvent.pointerMove(window, { clientX: 41, clientY: 40 });
+    // A second move over the same target keeps the same edge.
+    moveTo(41, 40);
     expect(tabEl("file2.md").getAttribute("data-drop")).toBe("after");
     expect(ghostEl()?.textContent).toBe("file0.md");
     expect(document.body.style.cursor).toBe("grabbing");
@@ -118,7 +149,7 @@ describe("pointer drag reordering", () => {
     dragFromTo(tabEl("file0.md"), tabEl("file1.md"));
     expect(tabEl("file1.md").getAttribute("data-drop")).toBe("after");
     setHit(tabEl("file0.md"));
-    fireEvent.pointerMove(window, { clientX: 10, clientY: 10 });
+    moveTo(10, 10);
     expect(tabEl("file0.md").hasAttribute("data-drop")).toBe(false);
     expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
     expect(document.body.style.cursor).toBe("no-drop");
@@ -177,7 +208,7 @@ describe("pointer drag reordering", () => {
     const moveTab = vi.fn();
     renderTabBar({ moveTab });
     setHit(tabEl("file1.md"));
-    fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
+    moveTo(40, 40);
     expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
     fireEvent.pointerUp(window, { clientX: 40, clientY: 40 });
     fireEvent.keyDown(window, { key: "Escape" });
@@ -201,7 +232,7 @@ describe("pointer drag reordering", () => {
     renderTabBar({ closeTab, moveTab });
     press("file1.md", { button: 1 });
     setHit(tabEl("file0.md"));
-    fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
+    moveTo(40, 40);
     expect(ghostEl()).toBeNull();
     releaseAt();
     fireEvent(tabEl("file1.md"), new MouseEvent("auxclick", { bubbles: true, button: 1 }));
@@ -213,7 +244,7 @@ describe("pointer drag reordering", () => {
     renderTabBar();
     press("file0.md", { pointerType: "touch" });
     setHit(tabEl("file1.md"));
-    fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
+    moveTo(40, 40);
     expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
     expect(ghostEl()).toBeNull();
   });

--- a/src/components/layout/TabBar.dnd.test.tsx
+++ b/src/components/layout/TabBar.dnd.test.tsx
@@ -1,14 +1,11 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
-import {
-  SidebarLayoutContext,
-  type SidebarLayoutContextValue,
-} from "@/contexts/SidebarLayoutContext";
-import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
-import { activeFileOf, type FileTab, type Tab } from "@/lib/tabs";
-import { COMPLETE_INDEX_STATUS } from "@/lib/workspaceScan";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SidebarLayoutContext } from "@/contexts/SidebarLayoutContext";
+import type { TabsContextValue } from "@/contexts/TabsContext";
+import type { FileTab, Tab } from "@/lib/tabs";
 import { sidebarLayoutValue } from "@/test/fixtures/sidebarLayout";
+import { TabsWrapper, tabsContextValue } from "@/test/fixtures/tabsContext";
+import { dragFromTo, ghostEl, releaseAt, setHit } from "@/test/pointerDrag";
 import { TabBar } from "./TabBar";
 
 const makeFileTab = (i: number): FileTab => ({
@@ -29,189 +26,196 @@ const makeFileTab = (i: number): FileTab => ({
 
 const makeTabs = (count: number): Tab[] => Array.from({ length: count }, (_, i) => makeFileTab(i));
 
-interface RenderOpts {
-  tabs?: Tab[];
-  activeTabId?: string | null;
-  workspace?: TabsContextValue["workspace"];
-  setActiveTab?: (id: string) => void;
-  closeTab?: (id: string) => Promise<boolean>;
-  closeTabs?: (ids: string[]) => Promise<boolean>;
-  setTabMode?: TabsContextValue["setTabMode"];
-  moveTab?: (id: string, toIndex: number) => void;
-  tocEntries?: TabsContextValue["tocEntries"];
-  openFileDialog?: TabsContextValue["openFileDialog"];
-  sidebar?: Partial<SidebarLayoutContextValue>;
-}
-
-function buildContext(opts: RenderOpts): TabsContextValue {
-  const tabs = opts.tabs ?? [];
-  const activeTabId = opts.activeTabId ?? null;
-  const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
-  return {
-    tabs,
-    activeTab,
-    activeTabId,
-    activeFile: activeFileOf(activeTab),
-    initializing: false,
-    workspaceFiles: [],
-    wikilinkRefs: [],
-    metadataEntries: [],
-    metadata: new Map(),
-    indexStatus: COMPLETE_INDEX_STATUS,
-    workspace: opts.workspace ?? null,
-    newDocument: vi.fn(),
-    openFile: vi.fn(),
-    openFolder: vi.fn(),
-    createWorkspace: vi.fn(),
-    openGraph: vi.fn(),
-    closeWorkspace: vi.fn(),
-    toggleExpand: vi.fn(),
-    createNote: vi.fn(),
-    createNoteInWorkspace: vi.fn(),
-    createCanvasInWorkspace: vi.fn(),
-    createCanvas: vi.fn(),
-    commitEdit: vi.fn(),
-    createFolder: vi.fn(),
-    renamePath: vi.fn(),
-    duplicatePath: vi.fn(),
-    movePath: vi.fn(),
-    collapseAll: vi.fn(),
-    expandAll: vi.fn(),
-    deletePath: vi.fn(),
-    closeTab: opts.closeTab ?? vi.fn(),
-    closeTabs: opts.closeTabs ?? vi.fn(),
-    setActiveTab: opts.setActiveTab ?? vi.fn(),
-    setTabMode: opts.setTabMode ?? vi.fn(),
-    moveTab: opts.moveTab ?? vi.fn(),
-    moveActiveTab: vi.fn(),
-    navigateBack: vi.fn(),
-    navigateForward: vi.fn(),
-    updateEditContent: vi.fn(),
-    saveDocument: vi.fn(),
-    flushForClose: vi.fn(),
-    flushSessionForClose: vi.fn(async () => {}),
-    toggleTask: vi.fn(),
-    saveScrollPosition: vi.fn(),
-    openFileDialog: opts.openFileDialog ?? vi.fn(),
-    undoEdit: vi.fn(),
-    redoEdit: vi.fn(),
-    displayContent: null,
-    tocEntries: opts.tocEntries ?? [],
-    backlinks: [],
-    workspaceNotice: null,
-    dismissWorkspaceNotice: vi.fn(),
-  };
-}
-
-function Wrapper({
-  value,
-  sidebar,
-  children,
-}: {
-  value: TabsContextValue;
-  sidebar: SidebarLayoutContextValue;
-  children: ReactNode;
-}) {
-  return (
-    <TabsContext.Provider value={value}>
-      <SidebarLayoutContext.Provider value={sidebar}>{children}</SidebarLayoutContext.Provider>
-    </TabsContext.Provider>
+function renderTabBar(over: Partial<TabsContextValue> = {}) {
+  return render(
+    <TabsWrapper value={tabsContextValue({ tabs: makeTabs(2), activeTabId: "tab-0", ...over })}>
+      <SidebarLayoutContext.Provider value={sidebarLayoutValue()}>
+        <TabBar onToggleAIChat={null} onOpenPalette={vi.fn()} />
+      </SidebarLayoutContext.Provider>
+    </TabsWrapper>,
   );
 }
 
-function renderTabBar(opts: RenderOpts = {}, onToggleAIChat: (() => void) | null = null) {
-  const value = buildContext(opts);
-  const sidebar = sidebarLayoutValue(opts.sidebar);
-  return {
-    ...render(
-      <Wrapper value={value} sidebar={sidebar}>
-        <TabBar onToggleAIChat={onToggleAIChat} onOpenPalette={vi.fn()} />
-      </Wrapper>,
-    ),
-    value,
-    sidebar,
-  };
-}
+describe("pointer drag reordering", () => {
+  // Scoped to the strip: the drag ghost repeats the label in document.body.
+  const strip = () => document.querySelector(".tab-bar-scroll") as HTMLElement;
+  const labelEl = (name: string) => within(strip()).getByText(name);
+  const tabEl = (name: string) => labelEl(name).closest(".tab-item") as HTMLElement;
+  const activateButton = (name: string) => screen.getByRole("button", { name });
 
-describe("drag-and-drop reordering", () => {
-  const dataTransfer = () => ({ setData: vi.fn(), effectAllowed: "", dropEffect: "" });
-  const tabEl = (name: string) => screen.getByText(name).closest(".tab-item") as HTMLElement;
+  const press = (name: string, init: Record<string, unknown> = {}) =>
+    fireEvent.pointerDown(tabEl(name), { button: 0, clientX: 0, clientY: 0, ...init });
 
-  it("marks every tab as draggable", () => {
-    renderTabBar({ tabs: makeTabs(2), activeTabId: "tab-0" });
-    expect(tabEl("file0.md").getAttribute("draggable")).toBe("true");
-    expect(tabEl("file1.md").getAttribute("draggable")).toBe("true");
+  beforeEach(() => {
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
   });
 
-  it("moves the dragged tab to the drop target's index", () => {
+  it("keeps a plain click activating the tab when movement stays below the threshold", () => {
+    const setActiveTab = vi.fn();
     const moveTab = vi.fn();
-    renderTabBar({ tabs: makeTabs(3), activeTabId: "tab-0", moveTab });
-    const dt = dataTransfer();
-    fireEvent.dragStart(tabEl("file0.md"), { dataTransfer: dt });
-    fireEvent.dragOver(tabEl("file2.md"), { dataTransfer: dt });
-    fireEvent.drop(tabEl("file2.md"), { dataTransfer: dt });
+    renderTabBar({ setActiveTab, moveTab });
+    press("file1.md");
+    fireEvent.pointerMove(window, { clientX: 2, clientY: 2 });
+    expect(ghostEl()).toBeNull();
+    releaseAt(2, 2);
+    fireEvent.click(activateButton("file1.md"));
+    expect(setActiveTab).toHaveBeenCalledWith("tab-1");
+    expect(moveTab).not.toHaveBeenCalled();
+  });
+
+  it("moves the dragged tab to the hovered tab's index on release", () => {
+    const moveTab = vi.fn();
+    renderTabBar({ tabs: makeTabs(3), moveTab });
+    // Hit the label span inside the tab: descendants resolve to their tab.
+    dragFromTo(tabEl("file0.md"), labelEl("file2.md"));
+    releaseAt();
+    expect(moveTab).toHaveBeenCalledWith("tab-0", 2);
+    expect(tabEl("file2.md").hasAttribute("data-drop")).toBe(false);
+    expect(ghostEl()).toBeNull();
+    expect(document.body.style.userSelect).toBe("");
+    expect(document.body.dataset.pointerDrag).toBeUndefined();
+  });
+
+  it("commits the target the indicator showed, not where the pointer was released", () => {
+    const moveTab = vi.fn();
+    renderTabBar({ tabs: makeTabs(3), moveTab });
+    dragFromTo(tabEl("file0.md"), tabEl("file2.md"));
+    // The release lands a few px further, past the last tab.
+    setHit(null);
+    releaseAt(60, 40);
     expect(moveTab).toHaveBeenCalledWith("tab-0", 2);
   });
 
-  it("shows the drop indicator on the trailing edge when dragging right", () => {
-    renderTabBar({ tabs: makeTabs(3), activeTabId: "tab-0" });
-    const dt = dataTransfer();
-    fireEvent.dragStart(tabEl("file0.md"), { dataTransfer: dt });
-    fireEvent.dragOver(tabEl("file2.md"), { dataTransfer: dt });
-    // dragover fires repeatedly over the same target; the indicator is stable.
-    fireEvent.dragOver(tabEl("file2.md"), { dataTransfer: dt });
-    expect(tabEl("file2.md").getAttribute("data-drop")).toBe("after");
+  it("captures the pointer on press so a release outside the window still ends the drag", () => {
+    renderTabBar();
+    const setPointerCapture = vi.fn();
+    Object.assign(tabEl("file0.md"), { setPointerCapture });
+    press("file0.md", { pointerId: 7 });
+    expect(setPointerCapture).toHaveBeenCalledWith(7);
   });
 
-  it("shows the drop indicator on the leading edge when dragging left", () => {
+  it("shows the trailing-edge indicator and the label ghost when dragging right", () => {
+    renderTabBar({ tabs: makeTabs(3) });
+    dragFromTo(tabEl("file0.md"), tabEl("file2.md"));
+    // pointermove fires continuously over the same target; the indicator is stable.
+    fireEvent.pointerMove(window, { clientX: 41, clientY: 40 });
+    expect(tabEl("file2.md").getAttribute("data-drop")).toBe("after");
+    expect(ghostEl()?.textContent).toBe("file0.md");
+    expect(document.body.style.cursor).toBe("grabbing");
+    expect(document.body.dataset.pointerDrag).toBe("");
+  });
+
+  it("shows the leading-edge indicator when dragging left", () => {
     renderTabBar({ tabs: makeTabs(3), activeTabId: "tab-2" });
-    const dt = dataTransfer();
-    fireEvent.dragStart(tabEl("file2.md"), { dataTransfer: dt });
-    fireEvent.dragOver(tabEl("file0.md"), { dataTransfer: dt });
+    dragFromTo(tabEl("file2.md"), tabEl("file0.md"));
     expect(tabEl("file0.md").getAttribute("data-drop")).toBe("before");
   });
 
-  it("shows no indicator over the dragged tab itself and does not move on self-drop", () => {
+  it("shows no indicator over the dragged tab itself and does not commit a self-drop", () => {
     const moveTab = vi.fn();
-    renderTabBar({ tabs: makeTabs(2), activeTabId: "tab-0", moveTab });
-    const dt = dataTransfer();
-    fireEvent.dragStart(tabEl("file0.md"), { dataTransfer: dt });
-    fireEvent.dragOver(tabEl("file1.md"), { dataTransfer: dt });
-    fireEvent.dragOver(tabEl("file0.md"), { dataTransfer: dt });
+    renderTabBar({ moveTab });
+    dragFromTo(tabEl("file0.md"), tabEl("file1.md"));
+    expect(tabEl("file1.md").getAttribute("data-drop")).toBe("after");
+    setHit(tabEl("file0.md"));
+    fireEvent.pointerMove(window, { clientX: 10, clientY: 10 });
     expect(tabEl("file0.md").hasAttribute("data-drop")).toBe(false);
     expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
-    fireEvent.drop(tabEl("file0.md"), { dataTransfer: dt });
+    expect(document.body.style.cursor).toBe("no-drop");
+    releaseAt(10, 10);
     expect(moveTab).not.toHaveBeenCalled();
   });
 
-  it("clears the indicator when the drag ends without a drop", () => {
-    renderTabBar({ tabs: makeTabs(2), activeTabId: "tab-0" });
-    const dt = dataTransfer();
-    fireEvent.dragStart(tabEl("file0.md"), { dataTransfer: dt });
-    fireEvent.dragOver(tabEl("file1.md"), { dataTransfer: dt });
-    expect(tabEl("file1.md").getAttribute("data-drop")).toBe("after");
-    fireEvent.dragEnd(tabEl("file0.md"), { dataTransfer: dt });
-    expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
-  });
-
-  it("ignores dragover and drop when no tab drag is in progress", () => {
+  it("treats space outside the tab strip as no target", () => {
     const moveTab = vi.fn();
-    renderTabBar({ tabs: makeTabs(2), activeTabId: "tab-0", moveTab });
-    const dt = dataTransfer();
-    fireEvent.dragOver(tabEl("file1.md"), { dataTransfer: dt });
-    expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
-    fireEvent.drop(tabEl("file1.md"), { dataTransfer: dt });
+    renderTabBar({ moveTab });
+    dragFromTo(tabEl("file0.md"), document.body);
+    expect(document.body.style.cursor).toBe("no-drop");
+    releaseAt();
+    expect(moveTab).not.toHaveBeenCalled();
+    // A hit-test miss (no element at the point at all) is equally inert.
+    dragFromTo(tabEl("file0.md"), null);
+    releaseAt();
     expect(moveTab).not.toHaveBeenCalled();
   });
 
-  it("clears the indicator after a completed drop", () => {
+  it("cancels on Escape without reordering", () => {
     const moveTab = vi.fn();
-    renderTabBar({ tabs: makeTabs(3), activeTabId: "tab-0", moveTab });
-    const dt = dataTransfer();
-    fireEvent.dragStart(tabEl("file0.md"), { dataTransfer: dt });
-    fireEvent.dragOver(tabEl("file1.md"), { dataTransfer: dt });
-    fireEvent.drop(tabEl("file1.md"), { dataTransfer: dt });
+    renderTabBar({ moveTab });
+    dragFromTo(tabEl("file0.md"), tabEl("file1.md"));
+    fireEvent.keyDown(window, { key: "Escape" });
     expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
+    expect(ghostEl()).toBeNull();
+    releaseAt();
+    expect(moveTab).not.toHaveBeenCalled();
+  });
+
+  it("cancels when the browser cancels the pointer sequence", () => {
+    const moveTab = vi.fn();
+    renderTabBar({ moveTab });
+    dragFromTo(tabEl("file0.md"), tabEl("file1.md"));
+    fireEvent.pointerCancel(window);
+    expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
+    expect(ghostEl()).toBeNull();
+    expect(document.body.style.cursor).toBe("");
+    releaseAt();
+    expect(moveTab).not.toHaveBeenCalled();
+  });
+
+  it("tears down the drag feedback when the strip unmounts mid-drag", () => {
+    const { unmount } = renderTabBar();
+    dragFromTo(tabEl("file0.md"), tabEl("file1.md"));
+    expect(ghostEl()).not.toBeNull();
+    unmount();
+    expect(ghostEl()).toBeNull();
+    expect(document.body.style.userSelect).toBe("");
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.dataset.pointerDrag).toBeUndefined();
+  });
+
+  it("ignores stray pointer and key events while no drag is in progress", () => {
+    const moveTab = vi.fn();
+    renderTabBar({ moveTab });
+    setHit(tabEl("file1.md"));
+    fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
+    expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
+    fireEvent.pointerUp(window, { clientX: 40, clientY: 40 });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(moveTab).not.toHaveBeenCalled();
+  });
+
+  it("suppresses exactly one click after a completed drag", () => {
+    const setActiveTab = vi.fn();
+    renderTabBar({ setActiveTab });
+    dragFromTo(tabEl("file0.md"), tabEl("file1.md"));
+    releaseAt();
+    fireEvent.click(activateButton("file0.md"));
+    expect(setActiveTab).not.toHaveBeenCalled();
+    fireEvent.click(activateButton("file0.md"));
+    expect(setActiveTab).toHaveBeenCalledWith("tab-0");
+  });
+
+  it("leaves middle-click presses to the aux-click close instead of the drag", () => {
+    const closeTab = vi.fn();
+    const moveTab = vi.fn();
+    renderTabBar({ closeTab, moveTab });
+    press("file1.md", { button: 1 });
+    setHit(tabEl("file0.md"));
+    fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
+    expect(ghostEl()).toBeNull();
+    releaseAt();
+    fireEvent(tabEl("file1.md"), new MouseEvent("auxclick", { bubbles: true, button: 1 }));
+    expect(closeTab).toHaveBeenCalledWith("tab-1");
+    expect(moveTab).not.toHaveBeenCalled();
+  });
+
+  it("ignores touch presses (mobile has its own interaction model)", () => {
+    renderTabBar();
+    press("file0.md", { pointerType: "touch" });
+    setHit(tabEl("file1.md"));
+    fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
+    expect(tabEl("file1.md").hasAttribute("data-drop")).toBe(false);
+    expect(ghostEl()).toBeNull();
   });
 });
 
@@ -219,7 +223,7 @@ describe("drag-and-drop reordering", () => {
 // spec, and React 19 logs a hydration error when it sees it. The close
 // button used to sit inside the tab activate button; now it's a sibling.
 it("does not nest a button inside another button", () => {
-  const { container } = renderTabBar({ tabs: makeTabs(2), activeTabId: "tab-0" });
+  const { container } = renderTabBar();
   for (const button of container.querySelectorAll("button")) {
     expect(button.querySelector("button")).toBeNull();
   }

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -107,7 +107,8 @@ export function TabBar({ onToggleAIChat, onOpenPalette }: TabBarProps) {
               data-tab-kind={tab.kind}
               data-loose={loose || undefined}
               data-drop={indicator?.index === index ? indicator.edge : undefined}
-              {...handlersFor(tab.id, index)}
+              data-tab-index={index}
+              {...handlersFor(tab.id, index, label)}
               onAuxClick={(e) => {
                 if (e.button === 1) {
                   e.preventDefault();

--- a/src/hooks/useFileTreeDragMove.test.ts
+++ b/src/hooks/useFileTreeDragMove.test.ts
@@ -1,11 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ghostEl, setHit } from "@/test/pointerDrag";
 import { useFileTreeDragMove } from "./useFileTreeDragMove";
-
-function setHit(el: Element | null) {
-  document.elementFromPoint = vi.fn(() => el) as typeof document.elementFromPoint;
-}
 
 function zoneEl(attrs: Record<string, string>): HTMLElement {
   const el = document.createElement("div");
@@ -20,10 +17,12 @@ const downEvent = (overrides: Partial<ReactPointerEvent> = {}) =>
   ({
     button: 0,
     pointerType: "mouse",
+    pointerId: 1,
     clientX: 0,
     clientY: 0,
+    currentTarget: document.createElement("div"),
     ...overrides,
-  }) as ReactPointerEvent;
+  }) as unknown as ReactPointerEvent;
 
 const clickEvent = () =>
   ({ preventDefault: vi.fn(), stopPropagation: vi.fn() }) as unknown as ReactPointerEvent & {
@@ -81,15 +80,15 @@ describe("useFileTreeDragMove", () => {
     expect(result.current.dropTarget).toBe("/root/sub");
     expect(document.body.style.userSelect).toBe("none");
     expect(document.body.style.cursor).toBe("grabbing");
-    const ghost = document.querySelector("[data-tree-drag-ghost]");
-    expect(ghost?.textContent).toBe("a.md");
-    expect((ghost as HTMLElement).style.pointerEvents).toBe("none");
+    expect(document.body.dataset.pointerDrag).toBe("");
+    expect(ghostEl()?.textContent).toBe("a.md");
     release();
+    expect(document.body.dataset.pointerDrag).toBeUndefined();
     expect(onMoveEntry).toHaveBeenCalledTimes(1);
     expect(onMoveEntry).toHaveBeenCalledWith("/root/a.md", "/root/sub");
     expect(result.current.dropTarget).toBeNull();
     expect(document.body.style.userSelect).toBe("");
-    expect(document.querySelector("[data-tree-drag-ghost]")).toBeNull();
+    expect(ghostEl()).toBeNull();
   });
 
   it("suppresses exactly one click after a completed drag", () => {
@@ -173,7 +172,7 @@ describe("useFileTreeDragMove", () => {
       window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     });
     expect(result.current.dropTarget).toBeNull();
-    expect(document.querySelector("[data-tree-drag-ghost]")).toBeNull();
+    expect(ghostEl()).toBeNull();
     release();
     expect(onMoveEntry).not.toHaveBeenCalled();
   });
@@ -217,9 +216,9 @@ describe("useFileTreeDragMove", () => {
     setHit(folderZone("/root/sub"));
     press("/root/a.md");
     moveTo();
-    expect(document.querySelector("[data-tree-drag-ghost]")).not.toBeNull();
+    expect(ghostEl()).not.toBeNull();
     unmount();
-    expect(document.querySelector("[data-tree-drag-ghost]")).toBeNull();
+    expect(ghostEl()).toBeNull();
     const removed = removeSpy.mock.calls.map(([type]) => type);
     expect(removed).toContain("pointermove");
     expect(removed).toContain("pointerup");

--- a/src/hooks/useFileTreeDragMove.test.ts
+++ b/src/hooks/useFileTreeDragMove.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import type { PointerEvent as ReactPointerEvent } from "react";
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ghostEl, setHit } from "@/test/pointerDrag";
 import { useFileTreeDragMove } from "./useFileTreeDragMove";
@@ -20,12 +20,12 @@ const downEvent = (overrides: Partial<ReactPointerEvent> = {}) =>
     pointerId: 1,
     clientX: 0,
     clientY: 0,
-    currentTarget: document.createElement("div"),
+    target: { setPointerCapture: vi.fn() },
     ...overrides,
   }) as unknown as ReactPointerEvent;
 
 const clickEvent = () =>
-  ({ preventDefault: vi.fn(), stopPropagation: vi.fn() }) as unknown as ReactPointerEvent & {
+  ({ preventDefault: vi.fn(), stopPropagation: vi.fn() }) as unknown as ReactMouseEvent & {
     preventDefault: ReturnType<typeof vi.fn>;
     stopPropagation: ReturnType<typeof vi.fn>;
   };
@@ -39,12 +39,14 @@ function renderDnd(onMoveEntry = vi.fn()) {
   };
   const moveTo = (x = 50, y = 50) => {
     act(() => {
-      window.dispatchEvent(new MouseEvent("pointermove", { clientX: x, clientY: y }));
+      window.dispatchEvent(
+        new PointerEvent("pointermove", { clientX: x, clientY: y, buttons: 1, pointerId: 1 }),
+      );
     });
   };
   const release = (x = 50, y = 50) => {
     act(() => {
-      window.dispatchEvent(new MouseEvent("pointerup", { clientX: x, clientY: y }));
+      window.dispatchEvent(new PointerEvent("pointerup", { clientX: x, clientY: y, pointerId: 1 }));
     });
   };
   return { result, unmount, onMoveEntry, press, moveTo, release };
@@ -52,6 +54,7 @@ function renderDnd(onMoveEntry = vi.fn()) {
 
 describe("useFileTreeDragMove", () => {
   beforeEach(() => {
+    setHit(null);
     document.body.innerHTML = "";
     document.body.style.cursor = "";
     document.body.style.userSelect = "";

--- a/src/hooks/useFileTreeDragMove.ts
+++ b/src/hooks/useFileTreeDragMove.ts
@@ -1,20 +1,11 @@
-import type { PointerEvent as ReactPointerEvent } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { basename, isPathInside, parentDir } from "@/lib/paths";
-
-/** Pointer movement (px) before a press becomes a drag instead of a click. */
-const DRAG_THRESHOLD_PX = 5;
-
-/** Drag-source handlers for any tree row. */
-export interface TreeDragHandlers {
-  onPointerDown: (event: ReactPointerEvent) => void;
-  onClickCapture: (event: ReactPointerEvent | React.MouseEvent) => void;
-}
+import { type DragSourceHandlers, usePointerDrag } from "./usePointerDrag";
 
 export interface FileTreeDragMove {
   /** Directory hovered by a valid drag, for the drop-target highlight. */
   dropTarget: string | null;
-  dragHandlersFor: (path: string) => TreeDragHandlers;
+  dragHandlersFor: (path: string) => DragSourceHandlers;
 }
 
 /** Resolve the drop directory under the pointer: the nearest marked ancestor
@@ -31,143 +22,35 @@ function dropDirAt(x: number, y: number): string | null {
   return zone.getAttribute("data-tree-drop-dir");
 }
 
-// Pointer-event drag-and-drop for moving tree entries into folders. HTML5
-// drag events are NOT used on purpose: Tauri's native drag-drop handler owns
-// the OS drag loop (for dropping external files onto the window), and on
-// Windows that swallows every in-page dragover/drop, so the HTML5 API can
-// never work there. Pointer events stay inside the page. A press only becomes
-// a drag past a small movement threshold, so row clicks keep working; targets
-// are hit-tested via elementFromPoint against data-tree-drop-* markers; the
-// move commits through `onMoveEntry(from, toDir)` on release. The backend
+// A drop into `dir` is rejected when it targets the dragged entry itself or
+// anywhere inside it, or the directory the entry already lives in (a no-op).
+function canDrop(dir: string, from: string, root: string): boolean {
+  if (isPathInside(dir, from)) return false;
+  return parentDir(from, root) !== dir;
+}
+
+// Drag-and-drop for moving tree entries into folders, on the shared pointer
+// drag core (see usePointerDrag for why HTML5 drag events cannot be used).
+// Targets are hit-tested against the data-tree-drop-* markers; the move
+// commits through `onMoveEntry(from, toDir)` on release. The backend
 // re-validates every move; the rules here only shape the drag affordance.
 export function useFileTreeDragMove(
   root: string,
   onMoveEntry: (from: string, toDir: string) => void,
 ): FileTreeDragMove {
-  const drag = useRef<{ path: string; startX: number; startY: number; active: boolean } | null>(
-    null,
-  );
-  const suppressClick = useRef(false);
-  const ghost = useRef<HTMLDivElement | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null);
 
-  // A drop into `dir` is rejected when it targets the dragged entry itself or
-  // anywhere inside it, or the directory the entry already lives in (a no-op).
-  const canDrop = useCallback(
-    (dir: string, from: string) => {
-      if (isPathInside(dir, from)) return false;
-      return parentDir(from, root) !== dir;
-    },
-    [root],
-  );
-
-  const finishDrag = useCallback(
-    (commitAt?: { x: number; y: number }) => {
-      const dragged = drag.current;
-      if (!dragged) return;
-      drag.current = null;
-      setDropTarget(null);
-      ghost.current?.remove();
-      ghost.current = null;
-      document.body.style.userSelect = "";
-      document.body.style.cursor = "";
-      if (!dragged.active) return;
-      // The click synthesized after a completed drag must not open/toggle.
-      suppressClick.current = true;
-      if (!commitAt) return;
-      const dir = dropDirAt(commitAt.x, commitAt.y);
-      if (dir !== null && canDrop(dir, dragged.path)) onMoveEntry(dragged.path, dir);
-    },
-    [canDrop, onMoveEntry],
-  );
-
-  const handleWindowPointerMove = useCallback(
-    (event: PointerEvent) => {
-      const dragged = drag.current;
-      if (!dragged) return;
-      if (!dragged.active) {
-        const moved =
-          Math.abs(event.clientX - dragged.startX) + Math.abs(event.clientY - dragged.startY);
-        if (moved < DRAG_THRESHOLD_PX) return;
-        dragged.active = true;
-        // No text selection while dragging; the cursor signals the mode.
-        document.body.style.userSelect = "none";
-        // The floating name pill is the drag feedback (there is no native
-        // ghost image without the HTML5 drag API). pointer-events:none keeps
-        // it invisible to the elementFromPoint hit-testing underneath it.
-        const pill = document.createElement("div");
-        pill.dataset.treeDragGhost = "";
-        pill.style.cssText =
-          "position:fixed;left:0;top:0;z-index:9999;pointer-events:none;" +
-          "padding:2px 8px;border-radius:var(--glyph-radius-sm);font-size:12px;" +
-          "background:var(--color-surface);border:1px solid var(--color-accent);" +
-          "color:var(--color-text-primary);box-shadow:0 2px 8px rgb(0 0 0 / 0.25);" +
-          "max-width:240px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap";
-        pill.textContent = basename(dragged.path);
-        document.body.appendChild(pill);
-        ghost.current = pill;
-      }
-      const dir = dropDirAt(event.clientX, event.clientY);
-      const valid = dir !== null && canDrop(dir, dragged.path);
-      ghost.current?.style.setProperty(
-        "transform",
-        `translate(${event.clientX + 14}px, ${event.clientY + 10}px)`,
-      );
-      document.body.style.cursor = valid ? "grabbing" : "no-drop";
-      const next = valid ? dir : null;
+  const { pressHandlersFor } = usePointerDrag<string, string>({
+    ghostLabel: basename,
+    onDragMove: (path, x, y) => {
+      const dir = dropDirAt(x, y);
+      const next = dir !== null && canDrop(dir, path, root) ? dir : null;
       setDropTarget((prev) => (prev === next ? prev : next));
+      return next;
     },
-    [canDrop],
-  );
+    onDrop: onMoveEntry,
+    onReset: () => setDropTarget(null),
+  });
 
-  const handleWindowPointerUp = useCallback(
-    (event: PointerEvent) => {
-      finishDrag({ x: event.clientX, y: event.clientY });
-    },
-    [finishDrag],
-  );
-
-  const handleWindowKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key === "Escape") finishDrag();
-    },
-    [finishDrag],
-  );
-
-  // Mount-lifetime listeners: every handler early-returns while no drag is in
-  // progress, which is cheaper and simpler than attach-on-press bookkeeping.
-  useEffect(() => {
-    window.addEventListener("pointermove", handleWindowPointerMove);
-    window.addEventListener("pointerup", handleWindowPointerUp);
-    window.addEventListener("keydown", handleWindowKeyDown);
-    return () => {
-      window.removeEventListener("pointermove", handleWindowPointerMove);
-      window.removeEventListener("pointerup", handleWindowPointerUp);
-      window.removeEventListener("keydown", handleWindowKeyDown);
-      ghost.current?.remove();
-      ghost.current = null;
-    };
-  }, [handleWindowPointerMove, handleWindowPointerUp, handleWindowKeyDown]);
-
-  const dragHandlersFor = useCallback(
-    (path: string): TreeDragHandlers => ({
-      onPointerDown: (event) => {
-        // Touch keeps scrolling the tree; mobile moves files via the menu.
-        if (event.button !== 0 || event.pointerType === "touch") return;
-        // A drag that ended off-row leaves the flag set with no click to eat;
-        // a new press starts a fresh interaction.
-        suppressClick.current = false;
-        drag.current = { path, startX: event.clientX, startY: event.clientY, active: false };
-      },
-      onClickCapture: (event) => {
-        if (!suppressClick.current) return;
-        suppressClick.current = false;
-        event.preventDefault();
-        event.stopPropagation();
-      },
-    }),
-    [],
-  );
-
-  return { dropTarget, dragHandlersFor };
+  return { dropTarget, dragHandlersFor: pressHandlersFor };
 }

--- a/src/hooks/usePointerDrag.test.ts
+++ b/src/hooks/usePointerDrag.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook } from "@testing-library/react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ghostEl } from "@/test/pointerDrag";
+import { usePointerDrag } from "./usePointerDrag";
+
+// The element-level behavior is pinned through the consumers
+// (TabBar.dnd.test.tsx, useFileTreeDragMove.test.ts); this covers what needs
+// two instances mounted at once, which is the normal app state (file tree and
+// tab strip both alive).
+
+function mountInstance() {
+  const onDrop = vi.fn();
+  const onReset = vi.fn();
+  const hook = renderHook(() =>
+    usePointerDrag<string, string>({
+      ghostLabel: (payload) => payload,
+      onDragMove: () => "target",
+      onDrop,
+      onReset,
+    }),
+  );
+  const press = (payload: string) => {
+    act(() => {
+      hook.result.current.pressHandlersFor(payload).onPointerDown({
+        button: 0,
+        pointerType: "mouse",
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+        target: { setPointerCapture: vi.fn() },
+      } as unknown as ReactPointerEvent);
+    });
+  };
+  return { ...hook, onDrop, onReset, press };
+}
+
+const moveTo = (x: number, y: number) => {
+  act(() => {
+    window.dispatchEvent(
+      new PointerEvent("pointermove", { clientX: x, clientY: y, buttons: 1, pointerId: 1 }),
+    );
+  });
+};
+
+const release = () => {
+  act(() => {
+    window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1 }));
+  });
+};
+
+describe("usePointerDrag with several instances mounted", () => {
+  it("lets an idle instance unmount without disturbing the active drag", () => {
+    const active = mountInstance();
+    const idle = mountInstance();
+    active.press("a");
+    moveTo(40, 40);
+    expect(ghostEl()?.textContent).toBe("a");
+    idle.unmount();
+    expect(ghostEl()).not.toBeNull();
+    expect(idle.onReset).not.toHaveBeenCalled();
+    release();
+    expect(active.onDrop).toHaveBeenCalledWith("a", "target");
+    expect(idle.onDrop).not.toHaveBeenCalled();
+    active.unmount();
+  });
+
+  it("routes Escape to the dragging instance only", () => {
+    const active = mountInstance();
+    const idle = mountInstance();
+    active.press("a");
+    moveTo(40, 40);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(ghostEl()).toBeNull();
+    expect(active.onReset).toHaveBeenCalledTimes(1);
+    expect(idle.onReset).not.toHaveBeenCalled();
+    release();
+    expect(active.onDrop).not.toHaveBeenCalled();
+    active.unmount();
+    idle.unmount();
+  });
+});

--- a/src/hooks/usePointerDrag.ts
+++ b/src/hooks/usePointerDrag.ts
@@ -6,7 +6,7 @@ const DRAG_THRESHOLD_PX = 5;
 
 export interface DragSourceHandlers {
   onPointerDown: (event: ReactPointerEvent) => void;
-  onClickCapture: (event: ReactPointerEvent | ReactMouseEvent) => void;
+  onClickCapture: (event: ReactMouseEvent) => void;
 }
 
 interface UsePointerDragOptions<T, R> {
@@ -24,6 +24,7 @@ interface UsePointerDrag<T> {
 
 interface DragState<T, R> {
   payload: T;
+  pointerId: number;
   startX: number;
   startY: number;
   active: boolean;
@@ -70,7 +71,13 @@ export function usePointerDrag<T, R>(options: UsePointerDragOptions<T, R>): UseP
 
     const handlePointerMove = (event: PointerEvent) => {
       const dragged = drag.current;
-      if (!dragged) return;
+      if (!dragged || event.pointerId !== dragged.pointerId) return;
+      // Primary button already up means the release never reached the page
+      // (focus stolen mid-press); end the drag instead of arming a phantom one.
+      if ((event.buttons & 1) === 0) {
+        finishDrag(false);
+        return;
+      }
       if (!dragged.active) {
         const moved =
           Math.abs(event.clientX - dragged.startX) + Math.abs(event.clientY - dragged.startY);
@@ -96,8 +103,13 @@ export function usePointerDrag<T, R>(options: UsePointerDragOptions<T, R>): UseP
       );
       document.body.style.cursor = dragged.target === null ? "no-drop" : "grabbing";
     };
-    const handlePointerUp = () => finishDrag(true);
-    const handlePointerCancel = () => finishDrag(false);
+    // Other pointers (a stray touch during a mouse drag) must not end the drag.
+    const handlePointerUp = (event: PointerEvent) => {
+      if (event.pointerId === drag.current?.pointerId) finishDrag(true);
+    };
+    const handlePointerCancel = (event: PointerEvent) => {
+      if (event.pointerId === drag.current?.pointerId) finishDrag(false);
+    };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") finishDrag(false);
     };
@@ -119,14 +131,17 @@ export function usePointerDrag<T, R>(options: UsePointerDragOptions<T, R>): UseP
     onPointerDown: (event) => {
       // Touch keeps scrolling; mobile has its own interaction model.
       if (event.button !== 0 || event.pointerType === "touch") return;
-      // Capture keeps pointerup (and the click to swallow) arriving on this
-      // element even when the button is released outside the window.
-      event.currentTarget.setPointerCapture?.(event.pointerId);
+      // Capture keeps pointerup arriving even when the button is released
+      // outside the window. It goes on the pressed element, not the wrapper
+      // carrying these handlers: the click after release is dispatched to the
+      // capturing element, and inner buttons must still receive theirs.
+      (event.target as Element).setPointerCapture(event.pointerId);
       // A drag that ended off-element leaves the flag set with no click to
       // eat; a new press starts a fresh interaction.
       suppressClick.current = false;
       drag.current = {
         payload,
+        pointerId: event.pointerId,
         startX: event.clientX,
         startY: event.clientY,
         active: false,

--- a/src/hooks/usePointerDrag.ts
+++ b/src/hooks/usePointerDrag.ts
@@ -1,0 +1,145 @@
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
+import { useEffect, useRef } from "react";
+
+/** Pointer movement (px) before a press becomes a drag instead of a click. */
+const DRAG_THRESHOLD_PX = 5;
+
+export interface DragSourceHandlers {
+  onPointerDown: (event: ReactPointerEvent) => void;
+  onClickCapture: (event: ReactPointerEvent | ReactMouseEvent) => void;
+}
+
+interface UsePointerDragOptions<T, R> {
+  ghostLabel: (payload: T) => string;
+  /** Resolves the valid drop target under the pointer (null shows no-drop); the
+   *  last result is what `onDrop` commits, so the drop matches the feedback. */
+  onDragMove: (payload: T, x: number, y: number) => R | null;
+  onDrop: (payload: T, target: R) => void;
+  onReset: () => void;
+}
+
+interface UsePointerDrag<T> {
+  pressHandlersFor: (payload: T) => DragSourceHandlers;
+}
+
+interface DragState<T, R> {
+  payload: T;
+  startX: number;
+  startY: number;
+  active: boolean;
+  target: R | null;
+}
+
+// Pointer-event press-to-drag core shared by the file tree and the tab strip.
+// HTML5 drag events are NOT used on purpose: Tauri's native drag-drop handler
+// owns the OS drag loop (for dropping external files onto the window), and on
+// Windows that swallows every in-page dragover/drop, so the HTML5 API can
+// never work there. Pointer events stay inside the page. A press only becomes
+// a drag past a small movement threshold, so plain clicks keep working;
+// consumers hit-test targets via elementFromPoint in `onDragMove`, and the
+// click synthesized after a completed drag is swallowed exactly once.
+export function usePointerDrag<T, R>(options: UsePointerDragOptions<T, R>): UsePointerDrag<T> {
+  // Latest callbacks behind a ref, so the window listeners mount once and
+  // never go stale, whatever identity the consumer passes each render.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const drag = useRef<DragState<T, R> | null>(null);
+  const suppressClick = useRef(false);
+  const ghost = useRef<HTMLDivElement | null>(null);
+
+  // Mount-lifetime listeners: every handler early-returns while no drag is in
+  // progress, which is cheaper and simpler than attach-on-press bookkeeping.
+  useEffect(() => {
+    const finishDrag = (commit: boolean) => {
+      const dragged = drag.current;
+      if (!dragged) return;
+      drag.current = null;
+      optionsRef.current.onReset();
+      ghost.current?.remove();
+      ghost.current = null;
+      delete document.body.dataset.pointerDrag;
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      if (!dragged.active) return;
+      // The click synthesized after a completed drag must not activate/toggle.
+      suppressClick.current = true;
+      if (commit && dragged.target !== null) {
+        optionsRef.current.onDrop(dragged.payload, dragged.target);
+      }
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const dragged = drag.current;
+      if (!dragged) return;
+      if (!dragged.active) {
+        const moved =
+          Math.abs(event.clientX - dragged.startX) + Math.abs(event.clientY - dragged.startY);
+        if (moved < DRAG_THRESHOLD_PX) return;
+        dragged.active = true;
+        // The body attribute lets the stylesheet force the drag cursor over
+        // elements with their own `cursor`, and no text selection meanwhile.
+        document.body.dataset.pointerDrag = "";
+        document.body.style.userSelect = "none";
+        // The floating label pill is the drag feedback (there is no native
+        // ghost image without the HTML5 drag API); its stylesheet rule keeps
+        // it pointer-events:none so elementFromPoint sees through it.
+        const pill = document.createElement("div");
+        pill.className = "drag-ghost";
+        pill.textContent = optionsRef.current.ghostLabel(dragged.payload);
+        document.body.appendChild(pill);
+        ghost.current = pill;
+      }
+      dragged.target = optionsRef.current.onDragMove(dragged.payload, event.clientX, event.clientY);
+      ghost.current?.style.setProperty(
+        "transform",
+        `translate(${event.clientX + 14}px, ${event.clientY + 10}px)`,
+      );
+      document.body.style.cursor = dragged.target === null ? "no-drop" : "grabbing";
+    };
+    const handlePointerUp = () => finishDrag(true);
+    const handlePointerCancel = () => finishDrag(false);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") finishDrag(false);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerCancel);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerCancel);
+      window.removeEventListener("keydown", handleKeyDown);
+      finishDrag(false);
+    };
+  }, []);
+
+  const pressHandlersFor = (payload: T): DragSourceHandlers => ({
+    onPointerDown: (event) => {
+      // Touch keeps scrolling; mobile has its own interaction model.
+      if (event.button !== 0 || event.pointerType === "touch") return;
+      // Capture keeps pointerup (and the click to swallow) arriving on this
+      // element even when the button is released outside the window.
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      // A drag that ended off-element leaves the flag set with no click to
+      // eat; a new press starts a fresh interaction.
+      suppressClick.current = false;
+      drag.current = {
+        payload,
+        startX: event.clientX,
+        startY: event.clientY,
+        active: false,
+        target: null,
+      };
+    },
+    onClickCapture: (event) => {
+      if (!suppressClick.current) return;
+      suppressClick.current = false;
+      event.preventDefault();
+      event.stopPropagation();
+    },
+  });
+
+  return { pressHandlersFor };
+}

--- a/src/hooks/useTabDragReorder.ts
+++ b/src/hooks/useTabDragReorder.ts
@@ -1,5 +1,5 @@
-import type { DragEvent } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useState } from "react";
+import { type DragSourceHandlers, usePointerDrag } from "./usePointerDrag";
 
 /** Insertion marker while a tab drag is in progress: the hovered tab's index
  *  and which edge of it the dragged tab would land on. */
@@ -8,71 +8,59 @@ export interface TabDropIndicator {
   edge: "before" | "after";
 }
 
-export interface TabDragHandlers {
-  draggable: true;
-  onDragStart: (event: DragEvent) => void;
-  onDragOver: (event: DragEvent) => void;
-  onDrop: (event: DragEvent) => void;
-  onDragEnd: () => void;
+interface TabDragPayload {
+  id: string;
+  index: number;
+  label: string;
 }
 
 interface UseTabDragReorder {
   indicator: TabDropIndicator | null;
-  handlersFor: (id: string, index: number) => TabDragHandlers;
+  handlersFor: (id: string, index: number, label: string) => DragSourceHandlers;
 }
 
-// Native HTML5 drag-and-drop reordering for the tab strip: no dependency, works
-// in every WebView. Tracks the dragged tab in a ref (only the indicator needs
-// renders) and commits the reorder through `onMove(id, toIndex)` on drop.
-// Dropping on a tab moves the dragged tab to that tab's index, so the edge the
-// indicator shows follows the drag direction: dragging right lands after the
-// hovered tab, dragging left lands before it (splice semantics).
+/** Resolve the tab under the pointer via the `data-tab-index` markers on the
+ *  tab elements (hits inside a tab, like its close button, resolve to it). */
+function tabIndexAt(x: number, y: number): number | null {
+  const tab = document.elementFromPoint(x, y)?.closest<HTMLElement>("[data-tab-index]");
+  const index = tab?.getAttribute("data-tab-index");
+  return index == null ? null : Number(index);
+}
+
+function indicatorFor(tab: TabDragPayload, hovered: number | null): TabDropIndicator | null {
+  if (hovered === null || hovered === tab.index) return null;
+  return { index: hovered, edge: hovered > tab.index ? "after" : "before" };
+}
+
+// Reordering for the tab strip, on the shared pointer drag core (see
+// usePointerDrag for why HTML5 drag events cannot be used). Dropping on a tab
+// moves the dragged tab to that tab's index through `onMove(id, toIndex)`
+// (splice semantics), so the edge the indicator shows follows the drag
+// direction: dragging right lands after the hovered tab, dragging left lands
+// before it.
 export function useTabDragReorder(
   onMove: (id: string, toIndex: number) => void,
 ): UseTabDragReorder {
-  const drag = useRef<{ id: string; index: number } | null>(null);
   const [indicator, setIndicator] = useState<TabDropIndicator | null>(null);
 
-  const handlersFor = useCallback(
-    (id: string, index: number): TabDragHandlers => ({
-      draggable: true,
-      onDragStart: (event) => {
-        drag.current = { id, index };
-        event.dataTransfer.effectAllowed = "move";
-        // WebKit refuses to start a drag with an empty payload.
-        event.dataTransfer.setData("text/plain", id);
-      },
-      onDragOver: (event) => {
-        const dragged = drag.current;
-        if (!dragged) return;
-        // preventDefault marks the tab as a valid drop target; without it the
-        // drop event never fires.
-        event.preventDefault();
-        event.dataTransfer.dropEffect = "move";
-        const next: TabDropIndicator | null =
-          index === dragged.index
-            ? null
-            : { index, edge: index > dragged.index ? "after" : "before" };
-        // dragover fires on every pointer move; keep the same object while the
-        // target is unchanged so React can bail out of re-rendering.
-        setIndicator((prev) =>
-          prev?.index === next?.index && prev?.edge === next?.edge ? prev : next,
-        );
-      },
-      onDrop: (event) => {
-        event.preventDefault();
-        const dragged = drag.current;
-        if (dragged && dragged.id !== id) onMove(dragged.id, index);
-        drag.current = null;
-        setIndicator(null);
-      },
-      onDragEnd: () => {
-        drag.current = null;
-        setIndicator(null);
-      },
-    }),
-    [onMove],
-  );
+  const { pressHandlersFor } = usePointerDrag<TabDragPayload, number>({
+    ghostLabel: (tab) => tab.label,
+    onDragMove: (tab, x, y) => {
+      const next = indicatorFor(tab, tabIndexAt(x, y));
+      // pointermove fires continuously; keep the same object while the target
+      // is unchanged so React can bail out of re-rendering.
+      setIndicator((prev) => {
+        const unchanged = prev?.index === next?.index && prev?.edge === next?.edge;
+        return unchanged ? prev : next;
+      });
+      return next?.index ?? null;
+    },
+    onDrop: (tab, index) => onMove(tab.id, index),
+    onReset: () => setIndicator(null),
+  });
 
-  return { indicator, handlersFor };
+  return {
+    indicator,
+    handlersFor: (id, index, label) => pressHandlersFor({ id, index, label }),
+  };
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -16,6 +16,7 @@
 @import "./print.css";
 @import "./ai-chat.css";
 @import "./motion.css";
+@import "./drag.css";
 
 :root {
   /* Native widgets (select popups, scrollbars) follow the app theme; WebKitGTK renders them unreadable otherwise. */

--- a/src/styles/drag.css
+++ b/src/styles/drag.css
@@ -1,0 +1,30 @@
+/* Pointer-drag chrome shared by the file tree and the tab strip
+   (src/hooks/usePointerDrag.ts). */
+
+/* While a drag is active the body carries the grabbing / no-drop cursor;
+   force it through elements that set their own (buttons, links) so the
+   feedback stays visible wherever the pointer is. */
+body[data-pointer-drag] * {
+  cursor: inherit !important;
+}
+
+/* Floating label pill that follows the pointer. pointer-events:none keeps it
+   invisible to the elementFromPoint hit-testing underneath it. */
+.drag-ghost {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 9999;
+  pointer-events: none;
+  padding: 2px 8px;
+  border-radius: var(--glyph-radius-sm);
+  font-size: 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-accent);
+  color: var(--color-text-primary);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.25);
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/test/pointerDrag.ts
+++ b/src/test/pointerDrag.ts
@@ -1,18 +1,22 @@
 import { fireEvent } from "@testing-library/react";
 import { vi } from "vitest";
 
-// Helpers for the pointer drag suites (usePointerDrag consumers). jsdom does
-// no hit-testing, so the element under the pointer is pinned per step.
+// Helpers for the pointer drag suites (usePointerDrag consumers). happy-dom
+// does no hit-testing, so the element under the pointer is pinned per step.
 
 export function setHit(el: Element | null) {
   document.elementFromPoint = vi.fn(() => el) as typeof document.elementFromPoint;
 }
 
+/** Move the held primary button (buttons: 1) to `x`, `y`. */
+export const moveTo = (x: number, y: number) =>
+  fireEvent.pointerMove(window, { clientX: x, clientY: y, buttons: 1 });
+
 /** Press `source`, cross the drag threshold, and hover `target`. */
 export function dragFromTo(source: Element, target: Element | null) {
   fireEvent.pointerDown(source, { button: 0, clientX: 0, clientY: 0 });
   setHit(target);
-  fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
+  moveTo(40, 40);
 }
 
 export const releaseAt = (x = 40, y = 40) =>

--- a/src/test/pointerDrag.ts
+++ b/src/test/pointerDrag.ts
@@ -1,0 +1,21 @@
+import { fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+
+// Helpers for the pointer drag suites (usePointerDrag consumers). jsdom does
+// no hit-testing, so the element under the pointer is pinned per step.
+
+export function setHit(el: Element | null) {
+  document.elementFromPoint = vi.fn(() => el) as typeof document.elementFromPoint;
+}
+
+/** Press `source`, cross the drag threshold, and hover `target`. */
+export function dragFromTo(source: Element, target: Element | null) {
+  fireEvent.pointerDown(source, { button: 0, clientX: 0, clientY: 0 });
+  setHit(target);
+  fireEvent.pointerMove(window, { clientX: 40, clientY: 40 });
+}
+
+export const releaseAt = (x = 40, y = 40) =>
+  fireEvent.pointerUp(window, { clientX: x, clientY: y });
+
+export const ghostEl = () => document.querySelector(".drag-ghost") as HTMLElement | null;


### PR DESCRIPTION
## Summary

Dragging a tab to reorder it did nothing on Windows: Tauri's native drag-drop handler owns the WebView2 drag loop (it has to, so dropping an OS file onto the window still opens it) and swallows every in-page HTML5 `dragover`/`drop`, so the tab strip never received its events. The strip now uses the same pointer-event drag pattern the file tree adopted in #679, with the shared core extracted into one hook both consumers use. Reorder semantics are unchanged: direction-based before/after indicator, splice-style `moveTab(id, toIndex)`.

Closes #693

## Changes

- `src/hooks/usePointerDrag.ts` (new): shared press-to-drag core. Press past a 5px threshold starts the drag; window `pointermove`/`pointerup`/`pointercancel`/`keydown` listeners mount once (callbacks behind a latest-ref); pointer capture on the pressed element; consumers resolve their target in `onDragMove` and the core commits that last resolved target on release, so the drop always matches the indicator shown; Escape cancels; the click synthesized after a completed drag is swallowed exactly once; unmount mid-drag tears everything down. A move arriving with the primary button already up, or a release from another pointer id (stray touch during a mouse drag), cannot end or commit the drag wrongly.
- `src/hooks/useTabDragReorder.ts`: rewritten on the core. `elementFromPoint` hit-testing against a `data-tab-index` marker, same `{ indicator, handlersFor }` shape.
- `src/hooks/useFileTreeDragMove.ts`: rebuilt on the core, behavior unchanged, its own suite untouched in intent.
- `src/components/layout/TabBar.tsx`: `data-tab-index` marker and the pointer handlers replace `draggable` and the four HTML5 handlers. Middle-click close, the context menu, and touch presses are left alone.
- `src/styles/drag.css` (new): the ghost pill styles (previously an inline style string) and a `body[data-pointer-drag] *` cursor rule, because `.tab-activate`/`.tab-close` set `cursor: pointer` which would otherwise hide the grabbing / no-drop feedback.
- `src/test/pointerDrag.ts` (new): drag helpers shared by the three drag suites; `TabBar.dnd.test.tsx` rewritten to the pointer pattern and onto the `tabsContextValue` fixture; `usePointerDrag.test.ts` pins the two-instances-mounted case.

Not included, unchanged from the HTML5 version: the dragged tab's index is snapshotted at press (tabs closing mid-drag are not re-resolved), no auto-scroll of an overflowing strip while dragging near its edges (scroll the strip first, then drag), and no touch reorder on mobile (the HTML5 `draggable` attribute never offered a working long-press drag in the WebViews either).

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [x] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

The only lifecycle path touched is unmounting the tab strip or the file tree while a drag is in progress. A drag owns no pending write, so INV-4 (owners flush before they die) is not at stake; what the unmount must guarantee is that the page-level feedback it installed (ghost pill, `user-select: none`, body cursor, the `data-pointer-drag` attribute) is removed and no reorder is committed. Evidence: `TabBar.dnd.test.tsx` "tears down the drag feedback when the strip unmounts mid-drag", `useFileTreeDragMove.test.ts` "detaches its window listeners and drops the ghost on unmount mid-drag", and `usePointerDrag.test.ts` for an idle second instance unmounting during another instance's drag. No Rust or IPC changes.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated: `pnpm typecheck`, `pnpm check`, `pnpm test` (3747 tests), `pnpm test:coverage` (100% lines and branches on every touched source file), `cargo clippy --all-targets -- -D warnings`.

Needs a hand check on Windows before merge (the original bug was only findable by hand, and happy-dom cannot model pointer capture click retargeting): drag reorder with the indicator on both edges, plain click still activates, close button and middle-click still close, right-click menu, Escape mid-drag, release outside the window.

## Screenshots

None.
