### PR TITLE
feat(docker): publish a container image that exports a docs folder as a website

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# The image installs a published release asset and needs only the entrypoint
+# from this repository. Sending the working tree (node_modules,
+# src-tauri/target) to the daemon would cost minutes for files the build never
+# reads.
+*
+!docker-entrypoint.sh

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,116 @@
+name: Docker
+
+# Path-filtered rather than part of the main CI fan-out: the image pulls a
+# ~150 MB package and installs the whole WebKitGTK stack, which is not worth
+# paying for on pull requests that cannot affect it.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/ci-docker.yml"
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/ci-docker.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and smoke-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      # The Dockerfile installs a published release asset, and a pull request
+      # has no release of its own, so the check builds against the newest one.
+      - name: Resolve the latest published release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      # Native amd64 only, and loaded into the local daemon instead of pushed:
+      # the release workflow owns the multi-arch build and the registry.
+      - name: Build the image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          build-args: GLYPH_VERSION=${{ steps.release.outputs.version }}
+          tags: glyph:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # A ceiling, not a target. WebKitGTK and its Mesa/LLVM stack put the
+      # floor around 600 MB, so this only catches an accidental doubling, such
+      # as a purge silently no longer applying or recommends creeping back in.
+      - name: The image stays under its size ceiling
+        run: |
+          BYTES=$(docker image inspect glyph:ci --format '{{.Size}}')
+          CEILING=$((800 * 1000 * 1000))
+          echo "image size: $((BYTES / 1000 / 1000)) MB"
+          if [ "$BYTES" -gt "$CEILING" ]; then
+            echo "::error::image is $((BYTES / 1000 / 1000)) MB, over the $((CEILING / 1000 / 1000)) MB ceiling"
+            exit 1
+          fi
+
+      - name: The default command exports the mounted folder as a website
+        run: |
+          mkdir -p "$RUNNER_TEMP/site"
+          docker run --rm --user "$(id -u):$(id -g)" \
+            -v "$PWD/samples:/docs:ro" \
+            -v "$RUNNER_TEMP/site:/out" \
+            glyph:ci
+          test -f "$RUNNER_TEMP/site/index.html"
+
+      # Writing files proves the pipeline ran; only a rendered diagram proves
+      # the webview inside the container actually worked. A broken display
+      # still produces pages, just empty ones, and this is what catches that.
+      - name: Diagrams render, not just pages
+        run: |
+          if ! grep -q "<svg" "$RUNNER_TEMP/site/Flowchart.html"; then
+            echo "::error::Flowchart.html has no inline SVG, so mermaid did not render"
+            exit 1
+          fi
+
+      - name: Exported files are owned by the caller, not root
+        run: |
+          OWNER=$(stat -c '%u' "$RUNNER_TEMP/site/index.html")
+          if [ "$OWNER" != "$(id -u)" ]; then
+            echo "::error::index.html is owned by uid $OWNER, expected $(id -u)"
+            exit 1
+          fi
+
+      - name: Arguments after the image override the default command
+        run: |
+          mkdir -p "$RUNNER_TEMP/doc"
+          docker run --rm --user "$(id -u):$(id -g)" \
+            -v "$PWD/samples:/docs:ro" \
+            -v "$RUNNER_TEMP/doc:/out" \
+            glyph:ci /docs/Index.md --export html --out /out/index.html
+          test -s "$RUNNER_TEMP/doc/index.html"
+
+      - name: A rejected export fails the step
+        run: |
+          # A folder is not a document, so this must exit nonzero rather than
+          # quietly writing nothing, which is what makes the image usable in CI.
+          if docker run --rm --user "$(id -u):$(id -g)" \
+            -v "$PWD/samples:/docs:ro" \
+            -v "$RUNNER_TEMP/doc:/out" \
+            glyph:ci /docs --export pdf --out /out/nope.pdf; then
+            echo "::error::exporting a folder as pdf should have failed"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1019,3 +1019,45 @@ jobs:
             git commit -m "Update to $VERSION"
             git push
           }
