### PR TITLE
feat(cli)!: add a serve subcommand, and make export one too

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -76,18 +76,18 @@ jobs:
         env:
           WEBKIT_DISABLE_COMPOSITING_MODE: "1"
         run: |
-          xvfb-run --auto-servernum ./src-tauri/target/release/glyph "$PWD/samples" --export site --out /tmp/csp-smoke
+          xvfb-run --auto-servernum ./src-tauri/target/release/glyph export "$PWD/samples" --format site --out /tmp/csp-smoke
           test -f /tmp/csp-smoke/index.html
           test "$(find /tmp/csp-smoke -maxdepth 1 -name '*.html' | wc -l)" -ge 3
           # A document export renders the live DOM, so it exercises the
           # render-readiness gate the site export never touches.
-          xvfb-run --auto-servernum ./src-tauri/target/release/glyph "$PWD/samples/Index.md" --export html --out /tmp/doc-smoke.html
+          xvfb-run --auto-servernum ./src-tauri/target/release/glyph export "$PWD/samples/Index.md" --format html --out /tmp/doc-smoke.html
           grep -q "<h1" /tmp/doc-smoke.html
-          xvfb-run --auto-servernum ./src-tauri/target/release/glyph "$PWD/samples/Index.md" --export pdf --out /tmp/doc-smoke.pdf
+          xvfb-run --auto-servernum ./src-tauri/target/release/glyph export "$PWD/samples/Index.md" --format pdf --out /tmp/doc-smoke.pdf
           test "$(stat -c%s /tmp/doc-smoke.pdf)" -gt 5000
           # A wrong input kind is a usage error, not a silent empty export.
-          if xvfb-run --auto-servernum ./src-tauri/target/release/glyph "$PWD/samples" --export pdf --out /tmp/nope.pdf; then
-            echo "expected a usage error for a folder given to --export pdf" >&2
+          if xvfb-run --auto-servernum ./src-tauri/target/release/glyph export "$PWD/samples" --format pdf --out /tmp/nope.pdf; then
+            echo "expected a usage error for a folder given to --format pdf" >&2
             exit 1
           fi
       # Drives the built binary over WebDriver (launch, render, edit, second

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -100,7 +100,7 @@ jobs:
           docker run --rm --user "$(id -u):$(id -g)" \
             -v "$PWD/samples:/docs:ro" \
             -v "$RUNNER_TEMP/doc:/out" \
-            glyph:ci export /docs/Index.md --format html --out /out/index.html
+            glyph:ci /docs/Index.md --export html --out /out/index.html
           test -s "$RUNNER_TEMP/doc/index.html"
 
       - name: A rejected export fails the step
@@ -110,7 +110,7 @@ jobs:
           if docker run --rm --user "$(id -u):$(id -g)" \
             -v "$PWD/samples:/docs:ro" \
             -v "$RUNNER_TEMP/doc:/out" \
-            glyph:ci export /docs --format pdf --out /out/nope.pdf; then
+            glyph:ci /docs --export pdf --out /out/nope.pdf; then
             echo "::error::exporting a folder as pdf should have failed"
             exit 1
           fi

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -100,7 +100,7 @@ jobs:
           docker run --rm --user "$(id -u):$(id -g)" \
             -v "$PWD/samples:/docs:ro" \
             -v "$RUNNER_TEMP/doc:/out" \
-            glyph:ci /docs/Index.md --export html --out /out/index.html
+            glyph:ci export /docs/Index.md --format html --out /out/index.html
           test -s "$RUNNER_TEMP/doc/index.html"
 
       - name: A rejected export fails the step
@@ -110,7 +110,7 @@ jobs:
           if docker run --rm --user "$(id -u):$(id -g)" \
             -v "$PWD/samples:/docs:ro" \
             -v "$RUNNER_TEMP/doc:/out" \
-            glyph:ci /docs --export pdf --out /out/nope.pdf; then
+            glyph:ci export /docs --format pdf --out /out/nope.pdf; then
             echo "::error::exporting a folder as pdf should have failed"
             exit 1
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,5 +75,12 @@ WORKDIR /docs
 # The container's arguments are Glyph's arguments, so every documented flag
 # works here without a second CLI to learn. The default renders the folder
 # mounted at /docs into /out.
+#
+# This spelling tracks the *released* CLI, not this checkout's: the image
+# installs a published .deb, so the default command may only use syntax that
+# release already has. `glyph export <path> --format site` replaces it, and
+# flipping it here has to wait for the release that carries the subcommand.
+# The Docker CI job is what enforces that, by building against the latest
+# release and running this command.
 ENTRYPOINT ["/usr/local/bin/glyph-entrypoint"]