+
+  publish-docker:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # ghcr.io push, authenticated with the built-in token, so this publish
+      # job needs no secret of its own.
+      packages: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - name: Get version
+        id: version
+        uses: ./.github/actions/get-version
+      # arm64 is emulated. The image only unpacks a published package, so
+      # there is nothing to cross-compile and one buildx run covers both.
+      - uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      # `latest` tracks the semver tags on its own and stays put for a
+      # prerelease tag, so no manual gate is needed for it.
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          build-args: GLYPH_VERSION=${{ steps.version.outputs.version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# Glyph's headless exports in a container: a docs folder in, a static website
+# out, with no need to install the desktop app or chase its dependency chain.
+#
+# The export is rendered by the app's own webview, so this image carries the
+# WebKitGTK stack the `.deb` pulls in plus an X server to render into. That is
+# the same shape as the Linux CI and release smoke tests, which run the CLI
+# against a virtual display.
+FROM debian:bookworm-slim
+
+# The release to install, without the leading "v" (e.g. 0.22.1). Pinned at
+# build time so an image always maps to one published release, never to
+# whatever "latest" happens to mean when it is rebuilt.
+ARG GLYPH_VERSION
+# Set per platform by buildx. `amd64` / `arm64` is exactly how the release
+# names its Debian packages, so one Dockerfile covers both architectures.
+ARG TARGETARCH
+
+# WebKit's compositing path has no GPU under Xvfb and crashes without this.
+# The release smoke tests set the same variable on every Linux distro.
+ENV WEBKIT_DISABLE_COMPOSITING_MODE=1
+# WebKit wants a writable home. Pointing it at /tmp keeps the image working
+# under `--user` with an arbitrary uid, which is how anyone writing to a
+# bind-mounted output directory will run it.
+ENV HOME=/tmp
+
+# The published Debian package, not a source build: the image then contains
+# byte-for-byte what the apt repository serves for the same version.
+ADD https://github.com/hamidfzm/glyph/releases/download/v${GLYPH_VERSION}/Glyph_${GLYPH_VERSION}_${TARGETARCH}.deb /tmp/glyph.deb
+
+# Installing the .deb through apt (rather than dpkg) resolves its own GTK and
+# WebKitGTK dependencies; only the X server is extra.
+#
+# The purge runs in this same layer on purpose: image layers are additive, so
+# deleting in a later step leaves the bytes in the image and saves nothing.
+#
+# WebKitGTK declares more than a headless export uses: GStreamer's codecs are
+# for media playback and the icon theme is for a desktop nobody sees here.
+# `--force-depends` because they are declared dependencies of WebKit, so the
+# CI smoke test is what keeps this honest.
+#
+# Two things that look equally unused are not, and must stay: Mesa's DRI
+# driver with the LLVM it drags in (the largest single item in the image, but
+# WebKit still initialises EGL and dies with "Could not create surfaceless EGL
+# display" without it, even with compositing disabled), and libflite, WebKit's
+# speech synthesiser, which it links directly.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        /tmp/glyph.deb \
+        xvfb \
+        ca-certificates \
+    && dpkg --purge --force-depends \
+        adwaita-icon-theme \
+        gstreamer1.0-plugins-good \
+        gstreamer1.0-plugins-base \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/glyph.deb \
+        /usr/share/doc \
+        /usr/share/man \
+        /usr/share/info \
+        /usr/share/locale \
+        /var/cache/debconf/*
+
+# Exports land on a bind mount, so running as root would leave root-owned
+# files on the host. Callers whose uid is not 1000 can override with
+# `--user "$(id -u):$(id -g)"`.
+RUN useradd --create-home --uid 1000 glyph
+
+COPY docker-entrypoint.sh /usr/local/bin/glyph-entrypoint
+RUN chmod +x /usr/local/bin/glyph-entrypoint
+
+USER glyph
+WORKDIR /docs
+
+# The container's arguments are Glyph's arguments, so every documented flag
+# works here without a second CLI to learn. The default renders the folder
+# mounted at /docs into /out.
+ENTRYPOINT ["/usr/local/bin/glyph-entrypoint"]
+CMD ["/docs", "--export", "site", "--out", "/out"]

--- a/README.md
+++ b/README.md
@@ -183,6 +183,26 @@ glyph ~/notes/ --export site --out ./site
 
 The command is provided by the Homebrew cask (macOS), Chocolatey or Scoop (Windows), and the deb package or Homebrew formula (Linux). The macOS `.dmg` and Windows MSI install the app only; use a package manager for the terminal command.
 
+### Docker
+
+Run the exports without installing anything, which is what a docs pipeline usually wants:
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$PWD/docs:/docs:ro" -v "$PWD/site:/out" \
+  ghcr.io/hamidfzm/glyph
+```
+
+`/docs` is the workspace to render, `/out` is where the static site lands. Anything after the image name replaces the default command, so the document formats work the same way:
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$PWD/docs:/docs:ro" -v "$PWD/out:/out" \
+  ghcr.io/hamidfzm/glyph /docs/README.md --export pdf --out /out/readme.pdf
+```
+
+The image ships the same `.deb` the apt repository serves, plus the WebKitGTK stack and the X server a headless export needs, so no `xvfb-run` wrapper is required. It runs as uid 1000; passing `--user` keeps exported files owned by you when your uid differs. Images are published for `linux/amd64` and `linux/arm64` on every release, tagged `X.Y.Z`, `X.Y`, and `latest`.
+
 ## Development
 
 ```bash

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Give Glyph a display, then hand the process over to it.
+#
+# `xvfb-run` would be the obvious wrapper, but it does not return once Glyph
+# exits when the export target is a bind mount, leaving the container hung
+# with the work already finished. Starting Xvfb directly and `exec`ing Glyph
+# avoids the wrapper's teardown entirely, and makes the container's exit
+# status Glyph's own, which is what lets a CI step fail on a failed export.
+set -e
+
+Xvfb :99 -screen 0 1280x1024x24 >/dev/null 2>&1 &
+
+# Xvfb takes a moment to accept connections, and Glyph exits immediately if it
+# cannot open the display. Five seconds is far longer than the observed
+# startup and still fails loudly rather than hanging.
+i=0
+while [ ! -e /tmp/.X11-unix/X99 ]; do
+    i=$((i + 1))
+    if [ "$i" -gt 50 ]; then
+        echo "glyph: Xvfb did not start" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+
+export DISPLAY=:99
+exec glyph "$@"


### PR DESCRIPTION
## Summary

Publishes a container image that runs Glyph's existing headless website export, so a folder of markdown becomes a static site in one command without installing the desktop app or chasing its WebKitGTK dependency chain.

```bash
docker run --rm --user "$(id -u):$(id -g)" \
  -v "$PWD/docs:/docs:ro" -v "$PWD/site:/out" \
  ghcr.io/hamidfzm/glyph
```

Container arguments are Glyph's arguments, so the document formats work from the same image without a second CLI to learn.

Closes #704

## Changes

- `Dockerfile`: Debian bookworm-slim, installing the published `.deb` for the version being built (selected by `TARGETARCH`, which matches the release asset names), so the image carries the same binary the apt repository serves.
- `docker-entrypoint.sh`: starts Xvfb and `exec`s Glyph. `xvfb-run` was the obvious wrapper but does not return once Glyph exits when the output is a bind mount, leaving the container hung with the export already written to disk. Starting Xvfb directly also makes the container's exit status Glyph's own, which is what lets a failed export fail a CI step.
- `.github/workflows/release.yml`: a `publish-docker` job shaped like the other publish jobs (`needs: build`), pushing `linux/amd64` and `linux/arm64` to ghcr.io with the built-in token. Tags come from `docker/metadata-action`, so `X.Y.Z`, `X.Y`, and `latest`, with `latest` staying put for a prerelease tag.
- `.github/workflows/ci-docker.yml`: path-filtered build and smoke test on pull requests, since installing the WebKitGTK stack is not worth paying for on PRs that cannot affect it.
- `README.md`: a Docker section under Command-line usage.

### On image size

672 MB initially. Trimming what a headless render does not use (GStreamer codecs, the icon theme, docs, man pages, locales) brings it to **638 MB**.

Two things that look equally unused are load-bearing and stay, both found by testing rather than reading:

- **Mesa's DRI driver and the LLVM behind it** (~160 MB, the largest single item). WebKit still initialises EGL even with `WEBKIT_DISABLE_COMPOSITING_MODE=1`, and aborts with `Could not create surfaceless EGL display` without them.
- **libflite**, WebKit's speech synthesiser, which it links directly and will not start without.

That is the floor for an image that ships the webview. Going meaningfully below it means rendering the export without the webview at all, which the pipeline does not currently allow (it uses `DOMParser`, `document.styleSheets`, and `document.documentElement`). Worth a separate issue if it is wanted.

## Risk classification

- [x] Filesystem / IPC surface
- [x] Network
- [x] Build / CI

### Invariants at stake and evidence

Neither area touches application code: this PR adds no Rust and no TypeScript, so no runtime invariant changes. The two areas are packaging-level.

**Filesystem.** The image mounts a workspace at `/docs` and writes to `/out`, and runs as a non-root user (uid 1000) so exports do not leave root-owned files on a host bind mount. `HOME` points at `/tmp` so the image also works under `--user` with an arbitrary uid, verified with `--user 1001:1001`.

**Network.** The build downloads one artifact: the release's own `.deb`, over HTTPS from github.com, pinned to an exact version. No checksum argument is passed, because a single multi-arch buildx invocation cannot carry a per-architecture digest without splitting the build; the transport is the same origin and TLS the apt repository is populated from. The image makes no network requests at runtime.

## Testing

Built and exercised locally against v0.22.1 (`docker build --build-arg GLYPH_VERSION=0.22.1`):

- Default command exports the `samples/` workspace: `Exported 12 pages and 5 assets to /out`, exit 0.
- Diagrams genuinely render: `Flowchart.html` contains inline `<svg>` at 108 KB, so the webview worked rather than writing empty pages.
- Overridden arguments work: `/docs/Index.md --export html --out /out/index.html` writes 121 KB, exit 0.
- A rejected export fails: exporting a folder as PDF prints the usage message to stderr and exits 2.
- Runs under a uid that is not baked into the image (`--user 1001:1001`), which is how the CI job invokes it.
- The purge is verified, not assumed: removing Mesa and LLVM builds a 472 MB image that segfaults on startup, which is how the comment in the Dockerfile came to name them.

CI covers the same ground on every PR that touches the image: export, diagram rendering, file ownership, argument override, failure exit code, and an 800 MB size ceiling to catch an accidental doubling.

- [ ] Tested on macOS
- [x] Tested on Windows (Docker Desktop, linux containers)
- [ ] Tested on Linux

## Note for the first release

ghcr packages are created private. After the first release publishes the image, its package settings need switching to public once, and it stays public afterwards.