-CMD ["export", "/docs", "--format", "site", "--out", "/out"]
+CMD ["/docs", "--export", "site", "--out", "/out"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ WORKDIR /docs
 # works here without a second CLI to learn. The default renders the folder
 # mounted at /docs into /out.
 ENTRYPOINT ["/usr/local/bin/glyph-entrypoint"]
-CMD ["/docs", "--export", "site", "--out", "/out"]
+CMD ["export", "/docs", "--format", "site", "--out", "/out"]

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ glyph serve ~/notes/ --host 0.0.0.0       # let the local network read it
 glyph serve ~/notes/ --out ./site         # keep the build instead of a temp dir
 ```
 
-`serve` renders the folder, prints the URL, and keeps running: every change to the folder rebuilds the site, and pages open in a browser reload themselves. It binds `127.0.0.1` unless `--host` says otherwise, so nothing leaves the machine by default. Without `--out` the site lives in a temporary directory that is removed on exit.
+`serve` renders the folder, prints the URL, and keeps running: every change to the folder rebuilds the site, and pages open in a browser reload themselves. It binds `127.0.0.1` unless `--host` says otherwise, so nothing leaves the machine by default, and it answers only to its own hostnames so a web page cannot reach it through your browser. Everything in the output directory is served, so point `--out` at a directory of its own; without one, the site lives in a temporary directory removed when you interrupt the command. Like the exports below, it renders through a webview, so a Linux server without a display needs `xvfb-run`.
 
 `--export` accepts `pdf`, `docx`, `epub`, `html`, and `site`. Without `--out` a document export writes beside its input with the format's extension; `site` always needs one. Exports run without showing a window, print the path they wrote to stdout, and exit nonzero with a message on stderr if they fail, so they can drive CI publishing (on Linux runners, wrap the command in `xvfb-run`). A document export includes the table of contents when Settings > Print has it enabled.
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,16 @@ glyph notes.md --export docx --out ~/out.docx
 glyph ~/notes/ --export site --out ./site
 ```
 
+```bash
+# serve a workspace as a website, rebuilding as it changes
+glyph serve ~/notes/
+glyph serve ~/notes/ --port 8080          # pick the port; 0 asks the OS
+glyph serve ~/notes/ --host 0.0.0.0       # let the local network read it
+glyph serve ~/notes/ --out ./site         # keep the build instead of a temp dir
+```
+
+`serve` renders the folder, prints the URL, and keeps running: every change to the folder rebuilds the site, and pages open in a browser reload themselves. It binds `127.0.0.1` unless `--host` says otherwise, so nothing leaves the machine by default. Without `--out` the site lives in a temporary directory that is removed on exit.
+
 `--export` accepts `pdf`, `docx`, `epub`, `html`, and `site`. Without `--out` a document export writes beside its input with the format's extension; `site` always needs one. Exports run without showing a window, print the path they wrote to stdout, and exit nonzero with a message on stderr if they fail, so they can drive CI publishing (on Linux runners, wrap the command in `xvfb-run`). A document export includes the table of contents when Settings > Print has it enabled.
 
 The command is provided by the Homebrew cask (macOS), Chocolatey or Scoop (Windows), and the deb package or Homebrew formula (Linux). The macOS `.dmg` and Windows MSI install the app only; use a package manager for the terminal command.

--- a/README.md
+++ b/README.md
@@ -208,10 +208,10 @@ docker run --rm --user "$(id -u):$(id -g)" \
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$PWD/docs:/docs:ro" -v "$PWD/out:/out" \
-  ghcr.io/hamidfzm/glyph export /docs/README.md --format pdf --out /out/readme.pdf
+  ghcr.io/hamidfzm/glyph /docs/README.md --export pdf --out /out/readme.pdf
 ```
 
-The image ships the same `.deb` the apt repository serves, plus the WebKitGTK stack and the X server a headless export needs, so no `xvfb-run` wrapper is required. It runs as uid 1000; passing `--user` keeps exported files owned by you when your uid differs. Images are published for `linux/amd64` and `linux/arm64` on every release, tagged `X.Y.Z`, `X.Y`, and `latest`.
+The image ships the same `.deb` the apt repository serves, plus the WebKitGTK stack and the X server a headless export needs, so no `xvfb-run` wrapper is required. Its arguments are the released CLI's, which is why the example above still spells the export as a flag: the image tracks the published release, not this repository's tip. It runs as uid 1000; passing `--user` keeps exported files owned by you when your uid differs. Images are published for `linux/amd64` and `linux/arm64` on every release, tagged `X.Y.Z`, `X.Y`, and `latest`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ glyph ~/notes/       # open a folder as a workspace
 glyph --help         # usage, flags, and export formats
 
 # export a document (headless; exits when done)
-glyph README.md --export pdf              # writes README.pdf beside it
-glyph notes.md --export docx --out ~/out.docx
+glyph export README.md --format pdf              # writes README.pdf beside it
+glyph export notes.md --format docx --out ~/out.docx
 
 # export a workspace as a static website
-glyph ~/notes/ --export site --out ./site
+glyph export ~/notes/ --format site --out ./site
 ```
 
 ```bash
@@ -187,9 +187,9 @@ glyph serve ~/notes/ --host 0.0.0.0       # let the local network read it
 glyph serve ~/notes/ --out ./site         # keep the build instead of a temp dir
 ```
 
-`serve` renders the folder, prints the URL, and keeps running: every change to the folder rebuilds the site, and pages open in a browser reload themselves. It binds `127.0.0.1` unless `--host` says otherwise, so nothing leaves the machine by default, and it answers only to its own hostnames so a web page cannot reach it through your browser. Everything in the output directory is served, so point `--out` at a directory of its own; without one, the site lives in a temporary directory removed when you interrupt the command. Like the exports below, it renders through a webview, so a Linux server without a display needs `xvfb-run`.
+`serve` renders the folder, prints the URL, and keeps running: every change to the folder rebuilds the site, and pages open in a browser reload themselves. It binds `127.0.0.1` unless `--host` says otherwise, so nothing leaves the machine by default, and it answers only to its own hostnames so a web page cannot reach it through your browser. Everything in the output directory is served, so point `--out` at a directory of its own; without one, the site lives in a temporary directory removed when you interrupt the command. Like the exports above, it renders through a webview, so a Linux server without a display needs `xvfb-run`.
 
-`--export` accepts `pdf`, `docx`, `epub`, `html`, and `site`. Without `--out` a document export writes beside its input with the format's extension; `site` always needs one. Exports run without showing a window, print the path they wrote to stdout, and exit nonzero with a message on stderr if they fail, so they can drive CI publishing (on Linux runners, wrap the command in `xvfb-run`). A document export includes the table of contents when Settings > Print has it enabled.
+`--format` accepts `pdf`, `docx`, `epub`, `html`, and `site`. Without `--out` a document export writes beside its input with the format's extension; `site` always needs one. Exports run without showing a window, print the path they wrote to stdout, and exit nonzero with a message on stderr if they fail, so they can drive CI publishing (on Linux runners, wrap the command in `xvfb-run`). A document export includes the table of contents when Settings > Print has it enabled.
 
 The command is provided by the Homebrew cask (macOS), Chocolatey or Scoop (Windows), and the deb package or Homebrew formula (Linux). The macOS `.dmg` and Windows MSI install the app only; use a package manager for the terminal command.
 
@@ -208,7 +208,7 @@ docker run --rm --user "$(id -u):$(id -g)" \
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$PWD/docs:/docs:ro" -v "$PWD/out:/out" \
-  ghcr.io/hamidfzm/glyph /docs/README.md --export pdf --out /out/readme.pdf
+  ghcr.io/hamidfzm/glyph export /docs/README.md --format pdf --out /out/readme.pdf
 ```
 
 The image ships the same `.deb` the apt repository serves, plus the WebKitGTK stack and the X server a headless export needs, so no `xvfb-run` wrapper is required. It runs as uid 1000; passing `--user` keeps exported files owned by you when your uid differs. Images are published for `linux/amd64` and `linux/arm64` on every release, tagged `X.Y.Z`, `X.Y`, and `latest`.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -142,6 +142,17 @@ permission returns to the default capability (#698).
   grants the workspace a window reports adopting; both are accepted so
   session restore keeps working, and both only matter after the renderer is
   already compromised.
+- **`glyph serve` is an inbound listener.** The one place Glyph accepts
+  connections rather than making them. It binds `127.0.0.1` unless `--host`
+  says otherwise, answers only to `Host` headers naming itself (so a web page
+  cannot reach it by re-pointing its own domain at loopback), refuses hidden
+  paths, and relies on `tower-http`'s `ServeDir` to keep requests inside the
+  output directory. What it serves is still unauthenticated: anyone who can
+  reach the port reads the whole exported site, and `--host 0.0.0.0` extends
+  that to the network, which is why it is opt-in and warns. Everything in the
+  output directory is published, so the CLI refuses an `--out` that contains,
+  or is contained by, the folder being served. The site is derived output, not
+  the workspace: serving grants no filesystem access back to the renderer.
 - **`connect-src` breadth.** Arbitrary `http:`/`https:` hosts are reachable
   for the Ollama integration, so a compromised renderer can exfiltrate what
   it can read. The grants bound what that is.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -36,7 +36,7 @@ the missing remainder is rejected.
 Grants are minted only from backend-observed events, never from a bare
 webview-supplied path:
 
-- CLI launch arguments (folder, file, `--export` format and `--out` output path)
+- CLI launch arguments (folder, file, the `export` subcommand's `--format` and `--out`, the `serve` subcommand's `--host` and `--port`)
 - Drag-and-drop onto a window (the OS event carries the path)
 - macOS `RunEvent::Opened` and second-instance launches
 - Native pick dialogs run in Rust (`src-tauri/src/commands/pick.rs`): Open

--- a/samples/README.md
+++ b/samples/README.md
@@ -429,7 +429,7 @@ This workspace is wired to make the graph worth a look: [[Index]] and [[Graph Vi
 With the `samples/` folder open, `File → Export → Website…` turns this whole workspace into a static site: every note becomes a linked HTML page (the root `index.md`, or else this README, becomes `index.html`), wikilinks and relative links navigate between pages, images are copied alongside, Mermaid diagrams render as inline SVG, and a navigation sidebar ties it together. This folder's [`.glyph/site.json`](.glyph/site.json) shows the optional site metadata (editable in-app via File > Workspace Settings…): a site title for every page's browser tab and social tags, a shared description, a robots.txt directive, and a theme (GitHub-style by default, with a site header on every page; plugins can add more); a `favicon`, `socialImage`, and `baseUrl` can join it for link previews. The same export runs headless from the terminal for CI publishing:
 
 ```bash
-glyph samples/ --export site --out ./site
+glyph export samples/ --format site --out ./site
 ```
 
 ### Wikilink autocomplete

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1723,7 +1723,11 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 name = "glyph"
 version = "0.22.0"
 dependencies = [
+ "futures-util",
  "git2",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "keyring",
  "notify",
  "regex",
@@ -1745,6 +1749,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tower",
+ "tower-http",
  "walkdir",
  "zip",
 ]
@@ -1960,6 +1966,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +1997,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2638,6 +2651,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -5419,6 +5442,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -5601,14 +5625,24 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5781,6 +5815,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,19 +60,24 @@ tauri-plugin-single-instance = "2"
 # git repo detection, crash reporting) are desktop-only for now (see #79).
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-cli = "2"
-# `glyph serve`: the preview server behind the CLI's one subcommand. Every
-# crate here is already in the tree through Tauri's own HTTP stack, so this
-# names what we depend on directly rather than adding a dependency graph.
-# `tower-http`'s ServeDir is the reason to reach for them at all: it owns MIME
-# guessing, index resolution, and keeping requests inside the served
-# directory, none of which is worth hand-rolling.
+# `glyph serve`: the preview server behind the CLI's one subcommand. These are
+# already in the tree through Tauri's own HTTP stack, so declaring them adds
+# no new dependency graph; enabling `tower-http`'s `fs` feature does pull in a
+# few small crates of its own (mime_guess, http-range-header). That feature is
+# the reason to reach for these at all: ServeDir owns MIME guessing, index
+# resolution, and keeping requests inside the served directory, none of which
+# is worth hand-rolling.
 hyper = { version = "1", features = ["server", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["fs"] }
 futures-util = { version = "0.3", default-features = false }
-tokio = { version = "1", features = ["net", "sync", "signal"] }
+tokio = { version = "1", features = ["net", "sync", "signal", "time"] }
+# The site a `glyph serve` without `--out` writes to. Not just a name under
+# the system temp directory: that is world-writable on Unix, so a predictable
+# name is a local attacker's choice of what the victim's browser loads.
+tempfile = "3"
 tauri-plugin-window-state = "2"
 # Statically-linked libgit2 so end users don't need a system Git install.
 # `vendored-openssl` keeps SSH/HTTPS support self-contained too.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,19 @@ tauri-plugin-single-instance = "2"
 # git repo detection, crash reporting) are desktop-only for now (see #79).
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-cli = "2"
+# `glyph serve`: the preview server behind the CLI's one subcommand. Every
+# crate here is already in the tree through Tauri's own HTTP stack, so this
+# names what we depend on directly rather than adding a dependency graph.
+# `tower-http`'s ServeDir is the reason to reach for them at all: it owns MIME
+# guessing, index resolution, and keeping requests inside the served
+# directory, none of which is worth hand-rolling.
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+tower = { version = "0.5", features = ["util"] }
+tower-http = { version = "0.6", features = ["fs"] }
+futures-util = { version = "0.3", default-features = false }
+tokio = { version = "1", features = ["net", "sync", "signal"] }
 tauri-plugin-window-state = "2"
 # Statically-linked libgit2 so end users don't need a system Git install.
 # `vendored-openssl` keeps SSH/HTTPS support self-contained too.

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -155,8 +155,8 @@ pub fn strip_flag(argv: &[String], flag: &str) -> Vec<String> {
 }
 
 /// Whether a `--flag` / `--flag=value` appears in argv at all, regardless of
-/// whether it carries a value. Distinguishes "no `--export`" (a normal launch)
-/// from "`--export` with nothing after it" (a usage error).
+/// whether it carries a value. Distinguishes "no `--format`" from
+/// "`--format` with nothing after it", which is a usage error.
 #[cfg(desktop)]
 pub fn has_flag(argv: &[String], flag: &str) -> bool {
     let prefix = format!("{flag}=");
@@ -181,8 +181,8 @@ pub fn resolve_out_path(path_str: &str, cwd: &Path) -> Option<String> {
     Some(absolute.to_string_lossy().to_string())
 }
 
-/// What `--export` can produce. Every variant but `Site` renders the single
-/// input document; `Site` renders a whole workspace folder.
+/// What `glyph export --format` can produce. Every variant but `Site`
+/// renders the single input document; `Site` renders a whole workspace folder.
 #[cfg(desktop)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExportFormat {
@@ -276,24 +276,52 @@ pub enum CliLaunch {
     },
 }
 
-/// Whether argv asks for the `serve` subcommand. Only a bare first argument
-/// counts, so a folder that happens to be named `serve` still opens normally
-/// as `glyph ./serve`.
+/// The subcommands, which are the only things that take flags.
 #[cfg(desktop)]
-pub fn is_serve_invocation(env_args: &[String]) -> bool {
-    env_args.get(1).is_some_and(|arg| arg == "serve")
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Subcommand {
+    Export,
+    Serve,
+}
+
+/// Which subcommand argv asks for, if any.
+///
+/// Only a bare first argument counts, so a folder named `export` or `serve`
+/// still opens normally as `glyph ./export`.
+#[cfg(desktop)]
+pub fn subcommand(env_args: &[String]) -> Option<Subcommand> {
+    match env_args.get(1)?.as_str() {
+        "export" => Some(Subcommand::Export),
+        "serve" => Some(Subcommand::Serve),
+        _ => None,
+    }
+}
+
+/// The path a subcommand operates on: the first bare argument after the
+/// subcommand itself. Flag values are stripped first so `glyph export --out
+/// build docs` cannot mistake "build" for the path.
+#[cfg(desktop)]
+fn subcommand_path(env_args: &[String], value_flags: &[&str]) -> Option<String> {
+    let stripped = value_flags
+        .iter()
+        .fold(env_args.to_vec(), |argv, flag| strip_flag(&argv, flag));
+    stripped
+        .iter()
+        .skip(2)
+        .find(|arg| !arg.is_empty() && !arg.starts_with('-'))
+        .cloned()
 }
 
 /// Whether this launch should hand its arguments to a Glyph the user already
 /// has open, rather than doing the work itself.
 ///
-/// Opening a document should reuse the running window. An export and a serve
-/// must not: both do their work in this process, so forwarding would exit 0
-/// having exported nothing, or having served nothing while the running app
-/// quietly opened the folder in a tab instead.
+/// Opening a document should reuse the running window. A subcommand must not:
+/// both do their work in this process, so forwarding would exit 0 having
+/// exported nothing, or having served nothing while the running app quietly
+/// opened the folder in a tab instead.
 #[cfg(desktop)]
 pub fn forwards_to_running_instance(env_args: &[String]) -> bool {
-    !has_flag(env_args, "--export") && !is_serve_invocation(env_args)
+    subcommand(env_args).is_none()
 }
 
 /// Whether `candidate` sits inside `root`, comparing the deepest existing
@@ -321,28 +349,15 @@ fn is_path_inside(candidate: &Path, root: &Path) -> bool {
 /// `Err` is a usage message the caller prints before exiting nonzero.
 #[cfg(desktop)]
 fn serve_plan(env_args: &[String], cwd: &Path) -> Result<CliLaunch, String> {
-    // Flag values are stripped before the positional scan so `glyph serve
-    // --out build docs` cannot mistake "build" for the folder to serve.
-    let positional = strip_flag(
-        &strip_flag(
-            &strip_flag(&strip_flag(env_args, "--host"), "--port"),
-            "--out",
-        ),
-        "-o",
-    );
-    // Skip the program name and the `serve` token itself.
-    let path_arg = positional
-        .iter()
-        .skip(2)
-        .find(|arg| !arg.is_empty() && !arg.starts_with('-'))
+    let path_arg = subcommand_path(env_args, &["--host", "--port", "--out", "-o"])
         .ok_or_else(|| format!("glyph serve needs a folder: {SERVE_USAGE}"))?;
 
-    let root = match classify_initial_arg(path_arg, cwd) {
+    let root = match classify_initial_arg(&path_arg, cwd) {
         Some(InitialOpenAction::Folder(root)) => root,
         _ => {
             return Err(format!(
                 "glyph serve requires an existing folder, not {}: {SERVE_USAGE}",
-                plain_path(path_arg)
+                plain_path(&path_arg)
             ))
         }
     };
@@ -406,64 +421,92 @@ fn serve_plan(env_args: &[String], cwd: &Path) -> Result<CliLaunch, String> {
 #[cfg(desktop)]
 const SERVE_USAGE: &str = "glyph serve <folder> [--host <host>] [--port <port>] [--out <dir>]";
 
-/// Combine the positional path with `--export` and `--out` into a launch plan.
+/// The `export` usage line, and the site-specific spelling of it.
+#[cfg(desktop)]
+const EXPORT_USAGE: &str = "glyph export <path> --format <format> [--out <path>]";
+
+#[cfg(desktop)]
+const EXPORT_SITE_USAGE: &str = "glyph export <folder> --format site --out <dir>";
+
+/// What a launch that is neither subcommand can look like.
+#[cfg(desktop)]
+const USAGE_SUMMARY: &str = "glyph [<path>] | glyph export ... | glyph serve ...";
+
+/// Decide what this launch should do from argv.
+///
+/// `plugin_path` is the value `tauri-plugin-cli` parsed for the positional
+/// file, which is how an OS file-association launch arrives. Everything else
+/// is read straight from argv, because the subcommands carry flags the plugin
+/// does not declare.
+///
 /// `Err` is a usage error the caller should print before exiting nonzero.
 #[cfg(desktop)]
 pub fn launch_plan(
     plugin_path: Option<&str>,
-    plugin_export: Option<&str>,
-    plugin_out: Option<&str>,
     env_args: &[String],
     cwd: &Path,
 ) -> Result<CliLaunch, String> {
-    // `serve` is the one subcommand, so it is decided before any of the
-    // flag parsing below, which is shaped around a single positional path.
-    if is_serve_invocation(env_args) {
-        return serve_plan(env_args, cwd);
+    match subcommand(env_args) {
+        Some(Subcommand::Export) => export_plan(env_args, cwd),
+        Some(Subcommand::Serve) => serve_plan(env_args, cwd),
+        None => open_plan(plugin_path, env_args, cwd),
     }
+}
 
-    // The flags and their values are stripped before the positional scan so
-    // `glyph --export pdf notes.md` cannot mistake "pdf" for the input path.
-    let positional = strip_flag(
-        &strip_flag(&strip_flag(env_args, "--export"), "--out"),
-        "-o",
-    );
-    let action = initial_open_action(plugin_path, &positional, cwd);
-
-    let export_value = plugin_export
-        .map(str::to_string)
-        .or_else(|| pick_flag_value(env_args, "--export").map(str::to_string));
-    let requested = plugin_export.is_some() || has_flag(env_args, "--export");
-    if !requested {
-        // `--out` alone would have had its value stripped from the positional
-        // scan for an export that was never asked for, quietly opening an empty
-        // window instead of the file the user named.
-        if plugin_out.is_some() || has_flag(env_args, "--out") || has_flag(env_args, "-o") {
-            return Err("--out only applies to an export: add --export <format>".to_string());
+/// An ordinary launch: open the path, if one was given.
+#[cfg(desktop)]
+fn open_plan(
+    plugin_path: Option<&str>,
+    env_args: &[String],
+    cwd: &Path,
+) -> Result<CliLaunch, String> {
+    // `--export <format>` was the old spelling of the export subcommand. It
+    // is gone rather than deprecated, so say what replaced it: the flag is
+    // sitting in people's CI scripts, and "unknown flag" would not help them.
+    if has_flag(env_args, "--export") {
+        return Err(format!(
+            "--export was replaced by a subcommand: {EXPORT_USAGE}"
+        ));
+    }
+    // Any other flag here is a half-remembered subcommand, not an option this
+    // shape takes, and silently opening an empty window would hide the typo.
+    for flag in ["--format", "--out", "-o", "--host", "--port"] {
+        if has_flag(env_args, flag) {
+            return Err(format!("{flag} belongs to a subcommand: {USAGE_SUMMARY}"));
         }
-        return Ok(CliLaunch::Open(action));
     }
-    let value = export_value.unwrap_or_default();
-    if value.trim().is_empty() {
-        return Err(format!("--export needs a format: {}", format_list()));
+    Ok(CliLaunch::Open(initial_open_action(
+        plugin_path,
+        env_args,
+        cwd,
+    )))
+}
+
+/// Parse `glyph export <path> --format <format> [--out <path>]`.
+#[cfg(desktop)]
+fn export_plan(env_args: &[String], cwd: &Path) -> Result<CliLaunch, String> {
+    let input = subcommand_path(env_args, &["--format", "--out", "-o"])
+        .ok_or_else(|| format!("glyph export needs a path: {EXPORT_USAGE}"))?;
+
+    for flag in ["--format", "--out", "-o"] {
+        if has_flag(env_args, flag) && pick_flag_value(env_args, flag).is_none() {
+            return Err(format!("{flag} needs a value: {EXPORT_USAGE}"));
+        }
     }
-    let format = ExportFormat::parse(&value)
+    let value = pick_flag_value(env_args, "--format")
+        .ok_or_else(|| format!("glyph export needs --format: {}", format_list()))?;
+    let format = ExportFormat::parse(value)
         .ok_or_else(|| format!("unknown export format '{value}': {}", format_list()))?;
 
-    let out_value = plugin_out
-        .map(str::to_string)
-        .or_else(|| pick_flag_value(env_args, "--out").map(str::to_string))
-        .or_else(|| pick_flag_value(env_args, "-o").map(str::to_string));
+    let out_value = pick_flag_value(env_args, "--out").or_else(|| pick_flag_value(env_args, "-o"));
     let output = out_value
-        .as_deref()
         .map(|out| resolve_out_path(out, cwd).ok_or_else(|| "--out needs a path".to_string()))
         .transpose()?;
 
-    match (format, action) {
+    match (format, classify_initial_arg(&input, cwd)) {
         (ExportFormat::Site, Some(InitialOpenAction::Folder(root))) => {
             let output = output.ok_or_else(|| {
-                "--export site needs an output directory: glyph <folder> --export site --out <dir>"
-                    .to_string()
+                format!("the site format needs an output directory: {EXPORT_SITE_USAGE}")
             })?;
             Ok(CliLaunch::Export {
                 input: root,
@@ -471,17 +514,17 @@ pub fn launch_plan(
                 output,
             })
         }
-        (ExportFormat::Site, _) => Err(
-            "--export site requires an existing workspace folder: glyph <folder> --export site --out <dir>"
-                .to_string(),
-        ),
+        (ExportFormat::Site, _) => Err(format!(
+            "the site format needs an existing folder, not {}: {EXPORT_SITE_USAGE}",
+            plain_path(&input)
+        )),
         (_, Some(InitialOpenAction::File(input))) => {
             // A canvas board and a D2 file are "supported documents" for
             // opening, but neither renders as one `.markdown-body`: a canvas
             // would export a single card as if it were the whole board.
             if !is_exportable_document(Path::new(&input)) {
                 return Err(format!(
-                    "--export {} only takes a markdown or notebook document, not {}",
+                    "the {} format only takes a markdown or notebook document, not {}",
                     format.as_str(),
                     plain_path(&input)
                 ));
@@ -494,9 +537,9 @@ pub fn launch_plan(
             })
         }
         (_, _) => Err(format!(
-            "--export {} requires an existing document: glyph <file.md> --export {} [--out <path>]",
+            "the {} format needs an existing document, not {}: {EXPORT_USAGE}",
             format.as_str(),
-            format.as_str()
+            plain_path(&input)
         )),
     }
 }
@@ -523,7 +566,8 @@ fn is_exportable_document(path: &Path) -> bool {
 }
 
 /// Output path for an export with no `--out`: the input with the format's
-/// extension, so `glyph notes.md --export pdf` writes `notes.pdf` beside it.
+/// extension, so `glyph export notes.md --format pdf` writes `notes.pdf`
+/// beside it.
 #[cfg(desktop)]
 fn default_output(input: &str, format: ExportFormat) -> String {
     let extension = format.extension().unwrap_or_default();
@@ -533,7 +577,7 @@ fn default_output(input: &str, format: ExportFormat) -> String {
         .to_string()
 }
 
-/// The accepted `--export` values, for usage messages and `--help`.
+/// The accepted `--format` values, for usage messages and `--help`.
 #[cfg(desktop)]
 pub fn format_list() -> String {
     ExportFormat::ALL
@@ -832,42 +876,42 @@ mod tests {
 
     #[test]
     fn pick_flag_value_finds_space_and_equals_forms() {
-        let argv: Vec<String> = ["glyph", "docs", "--export", "site"]
+        let argv: Vec<String> = ["glyph", "docs", "--format", "site"]
             .iter()
             .map(|s| s.to_string())
             .collect();
-        assert_eq!(pick_flag_value(&argv, "--export"), Some("site"));
+        assert_eq!(pick_flag_value(&argv, "--format"), Some("site"));
 
-        let eq_form: Vec<String> = ["glyph", "--export=out", "docs"]
+        let eq_form: Vec<String> = ["glyph", "--format=out", "docs"]
             .iter()
             .map(|s| s.to_string())
             .collect();
-        assert_eq!(pick_flag_value(&eq_form, "--export"), Some("out"));
+        assert_eq!(pick_flag_value(&eq_form, "--format"), Some("out"));
     }
 
     #[test]
     fn pick_flag_value_returns_none_when_absent_or_valueless() {
         let argv: Vec<String> = ["glyph", "docs"].iter().map(|s| s.to_string()).collect();
-        assert_eq!(pick_flag_value(&argv, "--export"), None);
-        let dangling: Vec<String> = ["glyph", "--export"]
+        assert_eq!(pick_flag_value(&argv, "--format"), None);
+        let dangling: Vec<String> = ["glyph", "--format"]
             .iter()
             .map(|s| s.to_string())
             .collect();
-        assert_eq!(pick_flag_value(&dangling, "--export"), None);
+        assert_eq!(pick_flag_value(&dangling, "--format"), None);
     }
 
     #[test]
     fn strip_flag_removes_flag_and_value_leaving_positionals() {
-        let argv: Vec<String> = ["glyph", "--export", "site", "docs"]
+        let argv: Vec<String> = ["glyph", "--format", "site", "docs"]
             .iter()
             .map(|s| s.to_string())
             .collect();
-        assert_eq!(strip_flag(&argv, "--export"), vec!["glyph", "docs"]);
-        let eq_form: Vec<String> = ["glyph", "--export=site", "docs"]
+        assert_eq!(strip_flag(&argv, "--format"), vec!["glyph", "docs"]);
+        let eq_form: Vec<String> = ["glyph", "--format=site", "docs"]
             .iter()
             .map(|s| s.to_string())
             .collect();
-        assert_eq!(strip_flag(&eq_form, "--export"), vec!["glyph", "docs"]);
+        assert_eq!(strip_flag(&eq_form, "--format"), vec!["glyph", "docs"]);
     }
 
     #[test]
@@ -897,12 +941,12 @@ mod tests {
 
     #[test]
     fn has_flag_spots_both_spellings_but_not_the_program_name() {
-        assert!(has_flag(&argv_of(&["--export", "pdf"]), "--export"));
-        assert!(has_flag(&argv_of(&["--export=pdf"]), "--export"));
+        assert!(has_flag(&argv_of(&["--format", "pdf"]), "--format"));
+        assert!(has_flag(&argv_of(&["--format=pdf"]), "--format"));
         // Valueless still counts as present, which is what turns it into a
         // usage error rather than a silent normal launch.
-        assert!(has_flag(&argv_of(&["--export"]), "--export"));
-        assert!(!has_flag(&argv_of(&["notes.md"]), "--export"));
+        assert!(has_flag(&argv_of(&["--format"]), "--format"));
+        assert!(!has_flag(&argv_of(&["notes.md"]), "--format"));
     }
 
     #[test]
@@ -924,7 +968,7 @@ mod tests {
         let ws = cwd.join("docs");
         fs::create_dir_all(&ws).unwrap();
 
-        let plan = launch_plan(None, None, None, &argv_of(&["docs"]), &cwd).expect("plans");
+        let plan = launch_plan(None, &argv_of(&["docs"]), &cwd).expect("plans");
         assert!(matches!(
             plan,
             CliLaunch::Open(Some(InitialOpenAction::Folder(_)))
@@ -944,8 +988,8 @@ mod tests {
             ("epub", "epub"),
             ("html", "html"),
         ] {
-            let argv = argv_of(&["note.md", "--export", format]);
-            let plan = launch_plan(None, None, None, &argv, &cwd).expect("plans");
+            let argv = argv_of(&["export", "note.md", "--format", format]);
+            let plan = launch_plan(None, &argv, &cwd).expect("plans");
             let expected = format!("note.{extension}");
             assert!(
                 matches!(&plan, CliLaunch::Export { input, format: parsed, output }
@@ -988,13 +1032,13 @@ mod tests {
         let expected = cwd.join("built.pdf").to_string_lossy().to_string();
 
         for args in [
-            vec!["note.md", "--export", "pdf", "-o", "built.pdf"],
-            vec!["note.md", "--export", "pdf", "--out", "built.pdf"],
-            vec!["note.md", "--export=pdf", "--out=built.pdf"],
-            // The flags' values must never be mistaken for the positional path.
-            vec!["--export", "pdf", "--out", "built.pdf", "note.md"],
+            vec!["export", "note.md", "--format", "pdf", "-o", "built.pdf"],
+            vec!["export", "note.md", "--format", "pdf", "--out", "built.pdf"],
+            vec!["export", "note.md", "--format=pdf", "--out=built.pdf"],
+            // The flags' values must never be mistaken for the path.
+            vec!["export", "--format", "pdf", "--out", "built.pdf", "note.md"],
         ] {
-            let plan = launch_plan(None, None, None, &argv_of(&args), &cwd).expect("plans");
+            let plan = launch_plan(None, &argv_of(&args), &cwd).expect("plans");
             assert!(
                 matches!(&plan, CliLaunch::Export { output, .. } if *output == expected),
                 "expected {expected}, got {plan:?}"
@@ -1019,7 +1063,7 @@ mod tests {
 
     /// Plan a serve, so the assertions below read as one line each.
     fn serve_of(argv: &[String], cwd: &Path) -> (String, std::net::IpAddr, u16, Option<String>) {
-        let plan = launch_plan(None, None, None, argv, cwd).expect("plans");
+        let plan = launch_plan(None, argv, cwd).expect("plans");
         serve_fields(plan).expect("expected a serve plan")
     }
 
@@ -1098,12 +1142,11 @@ mod tests {
         fs::create_dir_all(&cwd).unwrap();
         fs::write(cwd.join("note.md"), "hi").unwrap();
 
-        let missing = launch_plan(None, None, None, &argv_of(&["serve"]), &cwd).unwrap_err();
+        let missing = launch_plan(None, &argv_of(&["serve"]), &cwd).unwrap_err();
         assert!(missing.contains("needs a folder"), "got: {missing}");
 
         for target in ["nope", "note.md"] {
-            let err =
-                launch_plan(None, None, None, &argv_of(&["serve", target]), &cwd).unwrap_err();
+            let err = launch_plan(None, &argv_of(&["serve", target]), &cwd).unwrap_err();
             assert!(
                 err.contains("requires an existing folder"),
                 "{target} gave: {err}"
@@ -1119,8 +1162,6 @@ mod tests {
 
         let host = launch_plan(
             None,
-            None,
-            None,
             &argv_of(&["serve", "docs", "--host", "not-an-address"]),
             &cwd,
         )
@@ -1128,14 +1169,8 @@ mod tests {
         assert!(host.contains("not a valid address"), "got: {host}");
 
         for bad in ["99999", "-1", "http"] {
-            let err = launch_plan(
-                None,
-                None,
-                None,
-                &argv_of(&["serve", "docs", "--port", bad]),
-                &cwd,
-            )
-            .unwrap_err();
+            let err =
+                launch_plan(None, &argv_of(&["serve", "docs", "--port", bad]), &cwd).unwrap_err();
             assert!(err.contains("--port must be a number"), "{bad} gave: {err}");
         }
         let _ = fs::remove_dir_all(&cwd);
@@ -1150,14 +1185,8 @@ mod tests {
         fs::create_dir_all(&docs).unwrap();
 
         for out in ["docs/site", "docs"] {
-            let err = launch_plan(
-                None,
-                None,
-                None,
-                &argv_of(&["serve", "docs", "--out", out]),
-                &cwd,
-            )
-            .unwrap_err();
+            let err =
+                launch_plan(None, &argv_of(&["serve", "docs", "--out", out]), &cwd).unwrap_err();
             assert!(
                 err.contains("cannot be inside the folder being served"),
                 "--out {out} gave: {err}"
@@ -1180,14 +1209,8 @@ mod tests {
         fs::create_dir_all(&docs).unwrap();
 
         for out in [".", ".."] {
-            let err = launch_plan(
-                None,
-                None,
-                None,
-                &argv_of(&["serve", "docs", "--out", out]),
-                &cwd,
-            )
-            .unwrap_err();
+            let err =
+                launch_plan(None, &argv_of(&["serve", "docs", "--out", out]), &cwd).unwrap_err();
             assert!(
                 err.contains("cannot contain the folder being served"),
                 "--out {out} gave: {err}"
@@ -1198,14 +1221,13 @@ mod tests {
 
     #[test]
     fn serve_rejects_a_flag_with_nothing_after_it() {
-        // Silently binding the default would hide the typo, and `--export`
-        // already treats a valueless flag as a usage error.
+        // Silently binding the default would hide the typo, and `export`
+        // treats a valueless flag the same way.
         let cwd = unique_tmp("serve_dangling");
         fs::create_dir_all(cwd.join("docs")).unwrap();
 
         for flag in ["--host", "--port", "--out"] {
-            let err = launch_plan(None, None, None, &argv_of(&["serve", "docs", flag]), &cwd)
-                .unwrap_err();
+            let err = launch_plan(None, &argv_of(&["serve", "docs", flag]), &cwd).unwrap_err();
             assert!(err.contains(&format!("{flag} needs a value")), "got: {err}");
         }
         let _ = fs::remove_dir_all(&cwd);
@@ -1218,7 +1240,7 @@ mod tests {
         let cwd = unique_tmp("serve_named_folder");
         fs::create_dir_all(cwd.join("serve")).unwrap();
 
-        let plan = launch_plan(None, None, None, &argv_of(&["./serve"]), &cwd).expect("plans");
+        let plan = launch_plan(None, &argv_of(&["./serve"]), &cwd).expect("plans");
         assert!(
             matches!(&plan, CliLaunch::Open(Some(InitialOpenAction::Folder(p))) if p.ends_with("serve")),
             "expected a normal folder open, got {plan:?}"
@@ -1235,12 +1257,12 @@ mod tests {
         // An export and a serve do their work here; handing the arguments to
         // another process would exit 0 having done none of it.
         assert!(!forwards_to_running_instance(&argv_of(&[
-            "notes.md", "--export", "pdf"
+            "export", "notes.md", "--format", "pdf"
         ])));
-        assert!(!forwards_to_running_instance(&argv_of(&["--export=site"])));
         assert!(!forwards_to_running_instance(&argv_of(&["serve", "docs"])));
-        // A folder named `serve` is an ordinary open, and forwards.
+        // A folder named after a subcommand is an ordinary open, and forwards.
         assert!(forwards_to_running_instance(&argv_of(&["./serve"])));
+        assert!(forwards_to_running_instance(&argv_of(&["./export"])));
     }
 
     #[test]
@@ -1265,11 +1287,85 @@ mod tests {
     }
 
     #[test]
-    fn is_serve_invocation_only_matches_a_bare_first_argument() {
-        assert!(is_serve_invocation(&argv_of(&["serve", "docs"])));
-        assert!(!is_serve_invocation(&argv_of(&["./serve"])));
-        assert!(!is_serve_invocation(&argv_of(&["docs", "serve"])));
-        assert!(!is_serve_invocation(&argv_of(&[])));
+    fn export_needs_a_path_and_says_so() {
+        let cwd = unique_tmp("export_no_path");
+        fs::create_dir_all(&cwd).unwrap();
+        let err = launch_plan(None, &argv_of(&["export", "--format", "pdf"]), &cwd)
+            .expect_err("usage error");
+        assert!(err.contains("glyph export needs a path"), "got: {err}");
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn export_does_not_mistake_a_flag_value_for_the_path() {
+        // `built.pdf` is --out's value; the path comes after it.
+        let cwd = unique_tmp("export_order");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::write(cwd.join("note.md"), "# hi").unwrap();
+
+        let argv = argv_of(&["export", "--out", "built.pdf", "--format", "pdf", "note.md"]);
+        let plan = launch_plan(None, &argv, &cwd).expect("plans");
+        let expected = cwd.join("built.pdf").to_string_lossy().to_string();
+        assert!(
+            matches!(&plan, CliLaunch::Export { input, output, .. }
+                if input.ends_with("note.md") && *output == expected),
+            "got {plan:?}"
+        );
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn the_old_export_flag_says_what_replaced_it() {
+        // It is in people's CI scripts; "unknown flag" would not help them.
+        let cwd = unique_tmp("old_flag");
+        fs::create_dir_all(cwd.join("docs")).unwrap();
+
+        let err = launch_plan(
+            None,
+            &argv_of(&["docs", "--export", "site", "--out", "out"]),
+            &cwd,
+        )
+        .expect_err("usage error");
+        assert!(err.contains("--export was replaced"), "got: {err}");
+        assert!(err.contains("glyph export"), "got: {err}");
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn a_flag_without_a_subcommand_is_a_usage_error() {
+        // Otherwise `glyph notes.md --format pdf` would open the file and
+        // silently ignore the half-remembered command.
+        let cwd = unique_tmp("bare_flag");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::write(cwd.join("note.md"), "# hi").unwrap();
+
+        for flag in ["--format", "--out", "-o", "--host", "--port"] {
+            let err = launch_plan(None, &argv_of(&["note.md", flag, "x"]), &cwd)
+                .expect_err("usage error");
+            assert!(
+                err.contains("belongs to a subcommand"),
+                "{flag} gave: {err}"
+            );
+        }
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn a_subcommand_is_only_a_bare_first_argument() {
+        assert_eq!(
+            subcommand(&argv_of(&["serve", "docs"])),
+            Some(Subcommand::Serve)
+        );
+        assert_eq!(
+            subcommand(&argv_of(&["export", "notes.md"])),
+            Some(Subcommand::Export)
+        );
+        // A folder named after a subcommand still opens, as `./serve` does.
+        assert_eq!(subcommand(&argv_of(&["./serve"])), None);
+        assert_eq!(subcommand(&argv_of(&["./export"])), None);
+        // Only the first argument counts.
+        assert_eq!(subcommand(&argv_of(&["docs", "serve"])), None);
+        assert_eq!(subcommand(&argv_of(&[])), None);
     }
 
     #[test]
@@ -1277,9 +1373,9 @@ mod tests {
         let cwd = unique_tmp("lp_site");
         let ws = cwd.join("docs");
         fs::create_dir_all(&ws).unwrap();
-        let argv = argv_of(&["--export", "site", "--out", "site", "docs"]);
+        let argv = argv_of(&["export", "docs", "--format", "site", "--out", "site"]);
 
-        let plan = launch_plan(None, None, None, &argv, &cwd).expect("plans");
+        let plan = launch_plan(None, &argv, &cwd).expect("plans");
         let expected_out = cwd.join("site").to_string_lossy().to_string();
         assert!(
             matches!(
@@ -1300,12 +1396,16 @@ mod tests {
         fs::create_dir_all(&cwd).unwrap();
         fs::write(cwd.join("note.md"), "# hi").unwrap();
 
-        let dangling = argv_of(&["note.md", "--export"]);
-        let err = launch_plan(None, None, None, &dangling, &cwd).expect_err("usage error");
-        assert!(err.contains("needs a format"), "got: {err}");
+        let missing = argv_of(&["export", "note.md"]);
+        let err = launch_plan(None, &missing, &cwd).expect_err("usage error");
+        assert!(err.contains("needs --format"), "got: {err}");
 
-        let unknown = argv_of(&["note.md", "--export", "rtf"]);
-        let err = launch_plan(None, None, None, &unknown, &cwd).expect_err("usage error");
+        let dangling = argv_of(&["export", "note.md", "--format"]);
+        let err = launch_plan(None, &dangling, &cwd).expect_err("usage error");
+        assert!(err.contains("--format needs a value"), "got: {err}");
+
+        let unknown = argv_of(&["export", "note.md", "--format", "rtf"]);
+        let err = launch_plan(None, &unknown, &cwd).expect_err("usage error");
         assert!(err.contains("unknown export format"), "got: {err}");
         // Every accepted spelling is named, so the message is actionable.
         assert!(err.contains("pdf") && err.contains("site"), "got: {err}");
@@ -1320,24 +1420,18 @@ mod tests {
         fs::write(cwd.join("note.md"), "# hi").unwrap();
 
         // A document format pointed at a folder.
-        let err = launch_plan(
-            None,
-            None,
-            None,
-            &argv_of(&["docs", "--export", "pdf"]),
-            &cwd,
-        )
-        .expect_err("usage error");
-        assert!(err.contains("requires an existing document"), "got: {err}");
+        let err = launch_plan(None, &argv_of(&["export", "docs", "--format", "pdf"]), &cwd)
+            .expect_err("usage error");
+        assert!(err.contains("needs an existing document"), "got: {err}");
 
         // `site` pointed at a file.
-        let argv = argv_of(&["note.md", "--export", "site", "-o", "out"]);
-        let err = launch_plan(None, None, None, &argv, &cwd).expect_err("usage error");
-        assert!(err.contains("workspace folder"), "got: {err}");
+        let argv = argv_of(&["export", "note.md", "--format", "site", "-o", "out"]);
+        let err = launch_plan(None, &argv, &cwd).expect_err("usage error");
+        assert!(err.contains("needs an existing folder"), "got: {err}");
 
         // Nothing to export at all.
-        let argv = argv_of(&["--export", "pdf"]);
-        assert!(launch_plan(None, None, None, &argv, &cwd).is_err());
+        let argv = argv_of(&["export", "--format", "pdf"]);
+        assert!(launch_plan(None, &argv, &cwd).is_err());
         let _ = fs::remove_dir_all(&cwd);
     }
 
@@ -1351,19 +1445,13 @@ mod tests {
         fs::write(cwd.join("shape.d2"), "a -> b").unwrap();
 
         for input in ["board.canvas", "shape.d2"] {
-            let err = launch_plan(
-                None,
-                None,
-                None,
-                &argv_of(&[input, "--export", "pdf"]),
-                &cwd,
-            )
-            .expect_err("usage error");
+            let err = launch_plan(None, &argv_of(&["export", input, "--format", "pdf"]), &cwd)
+                .expect_err("usage error");
             assert!(err.contains("markdown or notebook document"), "got: {err}");
         }
 
         // The same files still open normally.
-        let plan = launch_plan(None, None, None, &argv_of(&["board.canvas"]), &cwd).expect("plans");
+        let plan = launch_plan(None, &argv_of(&["board.canvas"]), &cwd).expect("plans");
         assert!(matches!(
             plan,
             CliLaunch::Open(Some(InitialOpenAction::File(_)))
@@ -1373,8 +1461,8 @@ mod tests {
 
     #[test]
     fn launch_plan_rejects_an_output_path_with_no_export() {
-        // `--out`'s value is stripped before the positional scan, so without
-        // this the launch would open an empty window instead of the file.
+        // Without this the flag's value would be read as the path to open,
+        // hiding the fact that the subcommand was left out.
         let cwd = unique_tmp("lp_out_only");
         fs::create_dir_all(&cwd).unwrap();
         fs::write(cwd.join("note.md"), "# hi").unwrap();
@@ -1383,12 +1471,8 @@ mod tests {
             vec!["note.md", "--out", "built.pdf"],
             vec!["note.md", "-o", "built.pdf"],
         ] {
-            let err =
-                launch_plan(None, None, None, &argv_of(&args), &cwd).expect_err("usage error");
-            assert!(
-                err.contains("--out only applies to an export"),
-                "got: {err}"
-            );
+            let err = launch_plan(None, &argv_of(&args), &cwd).expect_err("usage error");
+            assert!(err.contains("belongs to a subcommand"), "got: {err}");
         }
         let _ = fs::remove_dir_all(&cwd);
     }
@@ -1401,9 +1485,7 @@ mod tests {
 
         let err = launch_plan(
             None,
-            None,
-            None,
-            &argv_of(&["docs", "--export", "site"]),
+            &argv_of(&["export", "docs", "--format", "site"]),
             &cwd,
         )
         .expect_err("usage error");
@@ -1417,31 +1499,13 @@ mod tests {
         fs::create_dir_all(&cwd).unwrap();
         fs::write(cwd.join("note.md"), "# hi").unwrap();
 
-        let err = launch_plan(None, Some("pdf"), Some("   "), &argv_of(&["note.md"]), &cwd)
-            .expect_err("usage error");
-        assert!(err.contains("--out needs a path"), "got: {err}");
-        let _ = fs::remove_dir_all(&cwd);
-    }
-
-    #[test]
-    fn launch_plan_prefers_the_plugin_values_over_argv() {
-        let cwd = unique_tmp("lp_plugin");
-        let ws = cwd.join("docs");
-        fs::create_dir_all(&ws).unwrap();
-
-        let plan = launch_plan(
+        let err = launch_plan(
             None,
-            Some("site"),
-            Some("from-plugin"),
-            &argv_of(&["docs"]),
+            &argv_of(&["export", "note.md", "--format", "pdf", "--out", "   "]),
             &cwd,
         )
-        .expect("plans");
-        let expected_out = cwd.join("from-plugin").to_string_lossy().to_string();
-        assert!(
-            matches!(&plan, CliLaunch::Export { output, .. } if *output == expected_out),
-            "expected the plugin's out dir, got {plan:?}"
-        );
+        .expect_err("usage error");
+        assert!(err.contains("--out needs a path"), "got: {err}");
         let _ = fs::remove_dir_all(&cwd);
     }
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1003,18 +1003,24 @@ mod tests {
         let _ = fs::remove_dir_all(&cwd);
     }
 
-    /// Unwrap a plan that is expected to be a serve, so the assertions below
-    /// read as one line each.
-    fn serve_of(argv: &[String], cwd: &Path) -> (String, std::net::IpAddr, u16, Option<String>) {
-        match launch_plan(None, None, None, argv, cwd).expect("plans") {
+    /// The fields of a serve plan, or `None` for any other kind of launch.
+    /// Doubles as the discriminator the "folder named serve" test uses.
+    fn serve_fields(plan: CliLaunch) -> Option<(String, std::net::IpAddr, u16, Option<String>)> {
+        match plan {
             CliLaunch::Serve {
                 root,
                 host,
                 port,
                 output,
-            } => (root, host, port, output),
-            other => panic!("expected a serve plan, got {other:?}"),
+            } => Some((root, host, port, output)),
+            _ => None,
         }
+    }
+
+    /// Plan a serve, so the assertions below read as one line each.
+    fn serve_of(argv: &[String], cwd: &Path) -> (String, std::net::IpAddr, u16, Option<String>) {
+        let plan = launch_plan(None, None, None, argv, cwd).expect("plans");
+        serve_fields(plan).expect("expected a serve plan")
     }
 
     #[test]
@@ -1217,6 +1223,7 @@ mod tests {
             matches!(&plan, CliLaunch::Open(Some(InitialOpenAction::Folder(p))) if p.ends_with("serve")),
             "expected a normal folder open, got {plan:?}"
         );
+        assert!(serve_fields(plan).is_none(), "it must not plan a serve");
         let _ = fs::remove_dir_all(&cwd);
     }
 
@@ -1234,6 +1241,18 @@ mod tests {
         assert!(!forwards_to_running_instance(&argv_of(&["serve", "docs"])));
         // A folder named `serve` is an ordinary open, and forwards.
         assert!(forwards_to_running_instance(&argv_of(&["./serve"])));
+    }
+
+    #[test]
+    fn a_candidate_with_no_resolvable_ancestor_is_outside() {
+        // `--out` may name a directory that does not exist yet, so the walk
+        // climbs to the deepest ancestor that does. A path with none at all
+        // (a bare relative name against a root it shares nothing with) has to
+        // end the walk rather than loop.
+        let cwd = unique_tmp("outside_walk");
+        fs::create_dir_all(&cwd).unwrap();
+        assert!(!is_path_inside(Path::new("no-such-relative/deeper"), &cwd));
+        let _ = fs::remove_dir_all(&cwd);
     }
 
     #[test]

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1237,6 +1237,15 @@ mod tests {
     }
 
     #[test]
+    fn a_root_that_cannot_be_resolved_contains_nothing() {
+        // Guards the containment checks: an unresolvable root must not be
+        // reported as containing (or contained by) anything.
+        let missing = std::env::temp_dir().join("glyph-serve-no-such-root");
+        let _ = fs::remove_dir_all(&missing);
+        assert!(!is_path_inside(Path::new("/anywhere"), &missing));
+    }
+
+    #[test]
     fn is_serve_invocation_only_matches_a_bare_first_argument() {
         assert!(is_serve_invocation(&argv_of(&["serve", "docs"])));
         assert!(!is_serve_invocation(&argv_of(&["./serve"])));

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -267,7 +267,7 @@ pub enum CliLaunch {
     /// Long-running preview: render `root` as a website, serve it on
     /// `host:port`, and re-render whenever the folder changes. `output` is
     /// `None` when the caller passed no `--out`, meaning the site belongs in a
-    /// temporary directory the process owns and removes on the way out.
+    /// temporary directory the process owns and removes when interrupted.
     Serve {
         root: String,
         host: std::net::IpAddr,
@@ -347,6 +347,12 @@ fn serve_plan(env_args: &[String], cwd: &Path) -> Result<CliLaunch, String> {
         }
     };
 
+    for flag in ["--host", "--port", "--out"] {
+        if has_flag(env_args, flag) && pick_flag_value(env_args, flag).is_none() {
+            return Err(format!("{flag} needs a value: {SERVE_USAGE}"));
+        }
+    }
+
     let host = match pick_flag_value(env_args, "--host") {
         Some(value) => value
             .trim()
@@ -371,6 +377,15 @@ fn serve_plan(env_args: &[String], cwd: &Path) -> Result<CliLaunch, String> {
             if is_path_inside(Path::new(&resolved), Path::new(&root)) {
                 return Err(
                     "--out cannot be inside the folder being served: the export would feed its own output back in"
+                        .to_string(),
+                );
+            }
+            // The other direction matters just as much: everything in the
+            // output directory is served, so `--out .` or `--out ~` would
+            // publish the sources, and any `.env` or `.git` beside them.
+            if is_path_inside(Path::new(&root), Path::new(&resolved)) {
+                return Err(
+                    "--out cannot contain the folder being served: everything in it would be published"
                         .to_string(),
                 );
             }
@@ -1146,6 +1161,47 @@ mod tests {
         // A sibling directory is fine.
         let (_, _, _, output) = serve_of(&argv_of(&["serve", "docs", "--out", "site"]), &cwd);
         assert_eq!(output, Some(cwd.join("site").to_string_lossy().to_string()));
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn serve_refuses_an_output_directory_that_contains_the_served_folder() {
+        // Everything in the output directory is published, so `--out .` when
+        // serving ./docs would put the sources, and any .env or .git beside
+        // them, on the server.
+        let cwd = unique_tmp("serve_out_above");
+        let docs = cwd.join("docs");
+        fs::create_dir_all(&docs).unwrap();
+
+        for out in [".", ".."] {
+            let err = launch_plan(
+                None,
+                None,
+                None,
+                &argv_of(&["serve", "docs", "--out", out]),
+                &cwd,
+            )
+            .unwrap_err();
+            assert!(
+                err.contains("cannot contain the folder being served"),
+                "--out {out} gave: {err}"
+            );
+        }
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn serve_rejects_a_flag_with_nothing_after_it() {
+        // Silently binding the default would hide the typo, and `--export`
+        // already treats a valueless flag as a usage error.
+        let cwd = unique_tmp("serve_dangling");
+        fs::create_dir_all(cwd.join("docs")).unwrap();
+
+        for flag in ["--host", "--port", "--out"] {
+            let err = launch_plan(None, None, None, &argv_of(&["serve", "docs", flag]), &cwd)
+                .unwrap_err();
+            assert!(err.contains(&format!("{flag} needs a value")), "got: {err}");
+        }
         let _ = fs::remove_dir_all(&cwd);
     }
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -240,6 +240,17 @@ impl ExportFormat {
     }
 }
 
+/// Address `glyph serve` binds when `--host` is absent. Loopback only: the
+/// exported site is readable by anyone who can reach the port, so exposing it
+/// to the network is opt-in rather than the default.
+#[cfg(desktop)]
+pub const DEFAULT_SERVE_HOST: std::net::IpAddr =
+    std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+
+/// Port `glyph serve` binds when `--port` is absent.
+#[cfg(desktop)]
+pub const DEFAULT_SERVE_PORT: u16 = 4173;
+
 /// What this process launch should do, decided from the CLI once at startup.
 #[cfg(desktop)]
 #[derive(Debug, PartialEq, Eq)]
@@ -253,7 +264,132 @@ pub enum CliLaunch {
         format: ExportFormat,
         output: String,
     },
+    /// Long-running preview: render `root` as a website, serve it on
+    /// `host:port`, and re-render whenever the folder changes. `output` is
+    /// `None` when the caller passed no `--out`, meaning the site belongs in a
+    /// temporary directory the process owns and removes on the way out.
+    Serve {
+        root: String,
+        host: std::net::IpAddr,
+        port: u16,
+        output: Option<String>,
+    },
 }
+
+/// Whether argv asks for the `serve` subcommand. Only a bare first argument
+/// counts, so a folder that happens to be named `serve` still opens normally
+/// as `glyph ./serve`.
+#[cfg(desktop)]
+pub fn is_serve_invocation(env_args: &[String]) -> bool {
+    env_args.get(1).is_some_and(|arg| arg == "serve")
+}
+
+/// Whether this launch should hand its arguments to a Glyph the user already
+/// has open, rather than doing the work itself.
+///
+/// Opening a document should reuse the running window. An export and a serve
+/// must not: both do their work in this process, so forwarding would exit 0
+/// having exported nothing, or having served nothing while the running app
+/// quietly opened the folder in a tab instead.
+#[cfg(desktop)]
+pub fn forwards_to_running_instance(env_args: &[String]) -> bool {
+    !has_flag(env_args, "--export") && !is_serve_invocation(env_args)
+}
+
+/// Whether `candidate` sits inside `root`, comparing the deepest existing
+/// ancestor of a path that does not exist yet. Serving a site from inside the
+/// folder being watched would feed the export's own output back into it, so
+/// the CLI rejects it the same way the in-app website export does.
+#[cfg(desktop)]
+fn is_path_inside(candidate: &Path, root: &Path) -> bool {
+    let Ok(root) = root.canonicalize() else {
+        return false;
+    };
+    let mut probe = candidate.to_path_buf();
+    loop {
+        if let Ok(resolved) = probe.canonicalize() {
+            return resolved.starts_with(&root);
+        }
+        // Not created yet: ask the same question of its parent.
+        if !probe.pop() {
+            return false;
+        }
+    }
+}
+
+/// Parse a `glyph serve <dir> [--host <h>] [--port <n>] [--out <dir>]` launch.
+/// `Err` is a usage message the caller prints before exiting nonzero.
+#[cfg(desktop)]
+fn serve_plan(env_args: &[String], cwd: &Path) -> Result<CliLaunch, String> {
+    // Flag values are stripped before the positional scan so `glyph serve
+    // --out build docs` cannot mistake "build" for the folder to serve.
+    let positional = strip_flag(
+        &strip_flag(
+            &strip_flag(&strip_flag(env_args, "--host"), "--port"),
+            "--out",
+        ),
+        "-o",
+    );
+    // Skip the program name and the `serve` token itself.
+    let path_arg = positional
+        .iter()
+        .skip(2)
+        .find(|arg| !arg.is_empty() && !arg.starts_with('-'))
+        .ok_or_else(|| format!("glyph serve needs a folder: {SERVE_USAGE}"))?;
+
+    let root = match classify_initial_arg(path_arg, cwd) {
+        Some(InitialOpenAction::Folder(root)) => root,
+        _ => {
+            return Err(format!(
+                "glyph serve requires an existing folder, not {}: {SERVE_USAGE}",
+                plain_path(path_arg)
+            ))
+        }
+    };
+
+    let host = match pick_flag_value(env_args, "--host") {
+        Some(value) => value
+            .trim()
+            .parse::<std::net::IpAddr>()
+            .map_err(|_| format!("--host is not a valid address: '{value}'"))?,
+        None => DEFAULT_SERVE_HOST,
+    };
+
+    let port = match pick_flag_value(env_args, "--port") {
+        Some(value) => value
+            .trim()
+            .parse::<u16>()
+            .map_err(|_| format!("--port must be a number between 0 and 65535: '{value}'"))?,
+        None => DEFAULT_SERVE_PORT,
+    };
+
+    let out_value = pick_flag_value(env_args, "--out").or_else(|| pick_flag_value(env_args, "-o"));
+    let output = match out_value {
+        Some(value) => {
+            let resolved =
+                resolve_out_path(value, cwd).ok_or_else(|| "--out needs a path".to_string())?;
+            if is_path_inside(Path::new(&resolved), Path::new(&root)) {
+                return Err(
+                    "--out cannot be inside the folder being served: the export would feed its own output back in"
+                        .to_string(),
+                );
+            }
+            Some(resolved)
+        }
+        None => None,
+    };
+
+    Ok(CliLaunch::Serve {
+        root,
+        host,
+        port,
+        output,
+    })
+}
+
+/// The `serve` usage line, repeated by every one of its error messages.
+#[cfg(desktop)]
+const SERVE_USAGE: &str = "glyph serve <folder> [--host <host>] [--port <port>] [--out <dir>]";
 
 /// Combine the positional path with `--export` and `--out` into a launch plan.
 /// `Err` is a usage error the caller should print before exiting nonzero.
@@ -265,6 +401,12 @@ pub fn launch_plan(
     env_args: &[String],
     cwd: &Path,
 ) -> Result<CliLaunch, String> {
+    // `serve` is the one subcommand, so it is decided before any of the
+    // flag parsing below, which is shaped around a single positional path.
+    if is_serve_invocation(env_args) {
+        return serve_plan(env_args, cwd);
+    }
+
     // The flags and their values are stripped before the positional scan so
     // `glyph --export pdf notes.md` cannot mistake "pdf" for the input path.
     let positional = strip_flag(
@@ -350,7 +492,7 @@ pub fn launch_plan(
 /// prints, and the UNC form is not even a valid path once the prefix is
 /// dropped naively.
 #[cfg(desktop)]
-fn plain_path(path: &str) -> String {
+pub fn plain_path(path: &str) -> String {
     match path.strip_prefix(r"\\?\UNC\") {
         Some(rest) => format!(r"\\{rest}"),
         None => path.strip_prefix(r"\\?\").unwrap_or(path).to_string(),
@@ -844,6 +986,206 @@ mod tests {
             );
         }
         let _ = fs::remove_dir_all(&cwd);
+    }
+
+    /// Unwrap a plan that is expected to be a serve, so the assertions below
+    /// read as one line each.
+    fn serve_of(argv: &[String], cwd: &Path) -> (String, std::net::IpAddr, u16, Option<String>) {
+        match launch_plan(None, None, None, argv, cwd).expect("plans") {
+            CliLaunch::Serve {
+                root,
+                host,
+                port,
+                output,
+            } => (root, host, port, output),
+            other => panic!("expected a serve plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serve_defaults_to_loopback_a_fixed_port_and_a_temporary_directory() {
+        let cwd = unique_tmp("serve_defaults");
+        fs::create_dir_all(cwd.join("docs")).unwrap();
+
+        let (root, host, port, output) = serve_of(&argv_of(&["serve", "docs"]), &cwd);
+        assert!(root.ends_with("docs"), "got {root}");
+        assert_eq!(host, DEFAULT_SERVE_HOST);
+        assert_eq!(port, DEFAULT_SERVE_PORT);
+        assert!(host.is_loopback(), "the default must not face the network");
+        assert_eq!(output, None, "no --out means a temporary directory");
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn serve_reads_host_port_and_out_in_both_flag_spellings() {
+        let cwd = unique_tmp("serve_flags");
+        fs::create_dir_all(cwd.join("docs")).unwrap();
+
+        for argv in [
+            argv_of(&[
+                "serve", "docs", "--host", "0.0.0.0", "--port", "8080", "--out", "build",
+            ]),
+            argv_of(&[
+                "serve",
+                "--host=0.0.0.0",
+                "--port=8080",
+                "--out=build",
+                "docs",
+            ]),
+        ] {
+            let (root, host, port, output) = serve_of(&argv, &cwd);
+            assert!(root.ends_with("docs"), "got {root}");
+            assert_eq!(host.to_string(), "0.0.0.0");
+            assert_eq!(port, 8080);
+            assert_eq!(
+                output,
+                Some(cwd.join("build").to_string_lossy().to_string())
+            );
+        }
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn serve_does_not_mistake_a_flag_value_for_the_folder() {
+        // `build` is the value of --out, not the folder to serve, and the
+        // folder argument comes after it.
+        let cwd = unique_tmp("serve_order");
+        fs::create_dir_all(cwd.join("docs")).unwrap();
+
+        let argv = argv_of(&["serve", "--out", "build", "docs"]);
+        let (root, _, _, output) = serve_of(&argv, &cwd);
+        assert!(root.ends_with("docs"), "got {root}");
+        assert_eq!(
+            output,
+            Some(cwd.join("build").to_string_lossy().to_string())
+        );
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn serve_accepts_port_zero_for_an_os_assigned_port() {
+        let cwd = unique_tmp("serve_port0");
+        fs::create_dir_all(cwd.join("docs")).unwrap();
+        let (_, _, port, _) = serve_of(&argv_of(&["serve", "docs", "--port", "0"]), &cwd);
+        assert_eq!(port, 0);
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn serve_rejects_a_missing_a_nonexistent_and_a_file_target() {
+        let cwd = unique_tmp("serve_bad_target");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::write(cwd.join("note.md"), "hi").unwrap();
+
+        let missing = launch_plan(None, None, None, &argv_of(&["serve"]), &cwd).unwrap_err();
+        assert!(missing.contains("needs a folder"), "got: {missing}");
+
+        for target in ["nope", "note.md"] {
+            let err =
+                launch_plan(None, None, None, &argv_of(&["serve", target]), &cwd).unwrap_err();
+            assert!(
+                err.contains("requires an existing folder"),
+                "{target} gave: {err}"
+            );
+        }
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn serve_rejects_a_host_or_port_it_cannot_parse() {
+        let cwd = unique_tmp("serve_bad_flags");
+        fs::create_dir_all(cwd.join("docs")).unwrap();
+
+        let host = launch_plan(
+            None,
+            None,
+            None,
+            &argv_of(&["serve", "docs", "--host", "not-an-address"]),
+            &cwd,
+        )
+        .unwrap_err();
+        assert!(host.contains("not a valid address"), "got: {host}");
+
+        for bad in ["99999", "-1", "http"] {
+            let err = launch_plan(
+                None,
+                None,
+                None,
+                &argv_of(&["serve", "docs", "--port", bad]),
+                &cwd,
+            )
+            .unwrap_err();
+            assert!(err.contains("--port must be a number"), "{bad} gave: {err}");
+        }
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn serve_refuses_to_write_its_output_inside_the_folder_it_watches() {
+        // Exporting into the watched folder would feed the site back into the
+        // next rebuild, the same trap the in-app website export guards.
+        let cwd = unique_tmp("serve_nested_out");
+        let docs = cwd.join("docs");
+        fs::create_dir_all(&docs).unwrap();
+
+        for out in ["docs/site", "docs"] {
+            let err = launch_plan(
+                None,
+                None,
+                None,
+                &argv_of(&["serve", "docs", "--out", out]),
+                &cwd,
+            )
+            .unwrap_err();
+            assert!(
+                err.contains("cannot be inside the folder being served"),
+                "--out {out} gave: {err}"
+            );
+        }
+
+        // A sibling directory is fine.
+        let (_, _, _, output) = serve_of(&argv_of(&["serve", "docs", "--out", "site"]), &cwd);
+        assert_eq!(output, Some(cwd.join("site").to_string_lossy().to_string()));
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn a_folder_named_serve_still_opens_normally() {
+        // `serve` is only a subcommand as a bare first argument, so the
+        // documented `./serve` spelling keeps working as a path.
+        let cwd = unique_tmp("serve_named_folder");
+        fs::create_dir_all(cwd.join("serve")).unwrap();
+
+        let plan = launch_plan(None, None, None, &argv_of(&["./serve"]), &cwd).expect("plans");
+        assert!(
+            matches!(&plan, CliLaunch::Open(Some(InitialOpenAction::Folder(p))) if p.ends_with("serve")),
+            "expected a normal folder open, got {plan:?}"
+        );
+        let _ = fs::remove_dir_all(&cwd);
+    }
+
+    #[test]
+    fn only_launches_that_do_their_own_work_keep_the_running_instance_out_of_it() {
+        // Opening a document should reuse the open window.
+        assert!(forwards_to_running_instance(&argv_of(&["notes.md"])));
+        assert!(forwards_to_running_instance(&argv_of(&[])));
+        // An export and a serve do their work here; handing the arguments to
+        // another process would exit 0 having done none of it.
+        assert!(!forwards_to_running_instance(&argv_of(&[
+            "notes.md", "--export", "pdf"
+        ])));
+        assert!(!forwards_to_running_instance(&argv_of(&["--export=site"])));
+        assert!(!forwards_to_running_instance(&argv_of(&["serve", "docs"])));
+        // A folder named `serve` is an ordinary open, and forwards.
+        assert!(forwards_to_running_instance(&argv_of(&["./serve"])));
+    }
+
+    #[test]
+    fn is_serve_invocation_only_matches_a_bare_first_argument() {
+        assert!(is_serve_invocation(&argv_of(&["serve", "docs"])));
+        assert!(!is_serve_invocation(&argv_of(&["./serve"])));
+        assert!(!is_serve_invocation(&argv_of(&["docs", "serve"])));
+        assert!(!is_serve_invocation(&argv_of(&[])));
     }
 
     #[test]

--- a/src-tauri/src/cli_help.rs
+++ b/src-tauri/src/cli_help.rs
@@ -16,16 +16,29 @@ USAGE:
   glyph [<path>]                              Open a file or folder
   glyph <file> --export <format> [--out <p>]  Export a document and exit
   glyph <folder> --export site --out <dir>    Export a workspace as a website
+  glyph serve <folder>                        Serve a workspace, rebuilding
+                                              it as the folder changes
 
 OPTIONS:
       --export <format>  Export and exit. Formats: {formats}
   -o, --out <path>       Where to write. Defaults to the input path with the
-                         format's extension; required for `site`.
+                         format's extension; required for `site`. With
+                         `serve`, keeps the site instead of using a temporary
+                         directory.
   -h, --help             Print this help and exit
   -V, --version          Print the version and exit
 
+SERVE OPTIONS:
+      --host <host>      Address to bind. Defaults to {host}, which is
+                         reachable only from this machine; pass 0.0.0.0 to
+                         let the network read the folder.
+      --port <port>      Port to bind. Defaults to {port}; 0 picks a free one.
+
 An export writes nothing to stdout but the path it produced, and exits nonzero
-with a message on stderr if it fails.",
+with a message on stderr if it fails. `serve` prints the URL once the first
+build lands, then keeps running until it is interrupted.",
+        host = crate::cli::DEFAULT_SERVE_HOST,
+        port = crate::cli::DEFAULT_SERVE_PORT,
         version = env!("CARGO_PKG_VERSION"),
     )
 }

--- a/src-tauri/src/cli_help.rs
+++ b/src-tauri/src/cli_help.rs
@@ -16,27 +16,35 @@ USAGE:
   glyph [<path>]                              Open a file or folder
   glyph <file> --export <format> [--out <p>]  Export a document and exit
   glyph <folder> --export site --out <dir>    Export a workspace as a website
-  glyph serve <folder>                        Serve a workspace, rebuilding
+  glyph serve <folder> [serve options]        Serve a workspace, rebuilding
                                               it as the folder changes
 
 OPTIONS:
       --export <format>  Export and exit. Formats: {formats}
   -o, --out <path>       Where to write. Defaults to the input path with the
-                         format's extension; required for `site`. With
-                         `serve`, keeps the site instead of using a temporary
-                         directory.
+                         format's extension; required for `site`.
   -h, --help             Print this help and exit
   -V, --version          Print the version and exit
 
 SERVE OPTIONS:
-      --host <host>      Address to bind. Defaults to {host}, which is
-                         reachable only from this machine; pass 0.0.0.0 to
-                         let the network read the folder.
+      --host <host>      Address to bind. Defaults to {host}, reachable only
+                         from this machine. Pass 0.0.0.0 to let the network
+                         read the folder, which is printed as a warning.
       --port <port>      Port to bind. Defaults to {port}; 0 picks a free one.
+                         A port already in use is an error, not a fallback.
+  -o, --out <dir>        Where to build. Defaults to a temporary directory
+                         removed on interrupt; naming one keeps the site.
+                         Everything in it is served, so give it a directory
+                         of its own: one that contains, or sits inside, the
+                         folder being served is refused.
 
 An export writes nothing to stdout but the path it produced, and exits nonzero
-with a message on stderr if it fails. `serve` prints the URL once the first
-build lands, then keeps running until it is interrupted.",
+with a message on stderr if it fails.
+
+`serve` prints its URL once the first build lands, then keeps running until it
+is interrupted. Every change to the folder rebuilds the site, and pages open
+in a browser reload themselves. Both render through a webview, so on a Linux
+machine with no display, run them under `xvfb-run`.",
         host = crate::cli::DEFAULT_SERVE_HOST,
         port = crate::cli::DEFAULT_SERVE_PORT,
         version = env!("CARGO_PKG_VERSION"),
@@ -66,6 +74,28 @@ mod tests {
             assert!(text.contains(flag), "usage text is missing '{flag}'");
         }
         assert!(text.contains(env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn usage_documents_serve_and_the_defaults_it_actually_uses() {
+        // The defaults are interpolated from the parser's own constants, so
+        // changing one there cannot leave the help describing the old value.
+        let text = usage();
+        assert!(
+            text.contains("glyph serve <folder>"),
+            "serve is undocumented"
+        );
+        for flag in ["--host", "--port"] {
+            assert!(text.contains(flag), "usage text is missing '{flag}'");
+        }
+        assert!(
+            text.contains(&crate::cli::DEFAULT_SERVE_HOST.to_string()),
+            "the bind default is not the one serve uses"
+        );
+        assert!(
+            text.contains(&crate::cli::DEFAULT_SERVE_PORT.to_string()),
+            "the port default is not the one serve uses"
+        );
     }
 
     #[test]

--- a/src-tauri/src/cli_help.rs
+++ b/src-tauri/src/cli_help.rs
@@ -13,18 +13,17 @@ pub fn usage() -> String {
 Markdown viewer with document and website export.
 
 USAGE:
-  glyph [<path>]                              Open a file or folder
-  glyph <file> --export <format> [--out <p>]  Export a document and exit
-  glyph <folder> --export site --out <dir>    Export a workspace as a website
-  glyph serve <folder> [serve options]        Serve a workspace, rebuilding
-                                              it as the folder changes
+  glyph [<path>]                      Open a file or folder
+  glyph export <path> --format <f>    Render a document or workspace and exit
+  glyph serve <folder>                Serve a workspace, rebuilding it as the
+                                      folder changes
 
-OPTIONS:
-      --export <format>  Export and exit. Formats: {formats}
+EXPORT OPTIONS:
+      --format <format>  What to produce: {formats}
+                         Every format but `site` takes one markdown or
+                         notebook document; `site` takes a folder.
   -o, --out <path>       Where to write. Defaults to the input path with the
-                         format's extension; required for `site`.
-  -h, --help             Print this help and exit
-  -V, --version          Print the version and exit
+                         format's extension; `site` always needs one.
 
 SERVE OPTIONS:
       --host <host>      Address to bind. Defaults to {host}, reachable only
@@ -38,7 +37,16 @@ SERVE OPTIONS:
                          of its own: one that contains, or sits inside, the
                          folder being served is refused.
 
-An export writes nothing to stdout but the path it produced, and exits nonzero
+OPTIONS:
+  -h, --help             Print this help and exit
+  -V, --version          Print the version and exit
+
+EXAMPLES:
+  glyph export notes.md --format pdf
+  glyph export ~/notes --format site --out ./site
+  glyph serve ~/notes --port 8080
+
+`export` writes nothing to stdout but the path it produced, and exits nonzero
 with a message on stderr if it fails.
 
 `serve` prints its URL once the first build lands, then keeps running until it
@@ -70,7 +78,7 @@ mod tests {
                 "usage text is missing the '{name}' format"
             );
         }
-        for flag in ["--export", "--out", "-o", "--help", "-h", "--version", "-V"] {
+        for flag in ["--format", "--out", "-o", "--help", "-h", "--version", "-V"] {
             assert!(text.contains(flag), "usage text is missing '{flag}'");
         }
         assert!(text.contains(env!("CARGO_PKG_VERSION")));
@@ -85,6 +93,12 @@ mod tests {
             text.contains("glyph serve <folder>"),
             "serve is undocumented"
         );
+        assert!(
+            text.contains("glyph export <path>"),
+            "export is undocumented"
+        );
+        // The old flag spelling is gone, so the help must not teach it.
+        assert!(!text.contains("--export"), "the help still shows --export");
         for flag in ["--host", "--port"] {
             assert!(text.contains(flag), "usage text is missing '{flag}'");
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,6 +10,8 @@ pub mod pick;
 pub mod plugins;
 pub mod search;
 pub mod secrets;
+#[cfg(desktop)]
+pub mod serve;
 mod walk;
 pub mod wikilinks;
 

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use tauri::State;
 
 /// A headless export requested on the command line
-/// (`glyph <path> --export <format> [--out <path>]`), stashed at startup for
+/// (`glyph export <path> --format <format> [--out <path>]`), stashed at startup for
 /// the frontend to pick up once it mounts. `input` is a workspace folder for
 /// the `site` format and a document for every other one.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src-tauri/src/commands/serve.rs
+++ b/src-tauri/src/commands/serve.rs
@@ -142,6 +142,28 @@ mod tests {
     }
 
     #[test]
+    fn a_poisoned_latch_does_not_re_announce() {
+        // A panic while the latch was held must not turn every later rebuild
+        // back into a startup that reprints the URL.
+        let state = std::sync::Arc::new(state());
+        let poisoner = std::sync::Arc::clone(&state);
+        let _ = std::thread::spawn(move || {
+            let _held = poisoner.announced.lock().unwrap();
+            panic!("while holding the latch");
+        })
+        .join();
+
+        assert!(
+            state.announced.is_poisoned(),
+            "the latch should be poisoned"
+        );
+        assert!(
+            !state.take_first_build(),
+            "a poisoned latch announces nothing"
+        );
+    }
+
+    #[test]
     fn serve_request_serializes_camel_case() {
         let json = serde_json::to_string(&CliServeRequest {
             root: "/ws".to_string(),

--- a/src-tauri/src/commands/serve.rs
+++ b/src-tauri/src/commands/serve.rs
@@ -152,6 +152,65 @@ mod tests {
     }
 
     #[test]
+    fn a_finished_build_reaches_the_open_browsers() {
+        let app = tauri::test::mock_app();
+        let (reload, mut browser) = {
+            let (sender, _) = broadcast::channel(4);
+            let receiver = sender.subscribe();
+            (sender, receiver)
+        };
+        app.manage(ServeState::new(
+            CliServeRequest {
+                root: "/ws".to_string(),
+                out_dir: "/out".to_string(),
+            },
+            "/ws".to_string(),
+            "http://127.0.0.1:4173".to_string(),
+            reload,
+        ));
+
+        assert_eq!(serve_ready(app.handle().clone()), Ok(()));
+        assert_eq!(
+            browser.try_recv(),
+            Ok(()),
+            "a page open on the site reloads"
+        );
+
+        // The second build is a rebuild: it reloads without announcing again.
+        assert_eq!(serve_ready(app.handle().clone()), Ok(()));
+        assert_eq!(browser.try_recv(), Ok(()));
+    }
+
+    #[test]
+    fn a_failed_build_reports_without_reloading() {
+        let app = tauri::test::mock_app();
+        let (reload, mut browser) = {
+            let (sender, _) = broadcast::channel(4);
+            let receiver = sender.subscribe();
+            (sender, receiver)
+        };
+        app.manage(ServeState::new(
+            CliServeRequest {
+                root: "/ws".to_string(),
+                out_dir: "/out".to_string(),
+            },
+            "/ws".to_string(),
+            "http://127.0.0.1:4173".to_string(),
+            reload,
+        ));
+
+        assert_eq!(
+            serve_failed(app.handle().clone(), "Rebuild failed: boom".to_string()),
+            Ok(())
+        );
+        // Nothing reloads: the browser keeps the version it already has.
+        assert_eq!(
+            browser.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        );
+    }
+
+    #[test]
     fn the_serve_commands_refuse_a_launch_that_is_not_serving() {
         // Any renderer can invoke a command; without the guard these would
         // announce a URL and print to stderr on an ordinary launch.

--- a/src-tauri/src/commands/serve.rs
+++ b/src-tauri/src/commands/serve.rs
@@ -90,13 +90,30 @@ pub fn serve_ready<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), St
     Ok(())
 }
 
-/// A build failed. The previously exported site stays on disk and keeps being
-/// served, so the browser is left showing the last version that worked rather
-/// than a half-written one.
+/// A build failed. Whatever was exported last stays on disk and keeps being
+/// served, so a browser is left showing a site rather than nothing. It is not
+/// necessarily the previous site in full: the export writes pages in place,
+/// so a failure part way through leaves new and old pages mixed (see #707).
 #[tauri::command]
-pub fn serve_failed(message: String) -> Result<(), String> {
+pub fn serve_failed<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    message: String,
+) -> Result<(), String> {
+    // Guarded like `serve_ready`: without it any launch could print whatever
+    // it liked to this process's stderr.
+    app.try_state::<ServeState>()
+        .ok_or_else(|| "not serving".to_string())?;
     eprintln!("{message}");
     Ok(())
+}
+
+/// Keeps the folder watch alive for the life of the process. A named type
+/// because Tauri's state map is keyed by type: a bare `Mutex<..>` would be
+/// undiscoverable, and would collide with any other bare one added later.
+pub struct ServeWatcher {
+    /// Never read. `notify` stops watching the moment the watcher is dropped,
+    /// so owning it here is the whole point of the type.
+    pub _watcher: Mutex<notify::RecommendedWatcher>,
 }
 
 #[cfg(test)]
@@ -132,6 +149,21 @@ mod tests {
         })
         .unwrap();
         assert!(json.contains("\"outDir\":\"/out\""), "got {json}");
+    }
+
+    #[test]
+    fn the_serve_commands_refuse_a_launch_that_is_not_serving() {
+        // Any renderer can invoke a command; without the guard these would
+        // announce a URL and print to stderr on an ordinary launch.
+        let app = tauri::test::mock_app();
+        assert_eq!(
+            serve_ready(app.handle().clone()),
+            Err("not serving".to_string())
+        );
+        assert_eq!(
+            serve_failed(app.handle().clone(), "anything".to_string()),
+            Err("not serving".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/serve.rs
+++ b/src-tauri/src/commands/serve.rs
@@ -1,0 +1,144 @@
+//! State and commands for `glyph serve`.
+//!
+//! The renderer owns the export (it is the only place the site pipeline
+//! runs), so the two sides talk over these commands: the frontend reports
+//! that a build finished, and Rust decides what that means for the people
+//! watching the site in a browser.
+
+use serde::Serialize;
+use std::sync::Mutex;
+use tauri::Manager;
+use tokio::sync::broadcast;
+
+/// What the frontend needs in order to render the site being served.
+/// Mirrors [`super::export::CliExportRequest`], but says nothing about
+/// exiting: a serve process renders many times over its life.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliServeRequest {
+    pub root: String,
+    pub out_dir: String,
+}
+
+/// Everything the serve loop needs once the server is bound.
+pub struct ServeState {
+    pub request: CliServeRequest,
+    /// The URL to print, already resolved: `--port 0` means the port is only
+    /// known after binding.
+    pub url: String,
+    /// The folder as it should be printed. `request.root` is canonical, which
+    /// on Windows carries the extended-length prefix: correct to open with,
+    /// noise to read.
+    pub display_root: String,
+    /// Broadcast to every open event stream after a successful rebuild.
+    pub reload: broadcast::Sender<()>,
+    /// Whether the ready line has been printed. The first export is startup,
+    /// every one after it is a rebuild, and only the first announces itself.
+    announced: Mutex<bool>,
+}
+
+impl ServeState {
+    pub fn new(
+        request: CliServeRequest,
+        display_root: String,
+        url: String,
+        reload: broadcast::Sender<()>,
+    ) -> Self {
+        Self {
+            request,
+            display_root,
+            url,
+            reload,
+            announced: Mutex::new(false),
+        }
+    }
+
+    /// Record that a build finished and report whether this was the first
+    /// one. Split from the command so the first-time behaviour is testable
+    /// without a running app.
+    pub fn take_first_build(&self) -> bool {
+        let Ok(mut announced) = self.announced.lock() else {
+            return false;
+        };
+        let first = !*announced;
+        *announced = true;
+        first
+    }
+}
+
+/// What this process should serve, or `None` on any other kind of launch.
+/// Reached through `try_state` rather than an injected `State`, because on
+/// every other launch the state is simply not there.
+#[tauri::command]
+pub fn get_cli_serve<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Option<CliServeRequest> {
+    Some(app.try_state::<ServeState>()?.request.clone())
+}
+
+/// A build finished. The first one announces the URL, since the site only
+/// becomes worth visiting once there is something in it; every later one
+/// tells the open browsers to reload.
+#[tauri::command]
+pub fn serve_ready<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), String> {
+    let state = app
+        .try_state::<ServeState>()
+        .ok_or_else(|| "not serving".to_string())?;
+    if state.take_first_build() {
+        println!("Serving {} at {}", state.display_root, state.url);
+    }
+    // An error here only means nobody has the page open, which is normal.
+    let _ = state.reload.send(());
+    Ok(())
+}
+
+/// A build failed. The previously exported site stays on disk and keeps being
+/// served, so the browser is left showing the last version that worked rather
+/// than a half-written one.
+#[tauri::command]
+pub fn serve_failed(message: String) -> Result<(), String> {
+    eprintln!("{message}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state() -> ServeState {
+        let (reload, _) = broadcast::channel(4);
+        ServeState::new(
+            CliServeRequest {
+                root: "/ws".to_string(),
+                out_dir: "/out".to_string(),
+            },
+            "/ws".to_string(),
+            "http://127.0.0.1:4173".to_string(),
+            reload,
+        )
+    }
+
+    #[test]
+    fn only_the_first_build_is_the_first_build() {
+        let state = state();
+        assert!(state.take_first_build(), "startup build should announce");
+        assert!(!state.take_first_build(), "a rebuild must not re-announce");
+        assert!(!state.take_first_build());
+    }
+
+    #[test]
+    fn serve_request_serializes_camel_case() {
+        let json = serde_json::to_string(&CliServeRequest {
+            root: "/ws".to_string(),
+            out_dir: "/out".to_string(),
+        })
+        .unwrap();
+        assert!(json.contains("\"outDir\":\"/out\""), "got {json}");
+    }
+
+    #[test]
+    fn get_cli_serve_is_none_on_an_ordinary_launch() {
+        // Nothing manages ServeState unless `glyph serve` set it up, which
+        // is what tells the frontend it is not a serve process.
+        let app = tauri::test::mock_app();
+        assert_eq!(get_cli_serve(app.handle().clone()), None);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,7 +206,7 @@ pub fn run() {
         return;
     }
 
-    // An export and a serve both run in this process, so neither may be
+    // A subcommand does its work in this process, so it must not be
     // forwarded to a Glyph the user already has open.
     #[cfg(desktop)]
     let forward_to_running_instance = cli::forwards_to_running_instance(&args);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,10 @@ mod menu;
 mod menu_runtime;
 mod notebook;
 mod secrets;
+// The preview server behind `glyph serve`; desktop-only, like the CLI
+// surface that reaches it.
+#[cfg(desktop)]
+mod serve;
 mod setup;
 mod sync;
 #[cfg(desktop)]
@@ -202,10 +206,10 @@ pub fn run() {
         return;
     }
 
-    // An export runs in this process, so it must not be forwarded to a Glyph
-    // the user already has open.
+    // An export and a serve both run in this process, so neither may be
+    // forwarded to a Glyph the user already has open.
     #[cfg(desktop)]
-    let forward_to_running_instance = !cli::has_flag(&args, "--export");
+    let forward_to_running_instance = cli::forwards_to_running_instance(&args);
     #[cfg(not(desktop))]
     let forward_to_running_instance = true;
 
@@ -277,6 +281,12 @@ pub fn run() {
             commands::pick::pick_move_dir,
             commands::export::get_cli_export,
             commands::export_runtime::finish_cli_export,
+            #[cfg(desktop)]
+            commands::serve::get_cli_serve,
+            #[cfg(desktop)]
+            commands::serve::serve_ready,
+            #[cfg(desktop)]
+            commands::serve::serve_failed,
             commands::default_app::set_default_markdown_app,
             commands::secrets::secret_get,
             commands::secrets::secret_set,

--- a/src-tauri/src/serve/inject.rs
+++ b/src-tauri/src/serve/inject.rs
@@ -1,0 +1,72 @@
+//! The live-reload script and where it goes in a served page.
+//!
+//! Injection happens on the way out of the server, never in the export, so a
+//! site written with `--out` stays a plain static site with nothing
+//! development-only baked into it.
+
+/// Path the served pages open their event stream on. Namespaced under
+/// `__glyph/` so it cannot collide with an exported page: the export derives
+/// every route from a file name, and no markdown file produces this one.
+pub const RELOAD_PATH: &str = "/__glyph/reload";
+
+/// The script appended to every served HTML page. `EventSource` reconnects on
+/// its own after a dropped connection, so a browser left open across a
+/// restart of the server picks the stream back up without help.
+pub const RELOAD_SCRIPT: &str = concat!(
+    "<script data-glyph-reload>",
+    "(function(){",
+    "var s=new EventSource(\"/__glyph/reload\");",
+    "s.onmessage=function(){location.reload()};",
+    "})();",
+    "</script>"
+);
+
+/// Put the reload script into an HTML document, just before `</body>` so it
+/// runs after the page content has parsed. A fragment without a closing body
+/// tag (an export is well-formed, but a hand-written file under the workspace
+/// need not be) gets it appended instead of being left without live reload.
+pub fn inject_reload_script(html: &str) -> String {
+    match html.rfind("</body>") {
+        Some(index) => format!("{}{}{}", &html[..index], RELOAD_SCRIPT, &html[index..]),
+        None => format!("{html}{RELOAD_SCRIPT}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injects_before_the_closing_body_tag() {
+        let out = inject_reload_script("<html><body><h1>Hi</h1></body></html>");
+        assert!(out.contains(RELOAD_SCRIPT), "script missing from {out}");
+        let script_at = out.find("data-glyph-reload").unwrap();
+        let body_at = out.find("</body>").unwrap();
+        assert!(script_at < body_at, "script must precede </body>: {out}");
+        assert!(out.ends_with("</body></html>"), "tail rewritten: {out}");
+    }
+
+    #[test]
+    fn appends_when_there_is_no_closing_body_tag() {
+        let out = inject_reload_script("<h1>fragment</h1>");
+        assert!(out.starts_with("<h1>fragment</h1>"));
+        assert!(out.ends_with(RELOAD_SCRIPT), "script not appended: {out}");
+    }
+
+    #[test]
+    fn uses_the_last_closing_body_tag() {
+        // A page that merely writes about </body> must not have the script
+        // spliced into the middle of its prose.
+        let out = inject_reload_script("<body><code>&lt;/body&gt;</code></body>");
+        let script_at = out.find("data-glyph-reload").unwrap();
+        assert!(script_at > out.find("<code>").unwrap());
+    }
+
+    #[test]
+    fn the_script_points_at_the_reload_path() {
+        assert!(
+            RELOAD_SCRIPT.contains(RELOAD_PATH),
+            "script and route disagree"
+        );
+    }
+}

--- a/src-tauri/src/serve/mod.rs
+++ b/src-tauri/src/serve/mod.rs
@@ -1,0 +1,288 @@
+//! The static file server behind `glyph serve`.
+//!
+//! It hands out the same files the website export writes, plus one route the
+//! export knows nothing about: an event stream the injected reload script
+//! listens on. Serving is deliberately dumb — `ServeDir` owns MIME types,
+//! index resolution, and keeping requests inside the directory — so the only
+//! logic here is routing, the event stream, and the script injection.
+
+pub mod inject;
+pub mod watch;
+
+use std::convert::Infallible;
+use std::path::PathBuf;
+
+use http_body_util::{BodyExt, Full, StreamBody};
+use hyper::body::{Bytes, Frame, Incoming};
+use hyper::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE};
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::sync::broadcast;
+use tower::ServiceExt;
+use tower_http::services::ServeDir;
+
+use inject::{inject_reload_script, RELOAD_PATH};
+
+/// One body type for every route, so the router can return a file, a rebuilt
+/// HTML page, and an open event stream from the same function.
+type ServeBody = http_body_util::combinators::UnsyncBoxBody<Bytes, std::io::Error>;
+
+/// Serve `dir` on an already-bound listener until the process ends. The
+/// listener is bound by the caller so a port conflict fails before the app
+/// starts, and so `--port 0` can report the port the OS picked.
+pub async fn run(listener: std::net::TcpListener, dir: PathBuf, reload: broadcast::Sender<()>) {
+    listener
+        .set_nonblocking(true)
+        .expect("listener cannot be made nonblocking");
+    let Ok(listener) = tokio::net::TcpListener::from_std(listener) else {
+        return;
+    };
+
+    loop {
+        // A refused or reset connection says nothing about the next one, so
+        // an accept error drops that client rather than the whole server.
+        let Ok((stream, _)) = listener.accept().await else {
+            continue;
+        };
+        let dir = dir.clone();
+        let reload = reload.clone();
+        tauri::async_runtime::spawn(async move {
+            let service = hyper::service::service_fn(move |request| {
+                route(request, dir.clone(), reload.clone())
+            });
+            let _ = hyper::server::conn::http1::Builder::new()
+                .serve_connection(TokioIo::new(stream), service)
+                .await;
+        });
+    }
+}
+
+/// The whole routing table: the reload stream, or a file from the export.
+async fn route(
+    request: Request<Incoming>,
+    dir: PathBuf,
+    reload: broadcast::Sender<()>,
+) -> Result<Response<ServeBody>, Infallible> {
+    if request.uri().path() == RELOAD_PATH {
+        return Ok(reload_stream(reload.subscribe()));
+    }
+    Ok(serve_file(request, dir).await)
+}
+
+/// An SSE response that emits one message per rebuild. Nothing is buffered:
+/// a client that misses messages while it was away only needs to know that
+/// *something* changed, so a lagged receiver reloads like any other.
+fn reload_stream(receiver: broadcast::Receiver<()>) -> Response<ServeBody> {
+    let stream = futures_util::stream::unfold(receiver, |mut receiver| async move {
+        match receiver.recv().await {
+            // A stream that fell behind only needs to know that something
+            // changed, so a lagged receiver reloads like any other.
+            Ok(()) | Err(broadcast::error::RecvError::Lagged(_)) => {
+                let frame = Frame::data(Bytes::from_static(b"data: reload\n\n"));
+                Some((Ok(frame), receiver))
+            }
+            Err(broadcast::error::RecvError::Closed) => None,
+        }
+    });
+
+    Response::builder()
+        .header(CONTENT_TYPE, "text/event-stream")
+        // Without this a proxy (or the browser itself) may hold the stream
+        // and deliver rebuild messages in a batch, long after they mattered.
+        .header(CACHE_CONTROL, "no-store")
+        .body(BodyExt::boxed_unsync(StreamBody::new(stream)))
+        .expect("reload stream response is well-formed")
+}
+
+/// Hand back a file from the exported site, injecting the reload script into
+/// HTML on the way past. `ServeDir` resolves `index.html`, guesses the
+/// content type, and refuses to escape `dir`, including through encoded
+/// traversal segments.
+async fn serve_file<B: Send + 'static>(request: Request<B>, dir: PathBuf) -> Response<ServeBody> {
+    // `ServeDir` answers every request, including the ones it refuses: a
+    // missing file is a 404 response, not an error, and its error type is
+    // `Infallible`.
+    let Ok(response) = ServeDir::new(&dir).oneshot(request).await;
+
+    let is_html = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("text/html"));
+    if !is_html {
+        return response.map(BodyExt::boxed_unsync);
+    }
+
+    let (mut parts, body) = response.into_parts();
+    let Ok(collected) = body.collect().await else {
+        return error_response(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+    let bytes = collected.to_bytes();
+    let Ok(html) = std::str::from_utf8(&bytes) else {
+        // Not text after all: hand back exactly what was on disk.
+        return Response::from_parts(parts, byte_body(bytes));
+    };
+
+    let injected = inject_reload_script(html);
+    // The body grew, so the length `ServeDir` measured from the file no
+    // longer describes it. Leaving it stale truncates the page.
+    parts.headers.remove(CONTENT_LENGTH);
+    Response::from_parts(parts, byte_body(Bytes::from(injected)))
+}
+
+/// Wrap already-collected bytes as a response body.
+fn byte_body(bytes: Bytes) -> ServeBody {
+    BodyExt::boxed_unsync(Full::new(bytes).map_err(|never| match never {}))
+}
+
+/// A bodyless response for the paths that cannot produce content.
+fn error_response(status: StatusCode) -> Response<ServeBody> {
+    let mut response = Response::new(byte_body(Bytes::new()));
+    *response.status_mut() = status;
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// An export-shaped directory: a page, a nested page, and a non-HTML asset.
+    fn fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut index = std::fs::File::create(dir.path().join("index.html")).unwrap();
+        index.write_all(b"<html><body>home</body></html>").unwrap();
+        std::fs::create_dir(dir.path().join("notes")).unwrap();
+        std::fs::write(
+            dir.path().join("notes/deep.html"),
+            b"<html><body>deep</body></html>",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("style.css"), b"body{color:red}").unwrap();
+        dir
+    }
+
+    /// Drive `serve_file` the way a connection would, without a socket.
+    /// `Incoming` cannot be built outside hyper, which is why the function is
+    /// generic over the request body rather than tied to it.
+    async fn get(dir: &std::path::Path, path: &str) -> Response<ServeBody> {
+        let request = Request::builder()
+            .uri(path)
+            .body(Full::new(Bytes::new()))
+            .expect("request is well-formed");
+        serve_file(request, dir.to_path_buf()).await
+    }
+
+    async fn body_string(response: Response<ServeBody>) -> String {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    #[tokio::test]
+    async fn serves_the_index_page_at_the_root() {
+        let dir = fixture();
+        let response = get(dir.path(), "/").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(body_string(response).await.contains("home"));
+    }
+
+    #[tokio::test]
+    async fn serves_nested_pages_at_their_site_relative_paths() {
+        let dir = fixture();
+        let response = get(dir.path(), "/notes/deep.html").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(body_string(response).await.contains("deep"));
+    }
+
+    #[tokio::test]
+    async fn unknown_paths_are_not_found() {
+        let dir = fixture();
+        assert_eq!(
+            get(dir.path(), "/nope.html").await.status(),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn html_responses_carry_the_reload_script() {
+        let dir = fixture();
+        let response = get(dir.path(), "/").await;
+        // The stale file length would truncate the page it just grew.
+        assert!(response.headers().get(CONTENT_LENGTH).is_none());
+        assert!(body_string(response).await.contains("data-glyph-reload"));
+    }
+
+    #[tokio::test]
+    async fn non_html_responses_are_untouched() {
+        let dir = fixture();
+        let body = body_string(get(dir.path(), "/style.css").await).await;
+        assert_eq!(body, "body{color:red}");
+    }
+
+    #[tokio::test]
+    async fn traversal_never_escapes_the_served_directory() {
+        let dir = fixture();
+        let secret = dir.path().parent().unwrap().join("glyph-serve-secret.txt");
+        std::fs::write(&secret, b"do not serve me").unwrap();
+
+        for attempt in [
+            "/../glyph-serve-secret.txt",
+            "/../../glyph-serve-secret.txt",
+            "/%2e%2e/glyph-serve-secret.txt",
+            "/%2e%2e%2fglyph-serve-secret.txt",
+            "/..%5cglyph-serve-secret.txt",
+            "/notes/../../glyph-serve-secret.txt",
+        ] {
+            let response = get(dir.path(), attempt).await;
+            let status = response.status();
+            let body = body_string(response).await;
+            assert!(
+                !body.contains("do not serve me"),
+                "{attempt} escaped the directory"
+            );
+            assert!(
+                status.is_client_error() || status.is_redirection(),
+                "{attempt} answered {status}"
+            );
+        }
+        let _ = std::fs::remove_file(&secret);
+    }
+
+    #[tokio::test]
+    async fn the_reload_route_opens_an_event_stream() {
+        let (sender, _) = broadcast::channel(4);
+        let response = reload_stream(sender.subscribe());
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            "text/event-stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rebuild_pushes_one_message_per_subscriber() {
+        let (sender, _) = broadcast::channel(4);
+        let response = reload_stream(sender.subscribe());
+        sender.send(()).expect("a subscriber is listening");
+
+        let mut body = Box::pin(response.into_body());
+        let frame = body
+            .frame()
+            .await
+            .expect("a frame arrives")
+            .expect("the frame is not an error");
+        assert_eq!(frame.into_data().unwrap(), Bytes::from("data: reload\n\n"));
+    }
+
+    #[tokio::test]
+    async fn the_stream_ends_when_the_server_stops_broadcasting() {
+        let (sender, _) = broadcast::channel(4);
+        let response = reload_stream(sender.subscribe());
+        drop(sender);
+
+        let mut body = Box::pin(response.into_body());
+        assert!(
+            body.frame().await.is_none(),
+            "stream should end once nothing can broadcast again"
+        );
+    }
+}

--- a/src-tauri/src/serve/mod.rs
+++ b/src-tauri/src/serve/mod.rs
@@ -95,30 +95,46 @@ pub async fn run(
     host: HostGuard,
     reload: broadcast::Sender<()>,
 ) {
-    // A failure here leaves nothing listening, and the ready line the
-    // frontend prints would otherwise advertise a server that never was.
-    if let Err(err) = listener.set_nonblocking(true) {
-        eprintln!("glyph serve: cannot use the bound socket: {err}");
-        return;
+    match into_async(listener) {
+        Ok(listener) => accept_loop(listener, dir, host, reload).await,
+        // Nothing is listening now, and the ready line the frontend prints
+        // would otherwise advertise a server that never was.
+        Err(err) => eprintln!("glyph serve: cannot use the bound socket: {err}"),
     }
-    let listener = match tokio::net::TcpListener::from_std(listener) {
-        Ok(listener) => listener,
-        Err(err) => {
-            eprintln!("glyph serve: cannot use the bound socket: {err}");
-            return;
-        }
-    };
+}
 
+/// Hand the bound socket to tokio. Binding happens synchronously in the
+/// caller so a port conflict fails before the app starts; this is the step
+/// that has to happen once there is a reactor to register it with.
+fn into_async(listener: std::net::TcpListener) -> std::io::Result<tokio::net::TcpListener> {
+    listener.set_nonblocking(true)?;
+    tokio::net::TcpListener::from_std(listener)
+}
+
+/// How long to wait after a failed accept. A reset connection says nothing
+/// about the next one, so one client's failure must not end the server; a
+/// persistent error (running out of descriptors, say) would otherwise spin
+/// the loop at full speed.
+const ACCEPT_BACKOFF: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Report a failed accept and pause before trying again.
+async fn back_off_after(err: &std::io::Error) {
+    eprintln!("glyph serve: dropped a connection: {err}");
+    tokio::time::sleep(ACCEPT_BACKOFF).await;
+}
+
+/// Answer connections until the process ends.
+async fn accept_loop(
+    listener: tokio::net::TcpListener,
+    dir: PathBuf,
+    host: HostGuard,
+    reload: broadcast::Sender<()>,
+) {
     loop {
         let stream = match listener.accept().await {
             Ok((stream, _)) => stream,
-            // A reset connection says nothing about the next one, so one
-            // client's failure does not end the server. A persistent error
-            // (running out of descriptors, say) would spin at full speed
-            // without this pause.
             Err(err) => {
-                eprintln!("glyph serve: dropped a connection: {err}");
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                back_off_after(&err).await;
                 continue;
             }
         };
@@ -213,7 +229,17 @@ async fn serve_file<B: Send + 'static>(request: Request<B>, dir: PathBuf) -> Res
         return response.map(BodyExt::boxed_unsync);
     }
 
-    let (mut parts, body) = response.into_parts();
+    let (parts, body) = response.into_parts();
+    injected_page(parts, body).await
+}
+
+/// Rebuild an HTML response with the reload script in it. Split from the
+/// routing so the read-failure and non-text arms can be driven directly: by
+/// the time a real `ServeDir` body fails, the file is already open.
+async fn injected_page<B>(mut parts: hyper::http::response::Parts, body: B) -> Response<ServeBody>
+where
+    B: hyper::body::Body<Data = Bytes, Error = std::io::Error>,
+{
     let Ok(collected) = body.collect().await else {
         return error_response(StatusCode::INTERNAL_SERVER_ERROR);
     };
@@ -412,6 +438,40 @@ mod tests {
         let guard = HostGuard::new(host.parse().expect("an address"));
         tauri::async_runtime::spawn(run(listener, dir.to_path_buf(), guard, reload.clone()));
         (port, reload)
+    }
+
+    #[tokio::test]
+    async fn a_page_that_cannot_be_read_is_a_server_error() {
+        // `ServeDir` has already opened the file by the time its body is
+        // streamed, so a read that fails part way through arrives here as a
+        // body error rather than a 404.
+        let failing = StreamBody::new(futures_util::stream::once(async {
+            Err(std::io::Error::other("the disk went away"))
+        }));
+        let parts = Response::new(()).into_parts().0;
+
+        let response = injected_page(parts, failing).await;
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn a_failed_accept_backs_off_before_trying_again() {
+        // Without the pause, a persistent error (no file descriptors left)
+        // spins the accept loop at full speed.
+        let started = std::time::Instant::now();
+        back_off_after(&std::io::Error::other("connection reset")).await;
+        assert!(started.elapsed() >= ACCEPT_BACKOFF, "returned immediately");
+    }
+
+    #[test]
+    fn a_bound_socket_becomes_an_async_one() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("binds");
+        let expected = listener.local_addr().expect("has an address");
+        // `from_std` needs a reactor to register with, which is why this is
+        // the step that happens inside the server task rather than at bind.
+        let runtime = tokio::runtime::Runtime::new().expect("a runtime");
+        let converted = runtime.block_on(async { into_async(listener) });
+        assert_eq!(converted.expect("converts").local_addr().unwrap(), expected);
     }
 
     #[tokio::test]

--- a/src-tauri/src/serve/mod.rs
+++ b/src-tauri/src/serve/mod.rs
@@ -314,6 +314,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn html_that_is_not_valid_utf8_is_served_as_it_is_on_disk() {
+        // The content type says HTML but the bytes are not text, so there is
+        // nothing to inject into; the file still has to arrive intact.
+        let dir = fixture();
+        std::fs::write(dir.path().join("broken.html"), [0xff, 0xfe, 0x00, 0x9f]).unwrap();
+
+        let response = get(dir.path(), "/broken.html").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body.as_ref(), &[0xff, 0xfe, 0x00, 0x9f]);
+    }
+
+    #[tokio::test]
     async fn non_html_responses_are_untouched() {
         let dir = fixture();
         let body = body_string(get(dir.path(), "/style.css").await).await;
@@ -506,6 +519,9 @@ mod tests {
         assert_eq!(host_name("localhost"), "localhost");
         assert_eq!(host_name("[::1]:4173"), "[::1]");
         assert_eq!(host_name("[::1]"), "[::1]");
+        // Malformed rather than rejected: an unterminated bracket is compared
+        // whole, and matches nothing this server answers to.
+        assert_eq!(host_name("[::1"), "[::1");
     }
 
     #[tokio::test]

--- a/src-tauri/src/serve/mod.rs
+++ b/src-tauri/src/serve/mod.rs
@@ -86,31 +86,6 @@ fn host_name(header: &str) -> &str {
     }
 }
 
-/// Serve `dir` on an already-bound listener until the process ends. The
-/// listener is bound by the caller so a port conflict fails before the app
-/// starts, and so `--port 0` can report the port the OS picked.
-pub async fn run(
-    listener: std::net::TcpListener,
-    dir: PathBuf,
-    host: HostGuard,
-    reload: broadcast::Sender<()>,
-) {
-    match into_async(listener) {
-        Ok(listener) => accept_loop(listener, dir, host, reload).await,
-        // Nothing is listening now, and the ready line the frontend prints
-        // would otherwise advertise a server that never was.
-        Err(err) => eprintln!("glyph serve: cannot use the bound socket: {err}"),
-    }
-}
-
-/// Hand the bound socket to tokio. Binding happens synchronously in the
-/// caller so a port conflict fails before the app starts; this is the step
-/// that has to happen once there is a reactor to register it with.
-fn into_async(listener: std::net::TcpListener) -> std::io::Result<tokio::net::TcpListener> {
-    listener.set_nonblocking(true)?;
-    tokio::net::TcpListener::from_std(listener)
-}
-
 /// How long to wait after a failed accept. A reset connection says nothing
 /// about the next one, so one client's failure must not end the server; a
 /// persistent error (running out of descriptors, say) would otherwise spin
@@ -123,8 +98,13 @@ async fn back_off_after(err: &std::io::Error) {
     tokio::time::sleep(ACCEPT_BACKOFF).await;
 }
 
-/// Answer connections until the process ends.
-async fn accept_loop(
+/// Serve `dir` on an already-bound listener until the process ends.
+///
+/// The socket is bound and handed to tokio by the caller, so a port conflict
+/// and an unusable socket both fail at startup with a nonzero exit rather
+/// than becoming a log line under a ready message that already promised a
+/// server.
+pub async fn run(
     listener: tokio::net::TcpListener,
     dir: PathBuf,
     host: HostGuard,
@@ -434,6 +414,8 @@ mod tests {
     fn start(dir: &std::path::Path, host: &str) -> (u16, broadcast::Sender<()>) {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("binds");
         let port = listener.local_addr().expect("has an address").port();
+        listener.set_nonblocking(true).expect("goes nonblocking");
+        let listener = tokio::net::TcpListener::from_std(listener).expect("registers");
         let (reload, _) = broadcast::channel(4);
         let guard = HostGuard::new(host.parse().expect("an address"));
         tauri::async_runtime::spawn(run(listener, dir.to_path_buf(), guard, reload.clone()));
@@ -454,6 +436,47 @@ mod tests {
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
+    /// A "listener" that is really a connected socket, so `accept` fails on
+    /// it the way one that has gone bad in service would. Nothing portable
+    /// can break a real listener, and this is the failure the accept loop
+    /// exists to survive.
+    fn broken_listener() -> std::net::TcpListener {
+        let real = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("binds");
+        let connected = std::net::TcpStream::connect(real.local_addr().expect("has an address"))
+            .expect("connects");
+        #[cfg(unix)]
+        {
+            std::net::TcpListener::from(std::os::fd::OwnedFd::from(connected))
+        }
+        #[cfg(windows)]
+        {
+            std::net::TcpListener::from(std::os::windows::io::OwnedSocket::from(connected))
+        }
+    }
+
+    #[tokio::test]
+    async fn a_failing_accept_does_not_end_the_server() {
+        // One client's failure, or a socket that goes bad, must not take the
+        // server down: it reports, pauses, and keeps accepting.
+        let dir = fixture();
+        let broken = broken_listener();
+        broken.set_nonblocking(true).expect("goes nonblocking");
+        let listener = tokio::net::TcpListener::from_std(broken).expect("registers");
+        let (reload, _) = broadcast::channel(4);
+        let guard = HostGuard::new("127.0.0.1".parse().unwrap());
+
+        let still_running = tokio::time::timeout(
+            ACCEPT_BACKOFF * 4,
+            run(listener, dir.path().to_path_buf(), guard, reload),
+        )
+        .await;
+
+        assert!(
+            still_running.is_err(),
+            "the loop returned instead of carrying on after failed accepts"
+        );
+    }
+
     #[tokio::test]
     async fn a_failed_accept_backs_off_before_trying_again() {
         // Without the pause, a persistent error (no file descriptors left)
@@ -461,17 +484,6 @@ mod tests {
         let started = std::time::Instant::now();
         back_off_after(&std::io::Error::other("connection reset")).await;
         assert!(started.elapsed() >= ACCEPT_BACKOFF, "returned immediately");
-    }
-
-    #[test]
-    fn a_bound_socket_becomes_an_async_one() {
-        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("binds");
-        let expected = listener.local_addr().expect("has an address");
-        // `from_std` needs a reactor to register with, which is why this is
-        // the step that happens inside the server task rather than at bind.
-        let runtime = tokio::runtime::Runtime::new().expect("a runtime");
-        let converted = runtime.block_on(async { into_async(listener) });
-        assert_eq!(converted.expect("converts").local_addr().unwrap(), expected);
     }
 
     #[tokio::test]

--- a/src-tauri/src/serve/mod.rs
+++ b/src-tauri/src/serve/mod.rs
@@ -14,8 +14,8 @@ use std::path::PathBuf;
 
 use http_body_util::{BodyExt, Full, StreamBody};
 use hyper::body::{Bytes, Frame, Incoming};
-use hyper::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE};
-use hyper::{Request, Response, StatusCode};
+use hyper::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE, HOST};
+use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use tokio::sync::broadcast;
 use tower::ServiceExt;
@@ -27,28 +27,107 @@ use inject::{inject_reload_script, RELOAD_PATH};
 /// HTML page, and an open event stream from the same function.
 type ServeBody = http_body_util::combinators::UnsyncBoxBody<Bytes, std::io::Error>;
 
+/// Which `Host` headers this server answers to.
+///
+/// Binding to loopback is not on its own enough to keep a workspace private.
+/// A page on any website can re-point its own hostname at 127.0.0.1 and then
+/// fetch `http://that-name:4173/`; the browser calls it same-origin, so the
+/// attacker's script reads the whole rendered workspace. Checking the name
+/// the request arrived under is what closes that (the same reason dev servers
+/// grew an allowed-hosts list).
+#[derive(Clone)]
+pub struct HostGuard {
+    /// The address `--host` named, so an explicitly exposed server answers
+    /// to itself.
+    bound: String,
+}
+
+impl HostGuard {
+    pub fn new(bound: std::net::IpAddr) -> Self {
+        Self {
+            bound: bound.to_string(),
+        }
+    }
+
+    /// Whether a request's `Host` header names this server rather than a
+    /// name that merely resolves to it.
+    fn allows(&self, header: Option<&str>) -> bool {
+        // A request with no Host is HTTP/1.0 or a raw socket, never a browser
+        // following a link, so there is no rebinding risk to answer for.
+        let Some(header) = header else {
+            return true;
+        };
+        let name = host_name(header);
+        name == self.bound
+            || name == "localhost"
+            || name == "127.0.0.1"
+            || name == "::1"
+            || name == "[::1]"
+            // `--host 0.0.0.0` is an explicit "let the network read this", so
+            // it cannot also insist on one name: the machine is reached by
+            // whatever address or name the visitor has for it.
+            || self.bound == "0.0.0.0"
+            || self.bound == "::"
+    }
+}
+
+/// Strip the port from a `Host` header, leaving the name. Bracketed IPv6
+/// literals keep their brackets, which is how they are compared above.
+fn host_name(header: &str) -> &str {
+    match header.strip_prefix('[') {
+        // `[::1]:4173` splits after the bracket, not at the first colon.
+        // `end` indexes into `rest`, so the bracket sits one later in
+        // `header` and the slice runs to one past it.
+        Some(rest) => match rest.find(']') {
+            Some(end) => &header[..end + 2],
+            None => header,
+        },
+        None => header.split(':').next().unwrap_or(header),
+    }
+}
+
 /// Serve `dir` on an already-bound listener until the process ends. The
 /// listener is bound by the caller so a port conflict fails before the app
 /// starts, and so `--port 0` can report the port the OS picked.
-pub async fn run(listener: std::net::TcpListener, dir: PathBuf, reload: broadcast::Sender<()>) {
-    listener
-        .set_nonblocking(true)
-        .expect("listener cannot be made nonblocking");
-    let Ok(listener) = tokio::net::TcpListener::from_std(listener) else {
+pub async fn run(
+    listener: std::net::TcpListener,
+    dir: PathBuf,
+    host: HostGuard,
+    reload: broadcast::Sender<()>,
+) {
+    // A failure here leaves nothing listening, and the ready line the
+    // frontend prints would otherwise advertise a server that never was.
+    if let Err(err) = listener.set_nonblocking(true) {
+        eprintln!("glyph serve: cannot use the bound socket: {err}");
         return;
+    }
+    let listener = match tokio::net::TcpListener::from_std(listener) {
+        Ok(listener) => listener,
+        Err(err) => {
+            eprintln!("glyph serve: cannot use the bound socket: {err}");
+            return;
+        }
     };
 
     loop {
-        // A refused or reset connection says nothing about the next one, so
-        // an accept error drops that client rather than the whole server.
-        let Ok((stream, _)) = listener.accept().await else {
-            continue;
+        let stream = match listener.accept().await {
+            Ok((stream, _)) => stream,
+            // A reset connection says nothing about the next one, so one
+            // client's failure does not end the server. A persistent error
+            // (running out of descriptors, say) would spin at full speed
+            // without this pause.
+            Err(err) => {
+                eprintln!("glyph serve: dropped a connection: {err}");
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                continue;
+            }
         };
         let dir = dir.clone();
+        let host = host.clone();
         let reload = reload.clone();
         tauri::async_runtime::spawn(async move {
             let service = hyper::service::service_fn(move |request| {
-                route(request, dir.clone(), reload.clone())
+                route(request, dir.clone(), host.clone(), reload.clone())
             });
             let _ = hyper::server::conn::http1::Builder::new()
                 .serve_connection(TokioIo::new(stream), service)
@@ -61,8 +140,12 @@ pub async fn run(listener: std::net::TcpListener, dir: PathBuf, reload: broadcas
 async fn route(
     request: Request<Incoming>,
     dir: PathBuf,
+    host: HostGuard,
     reload: broadcast::Sender<()>,
 ) -> Result<Response<ServeBody>, Infallible> {
+    if !host.allows(request.headers().get(HOST).and_then(|v| v.to_str().ok())) {
+        return Ok(error_response(StatusCode::FORBIDDEN));
+    }
     if request.uri().path() == RELOAD_PATH {
         return Ok(reload_stream(reload.subscribe()));
     }
@@ -99,6 +182,20 @@ fn reload_stream(receiver: broadcast::Receiver<()>) -> Response<ServeBody> {
 /// content type, and refuses to escape `dir`, including through encoded
 /// traversal segments.
 async fn serve_file<B: Send + 'static>(request: Request<B>, dir: PathBuf) -> Response<ServeBody> {
+    // The export writes no hidden files, so anything hidden under the output
+    // directory was already there. That matters when `--out` points at a
+    // directory of the user's own, where `.env` or `.git/config` would
+    // otherwise be readable over the network under `--host`.
+    if request
+        .uri()
+        .path()
+        .split('/')
+        .any(|segment| segment.starts_with('.') && segment != "." && segment != "..")
+    {
+        return error_response(StatusCode::NOT_FOUND);
+    }
+
+    let is_get = request.method() == Method::GET;
     // `ServeDir` answers every request, including the ones it refuses: a
     // missing file is a 404 response, not an error, and its error type is
     // `Infallible`.
@@ -109,7 +206,10 @@ async fn serve_file<B: Send + 'static>(request: Request<B>, dir: PathBuf) -> Res
         .get(CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
         .is_some_and(|value| value.starts_with("text/html"));
-    if !is_html {
+    // Only a whole page gets the script. A 206 carries a byte range whose
+    // length the injection would contradict, and a HEAD carries no body at
+    // all, so appending to one invents a length for a body that is not there.
+    if !is_html || !is_get || response.status() != StatusCode::OK {
         return response.map(BodyExt::boxed_unsync);
     }
 
@@ -168,6 +268,7 @@ mod tests {
     async fn get(dir: &std::path::Path, path: &str) -> Response<ServeBody> {
         let request = Request::builder()
             .uri(path)
+            .method(Method::GET)
             .body(Full::new(Bytes::new()))
             .expect("request is well-formed");
         serve_file(request, dir.to_path_buf()).await
@@ -246,6 +347,143 @@ mod tests {
             );
         }
         let _ = std::fs::remove_file(&secret);
+    }
+
+    /// Drive the router, which is what a real connection reaches.
+    async fn request(
+        dir: &std::path::Path,
+        path: &str,
+        host: &str,
+        guard: &HostGuard,
+    ) -> Response<ServeBody> {
+        let (sender, _) = broadcast::channel(4);
+        let mut builder = Request::builder().uri(path).method(Method::GET);
+        if !host.is_empty() {
+            builder = builder.header(HOST, host);
+        }
+        // `Incoming` cannot be built outside hyper, so the router is reached
+        // through the same generic path a connection takes.
+        let request = builder.body(Full::new(Bytes::new())).expect("well-formed");
+        if !guard.allows(request.headers().get(HOST).and_then(|v| v.to_str().ok())) {
+            return error_response(StatusCode::FORBIDDEN);
+        }
+        if request.uri().path() == RELOAD_PATH {
+            return reload_stream(sender.subscribe());
+        }
+        serve_file(request, dir.to_path_buf()).await
+    }
+
+    #[tokio::test]
+    async fn a_foreign_host_header_is_refused() {
+        // DNS rebinding: a page on evil.com re-points its own name at
+        // 127.0.0.1 and fetches the site, which the browser then treats as
+        // same-origin. Binding to loopback does not stop it; this does.
+        let dir = fixture();
+        let guard = HostGuard::new("127.0.0.1".parse().unwrap());
+        let response = request(dir.path(), "/", "evil.com", &guard).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert!(!body_string(response).await.contains("home"));
+    }
+
+    #[tokio::test]
+    async fn the_names_this_server_answers_to_are_allowed() {
+        let dir = fixture();
+        let guard = HostGuard::new("127.0.0.1".parse().unwrap());
+        for host in [
+            "127.0.0.1:4173",
+            "localhost:4173",
+            "localhost",
+            "[::1]:4173",
+        ] {
+            let response = request(dir.path(), "/", host, &guard).await;
+            assert_eq!(response.status(), StatusCode::OK, "{host} should be served");
+        }
+        // No Host at all is not a browser, so there is no rebinding to stop.
+        assert_eq!(
+            request(dir.path(), "/", "", &guard).await.status(),
+            StatusCode::OK
+        );
+    }
+
+    #[tokio::test]
+    async fn an_explicitly_exposed_server_answers_to_any_name() {
+        // `--host 0.0.0.0` is the user saying the network may read this, so
+        // it cannot also insist on the name the visitor used to get here.
+        let dir = fixture();
+        let guard = HostGuard::new("0.0.0.0".parse().unwrap());
+        let response = request(dir.path(), "/", "my-laptop.local:4173", &guard).await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn host_name_drops_the_port_and_keeps_ipv6_brackets() {
+        assert_eq!(host_name("localhost:4173"), "localhost");
+        assert_eq!(host_name("localhost"), "localhost");
+        assert_eq!(host_name("[::1]:4173"), "[::1]");
+        assert_eq!(host_name("[::1]"), "[::1]");
+    }
+
+    #[tokio::test]
+    async fn hidden_files_under_the_output_directory_are_not_served() {
+        // The export writes none, so anything hidden there is the user's, and
+        // `--out` pointed at a working directory would otherwise publish it.
+        let dir = fixture();
+        std::fs::write(dir.path().join(".env"), b"SECRET=1").unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        std::fs::write(dir.path().join(".git/config"), b"[core]").unwrap();
+
+        for path in ["/.env", "/.git/config"] {
+            let response = get(dir.path(), path).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "{path} was served"
+            );
+            assert!(!body_string(response).await.contains("SECRET"));
+        }
+    }
+
+    #[tokio::test]
+    async fn a_head_request_is_not_given_a_body() {
+        // Appending the script to an empty body invents a content length for
+        // a body that is not there.
+        let dir = fixture();
+        let request = Request::builder()
+            .uri("/")
+            .method(Method::HEAD)
+            .body(Full::new(Bytes::new()))
+            .expect("well-formed");
+        let response = serve_file(request, dir.path().to_path_buf()).await;
+        assert!(
+            !body_string(response).await.contains("data-glyph-reload"),
+            "a HEAD response must stay bodyless"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_range_request_is_not_rewritten() {
+        // A 206 carries a Content-Range the injected script would contradict.
+        let dir = fixture();
+        let request = Request::builder()
+            .uri("/")
+            .method(Method::GET)
+            .header(hyper::header::RANGE, "bytes=0-9")
+            .body(Full::new(Bytes::new()))
+            .expect("well-formed");
+        let response = serve_file(request, dir.path().to_path_buf()).await;
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+        assert!(!body_string(response).await.contains("data-glyph-reload"));
+    }
+
+    #[tokio::test]
+    async fn the_reload_route_is_reachable_through_the_router() {
+        let dir = fixture();
+        let guard = HostGuard::new("127.0.0.1".parse().unwrap());
+        let response = request(dir.path(), RELOAD_PATH, "localhost:4173", &guard).await;
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            "text/event-stream"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/serve/mod.rs
+++ b/src-tauri/src/serve/mod.rs
@@ -373,6 +373,91 @@ mod tests {
         serve_file(request, dir.to_path_buf()).await
     }
 
+    /// Speak HTTP/1.1 down a real socket and read the whole reply. Keeps the
+    /// end-to-end tests dependency-free: nothing in the tree is an HTTP
+    /// client, and the exchange under test is one request long.
+    fn http_get(port: u16, path: &str, host: &str) -> String {
+        use std::io::{Read, Write};
+        let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connects");
+        stream
+            .write_all(
+                format!("GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n")
+                    .as_bytes(),
+            )
+            .expect("writes");
+        let mut reply = String::new();
+        stream.read_to_string(&mut reply).expect("reads");
+        reply
+    }
+
+    /// Bind an ephemeral port and start the server on it, as `start_serve`
+    /// does, returning the port the OS chose.
+    fn start(dir: &std::path::Path, host: &str) -> (u16, broadcast::Sender<()>) {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("binds");
+        let port = listener.local_addr().expect("has an address").port();
+        let (reload, _) = broadcast::channel(4);
+        let guard = HostGuard::new(host.parse().expect("an address"));
+        tauri::async_runtime::spawn(run(listener, dir.to_path_buf(), guard, reload.clone()));
+        (port, reload)
+    }
+
+    #[tokio::test]
+    async fn serves_over_a_real_socket() {
+        // The accept loop and the connection handling only run for real over
+        // a socket; every other test here calls past them.
+        let dir = fixture();
+        let (port, _reload) = start(dir.path(), "127.0.0.1");
+
+        let reply = tokio::task::spawn_blocking(move || http_get(port, "/", "localhost"))
+            .await
+            .expect("the request thread finishes");
+
+        assert!(reply.starts_with("HTTP/1.1 200"), "got: {reply}");
+        assert!(reply.contains("home"), "page body missing: {reply}");
+        assert!(reply.contains("data-glyph-reload"), "script missing");
+    }
+
+    #[tokio::test]
+    async fn refuses_a_rebinding_host_over_a_real_socket() {
+        let dir = fixture();
+        let (port, _reload) = start(dir.path(), "127.0.0.1");
+
+        let reply = tokio::task::spawn_blocking(move || http_get(port, "/", "evil.com"))
+            .await
+            .expect("the request thread finishes");
+
+        assert!(reply.starts_with("HTTP/1.1 403"), "got: {reply}");
+        assert!(!reply.contains("home"), "the page leaked: {reply}");
+    }
+
+    #[tokio::test]
+    async fn a_rebuild_reaches_a_browser_on_a_real_socket() {
+        // The whole point of the server: an open stream is told to reload.
+        let dir = fixture();
+        let (port, reload) = start(dir.path(), "127.0.0.1");
+
+        let stream = tokio::task::spawn_blocking(move || {
+            use std::io::{Read, Write};
+            let mut socket = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connects");
+            socket
+                .write_all(
+                    format!("GET {RELOAD_PATH} HTTP/1.1\r\nHost: localhost\r\n\r\n").as_bytes(),
+                )
+                .expect("writes");
+            let mut buffer = [0u8; 512];
+            let read = socket.read(&mut buffer).expect("reads the headers");
+            String::from_utf8_lossy(&buffer[..read]).into_owned()
+        });
+
+        // Give the subscription time to reach the broadcast channel, then
+        // announce a rebuild the way `serve_ready` does.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let _ = reload.send(());
+
+        let headers = stream.await.expect("the request thread finishes");
+        assert!(headers.contains("text/event-stream"), "got: {headers}");
+    }
+
     #[tokio::test]
     async fn a_foreign_host_header_is_refused() {
         // DNS rebinding: a page on evil.com re-points its own name at

--- a/src-tauri/src/serve/watch.rs
+++ b/src-tauri/src/serve/watch.rs
@@ -1,0 +1,215 @@
+//! The rebuild trigger behind `glyph serve`.
+//!
+//! Separate from [`crate::watcher`], which serves the running app's open tabs
+//! and workspaces: this one watches a folder nobody has open, and its answer
+//! is not "refresh a view" but "render the whole site again".
+
+use std::path::Path;
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::time::{Duration, Instant};
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tauri::{AppHandle, Emitter, Runtime};
+
+/// Event the frontend listens on to know it should export again.
+pub const CHANGED_EVENT: &str = "serve://changed";
+
+/// How long to keep collecting changes before rebuilding. Saving a file
+/// commonly produces several events, and an editor writing a whole directory
+/// produces a burst of them; rebuilding per event would mean rendering the
+/// site several times to reach the same place.
+const DEBOUNCE: Duration = Duration::from_millis(300);
+
+/// Whether a filesystem change should rebuild the site.
+///
+/// Unlike the app's own directory watch this does not filter down to markdown:
+/// an image, a stylesheet, or the site configuration all change what the
+/// export produces.
+///
+/// What it does filter out is hidden paths, which the export's own walker
+/// skips, so a `.git` write during a commit would otherwise rebuild a site
+/// whose content cannot have changed. The workspace configuration folder is
+/// the exception: `.glyph/site.json` is hidden but the export reads it, so
+/// editing the site title has to rebuild like any other change.
+pub fn is_relevant_change(event: &Event) -> bool {
+    if !matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Remove(_) | EventKind::Modify(_)
+    ) {
+        return false;
+    }
+    event.paths.iter().any(|path| !is_ignored(path))
+}
+
+/// The workspace configuration folder, which is hidden but is read by the
+/// export. Kept in step with `SITE_CONFIG_PATH` on the frontend.
+const CONFIG_DIR: &str = ".glyph";
+
+/// Whether a path lives somewhere the export does not read: any hidden
+/// directory or file except the workspace configuration folder.
+fn is_ignored(path: &Path) -> bool {
+    path.components().any(|component| {
+        component.as_os_str().to_str().is_some_and(|name| {
+            name.starts_with('.') && name != "." && name != ".." && name != CONFIG_DIR
+        })
+    })
+}
+
+/// Watch `root` and emit [`CHANGED_EVENT`] whenever its contents change,
+/// coalescing bursts. The returned watcher must be kept alive: dropping it
+/// stops the watch.
+pub fn watch<R: Runtime>(app: AppHandle<R>, root: &Path) -> notify::Result<RecommendedWatcher> {
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let mut watcher = notify::recommended_watcher(move |result| {
+        let _ = sender.send(result);
+    })?;
+    watcher.watch(root, RecursiveMode::Recursive)?;
+
+    let root = root.to_path_buf();
+    std::thread::spawn(move || debounce_loop(&app, &receiver, &root));
+    Ok(watcher)
+}
+
+/// Block on changes, collapse each burst into one rebuild, and tell the
+/// frontend. Ends when the watcher is dropped and the channel closes.
+fn debounce_loop<R: Runtime>(
+    app: &AppHandle<R>,
+    receiver: &Receiver<Result<Event, notify::Error>>,
+    root: &Path,
+) {
+    while let Ok(first) = receiver.recv() {
+        if !first.is_ok_and(|event| is_relevant_change(&event)) {
+            continue;
+        }
+        drain_burst(receiver);
+        let _ = app.emit(CHANGED_EVENT, root.to_string_lossy().to_string());
+    }
+}
+
+/// Swallow everything that arrives within the debounce window, so a burst of
+/// saves produces one rebuild instead of one per event.
+fn drain_burst(receiver: &Receiver<Result<Event, notify::Error>>) {
+    let deadline = Instant::now() + DEBOUNCE;
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        match receiver.recv_timeout(remaining) {
+            Ok(_) => continue,
+            Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => return,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{CreateKind, ModifyKind, RemoveKind};
+    use std::path::PathBuf;
+
+    fn event(kind: EventKind, paths: &[&str]) -> Event {
+        Event {
+            kind,
+            paths: paths.iter().map(PathBuf::from).collect(),
+            attrs: Default::default(),
+        }
+    }
+
+    #[test]
+    fn content_changes_rebuild_whatever_the_file_type() {
+        // Not just markdown: images and stylesheets change the output too.
+        for path in ["/ws/notes.md", "/ws/assets/diagram.png", "/ws/style.css"] {
+            assert!(
+                is_relevant_change(&event(EventKind::Modify(ModifyKind::Any), &[path])),
+                "{path} should rebuild"
+            );
+        }
+        assert!(is_relevant_change(&event(
+            EventKind::Create(CreateKind::File),
+            &["/ws/new.md"]
+        )));
+        assert!(is_relevant_change(&event(
+            EventKind::Remove(RemoveKind::File),
+            &["/ws/gone.md"]
+        )));
+    }
+
+    #[test]
+    fn hidden_paths_do_not_rebuild() {
+        // A commit writes constantly inside .git, and none of it can change
+        // what the export produces, because the walker skips hidden paths.
+        for path in [
+            "/ws/.git/index",
+            "/ws/.git/objects/ab/cdef",
+            "/ws/.DS_Store",
+        ] {
+            assert!(
+                !is_relevant_change(&event(EventKind::Modify(ModifyKind::Any), &[path])),
+                "{path} should be ignored"
+            );
+        }
+    }
+
+    #[test]
+    fn the_workspace_configuration_folder_still_rebuilds() {
+        // .glyph is hidden but the export reads site.json out of it, so
+        // renaming the site has to reach the served pages.
+        assert!(is_relevant_change(&event(
+            EventKind::Modify(ModifyKind::Any),
+            &["/ws/.glyph/site.json"]
+        )));
+    }
+
+    #[test]
+    fn a_burst_touching_one_visible_file_still_rebuilds() {
+        let mixed = event(
+            EventKind::Modify(ModifyKind::Any),
+            &["/ws/.git/index", "/ws/notes.md"],
+        );
+        assert!(is_relevant_change(&mixed));
+    }
+
+    #[test]
+    fn access_only_events_do_not_rebuild() {
+        let accessed = event(
+            EventKind::Access(notify::event::AccessKind::Read),
+            &["/ws/notes.md"],
+        );
+        assert!(!is_relevant_change(&accessed));
+    }
+
+    #[test]
+    fn drain_burst_returns_once_the_channel_closes() {
+        let (sender, receiver) = std::sync::mpsc::channel::<Result<Event, notify::Error>>();
+        drop(sender);
+        let started = Instant::now();
+        drain_burst(&receiver);
+        assert!(
+            started.elapsed() < DEBOUNCE,
+            "a closed channel should not wait out the window"
+        );
+    }
+
+    #[test]
+    fn drain_burst_waits_out_the_window_when_events_keep_arriving() {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        // The original sender stays in this scope: dropping every sender is
+        // what the disconnect case above covers, and it would end the window
+        // early here for the wrong reason.
+        let ticker = sender.clone();
+        std::thread::spawn(move || {
+            for _ in 0..3 {
+                let _ = ticker.send(Ok(event(
+                    EventKind::Modify(ModifyKind::Any),
+                    &["/ws/notes.md"],
+                )));
+                std::thread::sleep(Duration::from_millis(40));
+            }
+        });
+
+        let started = Instant::now();
+        drain_burst(&receiver);
+        assert!(
+            started.elapsed() >= DEBOUNCE,
+            "a burst should be collapsed into one window, not cut short"
+        );
+        drop(sender);
+    }
+}

--- a/src-tauri/src/serve/watch.rs
+++ b/src-tauri/src/serve/watch.rs
@@ -221,6 +221,50 @@ mod tests {
     }
 
     #[test]
+    fn a_real_edit_reaches_the_frontend_as_one_rebuild() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+        use tauri::Listener;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(dir.path().join("index.md"), "# Home").unwrap();
+
+        let app = tauri::test::mock_app();
+        let rebuilds = Arc::new(AtomicUsize::new(0));
+        let counted = Arc::clone(&rebuilds);
+        app.listen(CHANGED_EVENT, move |_| {
+            counted.fetch_add(1, Ordering::SeqCst);
+        });
+
+        // Held for the length of the test: dropping it stops the watch.
+        let _watcher = watch(app.handle().clone(), dir.path()).expect("watches");
+        // The watch is registered asynchronously by the OS, so an edit made
+        // immediately can be missed.
+        std::thread::sleep(Duration::from_millis(300));
+
+        // A burst, the way an editor saves: several writes in quick
+        // succession that should amount to one rebuild.
+        for i in 0..3 {
+            std::fs::write(dir.path().join("index.md"), format!("# Home {i}")).unwrap();
+            std::thread::sleep(Duration::from_millis(30));
+        }
+
+        // Long enough for the debounce window to close and the event to land.
+        std::thread::sleep(DEBOUNCE + Duration::from_millis(700));
+        let seen = rebuilds.load(Ordering::SeqCst);
+        assert!(seen >= 1, "an edit should rebuild, saw {seen}");
+        assert!(seen <= 2, "a burst should coalesce, saw {seen} rebuilds");
+    }
+
+    #[test]
+    fn watching_a_folder_that_is_not_there_is_an_error_not_a_panic() {
+        let app = tauri::test::mock_app();
+        let missing = std::env::temp_dir().join("glyph-serve-no-such-folder");
+        let _ = std::fs::remove_dir_all(&missing);
+        assert!(watch(app.handle().clone(), &missing).is_err());
+    }
+
+    #[test]
     fn drain_burst_returns_once_the_channel_closes() {
         let (sender, receiver) = std::sync::mpsc::channel::<Result<Event, notify::Error>>();
         drop(sender);

--- a/src-tauri/src/serve/watch.rs
+++ b/src-tauri/src/serve/watch.rs
@@ -31,14 +31,20 @@ const DEBOUNCE: Duration = Duration::from_millis(300);
 /// whose content cannot have changed. The workspace configuration folder is
 /// the exception: `.glyph/site.json` is hidden but the export reads it, so
 /// editing the site title has to rebuild like any other change.
-pub fn is_relevant_change(event: &Event) -> bool {
+///
+/// Hidden-ness is judged relative to `root`, exactly as the export's walker
+/// judges it by depth. Serving a folder that lives under a hidden one is
+/// ordinary (`~/.config/notes`, a dotfiles repo), and testing the absolute
+/// path would classify every event inside it as hidden and quietly stop
+/// rebuilding for the life of the process.
+pub fn is_relevant_change(event: &Event, root: &Path) -> bool {
     if !matches!(
         event.kind,
         EventKind::Create(_) | EventKind::Remove(_) | EventKind::Modify(_)
     ) {
         return false;
     }
-    event.paths.iter().any(|path| !is_ignored(path))
+    event.paths.iter().any(|path| !is_ignored(path, root))
 }
 
 /// The workspace configuration folder, which is hidden but is read by the
@@ -46,9 +52,12 @@ pub fn is_relevant_change(event: &Event) -> bool {
 const CONFIG_DIR: &str = ".glyph";
 
 /// Whether a path lives somewhere the export does not read: any hidden
-/// directory or file except the workspace configuration folder.
-fn is_ignored(path: &Path) -> bool {
-    path.components().any(|component| {
+/// directory or file below `root`, except the workspace configuration folder.
+fn is_ignored(path: &Path, root: &Path) -> bool {
+    // Anything at or above the root is the user's choice of folder, not
+    // content, so only the part below it is classified.
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    relative.components().any(|component| {
         component.as_os_str().to_str().is_some_and(|name| {
             name.starts_with('.') && name != "." && name != ".." && name != CONFIG_DIR
         })
@@ -78,7 +87,7 @@ fn debounce_loop<R: Runtime>(
     root: &Path,
 ) {
     while let Ok(first) = receiver.recv() {
-        if !first.is_ok_and(|event| is_relevant_change(&event)) {
+        if !first.is_ok_and(|event| is_relevant_change(&event, root)) {
             continue;
         }
         drain_burst(receiver);
@@ -114,25 +123,27 @@ mod tests {
 
     #[test]
     fn content_changes_rebuild_whatever_the_file_type() {
+        let root = Path::new("/ws");
         // Not just markdown: images and stylesheets change the output too.
         for path in ["/ws/notes.md", "/ws/assets/diagram.png", "/ws/style.css"] {
             assert!(
-                is_relevant_change(&event(EventKind::Modify(ModifyKind::Any), &[path])),
+                is_relevant_change(&event(EventKind::Modify(ModifyKind::Any), &[path]), root),
                 "{path} should rebuild"
             );
         }
-        assert!(is_relevant_change(&event(
-            EventKind::Create(CreateKind::File),
-            &["/ws/new.md"]
-        )));
-        assert!(is_relevant_change(&event(
-            EventKind::Remove(RemoveKind::File),
-            &["/ws/gone.md"]
-        )));
+        assert!(is_relevant_change(
+            &event(EventKind::Create(CreateKind::File), &["/ws/new.md"]),
+            root
+        ));
+        assert!(is_relevant_change(
+            &event(EventKind::Remove(RemoveKind::File), &["/ws/gone.md"]),
+            root
+        ));
     }
 
     #[test]
     fn hidden_paths_do_not_rebuild() {
+        let root = Path::new("/ws");
         // A commit writes constantly inside .git, and none of it can change
         // what the export produces, because the walker skips hidden paths.
         for path in [
@@ -141,7 +152,7 @@ mod tests {
             "/ws/.DS_Store",
         ] {
             assert!(
-                !is_relevant_change(&event(EventKind::Modify(ModifyKind::Any), &[path])),
+                !is_relevant_change(&event(EventKind::Modify(ModifyKind::Any), &[path]), root),
                 "{path} should be ignored"
             );
         }
@@ -149,30 +160,64 @@ mod tests {
 
     #[test]
     fn the_workspace_configuration_folder_still_rebuilds() {
+        let root = Path::new("/ws");
         // .glyph is hidden but the export reads site.json out of it, so
         // renaming the site has to reach the served pages.
-        assert!(is_relevant_change(&event(
-            EventKind::Modify(ModifyKind::Any),
-            &["/ws/.glyph/site.json"]
-        )));
+        assert!(is_relevant_change(
+            &event(
+                EventKind::Modify(ModifyKind::Any),
+                &["/ws/.glyph/site.json"]
+            ),
+            root
+        ));
+    }
+
+    #[test]
+    fn a_workspace_inside_a_hidden_folder_still_rebuilds() {
+        // Serving `~/.config/notes` or a dotfiles repo is ordinary. Judging
+        // the absolute path would call every event inside it hidden and stop
+        // rebuilding for the life of the process, with nothing said.
+        for (root, changed) in [
+            ("/home/me/.config/notes", "/home/me/.config/notes/index.md"),
+            ("/home/me/.dotfiles/docs", "/home/me/.dotfiles/docs/a/b.md"),
+        ] {
+            assert!(
+                is_relevant_change(
+                    &event(EventKind::Modify(ModifyKind::Any), &[changed]),
+                    Path::new(root)
+                ),
+                "{changed} should rebuild when serving {root}"
+            );
+        }
+
+        // Hidden folders *below* the root are still ignored.
+        assert!(!is_relevant_change(
+            &event(
+                EventKind::Modify(ModifyKind::Any),
+                &["/home/me/.config/notes/.git/index"]
+            ),
+            Path::new("/home/me/.config/notes")
+        ));
     }
 
     #[test]
     fn a_burst_touching_one_visible_file_still_rebuilds() {
+        let root = Path::new("/ws");
         let mixed = event(
             EventKind::Modify(ModifyKind::Any),
             &["/ws/.git/index", "/ws/notes.md"],
         );
-        assert!(is_relevant_change(&mixed));
+        assert!(is_relevant_change(&mixed, root));
     }
 
     #[test]
     fn access_only_events_do_not_rebuild() {
+        let root = Path::new("/ws");
         let accessed = event(
             EventKind::Access(notify::event::AccessKind::Read),
             &["/ws/notes.md"],
         );
-        assert!(!is_relevant_change(&accessed));
+        assert!(!is_relevant_change(&accessed, root));
     }
 
     #[test]

--- a/src-tauri/src/serve/watch.rs
+++ b/src-tauri/src/serve/watch.rs
@@ -254,6 +254,20 @@ mod tests {
         let seen = rebuilds.load(Ordering::SeqCst);
         assert!(seen >= 1, "an edit should rebuild, saw {seen}");
         assert!(seen <= 2, "a burst should coalesce, saw {seen} rebuilds");
+
+        // Now the noise a real workspace generates: a commit writes inside
+        // .git constantly, and none of it can change what the export reads.
+        std::fs::create_dir_all(dir.path().join(".git/objects")).unwrap();
+        for i in 0..3 {
+            std::fs::write(dir.path().join(format!(".git/objects/{i}")), "x").unwrap();
+            std::thread::sleep(Duration::from_millis(30));
+        }
+        std::thread::sleep(DEBOUNCE + Duration::from_millis(700));
+        assert_eq!(
+            rebuilds.load(Ordering::SeqCst),
+            seen,
+            "writes under .git must not rebuild the site"
+        );
     }
 
     #[test]

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -59,8 +59,6 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
                 .and_then(|a| a.value.as_str().map(str::to_string))
         };
         let plugin_path = plugin_arg("file");
-        let plugin_export = plugin_arg("export");
-        let plugin_out = plugin_arg("out");
         let env_args: Vec<String> = std::env::args().collect();
         // Session restore and the recent-files menu re-open paths from
         // earlier sessions; seed their grants from the persisted settings
@@ -89,13 +87,7 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
             }
         }
         let grant_registry = app.state::<grants::GrantRegistry>();
-        match cli::launch_plan(
-            plugin_path.as_deref(),
-            plugin_export.as_deref(),
-            plugin_out.as_deref(),
-            &env_args,
-            &cwd,
-        ) {
+        match cli::launch_plan(plugin_path.as_deref(), &env_args, &cwd) {
             Err(usage) => {
                 eprintln!("{usage}");
                 std::process::exit(2);

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -168,12 +168,25 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
-/// Where a `glyph serve` with no `--out` puts the site. Named after the
-/// process so two concurrent previews cannot write over each other, and so
-/// the leftovers of a killed run are identifiable rather than anonymous.
+/// Where a `glyph serve` with no `--out` puts the site.
+///
+/// Created through `tempfile` rather than at a name derived from the process
+/// id: the system temp directory is world-writable on Unix and process ids
+/// are guessable, so a predictable name can be pre-created (or pointed
+/// somewhere else by a symlink) by any local user, who would then be choosing
+/// the HTML the victim's browser is about to load from localhost. `tempfile`
+/// creates it with a random name and owner-only permissions.
+///
+/// The directory outlives the handle on purpose. Removal happens on interrupt
+/// in [`spawn_temp_dir_cleanup`], because the process ends without unwinding
+/// and `Drop` would never run.
 #[cfg(desktop)]
-fn default_serve_dir() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("glyph-serve-{}", std::process::id()))
+fn default_serve_dir() -> Result<std::path::PathBuf, String> {
+    tempfile::Builder::new()
+        .prefix("glyph-serve-")
+        .tempdir()
+        .map(tempfile::TempDir::keep)
+        .map_err(|err| format!("cannot create a temporary directory to serve from: {err}"))
 }
 
 /// Bring up everything `glyph serve` needs before the frontend renders:
@@ -192,9 +205,15 @@ fn start_serve(
     output: Option<String>,
 ) -> Result<(), String> {
     let owns_output = output.is_none();
-    let out_dir = output.map_or_else(default_serve_dir, std::path::PathBuf::from);
-    std::fs::create_dir_all(&out_dir)
-        .map_err(|err| format!("cannot create the output directory {out_dir:?}: {err}"))?;
+    let out_dir = match output {
+        Some(path) => {
+            let path = std::path::PathBuf::from(path);
+            std::fs::create_dir_all(&path)
+                .map_err(|err| format!("cannot create the output directory {path:?}: {err}"))?;
+            path
+        }
+        None => default_serve_dir()?,
+    };
 
     let grant_registry = app.state::<grants::GrantRegistry>();
     let _ = grant_registry.grant_workspace(std::path::Path::new(root));
@@ -208,7 +227,8 @@ fn start_serve(
 
     if !host.is_loopback() {
         eprintln!(
-            "Warning: serving on {host} exposes {root} to the network. Anyone who can reach this machine can read the whole folder."
+            "Warning: serving on {host} exposes {} to the network. Anyone who can reach this machine can read the whole folder.",
+            cli::plain_path(root)
         );
     }
 
@@ -227,13 +247,20 @@ fn start_serve(
     // so it lives in managed state for as long as the process does.
     match crate::serve::watch::watch(app.clone(), std::path::Path::new(root)) {
         Ok(watcher) => {
-            app.manage(std::sync::Mutex::new(watcher));
+            app.manage(commands::serve::ServeWatcher {
+                _watcher: std::sync::Mutex::new(watcher),
+            });
         }
         Err(err) => eprintln!("Warning: changes to {root} will not rebuild the site: {err}"),
     }
 
     let served = out_dir.clone();
-    tauri::async_runtime::spawn(crate::serve::run(listener, served, reload));
+    tauri::async_runtime::spawn(crate::serve::run(
+        listener,
+        served,
+        crate::serve::HostGuard::new(host),
+        reload,
+    ));
 
     if owns_output {
         spawn_temp_dir_cleanup(out_dir);
@@ -247,9 +274,19 @@ fn start_serve(
 #[cfg(desktop)]
 fn spawn_temp_dir_cleanup(dir: std::path::PathBuf) {
     tauri::async_runtime::spawn(async move {
-        if tokio::signal::ctrl_c().await.is_ok() {
-            let _ = std::fs::remove_dir_all(&dir);
+        // Only exit on an actual interrupt. Exiting when the handler cannot
+        // be registered would end a healthy server moments after startup,
+        // reporting success and explaining nothing.
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => {
+                let _ = std::fs::remove_dir_all(&dir);
+                std::process::exit(0);
+            }
+            Err(err) => {
+                eprintln!(
+                    "glyph serve: cannot listen for interrupts, so {dir:?} will be left behind: {err}"
+                );
+            }
         }
-        std::process::exit(0);
     });
 }

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -130,6 +130,21 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
                         output,
                     });
             }
+            Ok(cli::CliLaunch::Serve {
+                root,
+                host,
+                port,
+                output,
+            }) => {
+                // Like a site export, the window stays hidden and the
+                // frontend renders on mount. Unlike one, the process then
+                // stays up: the server keeps answering and every change
+                // renders again.
+                if let Err(message) = start_serve(app.handle(), &root, host, port, output) {
+                    eprintln!("{message}");
+                    std::process::exit(1);
+                }
+            }
             Ok(cli::CliLaunch::Open(Some(cli::InitialOpenAction::Folder(p)))) => {
                 if let Ok(canonical) = grant_registry.grant_workspace(std::path::Path::new(&p)) {
                     grants::allow_asset_dir(app.handle(), &canonical);
@@ -151,4 +166,90 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
         }
     }
     Ok(())
+}
+
+/// Where a `glyph serve` with no `--out` puts the site. Named after the
+/// process so two concurrent previews cannot write over each other, and so
+/// the leftovers of a killed run are identifiable rather than anonymous.
+#[cfg(desktop)]
+fn default_serve_dir() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("glyph-serve-{}", std::process::id()))
+}
+
+/// Bring up everything `glyph serve` needs before the frontend renders:
+/// the output directory, the grants the export writes through, the bound
+/// socket, the file watch, and the state the two sides share.
+///
+/// Binding happens here rather than in the server task so that a port
+/// already in use fails immediately, with the process exiting nonzero rather
+/// than sitting there having served nothing.
+#[cfg(desktop)]
+fn start_serve(
+    app: &tauri::AppHandle,
+    root: &str,
+    host: std::net::IpAddr,
+    port: u16,
+    output: Option<String>,
+) -> Result<(), String> {
+    let owns_output = output.is_none();
+    let out_dir = output.map_or_else(default_serve_dir, std::path::PathBuf::from);
+    std::fs::create_dir_all(&out_dir)
+        .map_err(|err| format!("cannot create the output directory {out_dir:?}: {err}"))?;
+
+    let grant_registry = app.state::<grants::GrantRegistry>();
+    let _ = grant_registry.grant_workspace(std::path::Path::new(root));
+    let _ = grant_registry.grant_export_dir(&out_dir);
+
+    let listener = std::net::TcpListener::bind((host, port))
+        .map_err(|err| format!("cannot serve on {host}:{port}: {err}"))?;
+    let address = listener
+        .local_addr()
+        .map_err(|err| format!("cannot read the bound address: {err}"))?;
+
+    if !host.is_loopback() {
+        eprintln!(
+            "Warning: serving on {host} exposes {root} to the network. Anyone who can reach this machine can read the whole folder."
+        );
+    }
+
+    let (reload, _) = tokio::sync::broadcast::channel(16);
+    app.manage(commands::serve::ServeState::new(
+        commands::serve::CliServeRequest {
+            root: root.to_string(),
+            out_dir: out_dir.to_string_lossy().to_string(),
+        },
+        cli::plain_path(root),
+        format!("http://{address}"),
+        reload.clone(),
+    ));
+
+    // The watcher stops the moment it is dropped, and nothing else owns it,
+    // so it lives in managed state for as long as the process does.
+    match crate::serve::watch::watch(app.clone(), std::path::Path::new(root)) {
+        Ok(watcher) => {
+            app.manage(std::sync::Mutex::new(watcher));
+        }
+        Err(err) => eprintln!("Warning: changes to {root} will not rebuild the site: {err}"),
+    }
+
+    let served = out_dir.clone();
+    tauri::async_runtime::spawn(crate::serve::run(listener, served, reload));
+
+    if owns_output {
+        spawn_temp_dir_cleanup(out_dir);
+    }
+    Ok(())
+}
+
+/// Remove the temporary site on the way out. `Drop` never runs here: the
+/// process ends either through `std::process::exit` or through the interrupt
+/// that a foreground server is normally stopped with, and neither unwinds.
+#[cfg(desktop)]
+fn spawn_temp_dir_cleanup(dir: std::path::PathBuf) {
+    tauri::async_runtime::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+        std::process::exit(0);
+    });
 }

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -224,6 +224,12 @@ fn start_serve(
     let address = listener
         .local_addr()
         .map_err(|err| format!("cannot read the bound address: {err}"))?;
+    // tokio requires a nonblocking socket. Doing it here, rather than inside
+    // the server task, keeps an unusable socket a startup failure with a
+    // nonzero exit instead of a log line under a ready message.
+    listener
+        .set_nonblocking(true)
+        .map_err(|err| format!("cannot serve on {address}: {err}"))?;
 
     if !host.is_loopback() {
         eprintln!(
@@ -255,12 +261,15 @@ fn start_serve(
     }
 
     let served = out_dir.clone();
-    tauri::async_runtime::spawn(crate::serve::run(
-        listener,
-        served,
-        crate::serve::HostGuard::new(host),
-        reload,
-    ));
+    let guard = crate::serve::HostGuard::new(host);
+    tauri::async_runtime::spawn(async move {
+        // Registering with the reactor needs a runtime, so it happens here
+        // rather than beside the bind above.
+        match tokio::net::TcpListener::from_std(listener) {
+            Ok(listener) => crate::serve::run(listener, served, guard, reload).await,
+            Err(err) => eprintln!("glyph serve: cannot use the bound socket: {err}"),
+        }
+    });
 
     if owns_output {
         spawn_temp_dir_cleanup(out_dir);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,9 @@
     "security": {
       "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost https: http:; img-src 'self' asset: http://asset.localhost https://asset.localhost https: http: data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost https: http:; script-src 'self' data: blob: 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
       "devCsp": "default-src 'self' http://localhost:1420; connect-src 'self' ipc: http://ipc.localhost ws://localhost:1420 http://localhost:1420 https: http:; img-src 'self' asset: http://asset.localhost https://asset.localhost https: http: data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost https: http:; script-src 'self' data: blob: 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
-      "dangerousDisableAssetCspModification": ["style-src"],
+      "dangerousDisableAssetCspModification": [
+        "style-src"
+      ],
       "assetProtocol": {
         "enable": true,
         "scope": {
@@ -54,12 +56,24 @@
     },
     "fileAssociations": [
       {
-        "ext": ["md", "markdown", "mdown", "mkd", "mkdn", "mdx", "mmd", "mdtext", "mdtxt"],
+        "ext": [
+          "md",
+          "markdown",
+          "mdown",
+          "mkd",
+          "mkdn",
+          "mdx",
+          "mmd",
+          "mdtext",
+          "mdtxt"
+        ],
         "mimeType": "text/markdown",
         "description": "Markdown Document"
       },
       {
-        "ext": ["d2"],
+        "ext": [
+          "d2"
+        ],
         "mimeType": "text/plain",
         "description": "D2 Diagram"
       }
@@ -72,17 +86,6 @@
           "name": "file",
           "index": 1,
           "takesValue": true
-        },
-        {
-          "name": "export",
-          "takesValue": true,
-          "description": "Export the input and exit. Formats: pdf, docx, epub, html, site"
-        },
-        {
-          "name": "out",
-          "short": "o",
-          "takesValue": true,
-          "description": "Where to write the export. Defaults to the input path with the format's extension; required for site"
         }
       ]
     }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -88,6 +88,7 @@ export function AppShell() {
   // Headless CLI export: runs and exits when the process was launched with
   // --export, a no-op otherwise.
   useCliExport({ entries: tocEntries, content: displayContent });
+  // The other headless launch: renders repeatedly and never exits.
   useCliServe();
 
   useDocumentUndoRedo({ activeTabId, platform, onUndo: undoEdit, onRedo: redoEdit });

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { useTabsContext } from "@/contexts/TabsContext";
 import { useAppModals } from "@/hooks/useAppModals";
 import { useAutoSave } from "@/hooks/useAutoSave";
 import { useCliExport } from "@/hooks/useCliExport";
+import { useCliServe } from "@/hooks/useCliServe";
 import { useCloseFlush } from "@/hooks/useCloseFlush";
 import { useCommandPaletteController } from "@/hooks/useCommandPaletteController";
 import { useContextMenu } from "@/hooks/useContextMenu";
@@ -87,6 +88,7 @@ export function AppShell() {
   // Headless CLI export: runs and exits when the process was launched with
   // --export, a no-op otherwise.
   useCliExport({ entries: tocEntries, content: displayContent });
+  useCliServe();
 
   useDocumentUndoRedo({ activeTabId, platform, onUndo: undoEdit, onRedo: redoEdit });
   useTabReorderShortcuts({ platform, onMove: moveActiveTab });

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -86,7 +86,7 @@ export function AppShell() {
   } = tabs;
 
   // Headless CLI export: runs and exits when the process was launched with
-  // --export, a no-op otherwise.
+  // `glyph export`, a no-op otherwise.
   useCliExport({ entries: tocEntries, content: displayContent });
   // The other headless launch: renders repeatedly and never exits.
   useCliServe();

--- a/src/hooks/useCliExport.test.ts
+++ b/src/hooks/useCliExport.test.ts
@@ -3,9 +3,10 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PluginsContext, type PluginsContextValue } from "@/contexts/PluginsContext";
+import { CLI_PLUGIN_WAIT_MS } from "@/hooks/useExportReadiness";
 import { resetCliExportRequestCache } from "@/lib/cliExport";
 import { createRegistry } from "@/lib/plugins/registry";
-import { CLI_PLUGIN_WAIT_MS, resetCliExportRunner, useCliExport } from "./useCliExport";
+import { resetCliExportRunner, useCliExport } from "./useCliExport";
 
 const exportSiteMock = vi.fn();
 vi.mock("@/lib/export/site/exportSite", () => ({

--- a/src/hooks/useCliExport.ts
+++ b/src/hooks/useCliExport.ts
@@ -21,7 +21,7 @@ interface UseCliExportOptions {
 }
 
 /**
- * Runs the headless CLI export (`glyph <path> --export <format>`). When the
+ * Runs the headless CLI export (`glyph export <path> --format <format>`). When the
  * process was launched with an export request, the window stays hidden (see
  * useWindowReveal), the document or workspace renders straight to disk, and the
  * process exits: 0 on success, 1 with a stderr message on failure. On

--- a/src/hooks/useCliExport.ts
+++ b/src/hooks/useCliExport.ts
@@ -1,17 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useEffect, useRef, useState } from "react";
-import { usePluginsOptional } from "@/contexts/PluginsContext";
-import { useRegistryEntries } from "@/hooks/usePluginRegistry";
+import { useEffect, useRef } from "react";
+import { useExportReadiness } from "@/hooks/useExportReadiness";
 import { useSettings } from "@/hooks/useSettings";
 import type { TocEntry } from "@/hooks/useTableOfContents";
 import { getCliExportRequest } from "@/lib/cliExport";
 import { epubMediaLimitBytes } from "@/lib/settings";
-
-// How long the CLI export waits for the plugin host's startup load. A hung
-// plugin must not hang a CI job forever: past this, the export proceeds with
-// whatever themes have registered (a missing plugin theme then fails loudly
-// with the available ids, which beats a silent stall).
-export const CLI_PLUGIN_WAIT_MS = 10_000;
 
 // Once-per-process latch: the effect may fire more than once (StrictMode,
 // plugin readiness flipping) but the export itself must not.
@@ -39,13 +32,8 @@ interface UseCliExportOptions {
  * by the time the config names it.
  */
 export function useCliExport({ entries, content }: UseCliExportOptions): void {
-  const plugins = usePluginsOptional();
-  const pluginThemes = useRegistryEntries(plugins?.siteThemes ?? null);
-  const remarkPlugins = useRegistryEntries(plugins?.remarkPlugins ?? null);
-  const rehypePlugins = useRegistryEntries(plugins?.rehypePlugins ?? null);
-  // Without a provider there are no plugins to wait for.
-  const pluginsReady = plugins === null || plugins.initialLoadDone;
-  const { settings, loaded } = useSettings();
+  const { ready, themes, remarkPlugins, rehypePlugins } = useExportReadiness();
+  const { settings } = useSettings();
 
   // Held in refs so the document's own churn (a growing TOC, streaming
   // content) doesn't re-run the effect while an export is in flight, and so
@@ -59,16 +47,8 @@ export function useCliExport({ entries, content }: UseCliExportOptions): void {
   const epubMediaLimitRef = useRef(settings.print.epubMediaLimit);
   epubMediaLimitRef.current = settings.print.epubMediaLimit;
 
-  const [waitExpired, setWaitExpired] = useState(false);
   useEffect(() => {
-    if (pluginsReady) return;
-    const timer = window.setTimeout(() => setWaitExpired(true), CLI_PLUGIN_WAIT_MS);
-    return () => window.clearTimeout(timer);
-  }, [pluginsReady]);
-
-  useEffect(() => {
-    if (!loaded) return;
-    if (!pluginsReady && !waitExpired) return;
+    if (!ready) return;
     (async () => {
       const request = await getCliExportRequest();
       if (!request || started) return;
@@ -80,7 +60,7 @@ export function useCliExport({ entries, content }: UseCliExportOptions): void {
           const result = await exportSite({
             root: request.input,
             outDir: request.output,
-            themes: pluginThemes,
+            themes,
             remarkPlugins,
             rehypePlugins,
           });
@@ -107,5 +87,5 @@ export function useCliExport({ entries, content }: UseCliExportOptions): void {
         });
       }
     })();
-  }, [loaded, pluginsReady, waitExpired, pluginThemes, remarkPlugins, rehypePlugins]);
+  }, [ready, themes, remarkPlugins, rehypePlugins]);
 }

--- a/src/hooks/useCliServe.test.ts
+++ b/src/hooks/useCliServe.test.ts
@@ -10,8 +10,8 @@ vi.mock("@/lib/export/site/exportSite", () => ({
   exportSite: (...args: unknown[]) => exportSiteMock(...args),
 }));
 
-// The readiness gate has its own tests; here it is always open so the serve
-// loop itself is what is under test.
+// Stubbed open so the serve loop itself is what is under test; the gate has
+// its own tests in useExportReadiness.test.ts.
 vi.mock("@/hooks/useExportReadiness", () => ({
   useExportReadiness: () => ({
     ready: true,

--- a/src/hooks/useCliServe.test.ts
+++ b/src/hooks/useCliServe.test.ts
@@ -1,0 +1,176 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resetCliServeRequestCache } from "@/lib/cliServe";
+import { resetCliServeRunner, SERVE_CHANGED_EVENT, useCliServe } from "./useCliServe";
+
+const exportSiteMock = vi.fn();
+vi.mock("@/lib/export/site/exportSite", () => ({
+  exportSite: (...args: unknown[]) => exportSiteMock(...args),
+}));
+
+// The readiness gate has its own tests; here it is always open so the serve
+// loop itself is what is under test.
+vi.mock("@/hooks/useExportReadiness", () => ({
+  useExportReadiness: () => ({
+    ready: true,
+    themes: [],
+    remarkPlugins: [],
+    rehypePlugins: [],
+  }),
+}));
+
+const REQUEST = { root: "/ws", outDir: "/tmp/glyph-serve-1" };
+
+/** Fires whatever the hook registered for the change event. */
+let emitChange: (() => void) | undefined;
+const unlistenMock = vi.fn();
+
+function stubServe(request: unknown) {
+  vi.mocked(invoke).mockImplementation((cmd: string) =>
+    cmd === "get_cli_serve" ? Promise.resolve(request) : Promise.resolve(undefined),
+  );
+}
+
+function invokeCalls(command: string) {
+  return vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === command);
+}
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+  vi.mocked(listen).mockReset();
+  unlistenMock.mockReset();
+  emitChange = undefined;
+  vi.mocked(listen).mockImplementation((event, handler) => {
+    if (event === SERVE_CHANGED_EVENT) {
+      emitChange = () => handler({ event, id: 1, payload: "/ws" });
+    }
+    return Promise.resolve(unlistenMock);
+  });
+  exportSiteMock.mockReset().mockResolvedValue({ pages: 3, assets: 1 });
+  resetCliServeRequestCache();
+  resetCliServeRunner();
+});
+
+describe("useCliServe", () => {
+  it("renders the site once on mount and reports it ready", async () => {
+    stubServe(REQUEST);
+    renderHook(() => useCliServe());
+
+    await waitFor(() => expect(invokeCalls("serve_ready")).toHaveLength(1));
+    expect(exportSiteMock).toHaveBeenCalledTimes(1);
+    expect(exportSiteMock.mock.calls[0][0]).toMatchObject({
+      root: "/ws",
+      outDir: "/tmp/glyph-serve-1",
+    });
+  });
+
+  it("does nothing on a launch that is not a serve", async () => {
+    stubServe(null);
+    renderHook(() => useCliServe());
+
+    await waitFor(() => expect(invokeCalls("get_cli_serve")).toHaveLength(1));
+    expect(exportSiteMock).not.toHaveBeenCalled();
+    expect(invokeCalls("serve_ready")).toHaveLength(0);
+  });
+
+  it("re-renders the site when the folder changes", async () => {
+    stubServe(REQUEST);
+    renderHook(() => useCliServe());
+    await waitFor(() => expect(invokeCalls("serve_ready")).toHaveLength(1));
+
+    emitChange?.();
+    await waitFor(() => expect(invokeCalls("serve_ready")).toHaveLength(2));
+    expect(exportSiteMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("collapses changes that arrive mid-build into one extra build", async () => {
+    stubServe(REQUEST);
+    // Hold the first build open so the changes land while it is running.
+    let releaseFirst: (() => void) | undefined;
+    exportSiteMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseFirst = () => resolve({ pages: 1, assets: 0 });
+        }),
+    );
+    renderHook(() => useCliServe());
+    await waitFor(() => expect(exportSiteMock).toHaveBeenCalledTimes(1));
+
+    emitChange?.();
+    emitChange?.();
+    emitChange?.();
+    releaseFirst?.();
+
+    await waitFor(() => expect(invokeCalls("serve_ready")).toHaveLength(2));
+    // Three changes during one build are one rebuild, not three: the export
+    // reads the whole folder, so a single pass covers all of them.
+    expect(exportSiteMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a failed build without telling browsers to reload", async () => {
+    stubServe(REQUEST);
+    exportSiteMock.mockRejectedValueOnce(new Error("bad site.json"));
+    renderHook(() => useCliServe());
+
+    await waitFor(() => expect(invokeCalls("serve_failed")).toHaveLength(1));
+    expect(invokeCalls("serve_failed")[0][1]).toEqual({
+      message: "Rebuild failed: bad site.json",
+    });
+    // The previous site is still on disk and still served, so nothing reloads.
+    expect(invokeCalls("serve_ready")).toHaveLength(0);
+  });
+
+  it("reports a rejection that is not an Error", async () => {
+    stubServe(REQUEST);
+    exportSiteMock.mockRejectedValueOnce("site.json is not valid JSON");
+    renderHook(() => useCliServe());
+
+    await waitFor(() => expect(invokeCalls("serve_failed")).toHaveLength(1));
+    expect(invokeCalls("serve_failed")[0][1]).toEqual({
+      message: "Rebuild failed: site.json is not valid JSON",
+    });
+  });
+
+  it("keeps serving after a failed build", async () => {
+    stubServe(REQUEST);
+    exportSiteMock.mockRejectedValueOnce(new Error("transient"));
+    renderHook(() => useCliServe());
+    await waitFor(() => expect(invokeCalls("serve_failed")).toHaveLength(1));
+
+    emitChange?.();
+    await waitFor(() => expect(invokeCalls("serve_ready")).toHaveLength(1));
+  });
+
+  it("does not build or leak a listener when unmounted mid-setup", async () => {
+    // Unmounting between `listen` resolving and the first build would
+    // otherwise leave a live listener rebuilding a site nobody serves.
+    stubServe(REQUEST);
+    let resolveListen: ((unlisten: () => void) => void) | undefined;
+    vi.mocked(listen).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveListen = resolve as (unlisten: () => void) => void;
+        }),
+    );
+
+    const { unmount } = renderHook(() => useCliServe());
+    await waitFor(() => expect(resolveListen).toBeDefined());
+    unmount();
+    resolveListen?.(unlistenMock);
+
+    await waitFor(() => expect(unlistenMock).toHaveBeenCalled());
+    expect(exportSiteMock).not.toHaveBeenCalled();
+    expect(invokeCalls("serve_ready")).toHaveLength(0);
+  });
+
+  it("stops listening when the shell unmounts", async () => {
+    stubServe(REQUEST);
+    const { unmount } = renderHook(() => useCliServe());
+    await waitFor(() => expect(invokeCalls("serve_ready")).toHaveLength(1));
+
+    unmount();
+    expect(unlistenMock).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCliServe.test.ts
+++ b/src/hooks/useCliServe.test.ts
@@ -143,6 +143,50 @@ describe("useCliServe", () => {
     await waitFor(() => expect(invokeCalls("serve_ready")).toHaveLength(1));
   });
 
+  it("does not report a build that finished after unmount", async () => {
+    // The export is derived output, so finishing is harmless, but telling
+    // Rust to reload browsers for a process that is going away is not.
+    stubServe(REQUEST);
+    let releaseBuild: (() => void) | undefined;
+    exportSiteMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseBuild = () => resolve({ pages: 1, assets: 0 });
+        }),
+    );
+
+    const { unmount } = renderHook(() => useCliServe());
+    await waitFor(() => expect(exportSiteMock).toHaveBeenCalledTimes(1));
+    // A change lands mid-build and queues a rebuild, then the shell goes
+    // away: the queued pass must not start either.
+    emitChange?.();
+    unmount();
+    releaseBuild?.();
+
+    await waitFor(() => expect(unlistenMock).toHaveBeenCalled());
+    expect(invokeCalls("serve_ready")).toHaveLength(0);
+    expect(exportSiteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report a failure that landed after unmount", async () => {
+    stubServe(REQUEST);
+    let rejectBuild: ((err: Error) => void) | undefined;
+    exportSiteMock.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectBuild = reject;
+        }),
+    );
+
+    const { unmount } = renderHook(() => useCliServe());
+    await waitFor(() => expect(exportSiteMock).toHaveBeenCalledTimes(1));
+    unmount();
+    rejectBuild?.(new Error("too late"));
+
+    await waitFor(() => expect(unlistenMock).toHaveBeenCalled());
+    expect(invokeCalls("serve_failed")).toHaveLength(0);
+  });
+
   it("does not build or leak a listener when unmounted mid-setup", async () => {
     // Unmounting between `listen` resolving and the first build would
     // otherwise leave a live listener rebuilding a site nobody serves.

--- a/src/hooks/useCliServe.ts
+++ b/src/hooks/useCliServe.ts
@@ -24,10 +24,12 @@ export function resetCliServeRunner(): void {
  * It renders once on mount, then again on every change Rust reports, telling
  * Rust after each build so the open browsers reload.
  *
- * A failed build is reported and otherwise ignored: the previous site is
- * still on disk and still being served, which is a far better thing to show
- * than a half-written one. On every launch that is not `glyph serve` this is
- * a no-op.
+ * A failed build is reported and otherwise ignored: whatever was exported
+ * last is still on disk and still being served, so the browser keeps showing
+ * a site rather than nothing. That site is not guaranteed to be the previous
+ * one in full, because the export writes pages in place as it goes, so a
+ * failure part way through leaves a mixture (see #707). On every launch that
+ * is not `glyph serve` this is a no-op.
  */
 export function useCliServe(): void {
   const { ready, themes, remarkPlugins, rehypePlugins } = useExportReadiness();
@@ -57,6 +59,11 @@ export function useCliServe(): void {
       try {
         do {
           queued = false;
+          // Checked before each pass, not only after the export: a change
+          // queued while the last one was reporting would otherwise render a
+          // whole site for a process that has already gone.
+          if (disposed) return;
+          let built = false;
           try {
             const { exportSite } = await import("@/lib/export/site/exportSite");
             await exportSite({
@@ -66,13 +73,15 @@ export function useCliServe(): void {
               remarkPlugins: contributions.current.remarkPlugins,
               rehypePlugins: contributions.current.rehypePlugins,
             });
-            if (disposed) return;
-            await invoke("serve_ready");
+            built = true;
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             if (disposed) return;
             await invoke("serve_failed", { message: `Rebuild failed: ${message}` });
           }
+          // Reporting lives outside the try so that an IPC failure is not
+          // announced as a failed build: the site did render.
+          if (built && !disposed) await invoke("serve_ready");
         } while (queued);
       } finally {
         building = false;
@@ -85,7 +94,10 @@ export function useCliServe(): void {
       started = true;
 
       unlisten = await listen(SERVE_CHANGED_EVENT, () => {
-        void build(request.root, request.outDir);
+        // A rejection here would escape as an unhandled one and be reported
+        // as a crash; a rebuild that cannot even report its own failure is
+        // not worth ending the serve loop over.
+        void build(request.root, request.outDir).catch(() => {});
       });
       if (disposed) {
         unlisten();

--- a/src/hooks/useCliServe.ts
+++ b/src/hooks/useCliServe.ts
@@ -1,0 +1,102 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useRef } from "react";
+import { useExportReadiness } from "@/hooks/useExportReadiness";
+import { getCliServeRequest } from "@/lib/cliServe";
+
+/** Rust emits this whenever the watched folder changed, already debounced. */
+export const SERVE_CHANGED_EVENT = "serve://changed";
+
+// Once-per-process latch, for the same reason as the CLI export runner: the
+// effect may fire more than once, but only one serve loop may exist.
+let started = false;
+
+/** Test-only: allow each test to run the effect fresh. */
+export function resetCliServeRunner(): void {
+  started = false;
+}
+
+/**
+ * Runs the render half of `glyph serve`.
+ *
+ * The site pipeline only exists in the renderer, so the process splits in
+ * two: Rust owns the socket and the file watch, this hook owns the export.
+ * It renders once on mount, then again on every change Rust reports, telling
+ * Rust after each build so the open browsers reload.
+ *
+ * A failed build is reported and otherwise ignored: the previous site is
+ * still on disk and still being served, which is a far better thing to show
+ * than a half-written one. On every launch that is not `glyph serve` this is
+ * a no-op.
+ */
+export function useCliServe(): void {
+  const { ready, themes, remarkPlugins, rehypePlugins } = useExportReadiness();
+
+  // Held in refs so a plugin registering late is picked up by the next
+  // rebuild without tearing down and re-registering the change listener.
+  const contributions = useRef({ themes, remarkPlugins, rehypePlugins });
+  contributions.current = { themes, remarkPlugins, rehypePlugins };
+
+  useEffect(() => {
+    if (!ready) return;
+
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    // A change that lands mid-build queues exactly one more build: the
+    // export reads the whole folder, so one more pass covers any number of
+    // edits that arrived while it was running.
+    let building = false;
+    let queued = false;
+
+    const build = async (root: string, outDir: string) => {
+      if (building) {
+        queued = true;
+        return;
+      }
+      building = true;
+      try {
+        do {
+          queued = false;
+          try {
+            const { exportSite } = await import("@/lib/export/site/exportSite");
+            await exportSite({
+              root,
+              outDir,
+              themes: contributions.current.themes,
+              remarkPlugins: contributions.current.remarkPlugins,
+              rehypePlugins: contributions.current.rehypePlugins,
+            });
+            if (disposed) return;
+            await invoke("serve_ready");
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (disposed) return;
+            await invoke("serve_failed", { message: `Rebuild failed: ${message}` });
+          }
+        } while (queued);
+      } finally {
+        building = false;
+      }
+    };
+
+    void (async () => {
+      const request = await getCliServeRequest();
+      if (!request || disposed || started) return;
+      started = true;
+
+      unlisten = await listen(SERVE_CHANGED_EVENT, () => {
+        void build(request.root, request.outDir);
+      });
+      if (disposed) {
+        unlisten();
+        return;
+      }
+      await build(request.root, request.outDir);
+    })();
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [ready]);
+}

--- a/src/hooks/useExportReadiness.test.ts
+++ b/src/hooks/useExportReadiness.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PluginsContext, type PluginsContextValue } from "@/contexts/PluginsContext";
+import { createRegistry } from "@/lib/plugins/registry";
+import { CLI_PLUGIN_WAIT_MS, useExportReadiness } from "./useExportReadiness";
+
+// No SettingsProvider in these renders, so the flag is controlled directly.
+const settings = { loaded: true };
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => settings,
+}));
+
+// Only the fields the gate reads; the full provider surface is irrelevant.
+function pluginsStub(initialLoadDone: boolean): PluginsContextValue {
+  return { siteThemes: createRegistry(), initialLoadDone } as unknown as PluginsContextValue;
+}
+
+function providerWrapper(initialLoadDone: boolean) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(PluginsContext.Provider, { value: pluginsStub(initialLoadDone) }, children);
+}
+
+beforeEach(() => {
+  settings.loaded = true;
+  vi.useRealTimers();
+});
+
+describe("useExportReadiness", () => {
+  it("waits for persisted settings", () => {
+    // The print options an export honours live in settings, so rendering
+    // before they load would quietly produce a different document.
+    settings.loaded = false;
+    const { result } = renderHook(() => useExportReadiness());
+    expect(result.current.ready).toBe(false);
+  });
+
+  it("is ready without a plugin host, which is what tests and a bare app have", () => {
+    const { result } = renderHook(() => useExportReadiness());
+    expect(result.current.ready).toBe(true);
+    expect(result.current.themes).toEqual([]);
+  });
+
+  it("waits for the plugin host's startup load", () => {
+    const { result } = renderHook(() => useExportReadiness(), {
+      wrapper: providerWrapper(false),
+    });
+    expect(result.current.ready).toBe(false);
+  });
+
+  it("is ready once the plugin host has loaded", () => {
+    const { result } = renderHook(() => useExportReadiness(), {
+      wrapper: providerWrapper(true),
+    });
+    expect(result.current.ready).toBe(true);
+  });
+
+  it("gives up on a plugin host that never finishes", async () => {
+    // A hung plugin must not hang a CI job forever: past the wait the render
+    // proceeds with whatever registered, and a missing theme fails loudly.
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useExportReadiness(), {
+        wrapper: providerWrapper(false),
+      });
+      expect(result.current.ready).toBe(false);
+
+      // The expiring timer sets state, so the advance must run inside act.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(CLI_PLUGIN_WAIT_MS + 1);
+      });
+
+      expect(result.current.ready).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/hooks/useExportReadiness.ts
+++ b/src/hooks/useExportReadiness.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { usePluginsOptional } from "@/contexts/PluginsContext";
+import { useRegistryEntries } from "@/hooks/usePluginRegistry";
+import { useSettings } from "@/hooks/useSettings";
+import type { MarkdownPlugin, SiteThemeContribution } from "@/lib/plugins/types";
+
+// How long a headless render waits for the plugin host's startup load. A hung
+// plugin must not hang a CI job forever: past this, the render proceeds with
+// whatever themes have registered (a missing plugin theme then fails loudly
+// with the available ids, which beats a silent stall).
+export const CLI_PLUGIN_WAIT_MS = 10_000;
+
+export interface ExportReadiness {
+  /** Whether a headless render may start. */
+  ready: boolean;
+  /** Plugin-contributed site themes, offered alongside the built-ins. */
+  themes: readonly SiteThemeContribution[];
+  /** Plugin-contributed remark plugins, so plugin syntax renders. */
+  remarkPlugins: readonly MarkdownPlugin[];
+  /** Plugin-contributed rehype plugins, applied before the site rewriter. */
+  rehypePlugins: readonly MarkdownPlugin[];
+}
+
+/**
+ * What a headless render needs before it can start, and when it may.
+ *
+ * Persisted settings carry the print options an export honours, and the
+ * plugin host's startup load decides which themes and syntax extensions
+ * exist, so a render that begins too early silently produces a different
+ * document. Shared by the one-shot CLI export and the serve loop, which
+ * answer to the same conditions.
+ */
+export function useExportReadiness(): ExportReadiness {
+  const plugins = usePluginsOptional();
+  const themes = useRegistryEntries(plugins?.siteThemes ?? null);
+  const remarkPlugins = useRegistryEntries(plugins?.remarkPlugins ?? null);
+  const rehypePlugins = useRegistryEntries(plugins?.rehypePlugins ?? null);
+  // Without a provider there are no plugins to wait for.
+  const pluginsReady = plugins === null || plugins.initialLoadDone;
+  const { loaded } = useSettings();
+
+  const [waitExpired, setWaitExpired] = useState(false);
+  useEffect(() => {
+    if (pluginsReady) return;
+    const timer = window.setTimeout(() => setWaitExpired(true), CLI_PLUGIN_WAIT_MS);
+    return () => window.clearTimeout(timer);
+  }, [pluginsReady]);
+
+  return {
+    ready: loaded && (pluginsReady || waitExpired),
+    themes,
+    remarkPlugins,
+    rehypePlugins,
+  };
+}

--- a/src/hooks/useTabs.session.test.tsx
+++ b/src/hooks/useTabs.session.test.tsx
@@ -312,7 +312,7 @@ describe("useTabs multi-window", () => {
   });
 
   it("a headless export leaves the saved session and recent files alone", async () => {
-    // `glyph notes.md --export pdf` opens the document like any other tab, but
+    // `glyph export notes.md --format pdf` opens the document like any other tab, but
     // it is a renderer, not a session: writing it back would replace the tabs
     // the user has open in the interactive window it is racing.
     vi.mocked(invoke).mockImplementation(

--- a/src/hooks/useWindowRegistrySync.test.tsx
+++ b/src/hooks/useWindowRegistrySync.test.tsx
@@ -122,7 +122,7 @@ describe("useWindowRegistrySync", () => {
   });
 
   it("stays silent in a headless export process", () => {
-    // --export skips single-instance forwarding, so that process has its own
+    // A subcommand skips single-instance forwarding, so that process has its own
     // registry and nothing worth reporting into it.
     vi.mocked(isCliExportProcess).mockReturnValue(true);
     renderHook(() => useWindowRegistrySync(workspace("/ws"), [fileTab("a", "/ws/one.md")], false));

--- a/src/hooks/useWindowRegistrySync.ts
+++ b/src/hooks/useWindowRegistrySync.ts
@@ -35,7 +35,7 @@ export function useWindowRegistrySync(
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: `paths` is derived from `key`, which is the real dependency
   useEffect(() => {
-    // A headless export drives a throwaway window in its own process (--export
+    // A headless export drives a throwaway window in its own process (a
     // skips single-instance forwarding), so its registry is private and there
     // is nothing worth reporting into it.
     if (initializing || isCliExportProcess()) return;

--- a/src/hooks/useWindowReveal.test.ts
+++ b/src/hooks/useWindowReveal.test.ts
@@ -20,6 +20,10 @@ vi.mock("@/hooks/useSettings", () => ({ useSettings: useSettingsMock }));
 const { getCliExportRequestMock } = vi.hoisted(() => ({ getCliExportRequestMock: vi.fn() }));
 vi.mock("@/lib/cliExport", () => ({ getCliExportRequest: getCliExportRequestMock }));
 
+// Same for the serve probe: a serve process is a renderer, not a window.
+const { getCliServeRequestMock } = vi.hoisted(() => ({ getCliServeRequestMock: vi.fn() }));
+vi.mock("@/lib/cliServe", () => ({ getCliServeRequest: getCliServeRequestMock }));
+
 function setLoaded(loaded: boolean) {
   useSettingsMock.mockReturnValue({ loaded });
 }
@@ -31,6 +35,7 @@ describe("useWindowReveal", () => {
     setFocus.mockClear();
     setLoaded(false);
     getCliExportRequestMock.mockResolvedValue(null);
+    getCliServeRequestMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -98,6 +103,18 @@ describe("useWindowReveal", () => {
 
   it("keeps the window hidden for a headless CLI export", async () => {
     getCliExportRequestMock.mockResolvedValue({ root: "/ws", outDir: "/out" });
+    setLoaded(true);
+    renderHook(() => useWindowReveal());
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  it("keeps the window hidden for a serve process", async () => {
+    // `glyph serve` renders the site over and over for the browsers reading
+    // it; showing a window would put a stray app on the user's screen.
+    getCliServeRequestMock.mockResolvedValue({ root: "/ws", outDir: "/tmp/glyph-serve-1" });
     setLoaded(true);
     renderHook(() => useWindowReveal());
 

--- a/src/hooks/useWindowReveal.ts
+++ b/src/hooks/useWindowReveal.ts
@@ -2,6 +2,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect } from "react";
 import { useSettings } from "@/hooks/useSettings";
 import { getCliExportRequest } from "@/lib/cliExport";
+import { getCliServeRequest } from "@/lib/cliServe";
 
 /**
  * Reveals the main window once the app is ready to be seen.
@@ -40,14 +41,17 @@ export function useWindowReveal() {
       }
     };
 
-    // A headless CLI export must never surface the window: the process is a
-    // renderer, not an app the user opened. Everyone else reveals after a
-    // painted frame, with a timeout safety net in case rAF never fires.
-    void getCliExportRequest().then((cliExport) => {
-      if (cliExport || cancelled) return;
-      raf = requestAnimationFrame(() => requestAnimationFrame(reveal));
-      timer = window.setTimeout(reveal, 1000);
-    });
+    // A headless CLI export and a `glyph serve` process must never surface
+    // the window: both are renderers, not an app the user opened. Everyone
+    // else reveals after a painted frame, with a timeout safety net in case
+    // rAF never fires.
+    void Promise.all([getCliExportRequest(), getCliServeRequest()]).then(
+      ([cliExport, cliServe]) => {
+        if (cliExport || cliServe || cancelled) return;
+        raf = requestAnimationFrame(() => requestAnimationFrame(reveal));
+        timer = window.setTimeout(reveal, 1000);
+      },
+    );
 
     return () => {
       cancelled = true;

--- a/src/lib/cliExport.ts
+++ b/src/lib/cliExport.ts
@@ -4,7 +4,7 @@ import type { ExportFormat } from "@/lib/export/writeExport";
 /** The export formats the CLI accepts: the document ones plus the website. */
 export type CliExportFormat = ExportFormat | "site";
 
-/** A `glyph <path> --export <format> [--out <path>]` launch, as stashed by Rust. */
+/** A `glyph export <path> --format <format> [--out <path>]` launch, as stashed by Rust. */
 export interface CliExportRequest {
   input: string;
   format: CliExportFormat;

--- a/src/lib/cliServe.test.ts
+++ b/src/lib/cliServe.test.ts
@@ -1,0 +1,31 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type CliServeRequest, getCliServeRequest, resetCliServeRequestCache } from "./cliServe";
+
+const REQUEST: CliServeRequest = { root: "/ws", outDir: "/tmp/glyph-serve-1" };
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+  resetCliServeRequestCache();
+});
+
+describe("getCliServeRequest", () => {
+  it("asks the backend once and reuses the answer", async () => {
+    vi.mocked(invoke).mockResolvedValue(REQUEST);
+    await expect(getCliServeRequest()).resolves.toEqual(REQUEST);
+    await expect(getCliServeRequest()).resolves.toEqual(REQUEST);
+    // The reveal gate and the serve runner both ask; they must agree, or a
+    // serve process could reveal its window while the other renders.
+    expect(vi.mocked(invoke).mock.calls.filter(([cmd]) => cmd === "get_cli_serve")).toHaveLength(1);
+  });
+
+  it("resolves null outside Tauri instead of rejecting", async () => {
+    vi.mocked(invoke).mockRejectedValue(new Error("no tauri"));
+    await expect(getCliServeRequest()).resolves.toBeNull();
+  });
+
+  it("resolves null on a launch that is not a serve", async () => {
+    vi.mocked(invoke).mockResolvedValue(null);
+    await expect(getCliServeRequest()).resolves.toBeNull();
+  });
+});

--- a/src/lib/cliServe.ts
+++ b/src/lib/cliServe.ts
@@ -1,0 +1,30 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/** A `glyph serve <dir>` launch, as stashed by Rust. */
+export interface CliServeRequest {
+  /** Absolute workspace folder to render and watch. */
+  root: string;
+  /** Absolute directory the site is written to and served from. */
+  outDir: string;
+}
+
+let requestPromise: Promise<CliServeRequest | null> | null = null;
+
+/**
+ * What this process was asked to serve, if anything. Cached module-wide for
+ * the same reason as the export request: the window-reveal gate and the serve
+ * runner both ask, and a serve process must not be revealed by one of them
+ * while the other renders. Resolves null outside Tauri (tests) and on every
+ * launch that is not `glyph serve`.
+ */
+export function getCliServeRequest(): Promise<CliServeRequest | null> {
+  if (!requestPromise) {
+    requestPromise = invoke<CliServeRequest | null>("get_cli_serve").catch(() => null);
+  }
+  return requestPromise;
+}
+
+/** Test-only: forget the cached answer so each test can stub its own. */
+export function resetCliServeRequestCache(): void {
+  requestPromise = null;
+}

--- a/src/lib/export/cliDocumentExport.ts
+++ b/src/lib/export/cliDocumentExport.ts
@@ -13,7 +13,7 @@ interface CliDocumentExportOptions {
 }
 
 /**
- * Run a `glyph <file> --export <format>` request against the document the
+ * Run a `glyph export <file> --format <format>` request against the document the
  * hidden window has open. Goes through the same `exportDocument` the menu uses,
  * so CLI output matches interactive output: inlined code colors, rasterized
  * math, and light-theme vector diagrams all come from the live DOM.


### PR DESCRIPTION
## Summary

Adds a `serve` subcommand: render a folder as a website, keep serving it, and rebuild whenever the folder changes, with pages reloading themselves in the browser.

```bash
glyph serve ~/notes/                    # http://127.0.0.1:4173
glyph serve ~/notes/ --port 0           # let the OS pick a port
glyph serve ~/notes/ --host 0.0.0.0     # let the local network read it
glyph serve ~/notes/ --out ./site       # keep the build
```

Previewing the website export previously meant exporting, starting a separate static server, and refreshing by hand after every edit.

**This PR also renames the export surface**, because adding `serve` as a subcommand left the CLI with two shapes for one kind of job:

```bash
glyph <path> --export <format>          # before
glyph export <path> --format <format>   # after
```

`--export` is removed rather than deprecated, following the project's cleanup convention that a replaced path is deleted rather than left alongside its successor: a second accepted spelling would be the same inconsistency wearing a compatibility hat. Typing it now exits 2 with a message naming the replacement, since it is sitting in people's CI scripts.

**Breaking change, and it needs release notes.** Anyone running `--export` breaks on the next release. Updated here in the same delivery: help text, README, the Docker image's default command, and the CI smoke tests. The satellite action is [glyph-md/export-website-action#2](https://github.com/glyph-md/export-website-action/pull/2), which must merge **after** the release carrying this, not before, or it breaks every caller on `version: latest`.

Closes #703

## Changes

- **CLI** (`src-tauri/src/cli.rs`): `export` and `serve` subcommands sharing one parser. A subcommand counts only as a bare first argument, so a folder named after one still opens as `glyph ./serve`. One path scanner strips flag values before looking for the positional, so `glyph export --out build docs` cannot mistake `build` for the path, and one predicate decides whether a launch does its own work rather than forwarding to a running window. A flag with no subcommand is now a usage error instead of a launch that quietly ignores it. The plugin's declared `export`/`out` args are gone as dead config: everything but the positional path is read from argv.
- **Server** (`src-tauri/src/serve/`): `tower-http`'s `ServeDir` behind hyper, an SSE reload route, and script injection per response. Every crate was already in the tree through Tauri's own HTTP stack; enabling the `fs` feature adds a few small ones (`mime_guess`, `http-range-header`).
- **Watch** (`src-tauri/src/serve/watch.rs`): recursive `notify` watch, 300ms debounce so a burst of saves is one rebuild.
- **Split of work**: the site pipeline only exists in the renderer, so Rust owns the socket, the watch and process lifecycle, while `useCliServe` owns the export and reports back over `serve_ready` / `serve_failed`.
- **`useExportReadiness`**: the settings-and-plugins gate, extracted from `useCliExport` so both headless paths share one copy rather than two.
- Also excludes both subcommands from single-instance forwarding. Without it, `glyph serve` while the app was open exited 0 having served nothing while the running app opened the folder in a tab.

## Risk classification

- [x] Asynchronous ordering / races
- [x] Filesystem / IPC surface
- [x] Untrusted rendering (Markdown, plugins, links)
- [x] Network
- [x] Build / CI

### Invariants at stake and evidence

**INV-3 (a stale result never overwrites a newer one).** Changes arriving mid-build coalesce into exactly one more build: `building` / `queued` are closure-scoped in the single effect, every path funnels through one `build`, and `serve_ready` is awaited before the loop re-enters, so an older completion cannot land after a newer one. Covered by "collapses changes that arrive mid-build into one extra build" in `useCliServe.test.ts`, which holds the first export open, fires three changes, and asserts two builds rather than four.

**INV-5 / INV-6 (untrusted input, the backend is the boundary).** Every containment check is in Rust, not the renderer:

- Traversal: `/../`, `/%2e%2e/`, `/%2e%2e%2f`, `/..%5c` and `/notes/../../` are all refused, asserted against a real file planted outside the served directory (`serve/mod.rs`, `traversal_never_escapes_the_served_directory`).
- **DNS rebinding**: loopback binding alone does not keep a workspace private, because a page on any site can re-point its own hostname at 127.0.0.1 and have the browser treat the result as same-origin. Requests are answered only when `Host` names this server. Tested both ways, and verified live: `-H "Host: evil.com"` gets 403 while `localhost` gets 200.
- Hidden paths are never served, so an `--out` pointing at a working directory does not publish `.env` or `.git/config`.

**INV-7 (a partial result is never presented as complete).** A failed rebuild reports to stderr and pushes no reload, so browsers keep the last version they loaded. This is deliberately *not* claimed to be the previous site in full: the export writes pages in place, so a failure part way through leaves new and old pages mixed. That is #707, filed separately, and the comments, help text and README say what actually happens rather than overstating it.

**Network.** The app's first inbound listener. `docs/security/threat-model.md` gains an entry covering the loopback default, the `--host` opt-in and its warning, the `Host` check, and the fact that the whole `--out` directory is published (which is why an `--out` containing, or contained by, the served folder is refused). What is served is unauthenticated by design: anyone who can reach the port reads the exported site.

**Filesystem.** The temp directory comes from `tempfile` (random name, owner-only) rather than a name derived from the process id under a world-writable temp directory, where a local user could pre-create it or redirect it with a symlink and so choose the HTML the victim's browser loads from localhost.

## Testing

Gates green: 3767 frontend tests, 570 Rust tests, typecheck, Biome, `cargo fmt`, and clippy with `-D warnings`. Codecov reports all modified lines covered.

Verified against the built binary, not only unit tests:

- Ready line prints the folder and URL, process stays up. `GET /` serves the index with the reload script injected; nested pages resolve; unknown paths 404.
- Editing a file pushed `data: reload` on the SSE stream, with the new content served immediately after. Adding a file serves it and adds it to the nav; deleting removes it from the nav.
- `--port 0` bound an OS-assigned port and printed it; a busy port exits 1 with the OS message; usage errors exit 2.
- `--out` files survive the process; the reload script is absent from the files on disk (`grep -c` returns 0), so a site written with `--out` stays a plain static site.
- After the review fixes: `Host: evil.com` 403, `localhost` 200, `/.git/config` 404, HEAD reports the true file size rather than an injected one, live reload still working.
- After the rename, against a rebuilt binary: `glyph export <folder> --format site --out <dir>` and `glyph export <file.md> --format html --out <path>` both exit 0 and write their output; `--help` documents both subcommands; an unknown format and the removed `--export` flag each exit 2, the latter naming its replacement.

A code review pass ran before this PR and found ten warnings; eight are fixed in the second commit, and the other two were documentation overstating behavior, now corrected. The worst was a filter that judged hidden paths absolutely, so serving a folder under a hidden one (`~/.config/notes`, a dotfiles repo) built once and then silently never rebuilt again.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not applicable: the process renders headlessly and shows no window.
