### PR TITLE
feat(vault): index the workspace in Rust

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -78,7 +78,7 @@ and files: <path>`), which never echoes the grant list.
 | Command | Check |
 | ------- | ----- |
 | `read_file`, `get_file_metadata`, `read_directory`, `list_markdown_files`, `scan_wikilinks`, `scan_metadata` | readable |
-| `vault_snapshot`, `vault_refresh`, `vault_backlinks`, `vault_resolve`, `vault_neighbors`, `vault_query`, `vault_paths_with_tag`, `vault_canvas` | root readable (the second path argument is answered from the index in memory, never read from disk, so an ungranted one returns nothing rather than content) |
+| `vault_snapshot`, `vault_refresh`, `vault_backlinks`, `vault_resolve`, `vault_neighbors`, `vault_query`, `vault_paths_with_tag`, `vault_canvas` | granted workspace, not merely readable: the index is per workspace, and a readable check would also accept every directory inside one, letting a caller cache an index per subdirectory. The second path argument is answered from the index in memory, never read from disk, so an ungranted one returns nothing rather than content |
 | `write_file`, `write_binary_file`, `create_dir_all` | writable |
 | `copy_file` | source readable and destination writable |
 | `watch_file`, `watch_directory` | readable (unwatch stays open; it only drops a watcher) |

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -78,6 +78,7 @@ and files: <path>`), which never echoes the grant list.
 | Command | Check |
 | ------- | ----- |
 | `read_file`, `get_file_metadata`, `read_directory`, `list_markdown_files`, `scan_wikilinks`, `scan_metadata` | readable |
+| `vault_snapshot`, `vault_refresh`, `vault_backlinks`, `vault_resolve`, `vault_neighbors`, `vault_query`, `vault_paths_with_tag`, `vault_canvas` | root readable (the second path argument is answered from the index in memory, never read from disk, so an ungranted one returns nothing rather than content) |
 | `write_file`, `write_binary_file`, `create_dir_all` | writable |
 | `copy_file` | source readable and destination writable |
 | `watch_file`, `watch_directory` | readable (unwatch stays open; it only drops a watcher) |
@@ -88,6 +89,10 @@ and files: <path>`), which never echoes the grant list.
 | `workspace_get_last_file`, `workspace_set_last_file` | granted workspace |
 | `sync_*` | granted workspace (`sync_clone_remote` clones into the workspace path itself); `sync_init_repo`, `sync_clone_remote`, and `sync_set_origin` accept only `https://` without credentials, `ssh://`, or scp-like `user@host:path` remotes, since libgit2 would also take a local path or `file://` (pulling any local repository into a granted workspace) and cleartext `http://`/`git://` |
 | `install_plugin` | consumes the pending picked folder; no path argument |
+
+`vault_forget` takes no readable check: it only drops an index the process
+already built, so the worst a renderer can do with it is make the next
+snapshot rebuild from disk.
 
 `workspace_resolve` is deliberately not gated: it is the pre-open probe that
 inspects a folder before it becomes a workspace (the grant is minted when the

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -128,6 +128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1759,7 @@ dependencies = [
  "tower",
  "tower-http",
  "walkdir",
+ "yaml-rust2",
  "zip",
 ]
 
@@ -1869,6 +1876,24 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "heck"
@@ -6994,6 +7019,17 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "yaml-rust2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6edb26322e610d4f04b7cd34478317685d24d0999437e551fb97c5441151041"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
+]
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,11 @@ thiserror = "2"
 # single compiled pattern. Already in the tree transitively.
 regex = "1"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
+# Frontmatter for the vault index. Driven through the event parser rather than
+# `YamlLoader`, because `Event::Scalar` carries the scalar's source text: that
+# is the FAILSAFE behaviour the renderer's js-yaml schema gives, so `2026-04-15`
+# and `true` stay the strings the document shows.
+yaml-rust2 = "0.12"
 # OS credential manager for AI provider API keys (macOS Keychain, Windows
 # Credential Manager, Linux Secret Service). `vendored` builds libdbus from
 # source so Linux builds and CI don't need libdbus-1-dev installed.

--- a/src-tauri/fixtures/vault-frontmatter.json
+++ b/src-tauri/fixtures/vault-frontmatter.json
@@ -1,0 +1,53 @@
+{
+  "Index.md": {
+    "title": "Index",
+    "author": "Ada Lovelace",
+    "tags": [
+      "home",
+      "reference"
+    ],
+    "extra": [
+      [
+        "status",
+        "published"
+      ]
+    ]
+  },
+  "Notes/Cooking.md": {
+    "title": "Cooking",
+    "tags": [
+      "food",
+      "food/baking"
+    ],
+    "extra": []
+  },
+  "Notes/Travel.md": null,
+  "Archive/Travel.md": null,
+  "Archive/Old Note.md": {
+    "date": "2026-04-15",
+    "extra": [
+      [
+        "draft",
+        "true"
+      ],
+      [
+        "version",
+        "1.0"
+      ],
+      [
+        "project",
+        "Glyph Docs"
+      ]
+    ]
+  },
+  "Aliased.md": {
+    "title": "Aliased",
+    "extra": [
+      [
+        "aliases",
+        "Second Name, Third Name"
+      ]
+    ]
+  },
+  "Broken.md": null
+}

--- a/src-tauri/fixtures/vault/Aliased.md
+++ b/src-tauri/fixtures/vault/Aliased.md
@@ -1,0 +1,6 @@
+---
+title: Aliased
+aliases: [Second Name, Third Name]
+---
+
+Reachable under another name.

--- a/src-tauri/fixtures/vault/Archive/Old Note.md
+++ b/src-tauri/fixtures/vault/Archive/Old Note.md
@@ -1,0 +1,8 @@
+---
+date: 2026-04-15
+draft: true
+version: 1.0
+project: Glyph Docs
+---
+
+A note whose name has a space. #archive/old

--- a/src-tauri/fixtures/vault/Archive/Travel.md
+++ b/src-tauri/fixtures/vault/Archive/Travel.md
@@ -1,0 +1,3 @@
+# Travel
+
+The Archive copy, linking [[Travel]] which must stay in Archive.

--- a/src-tauri/fixtures/vault/Board.canvas
+++ b/src-tauri/fixtures/vault/Board.canvas
@@ -1,0 +1,59 @@
+{
+  "nodes": [
+    {
+      "id": "n1",
+      "type": "file",
+      "file": "Notes/Cooking.md",
+      "subpath": "#Recipes",
+      "x": 0,
+      "y": 0,
+      "width": 400,
+      "height": 300
+    },
+    {
+      "id": "n2",
+      "type": "text",
+      "text": "A card about [[Index]]",
+      "x": 500,
+      "y": 0,
+      "width": 400,
+      "height": 300
+    },
+    {
+      "id": "n3",
+      "type": "link",
+      "url": "https://glyph-md.github.io",
+      "x": 0,
+      "y": 400,
+      "width": 400,
+      "height": 300
+    },
+    {
+      "id": "n4",
+      "type": "group",
+      "label": "Kitchen",
+      "x": -50,
+      "y": -50,
+      "width": 1000,
+      "height": 800
+    },
+    {
+      "id": "bad",
+      "type": "text",
+      "text": "no geometry"
+    }
+  ],
+  "edges": [
+    {
+      "id": "e1",
+      "fromNode": "n1",
+      "toNode": "n2",
+      "label": "explains"
+    },
+    {
+      "id": "e2",
+      "fromNode": "n1",
+      "toNode": "ghost"
+    }
+  ]
+}

--- a/src-tauri/fixtures/vault/Broken.md
+++ b/src-tauri/fixtures/vault/Broken.md
@@ -1,0 +1,1 @@
+Nothing here resolves: [[Nowhere]], [[Also Nowhere#Section]].

--- a/src-tauri/fixtures/vault/Index.md
+++ b/src-tauri/fixtures/vault/Index.md
@@ -1,0 +1,11 @@
+---
+title: Index
+author: Ada Lovelace
+tags: [home, reference]
+status: published
+---
+
+# Index
+
+The hub. See [[Cooking]], [[Notes/Travel]], [[Aliased]] and [[Missing Note]].
+Also embeds ![[Board]] and links [[Cooking#Recipes|the recipe section]].

--- a/src-tauri/fixtures/vault/Notes/Cooking.md
+++ b/src-tauri/fixtures/vault/Notes/Cooking.md
@@ -1,0 +1,18 @@
+---
+title: Cooking
+tags:
+  - food
+  - food/baking
+---
+
+# Cooking
+
+## Recipes
+
+Back to [[Index]].
+
+```
+[[NotALink]] and #notatag
+```
+
+Tagged #kitchen and closes #42 for mid#word.

--- a/src-tauri/fixtures/vault/Notes/Travel.md
+++ b/src-tauri/fixtures/vault/Notes/Travel.md
@@ -1,0 +1,3 @@
+# Travel
+
+The Notes copy. Points at [[Index]].

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ pub mod search;
 pub mod secrets;
 #[cfg(desktop)]
 pub mod serve;
-mod walk;
+pub(crate) mod walk;
 pub mod wikilinks;
 
 pub use directory::InitialFolder;

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -3,12 +3,7 @@ use std::path::Path;
 
 use super::walk::{scan_files, ScanStatus, WALK_MAX_DEPTH, WALK_MAX_FILES};
 use crate::grants::GrantRegistry;
-use crate::vault::inline_tags;
-
-// Note content is untrusted, and the index ships every block to the frontend
-// for YAML parsing, so the block is bounded here rather than at the far end.
-// A file whose frontmatter exceeds the cap is indexed for its inline tags only.
-const SCAN_MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
+use crate::vault::{inline_tags, split_frontmatter};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -53,7 +48,10 @@ fn scan_metadata_capped(
         max_files,
         max_depth,
         |p, content| {
-            let (frontmatter, body_start) = split_frontmatter(content);
+            // Rebuilt with newline endings so the frontend parser sees one
+            // shape regardless of the file's own line endings.
+            let (inner, body_start) = split_frontmatter(content);
+            let frontmatter = inner.map(|inner| format!("---\n{inner}---\n"));
             let tags = inline_tags(content.lines().skip(body_start));
             if frontmatter.is_none() && tags.is_empty() {
                 return;
@@ -67,30 +65,6 @@ fn scan_metadata_capped(
     )?;
 
     Ok(MetadataScan { files, status })
-}
-
-/// The leading `---` fenced block (rebuilt with `\n` endings so the frontend
-/// parser sees one shape regardless of the file's line endings) plus the line
-/// index the body starts at. The block is `None` unless the file opens with
-/// the fence and closes it.
-fn split_frontmatter(content: &str) -> (Option<String>, usize) {
-    let mut lines = content.lines();
-    if lines.next().map(str::trim_end) != Some("---") {
-        return (None, 0);
-    }
-    let mut block = String::from("---\n");
-    for (idx, line) in lines.enumerate() {
-        if line.trim_end() == "---" {
-            block.push_str("---\n");
-            return (Some(block), idx + 2);
-        }
-        if block.len() + line.len() > SCAN_MAX_FRONTMATTER_BYTES {
-            return (None, 0);
-        }
-        block.push_str(line);
-        block.push('\n');
-    }
-    (None, 0)
 }
 
 #[cfg(test)]
@@ -211,7 +185,7 @@ mod tests {
     #[test]
     fn scan_metadata_drops_oversized_frontmatter_but_keeps_inline_tags() {
         let dir = unique_tmp("meta_big_frontmatter");
-        let filler = "x".repeat(SCAN_MAX_FRONTMATTER_BYTES + 1);
+        let filler = "x".repeat(9000);
         fs::write(
             dir.join("a.md"),
             format!("---\nnote: {filler}\n---\nBody #alpha\n"),

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -1,16 +1,14 @@
 use serde::Serialize;
 use std::path::Path;
 
-use super::walk::{scan_markdown_files, ScanStatus, WALK_MAX_DEPTH, WALK_MAX_FILES};
+use super::walk::{scan_files, ScanStatus, WALK_MAX_DEPTH, WALK_MAX_FILES};
 use crate::grants::GrantRegistry;
+use crate::vault::inline_tags;
 
 // Note content is untrusted, and the index ships every block to the frontend
-// for YAML parsing, so both the block and each tag are bounded here rather than
-// at the far end. A file whose frontmatter exceeds the cap is indexed for its
-// inline tags only.
+// for YAML parsing, so the block is bounded here rather than at the far end.
+// A file whose frontmatter exceeds the cap is indexed for its inline tags only.
 const SCAN_MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
-const SCAN_MAX_TAG_CHARS: usize = 64;
-const SCAN_MAX_TAGS_PER_FILE: usize = 100;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -49,18 +47,24 @@ fn scan_metadata_capped(
     max_depth: usize,
 ) -> Result<MetadataScan, String> {
     let mut files: Vec<MetadataEntry> = Vec::new();
-    let status = scan_markdown_files(Path::new(path), max_files, max_depth, |p, content| {
-        let (frontmatter, body_start) = split_frontmatter(content);
-        let tags = inline_tags(content.lines().skip(body_start));
-        if frontmatter.is_none() && tags.is_empty() {
-            return;
-        }
-        files.push(MetadataEntry {
-            path: p.to_string_lossy().to_string(),
-            frontmatter,
-            tags,
-        });
-    })?;
+    let status = scan_files(
+        Path::new(path),
+        crate::is_markdown_file,
+        max_files,
+        max_depth,
+        |p, content| {
+            let (frontmatter, body_start) = split_frontmatter(content);
+            let tags = inline_tags(content.lines().skip(body_start));
+            if frontmatter.is_none() && tags.is_empty() {
+                return;
+            }
+            files.push(MetadataEntry {
+                path: p.to_string_lossy().to_string(),
+                frontmatter,
+                tags,
+            });
+        },
+    )?;
 
     Ok(MetadataScan { files, status })
 }
@@ -89,59 +93,11 @@ fn split_frontmatter(content: &str) -> (Option<String>, usize) {
     (None, 0)
 }
 
-fn inline_tags<'a>(body: impl Iterator<Item = &'a str>) -> Vec<String> {
-    let mut tags: Vec<String> = Vec::new();
-    let mut in_fence = false;
-    for line in body {
-        let trimmed_start = line.trim_start();
-        if trimmed_start.starts_with("```") || trimmed_start.starts_with("~~~") {
-            in_fence = !in_fence;
-            continue;
-        }
-        if in_fence {
-            continue;
-        }
-        push_line_tags(line, &mut tags);
-    }
-    tags.sort();
-    tags.dedup();
-    tags.truncate(SCAN_MAX_TAGS_PER_FILE);
-    tags
-}
-
-fn push_line_tags(line: &str, out: &mut Vec<String>) {
-    let chars: Vec<char> = line.chars().collect();
-    let mut i = 0;
-    while i < chars.len() {
-        if chars[i] != '#' || (i > 0 && !chars[i - 1].is_whitespace()) {
-            i += 1;
-            continue;
-        }
-        let start = i + 1;
-        let mut end = start;
-        while end < chars.len() && is_tag_char(chars[end]) {
-            end += 1;
-        }
-        let tag: String = chars[start..end].iter().collect();
-        // A digits-only run is an issue reference (`#42`), not a tag.
-        let usable = !tag.is_empty()
-            && tag.chars().count() <= SCAN_MAX_TAG_CHARS
-            && tag.chars().any(|c| !c.is_ascii_digit());
-        if usable {
-            out.push(tag.to_lowercase());
-        }
-        i = end.max(start);
-    }
-}
-
-fn is_tag_char(c: char) -> bool {
-    c.is_alphanumeric() || c == '_' || c == '-' || c == '/'
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::commands::walk::WALK_MAX_DEPTH;
+    use crate::vault::{MAX_INLINE_TAGS_PER_FILE, MAX_TAG_CHARS};
     use std::fs;
     use std::time::UNIX_EPOCH;
     use tauri::test::{mock_app, MockRuntime};
@@ -273,15 +229,15 @@ mod tests {
     #[test]
     fn scan_metadata_caps_tag_length_and_count() {
         let dir = unique_tmp("meta_tag_caps");
-        let long = "y".repeat(SCAN_MAX_TAG_CHARS + 1);
-        let many: String = (0..SCAN_MAX_TAGS_PER_FILE + 10)
+        let long = "y".repeat(MAX_TAG_CHARS + 1);
+        let many: String = (0..MAX_INLINE_TAGS_PER_FILE + 10)
             .map(|i| format!("#tag{i} "))
             .collect();
         fs::write(dir.join("a.md"), format!("#{long} #ok\n{many}\n")).unwrap();
 
         let files = scan(&dir);
-        assert_eq!(files[0].tags.len(), SCAN_MAX_TAGS_PER_FILE);
-        assert!(!files[0].tags.iter().any(|t| t.len() > SCAN_MAX_TAG_CHARS));
+        assert_eq!(files[0].tags.len(), MAX_INLINE_TAGS_PER_FILE);
+        assert!(!files[0].tags.iter().any(|t| t.len() > MAX_TAG_CHARS));
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/commands/walk.rs
+++ b/src-tauri/src/commands/walk.rs
@@ -10,7 +10,7 @@ pub(crate) const SCAN_MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
 
 /// Whether a workspace scan covered every file, returned alongside the items
 /// so the UI can warn instead of presenting a truncated index as complete.
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScanStatus {
     pub truncated: bool,

--- a/src-tauri/src/commands/walk.rs
+++ b/src-tauri/src/commands/walk.rs
@@ -3,10 +3,10 @@ use std::fs;
 use std::path::Path;
 use walkdir::{DirEntry, WalkDir};
 
-pub(super) const WALK_MAX_DEPTH: usize = 32;
-pub(super) const WALK_MAX_FILES: usize = 10_000;
-pub(super) const WALK_SKIP_DIRS: &[&str] = &[".git", "node_modules", "target", ".svn", ".hg"];
-pub(super) const SCAN_MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
+pub(crate) const WALK_MAX_DEPTH: usize = 32;
+pub(crate) const WALK_MAX_FILES: usize = 10_000;
+pub(crate) const WALK_SKIP_DIRS: &[&str] = &[".git", "node_modules", "target", ".svn", ".hg"];
+pub(crate) const SCAN_MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
 
 /// Whether a workspace scan covered every file, returned alongside the items
 /// so the UI can warn instead of presenting a truncated index as complete.
@@ -49,7 +49,7 @@ impl ScanStatus {
 /// Shared workspace walker: bounded depth, no symlinks, hidden and noisy
 /// directories skipped. Sorted by file name so traversal order (and therefore
 /// which files a capped scan covers) is deterministic across platforms.
-pub(super) fn workspace_walker(root: &Path, max_depth: usize) -> impl Iterator<Item = DirEntry> {
+pub(crate) fn workspace_walker(root: &Path, max_depth: usize) -> impl Iterator<Item = DirEntry> {
     WalkDir::new(root)
         .max_depth(max_depth)
         .follow_links(false)
@@ -68,11 +68,12 @@ pub(super) fn workspace_walker(root: &Path, max_depth: usize) -> impl Iterator<I
         .flatten()
 }
 
-/// Read every markdown file under `root` within the scan caps and hand its
-/// path and contents to `visit`. Oversized and non-UTF-8 files are skipped so
-/// one unreadable note can't fail a whole workspace index.
-pub(super) fn scan_markdown_files(
+/// Read every file under `root` that `accept` selects, within the scan caps,
+/// and hand its path and contents to `visit`. Oversized and non-UTF-8 files are
+/// skipped so one unreadable note can't fail a whole workspace index.
+pub(crate) fn scan_files(
     root: &Path,
+    accept: fn(&Path) -> bool,
     max_files: usize,
     max_depth: usize,
     mut visit: impl FnMut(&Path, &str),
@@ -96,7 +97,7 @@ pub(super) fn scan_markdown_files(
             continue;
         }
         let path = entry.path();
-        if !crate::is_markdown_file(path) {
+        if !accept(path) {
             continue;
         }
         if files_scanned >= max_files {
@@ -139,9 +140,15 @@ mod tests {
         let _ = std::os::unix::fs::symlink(dir.join("real.md"), dir.join("link.md"));
 
         let mut seen: Vec<String> = Vec::new();
-        let status = scan_markdown_files(&dir, WALK_MAX_FILES, WALK_MAX_DEPTH, |path, _| {
-            seen.push(path.file_name().unwrap().to_string_lossy().to_string());
-        })
+        let status = scan_files(
+            &dir,
+            crate::is_markdown_file,
+            WALK_MAX_FILES,
+            WALK_MAX_DEPTH,
+            |path, _| {
+                seen.push(path.file_name().unwrap().to_string_lossy().to_string());
+            },
+        )
         .unwrap();
 
         assert_eq!(seen, vec!["real.md"]);

--- a/src-tauri/src/commands/wikilinks.rs
+++ b/src-tauri/src/commands/wikilinks.rs
@@ -1,10 +1,9 @@
 use serde::Serialize;
 use std::path::Path;
 
-use super::walk::{scan_markdown_files, ScanStatus, WALK_MAX_DEPTH, WALK_MAX_FILES};
+use super::walk::{scan_files, ScanStatus, WALK_MAX_DEPTH, WALK_MAX_FILES};
 use crate::grants::GrantRegistry;
-
-const SCAN_MAX_SNIPPET: usize = 200;
+use crate::vault::snippet_for;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -44,9 +43,15 @@ fn scan_wikilinks_capped(
     max_depth: usize,
 ) -> Result<WikilinkScan, String> {
     let mut refs: Vec<WikilinkRef> = Vec::new();
-    let status = scan_markdown_files(Path::new(path), max_files, max_depth, |p, content| {
-        scan_wikilinks_in_file(content, &p.to_string_lossy(), &mut refs);
-    })?;
+    let status = scan_files(
+        Path::new(path),
+        crate::is_markdown_file,
+        max_files,
+        max_depth,
+        |p, content| {
+            scan_wikilinks_in_file(content, &p.to_string_lossy(), &mut refs);
+        },
+    )?;
 
     Ok(WikilinkScan { refs, status })
 }
@@ -99,20 +104,11 @@ fn scan_wikilinks_in_file(content: &str, source: &str, out: &mut Vec<WikilinkRef
     }
 }
 
-fn snippet_for(line: &str) -> String {
-    let trimmed = line.trim();
-    if trimmed.chars().count() <= SCAN_MAX_SNIPPET {
-        return trimmed.to_string();
-    }
-    let mut out: String = trimmed.chars().take(SCAN_MAX_SNIPPET).collect();
-    out.push('…');
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::commands::walk::{SCAN_MAX_FILE_BYTES, WALK_SKIP_DIRS};
+    use crate::vault::MAX_SNIPPET_CHARS;
     use std::fs;
     use std::time::UNIX_EPOCH;
     use tauri::test::{mock_app, MockRuntime};
@@ -247,7 +243,7 @@ mod tests {
         .refs;
         assert_eq!(refs.len(), 1);
         assert!(refs[0].snippet.ends_with('…'));
-        assert!(refs[0].snippet.chars().count() <= SCAN_MAX_SNIPPET + 1);
+        assert!(refs[0].snippet.chars().count() <= MAX_SNIPPET_CHARS + 1);
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ mod setup;
 mod sync;
 #[cfg(desktop)]
 mod telemetry;
+mod vault;
 mod watcher;
 mod window_events;
 mod windows;
@@ -253,6 +254,7 @@ pub fn run() {
         .manage(commands::CliExport(Mutex::new(None)))
         .manage(windows::WindowRegistry::new())
         .manage(grants::GrantRegistry::default())
+        .manage(vault::commands::VaultStore::default())
         .setup(setup_app)
         .on_window_event(handle_window_event)
         .invoke_handler(tauri::generate_handler![
@@ -303,6 +305,15 @@ pub fn run() {
             commands::create::delete_path,
             commands::wikilinks::scan_wikilinks,
             commands::metadata::scan_metadata,
+            vault::commands::vault_snapshot,
+            vault::commands::vault_refresh,
+            vault::commands::vault_forget,
+            vault::commands::vault_backlinks,
+            vault::commands::vault_resolve,
+            vault::commands::vault_neighbors,
+            vault::commands::vault_query,
+            vault::commands::vault_paths_with_tag,
+            vault::commands::vault_canvas,
             commands::search::search_workspace,
             commands::plugins::list_plugins,
             commands::plugins::inspect_plugin,

--- a/src-tauri/src/vault/canvas.rs
+++ b/src-tauri/src/vault/canvas.rs
@@ -140,12 +140,6 @@ pub(crate) fn extract_canvas(path: &str, content: &str) -> (Note, Canvas) {
             Some(Link {
                 snippet: target.clone(),
                 target,
-                heading: node
-                    .subpath
-                    .as_ref()
-                    .map(|s| s.trim_start_matches('#').to_string()),
-                alias: node.label.clone(),
-                embed: true,
                 line: 0,
             })
         })
@@ -278,8 +272,6 @@ mod tests {
         assert_eq!(note.path, "/w/board.canvas");
         assert_eq!(note.links.len(), 1);
         assert_eq!(note.links[0].target, "Notes/A.md");
-        assert_eq!(note.links[0].heading.as_deref(), Some("Top"));
-        assert!(note.links[0].embed);
     }
 
     #[test]

--- a/src-tauri/src/vault/canvas.rs
+++ b/src-tauri/src/vault/canvas.rs
@@ -1,0 +1,304 @@
+//! JSON Canvas (https://jsoncanvas.org) for the vault index: which cards a
+//! board holds and how they connect. Geometry is rendering data and stays with
+//! the editor's own model; the validation that decides whether a node exists
+//! at all is kept, so both sides see the same set of cards.
+
+use serde::Serialize;
+use serde_json::Value;
+
+use super::note::{Link, Note};
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanvasNode {
+    pub id: String,
+    /// `text`, `file`, `link` or `group`.
+    pub kind: String,
+    pub text: Option<String>,
+    /// Linked path of a file card, relative to the workspace.
+    pub file: Option<String>,
+    /// In-file anchor of a file card, always beginning with `#`.
+    pub subpath: Option<String>,
+    pub url: Option<String>,
+    pub label: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanvasEdge {
+    pub id: String,
+    pub from_node: String,
+    pub to_node: String,
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Canvas {
+    pub nodes: Vec<CanvasNode>,
+    pub edges: Vec<CanvasEdge>,
+}
+
+/// Parse a `.canvas` file. A blank file is an empty board rather than an
+/// error; malformed JSON, or a root that is not an object, indexes as nothing.
+pub(crate) fn parse_canvas(json: &str) -> Option<Canvas> {
+    if json.trim().is_empty() {
+        return Some(Canvas::default());
+    }
+    let Ok(Value::Object(root)) = serde_json::from_str::<Value>(json) else {
+        return None;
+    };
+
+    let nodes: Vec<CanvasNode> = array(root.get("nodes"))
+        .iter()
+        .filter_map(parse_node)
+        .collect();
+    let edges = array(root.get("edges"))
+        .iter()
+        .filter_map(|raw| parse_edge(raw, &nodes))
+        .collect();
+
+    Some(Canvas { nodes, edges })
+}
+
+fn array(value: Option<&Value>) -> &[Value] {
+    value.and_then(Value::as_array).map_or(&[], Vec::as_slice)
+}
+
+fn text(raw: &Value, key: &str) -> Option<String> {
+    raw.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+/// A non-empty string field, for the ones a card cannot exist without.
+fn required(raw: &Value, key: &str) -> Option<String> {
+    text(raw, key).filter(|value| !value.is_empty())
+}
+
+fn parse_node(raw: &Value) -> Option<CanvasNode> {
+    let id = required(raw, "id")?;
+    // Geometry is not indexed, but a card missing it is not a card.
+    for key in ["x", "y", "width", "height"] {
+        raw.get(key)
+            .and_then(Value::as_f64)
+            .filter(|n| n.is_finite())?;
+    }
+
+    let kind = text(raw, "type")?;
+    let mut node = CanvasNode {
+        id,
+        kind: kind.clone(),
+        text: None,
+        file: None,
+        subpath: None,
+        url: None,
+        label: None,
+    };
+    match kind.as_str() {
+        // An empty text card is still a card; only a missing field drops it.
+        "text" => node.text = Some(text(raw, "text")?),
+        "file" => {
+            node.file = required(raw, "file");
+            node.file.as_ref()?;
+            node.subpath = required(raw, "subpath");
+        }
+        "link" => {
+            node.url = required(raw, "url");
+            node.url.as_ref()?;
+        }
+        "group" => node.label = text(raw, "label"),
+        _ => return None,
+    }
+    Some(node)
+}
+
+fn parse_edge(raw: &Value, nodes: &[CanvasNode]) -> Option<CanvasEdge> {
+    let id = required(raw, "id")?;
+    let from_node = required(raw, "fromNode")?;
+    let to_node = required(raw, "toNode")?;
+    // An edge to a card that did not survive parsing is not an edge.
+    let known = |id: &str| nodes.iter().any(|node| node.id == id);
+    if !known(&from_node) || !known(&to_node) {
+        return None;
+    }
+    Some(CanvasEdge {
+        id,
+        from_node,
+        to_node,
+        label: text(raw, "label"),
+    })
+}
+
+/// Index one `.canvas` file: the board itself, plus the note entry that puts
+/// its file cards into the workspace graph as outgoing links.
+pub(crate) fn extract_canvas(path: &str, content: &str) -> (Note, Canvas) {
+    let canvas = parse_canvas(content).unwrap_or_default();
+    let links = canvas
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            let target = node.file.clone()?;
+            Some(Link {
+                snippet: target.clone(),
+                target,
+                heading: node
+                    .subpath
+                    .as_ref()
+                    .map(|s| s.trim_start_matches('#').to_string()),
+                alias: node.label.clone(),
+                embed: true,
+                line: 0,
+            })
+        })
+        .collect();
+
+    let note = Note {
+        path: path.to_string(),
+        links,
+        ..Note::default()
+    };
+    (note, canvas)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(json: &str) -> Option<CanvasNode> {
+        parse_canvas(&format!("{{\"nodes\":[{json}]}}"))?
+            .nodes
+            .into_iter()
+            .next()
+    }
+
+    #[test]
+    fn a_blank_file_is_an_empty_board() {
+        assert_eq!(parse_canvas("   "), Some(Canvas::default()));
+        assert_eq!(parse_canvas("{}"), Some(Canvas::default()));
+    }
+
+    #[test]
+    fn malformed_input_indexes_as_nothing() {
+        assert_eq!(parse_canvas("{not json"), None);
+        assert_eq!(parse_canvas("[1, 2]"), None);
+        assert_eq!(parse_canvas("null"), None);
+    }
+
+    #[test]
+    fn every_card_kind_parses() {
+        let text =
+            node(r##"{"id":"a","type":"text","text":"# Hi","x":0,"y":0,"width":1,"height":1}"##)
+                .unwrap();
+        assert_eq!(text.kind, "text");
+        assert_eq!(text.text.as_deref(), Some("# Hi"));
+
+        let file = node(
+            r##"{"id":"b","type":"file","file":"Notes/A.md","subpath":"#Top","x":0,"y":0,"width":1,"height":1}"##,
+        )
+        .unwrap();
+        assert_eq!(file.file.as_deref(), Some("Notes/A.md"));
+        assert_eq!(file.subpath.as_deref(), Some("#Top"));
+
+        let link = node(
+            r##"{"id":"c","type":"link","url":"https://x.test","x":0,"y":0,"width":1,"height":1}"##,
+        )
+        .unwrap();
+        assert_eq!(link.url.as_deref(), Some("https://x.test"));
+
+        let group =
+            node(r##"{"id":"d","type":"group","label":"Area","x":0,"y":0,"width":1,"height":1}"##)
+                .unwrap();
+        assert_eq!(group.label.as_deref(), Some("Area"));
+    }
+
+    #[test]
+    fn an_empty_text_card_survives_but_a_missing_field_does_not() {
+        assert!(
+            node(r##"{"id":"a","type":"text","text":"","x":0,"y":0,"width":1,"height":1}"##)
+                .is_some()
+        );
+        assert!(node(r##"{"id":"a","type":"text","x":0,"y":0,"width":1,"height":1}"##).is_none());
+        assert!(node(r##"{"id":"b","type":"file","x":0,"y":0,"width":1,"height":1}"##).is_none());
+        assert!(node(r##"{"id":"c","type":"link","x":0,"y":0,"width":1,"height":1}"##).is_none());
+    }
+
+    #[test]
+    fn cards_without_an_id_geometry_or_known_kind_are_dropped() {
+        assert!(node(r##"{"type":"text","text":"x","x":0,"y":0,"width":1,"height":1}"##).is_none());
+        assert!(
+            node(r##"{"id":"a","type":"text","text":"x","y":0,"width":1,"height":1}"##).is_none()
+        );
+        assert!(node(
+            r##"{"id":"a","type":"text","text":"x","x":null,"y":0,"width":1,"height":1}"##
+        )
+        .is_none());
+        assert!(node(r##"{"id":"a","type":"other","x":0,"y":0,"width":1,"height":1}"##).is_none());
+        assert!(node("42").is_none());
+    }
+
+    #[test]
+    fn edges_need_both_endpoints_to_exist() {
+        let canvas = parse_canvas(
+            r##"{"nodes":[
+                {"id":"a","type":"text","text":"a","x":0,"y":0,"width":1,"height":1},
+                {"id":"b","type":"text","text":"b","x":0,"y":0,"width":1,"height":1}
+            ],"edges":[
+                {"id":"e1","fromNode":"a","toNode":"b","label":"via"},
+                {"id":"e2","fromNode":"a","toNode":"ghost"},
+                {"id":"e3","fromNode":"a"}
+            ]}"##,
+        )
+        .unwrap();
+        assert_eq!(
+            canvas.edges,
+            vec![CanvasEdge {
+                id: "e1".into(),
+                from_node: "a".into(),
+                to_node: "b".into(),
+                label: Some("via".into()),
+            }]
+        );
+    }
+
+    #[test]
+    fn non_array_node_and_edge_fields_are_treated_as_empty() {
+        let canvas = parse_canvas(r##"{"nodes":"nope","edges":7}"##).unwrap();
+        assert_eq!(canvas, Canvas::default());
+    }
+
+    #[test]
+    fn file_cards_become_outgoing_links() {
+        let (note, canvas) = extract_canvas(
+            "/w/board.canvas",
+            r##"{"nodes":[
+                {"id":"a","type":"file","file":"Notes/A.md","subpath":"#Top","x":0,"y":0,"width":1,"height":1},
+                {"id":"b","type":"text","text":"card","x":0,"y":0,"width":1,"height":1}
+            ]}"##,
+        );
+        assert_eq!(canvas.nodes.len(), 2);
+        assert_eq!(note.path, "/w/board.canvas");
+        assert_eq!(note.links.len(), 1);
+        assert_eq!(note.links[0].target, "Notes/A.md");
+        assert_eq!(note.links[0].heading.as_deref(), Some("Top"));
+        assert!(note.links[0].embed);
+    }
+
+    #[test]
+    fn an_unreadable_board_indexes_as_an_empty_one() {
+        let (note, canvas) = extract_canvas("/w/board.canvas", "{not json");
+        assert_eq!(canvas, Canvas::default());
+        assert!(note.links.is_empty());
+    }
+
+    #[test]
+    fn serialized_keys_are_camel_case() {
+        let json = serde_json::to_string(&CanvasEdge {
+            id: "e".into(),
+            from_node: "a".into(),
+            to_node: "b".into(),
+            label: None,
+        })
+        .unwrap();
+        assert!(json.contains("\"fromNode\":\"a\""));
+        assert!(!json.contains("from_node"));
+    }
+}

--- a/src-tauri/src/vault/commands.rs
+++ b/src-tauri/src/vault/commands.rs
@@ -11,13 +11,22 @@ use serde_json::Value;
 use super::Vault;
 use crate::grants::GrantRegistry;
 
-/// One index per open workspace root, keyed by the root exactly as the caller
-/// spells it, so indexed paths keep matching the frontend's tab paths.
+/// One index per open workspace root, keyed by the root's canonical path. The
+/// key cannot be the caller's spelling: `<ws>`, `<ws>/`, and `<ws>/./.` are one
+/// workspace, and a renderer that cached an index under each would grow this
+/// map without bound. `Vault.root` keeps the caller's spelling instead, so
+/// indexed paths still match the frontend's tab paths.
 #[derive(Default)]
-pub struct VaultStore(pub Mutex<HashMap<String, Vault>>);
+pub struct VaultStore(pub Mutex<HashMap<PathBuf, Vault>>);
 
-fn lock(store: &VaultStore) -> Result<std::sync::MutexGuard<'_, HashMap<String, Vault>>, String> {
+fn lock(store: &VaultStore) -> Result<std::sync::MutexGuard<'_, HashMap<PathBuf, Vault>>, String> {
     store.0.lock().map_err(|e| format!("Lock error: {e}"))
+}
+
+/// The store key for a root that has not been through a grant check.
+fn key_for(root: &str) -> PathBuf {
+    let path = Path::new(root);
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Run `read` against the index for `root`, building it first if this is the
@@ -28,17 +37,19 @@ fn with_vault<T>(
     store: &VaultStore,
     read: impl FnOnce(&Vault) -> Result<T, String>,
 ) -> Result<T, String> {
-    grants.ensure_readable(root)?;
-    if !lock(store)?.contains_key(root) {
+    // `ensure_workspace`, not `ensure_readable`: the index is per workspace,
+    // and a readable check would also accept every directory inside one.
+    let key = grants.ensure_workspace(root)?;
+    if !lock(store)?.contains_key(&key) {
         // Built outside the lock: the walk reads the whole workspace, and
         // holding the store through it would stall every other root's queries
-        // and block the watcher thread behind them. A concurrent build of the
-        // same root loses the race and is discarded rather than replacing an
-        // index that has since taken watcher updates.
+        // and block the watcher thread behind them. A build that loses the race
+        // is discarded rather than replacing an index that has since taken
+        // watcher updates.
         let vault = Vault::build(Path::new(root))?;
-        lock(store)?.entry(root.to_string()).or_insert(vault);
+        lock(store)?.entry(key.clone()).or_insert(vault);
     }
-    read(lock(store)?.get(root).ok_or("index was released")?)
+    read(lock(store)?.get(&key).ok_or("index was released")?)
 }
 
 fn to_value<T: serde::Serialize>(value: T) -> Result<Value, String> {
@@ -48,11 +59,16 @@ fn to_value<T: serde::Serialize>(value: T) -> Result<Value, String> {
 /// Re-index the changed paths under `root`. Called from the directory watcher
 /// before it tells the frontend to refresh, so the snapshot the frontend then
 /// asks for is already current.
+///
+/// The store lock is held across the re-read and the rebuild. That is the
+/// opposite trade to the initial build, and deliberate: an update touches the
+/// paths that changed rather than the whole workspace, and letting a snapshot
+/// interleave with it would serve a half-applied index.
 pub fn apply_changes(store: &VaultStore, root: &str, paths: &[PathBuf]) {
     let Ok(mut vaults) = store.0.lock() else {
         return;
     };
-    if let Some(vault) = vaults.get_mut(root) {
+    if let Some(vault) = vaults.get_mut(&key_for(root)) {
         vault.apply_changes(paths);
     }
 }
@@ -61,7 +77,7 @@ pub fn apply_changes(store: &VaultStore, root: &str, paths: &[PathBuf]) {
 /// holds every note's tags, fields and links for the rest of the session.
 pub fn forget(store: &VaultStore, root: &str) {
     if let Ok(mut vaults) = store.0.lock() {
-        vaults.remove(root);
+        vaults.remove(&key_for(root));
     }
 }
 
@@ -81,14 +97,14 @@ pub fn vault_refresh(
     grants: tauri::State<'_, GrantRegistry>,
     store: tauri::State<'_, VaultStore>,
 ) -> Result<Value, String> {
-    grants.ensure_readable(&path)?;
+    let key = grants.ensure_workspace(&path)?;
+    // A refresh is the frontend saying it wants the disk's answer, so unlike
+    // `with_vault` this one replaces whatever is cached, including an index
+    // that took watcher updates while the walk ran.
     let vault = Vault::build(Path::new(&path))?;
-    // Stored first, then read back under the same lock: a watcher update that
-    // landed while the walk ran would otherwise be reported as absent by a
-    // snapshot taken from the copy that predates it.
     let mut vaults = lock(&store)?;
-    vaults.insert(path.clone(), vault);
-    to_value(vaults[&path].snapshot())
+    vaults.insert(key.clone(), vault);
+    to_value(vaults[&key].snapshot())
 }
 
 #[tauri::command]

--- a/src-tauri/src/vault/commands.rs
+++ b/src-tauri/src/vault/commands.rs
@@ -1,0 +1,183 @@
+//! The Tauri surface over [`Vault`]. Every command checks the grant registry
+//! before the core touches the filesystem; the core itself takes no app handle,
+//! so a headless process reaches it directly.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde_json::Value;
+
+use super::Vault;
+use crate::grants::GrantRegistry;
+
+/// One index per open workspace root, keyed by the root exactly as the caller
+/// spells it, so indexed paths keep matching the frontend's tab paths.
+#[derive(Default)]
+pub struct VaultStore(pub Mutex<HashMap<String, Vault>>);
+
+fn lock(store: &VaultStore) -> Result<std::sync::MutexGuard<'_, HashMap<String, Vault>>, String> {
+    store.0.lock().map_err(|e| format!("Lock error: {e}"))
+}
+
+/// Run `read` against the index for `root`, building it first if this is the
+/// first call for that root.
+fn with_vault<T>(
+    root: &str,
+    grants: &GrantRegistry,
+    store: &VaultStore,
+    read: impl FnOnce(&Vault) -> Result<T, String>,
+) -> Result<T, String> {
+    grants.ensure_readable(root)?;
+    if !lock(store)?.contains_key(root) {
+        // Built outside the lock: the walk reads the whole workspace, and
+        // holding the store through it would stall every other root's queries
+        // and block the watcher thread behind them. A concurrent build of the
+        // same root loses the race and is discarded rather than replacing an
+        // index that has since taken watcher updates.
+        let vault = Vault::build(Path::new(root))?;
+        lock(store)?.entry(root.to_string()).or_insert(vault);
+    }
+    read(lock(store)?.get(root).ok_or("index was released")?)
+}
+
+fn to_value<T: serde::Serialize>(value: T) -> Result<Value, String> {
+    serde_json::to_value(value).map_err(|e| format!("Failed to serialize index: {e}"))
+}
+
+/// Re-index the changed paths under `root`. Called from the directory watcher
+/// before it tells the frontend to refresh, so the snapshot the frontend then
+/// asks for is already current.
+pub fn apply_changes(store: &VaultStore, root: &str, paths: &[PathBuf]) {
+    let Ok(mut vaults) = store.0.lock() else {
+        return;
+    };
+    if let Some(vault) = vaults.get_mut(root) {
+        vault.apply_changes(paths);
+    }
+}
+
+/// Drop the index for a closing workspace. Nothing else releases it, and it
+/// holds every note's tags, fields and links for the rest of the session.
+pub fn forget(store: &VaultStore, root: &str) {
+    if let Ok(mut vaults) = store.0.lock() {
+        vaults.remove(root);
+    }
+}
+
+#[tauri::command]
+pub fn vault_snapshot(
+    path: String,
+    grants: tauri::State<'_, GrantRegistry>,
+    store: tauri::State<'_, VaultStore>,
+) -> Result<Value, String> {
+    with_vault(&path, &grants, &store, |vault| to_value(vault.snapshot()))
+}
+
+/// Rebuild the index for `path` from disk, discarding what is cached for it.
+#[tauri::command]
+pub fn vault_refresh(
+    path: String,
+    grants: tauri::State<'_, GrantRegistry>,
+    store: tauri::State<'_, VaultStore>,
+) -> Result<Value, String> {
+    grants.ensure_readable(&path)?;
+    let vault = Vault::build(Path::new(&path))?;
+    // Stored first, then read back under the same lock: a watcher update that
+    // landed while the walk ran would otherwise be reported as absent by a
+    // snapshot taken from the copy that predates it.
+    let mut vaults = lock(&store)?;
+    vaults.insert(path.clone(), vault);
+    to_value(vaults[&path].snapshot())
+}
+
+#[tauri::command]
+pub fn vault_forget(path: String, store: tauri::State<'_, VaultStore>) -> Result<(), String> {
+    forget(&store, &path);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn vault_backlinks(
+    root: String,
+    path: String,
+    grants: tauri::State<'_, GrantRegistry>,
+    store: tauri::State<'_, VaultStore>,
+) -> Result<Value, String> {
+    with_vault(&root, &grants, &store, |vault| {
+        to_value(vault.backlinks(&path))
+    })
+}
+
+#[tauri::command]
+pub fn vault_resolve(
+    root: String,
+    from: Option<String>,
+    targets: Vec<String>,
+    grants: tauri::State<'_, GrantRegistry>,
+    store: tauri::State<'_, VaultStore>,
+) -> Result<Vec<Option<String>>, String> {
+    with_vault(&root, &grants, &store, |vault| {
+        Ok(vault
+            .resolve_many(from.as_deref(), &targets)
+            .into_iter()
+            .map(|path| path.map(str::to_string))
+            .collect())
+    })
+}
+
+#[tauri::command]
+pub fn vault_neighbors(
+    root: String,
+    path: String,
+    grants: tauri::State<'_, GrantRegistry>,
+    store: tauri::State<'_, VaultStore>,
+) -> Result<Vec<String>, String> {
+    with_vault(&root, &grants, &store, |vault| {
+        Ok(vault
+            .neighbors(&path)
+            .into_iter()
+            .map(str::to_string)
+            .collect())
+    })
+}
+
+#[tauri::command]
+pub fn vault_query(
+    root: String,
+    query: String,
+    grants: tauri::State<'_, GrantRegistry>,
+    store: tauri::State<'_, VaultStore>,
+) -> Result<Value, String> {
+    with_vault(&root, &grants, &store, |vault| {
+        to_value(vault.query(&query))
+    })
+}
+
+#[tauri::command]
+pub fn vault_paths_with_tag(
+    root: String,
+    tag: String,
+    grants: tauri::State<'_, GrantRegistry>,
+    store: tauri::State<'_, VaultStore>,
+) -> Result<Vec<String>, String> {
+    with_vault(&root, &grants, &store, |vault| {
+        Ok(vault
+            .paths_with_tag(&tag)
+            .into_iter()
+            .map(str::to_string)
+            .collect())
+    })
+}
+
+#[tauri::command]
+pub fn vault_canvas(
+    root: String,
+    path: String,
+    grants: tauri::State<'_, GrantRegistry>,
+    store: tauri::State<'_, VaultStore>,
+) -> Result<Option<Value>, String> {
+    with_vault(&root, &grants, &store, |vault| {
+        vault.canvas(&path).map(to_value).transpose()
+    })
+}

--- a/src-tauri/src/vault/frontmatter.rs
+++ b/src-tauri/src/vault/frontmatter.rs
@@ -1,0 +1,481 @@
+//! Frontmatter for the vault index, parsed with FAILSAFE semantics: every
+//! scalar keeps its source text, so `2026-04-15`, `true` and `1.0` stay the
+//! strings the document shows. Sequences and mappings still parse, which is
+//! all `tags: [a, b]` needs.
+//!
+//! This tracks `src/lib/frontmatter.ts`, which parses the same block for the
+//! renderer and the exporters. `fixtures/vault/` and `vault-frontmatter.json`
+//! pin the fields, values and orderings both are expected to produce. Three
+//! behaviours are known to differ and are deliberately not asserted there: an
+//! explicit type tag such as `!!int` (which makes js-yaml's FAILSAFE schema
+//! throw and this parser keep the scalar), the ordering of an integer-like
+//! extra key (which `Object.entries` hoists on the JavaScript side), and an
+//! anchor pointing at a sequence or mapping rather than a scalar.
+
+use std::collections::HashMap;
+
+use yaml_rust2::parser::{Event, EventReceiver, Parser};
+
+/// The block is untrusted note content and every field reaches the frontend,
+/// so it is bounded here rather than at the far end. A file whose frontmatter
+/// exceeds the cap is indexed for its inline tags only.
+const MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
+/// How deeply a block may nest. The parser recurses once per level and a
+/// stack overflow aborts the process rather than unwinding, so this is checked
+/// against the source text before the parser sees it. Frontmatter that nests
+/// past this is pathological; real notes sit in single digits.
+const MAX_NESTING_DEPTH: usize = 64;
+
+#[derive(Debug, PartialEq)]
+enum Value {
+    Scalar(String),
+    Sequence(Vec<Value>),
+    Mapping(Vec<(String, Value)>),
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct Frontmatter {
+    pub title: Option<String>,
+    pub author: Option<String>,
+    pub date: Option<String>,
+    pub tags: Vec<String>,
+    /// `aliases:` in list or scalar form. Also present in `extra` as the
+    /// joined string the renderer displays.
+    pub aliases: Vec<String>,
+    /// Every other key, in source order, with its original casing.
+    pub extra: Vec<(String, String)>,
+}
+
+impl Frontmatter {
+    fn is_empty(&self) -> bool {
+        self.title.is_none()
+            && self.author.is_none()
+            && self.date.is_none()
+            && self.tags.is_empty()
+            && self.extra.is_empty()
+    }
+}
+
+/// The leading `---` fenced block's inner text plus the line index the body
+/// starts at. `None` unless the file opens with the fence and closes it within
+/// the byte cap.
+pub(crate) fn split_frontmatter(content: &str) -> (Option<String>, usize) {
+    // `lines` has already taken the `\r` of a CRLF ending, and the renderer's
+    // pattern allows nothing else around the delimiter, so `---   ` opens no
+    // block there and must open none here.
+    let mut lines = content.lines();
+    if lines.next() != Some("---") {
+        return (None, 0);
+    }
+    let mut inner = String::new();
+    for (idx, line) in lines.enumerate() {
+        if line == "---" {
+            return (Some(inner), idx + 2);
+        }
+        if inner.len() + line.len() > MAX_FRONTMATTER_BYTES {
+            return (None, 0);
+        }
+        inner.push_str(line);
+        inner.push('\n');
+    }
+    (None, 0)
+}
+
+/// Parse the inner text of a frontmatter block. `None` when the YAML is
+/// malformed, is not a mapping, or carries nothing worth showing.
+pub(crate) fn parse_frontmatter(inner: &str) -> Option<Frontmatter> {
+    let entries = match parse_mapping(inner)? {
+        Value::Mapping(entries) => entries,
+        _ => return None,
+    };
+
+    let mut out = Frontmatter::default();
+    for (key, value) in &entries {
+        match key.as_str() {
+            "title" => out.title = non_empty_scalar(value),
+            "author" => out.author = non_empty_scalar(value),
+            "date" => out.date = non_empty_scalar(value),
+            "tags" => out.tags = string_list(value),
+            _ => {
+                if key == "aliases" {
+                    out.aliases = string_list(value);
+                }
+                if let Some(text) = stringify(value) {
+                    out.extra.push((key.clone(), text));
+                }
+            }
+        }
+    }
+
+    if out.is_empty() {
+        return None;
+    }
+    Some(out)
+}
+
+fn non_empty_scalar(value: &Value) -> Option<String> {
+    match value {
+        Value::Scalar(s) if !s.is_empty() => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// `tags: [a, b]`, `tags:\n  - a` and `tags: a` all reach the index as a list.
+fn string_list(value: &Value) -> Vec<String> {
+    match value {
+        Value::Sequence(items) => items.iter().filter_map(non_empty_scalar).collect(),
+        Value::Scalar(s) if !s.is_empty() => vec![s.clone()],
+        _ => Vec::new(),
+    }
+}
+
+/// How a field renders: a string as itself, a sequence joined, anything else
+/// dropped.
+fn stringify(value: &Value) -> Option<String> {
+    match value {
+        Value::Scalar(s) if !s.is_empty() => Some(s.clone()),
+        Value::Sequence(items) => {
+            let parts: Vec<String> = items
+                .iter()
+                .filter_map(|item| match item {
+                    Value::Scalar(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join(", "))
+            }
+        }
+        _ => None,
+    }
+}
+
+enum Frame {
+    Sequence(Vec<Value>),
+    Mapping {
+        entries: Vec<(String, Value)>,
+        key: Option<String>,
+    },
+}
+
+#[derive(Default)]
+struct Builder {
+    stack: Vec<Frame>,
+    root: Option<Value>,
+    rejected: bool,
+    /// Scalars carrying an `&anchor`, so a later `*alias` resolves to the same
+    /// text the renderer's parser substitutes.
+    anchors: HashMap<usize, String>,
+}
+
+impl Builder {
+    fn push(&mut self, value: Value) {
+        match self.stack.last_mut() {
+            Some(Frame::Sequence(items)) => items.push(value),
+            Some(Frame::Mapping { entries, key }) => match key.take() {
+                Some(k) => entries.push((k, value)),
+                // A non-scalar mapping key. The renderer's parser rejects the
+                // document outright; matching that keeps the two in step.
+                None => self.rejected = true,
+            },
+            None => {
+                if self.root.is_some() {
+                    self.rejected = true;
+                } else {
+                    self.root = Some(value);
+                }
+            }
+        }
+    }
+
+    fn open(&mut self, frame: Frame) {
+        self.stack.push(frame);
+    }
+
+    fn close(&mut self) {
+        let value = match self.stack.pop() {
+            Some(Frame::Sequence(items)) => Value::Sequence(items),
+            Some(Frame::Mapping { entries, key }) => {
+                if key.is_some() || has_duplicate_key(&entries) {
+                    self.rejected = true;
+                }
+                Value::Mapping(entries)
+            }
+            None => {
+                self.rejected = true;
+                return;
+            }
+        };
+        self.push(value);
+    }
+}
+
+impl EventReceiver for Builder {
+    fn on_event(&mut self, ev: Event) {
+        match ev {
+            Event::Scalar(text, _, anchor, _) => {
+                if anchor > 0 {
+                    self.anchors.insert(anchor, text.clone());
+                }
+                match self.stack.last_mut() {
+                    Some(Frame::Mapping {
+                        key: key @ None, ..
+                    }) => *key = Some(text),
+                    _ => self.push(Value::Scalar(text)),
+                }
+            }
+            // An anchor on a sequence or mapping resolves to nothing, which is
+            // what a field holding one already shows.
+            Event::Alias(anchor) => {
+                let text = self.anchors.get(&anchor).cloned().unwrap_or_default();
+                self.push(Value::Scalar(text));
+            }
+            Event::SequenceStart(..) => self.open(Frame::Sequence(Vec::new())),
+            Event::MappingStart(..) => self.open(Frame::Mapping {
+                entries: Vec::new(),
+                key: None,
+            }),
+            Event::SequenceEnd | Event::MappingEnd => self.close(),
+            _ => {}
+        }
+    }
+}
+
+/// Whether `inner` nests past [`MAX_NESTING_DEPTH`] anywhere. Counted from the
+/// source text because the parser recurses one frame per level as it reads,
+/// so a block that is too deep has already overflowed the stack by the time
+/// any event arrives. The three ways to open a level are an unclosed flow
+/// bracket, a repeated `- ` on one line, and indentation.
+fn too_deep(inner: &str) -> bool {
+    let mut flow = 0usize;
+    for line in inner.lines() {
+        let indent = line.len() - line.trim_start_matches([' ', '\t']).len();
+        let dashes = line
+            .trim_start_matches([' ', '\t'])
+            .split("- ")
+            .count()
+            .saturating_sub(1);
+        if indent > MAX_NESTING_DEPTH || dashes > MAX_NESTING_DEPTH {
+            return true;
+        }
+        for c in line.chars() {
+            match c {
+                '[' | '{' => flow += 1,
+                ']' | '}' => flow = flow.saturating_sub(1),
+                _ => {}
+            }
+            if flow > MAX_NESTING_DEPTH {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn parse_mapping(inner: &str) -> Option<Value> {
+    if too_deep(inner) {
+        return None;
+    }
+    let mut builder = Builder::default();
+    Parser::new_from_str(inner).load(&mut builder, false).ok()?;
+    if builder.rejected || !builder.stack.is_empty() {
+        return None;
+    }
+    let root = builder.root?;
+    let Value::Mapping(entries) = &root else {
+        return None;
+    };
+    if has_duplicate_key(entries) {
+        return None;
+    }
+    Some(root)
+}
+
+/// js-yaml throws on a duplicate mapping key, so a block carrying one shows
+/// nothing in the renderer and must index as nothing here too. Nested mappings
+/// are checked as they close; this covers the root, which never does.
+fn has_duplicate_key(entries: &[(String, Value)]) -> bool {
+    let mut seen: Vec<&str> = Vec::with_capacity(entries.len());
+    for (key, _) in entries {
+        if seen.contains(&key.as_str()) {
+            return true;
+        }
+        seen.push(key);
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(block: &str) -> Option<Frontmatter> {
+        let (inner, _) = split_frontmatter(block);
+        parse_frontmatter(&inner?)
+    }
+
+    #[test]
+    fn no_frontmatter_yields_nothing() {
+        assert_eq!(parse("# Heading\n\nBody\n"), None);
+        // The block must open the file, exactly as the renderer requires.
+        assert_eq!(parse("intro\n---\ntitle: Note\n---\n"), None);
+    }
+
+    #[test]
+    fn unterminated_block_yields_nothing() {
+        assert_eq!(parse("---\ntitle: Note\n\nBody\n"), None);
+    }
+
+    #[test]
+    fn known_fields_are_read() {
+        let fm = parse("---\ntitle: Note\nauthor: Ada\ndate: 2026-04-15\n---\n").unwrap();
+        assert_eq!(fm.title.as_deref(), Some("Note"));
+        assert_eq!(fm.author.as_deref(), Some("Ada"));
+        assert_eq!(fm.date.as_deref(), Some("2026-04-15"));
+    }
+
+    #[test]
+    fn scalars_keep_their_source_text() {
+        let fm =
+            parse("---\ndate: 2026-04-15\ndraft: true\nversion: 1.0\ncount: 007\n---\n").unwrap();
+        assert_eq!(fm.date.as_deref(), Some("2026-04-15"));
+        assert_eq!(
+            fm.extra,
+            vec![
+                ("draft".to_string(), "true".to_string()),
+                ("version".to_string(), "1.0".to_string()),
+                ("count".to_string(), "007".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn quoted_scalars_lose_their_quotes() {
+        let fm = parse("---\ntitle: \"Quoted\"\nnote: 'single'\n---\n").unwrap();
+        assert_eq!(fm.title.as_deref(), Some("Quoted"));
+        assert_eq!(fm.extra, vec![("note".to_string(), "single".to_string())]);
+    }
+
+    #[test]
+    fn tags_parse_from_flow_and_block_sequences_and_a_scalar() {
+        let flow = parse("---\ntags: [work, ideas]\n---\n").unwrap();
+        assert_eq!(flow.tags, vec!["work", "ideas"]);
+
+        let block = parse("---\ntags:\n  - work\n  - ideas\n---\n").unwrap();
+        assert_eq!(block.tags, vec!["work", "ideas"]);
+
+        let scalar = parse("---\ntags: work\n---\n").unwrap();
+        assert_eq!(scalar.tags, vec!["work"]);
+    }
+
+    #[test]
+    fn aliases_are_listed_and_still_shown_as_a_field() {
+        let fm = parse("---\ntitle: Note\naliases: [Alt, Other]\n---\n").unwrap();
+        assert_eq!(fm.aliases, vec!["Alt", "Other"]);
+        assert_eq!(
+            fm.extra,
+            vec![("aliases".to_string(), "Alt, Other".to_string())]
+        );
+    }
+
+    #[test]
+    fn sequence_fields_join_with_commas_and_mappings_are_dropped() {
+        let fm = parse("---\nlinks: [a, b]\nnested:\n  key: value\ntitle: Note\n---\n").unwrap();
+        assert_eq!(fm.extra, vec![("links".to_string(), "a, b".to_string())]);
+        assert_eq!(fm.title.as_deref(), Some("Note"));
+    }
+
+    #[test]
+    fn empty_values_are_dropped() {
+        assert_eq!(parse("---\ntitle:\nauthor:\n---\n"), None);
+        let fm = parse("---\ntitle:\nkeep: yes\n---\n").unwrap();
+        assert!(fm.title.is_none());
+        assert_eq!(fm.extra, vec![("keep".to_string(), "yes".to_string())]);
+    }
+
+    #[test]
+    fn malformed_yaml_yields_nothing() {
+        assert_eq!(parse("---\n\tbad: [unclosed\n---\n"), None);
+    }
+
+    #[test]
+    fn a_non_mapping_root_yields_nothing() {
+        assert_eq!(parse("---\n- one\n- two\n---\n"), None);
+        assert_eq!(parse("---\njust a string\n---\n"), None);
+        assert_eq!(parse("---\n---\n"), None);
+    }
+
+    #[test]
+    fn a_duplicate_key_yields_nothing() {
+        assert_eq!(parse("---\ntitle: One\ntitle: Two\n---\n"), None);
+    }
+
+    #[test]
+    fn crlf_blocks_parse() {
+        let fm = parse("---\r\ntitle: Note\r\ntags: [a]\r\n---\r\n").unwrap();
+        assert_eq!(fm.title.as_deref(), Some("Note"));
+        assert_eq!(fm.tags, vec!["a"]);
+    }
+
+    #[test]
+    fn an_oversized_block_is_skipped_entirely() {
+        let block = format!(
+            "---\nbig: {}\n---\nbody\n",
+            "x".repeat(MAX_FRONTMATTER_BYTES)
+        );
+        assert_eq!(split_frontmatter(&block), (None, 0));
+    }
+
+    #[test]
+    fn deeply_nested_values_are_refused_before_the_parser_recurses() {
+        // Each of these opens one parser frame per level, and the parser
+        // recurses as it reads: reaching it at all overflows the stack, which
+        // aborts the process rather than unwinding. The block cap allows
+        // thousands of levels, so the depth check has to come first.
+        let depth = MAX_NESTING_DEPTH + 5;
+        let flow = format!("key: {}{}", "[".repeat(depth), "]".repeat(depth));
+        assert_eq!(parse_frontmatter(&flow), None);
+
+        let block_sequence = format!("{}x\n", "- ".repeat(1_000));
+        assert_eq!(parse_frontmatter(&block_sequence), None);
+
+        let indented = format!("{}deep: value\n", " ".repeat(depth + 1));
+        assert_eq!(parse_frontmatter(&indented), None);
+
+        // A block that nests normally still parses.
+        let shallow = "outer:\n  middle:\n    inner: value\ntitle: Note\n";
+        assert!(parse_frontmatter(shallow).is_some());
+    }
+
+    #[test]
+    fn an_alias_resolves_to_its_anchor() {
+        let fm = parse("---\nauthor: &who Ada\ncredit: *who\n---\n").unwrap();
+        assert_eq!(fm.author.as_deref(), Some("Ada"));
+        assert_eq!(fm.extra, vec![("credit".to_string(), "Ada".to_string())]);
+    }
+
+    #[test]
+    fn a_duplicate_key_nested_in_a_mapping_yields_nothing() {
+        assert_eq!(
+            parse("---\ntitle: Note\nnested:\n  a: 1\n  a: 2\n---\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_delimiter_with_trailing_space_is_not_a_fence() {
+        // The renderer's pattern does not accept it, so neither does the index.
+        assert_eq!(parse("---   \ntitle: Note\n---\n"), None);
+        assert_eq!(parse("---\ntitle: Note\n---   \n"), None);
+    }
+
+    #[test]
+    fn body_starts_after_the_closing_fence() {
+        let (inner, body_start) = split_frontmatter("---\ntitle: Note\n---\n\n#tag body\n");
+        assert_eq!(inner.as_deref(), Some("title: Note\n"));
+        // Lines 0 to 2 are the block itself, so the body opens at line 3.
+        assert_eq!(body_start, 3);
+    }
+}

--- a/src-tauri/src/vault/frontmatter.rs
+++ b/src-tauri/src/vault/frontmatter.rs
@@ -10,9 +10,10 @@
 //! explicit type tag such as `!!int` (which makes js-yaml's FAILSAFE schema
 //! throw and this parser keep the scalar), the ordering of an integer-like
 //! extra key (which `Object.entries` hoists on the JavaScript side), and an
-//! anchor pointing at a sequence or mapping rather than a scalar.
+//! anchor pointing at a sequence or mapping rather than a scalar. An alias in
+//! key position is refused outright here and resolved by js-yaml.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use yaml_rust2::parser::{Event, EventReceiver, Parser};
 
@@ -20,10 +21,8 @@ use yaml_rust2::parser::{Event, EventReceiver, Parser};
 /// so it is bounded here rather than at the far end. A file whose frontmatter
 /// exceeds the cap is indexed for its inline tags only.
 const MAX_FRONTMATTER_BYTES: usize = 8 * 1024;
-/// How deeply a block may nest. The parser recurses once per level and a
-/// stack overflow aborts the process rather than unwinding, so this is checked
-/// against the source text before the parser sees it. Frontmatter that nests
-/// past this is pathological; real notes sit in single digits.
+/// How deeply a block may nest. Frontmatter past this is pathological; real
+/// notes sit in single digits.
 const MAX_NESTING_DEPTH: usize = 64;
 
 #[derive(Debug, PartialEq)]
@@ -59,7 +58,7 @@ impl Frontmatter {
 /// The leading `---` fenced block's inner text plus the line index the body
 /// starts at. `None` unless the file opens with the fence and closes it within
 /// the byte cap.
-pub(crate) fn split_frontmatter(content: &str) -> (Option<String>, usize) {
+pub fn split_frontmatter(content: &str) -> (Option<String>, usize) {
     // `lines` has already taken the `\r` of a CRLF ending, and the renderer's
     // pattern allows nothing else around the delimiter, so `---   ` opens no
     // block there and must open none here.
@@ -243,44 +242,26 @@ impl EventReceiver for Builder {
     }
 }
 
-/// Whether `inner` nests past [`MAX_NESTING_DEPTH`] anywhere. Counted from the
-/// source text because the parser recurses one frame per level as it reads,
-/// so a block that is too deep has already overflowed the stack by the time
-/// any event arrives. The three ways to open a level are an unclosed flow
-/// bracket, a repeated `- ` on one line, and indentation.
-fn too_deep(inner: &str) -> bool {
-    let mut flow = 0usize;
-    for line in inner.lines() {
-        let indent = line.len() - line.trim_start_matches([' ', '\t']).len();
-        let dashes = line
-            .trim_start_matches([' ', '\t'])
-            .split("- ")
-            .count()
-            .saturating_sub(1);
-        if indent > MAX_NESTING_DEPTH || dashes > MAX_NESTING_DEPTH {
-            return true;
-        }
-        for c in line.chars() {
-            match c {
-                '[' | '{' => flow += 1,
-                ']' | '}' => flow = flow.saturating_sub(1),
-                _ => {}
-            }
-            if flow > MAX_NESTING_DEPTH {
-                return true;
-            }
-        }
-    }
-    false
-}
-
 fn parse_mapping(inner: &str) -> Option<Value> {
-    if too_deep(inner) {
-        return None;
-    }
+    // Events are pulled one at a time rather than through `Parser::load`,
+    // which recurses once per nesting level as it reads: a block deep enough
+    // overflows the stack, and that aborts the process instead of unwinding.
+    // The parser's own state machine is iterative, so driving it flat bounds
+    // the depth exactly, against the tree being built rather than a guess at
+    // what the source text will open.
+    let mut parser = Parser::new_from_str(inner);
     let mut builder = Builder::default();
-    Parser::new_from_str(inner).load(&mut builder, false).ok()?;
-    if builder.rejected || !builder.stack.is_empty() {
+    loop {
+        let (event, _) = parser.next_token().ok()?;
+        if event == Event::StreamEnd {
+            break;
+        }
+        builder.on_event(event);
+        if builder.rejected || builder.stack.len() > MAX_NESTING_DEPTH {
+            return None;
+        }
+    }
+    if !builder.stack.is_empty() {
         return None;
     }
     let root = builder.root?;
@@ -297,14 +278,8 @@ fn parse_mapping(inner: &str) -> Option<Value> {
 /// nothing in the renderer and must index as nothing here too. Nested mappings
 /// are checked as they close; this covers the root, which never does.
 fn has_duplicate_key(entries: &[(String, Value)]) -> bool {
-    let mut seen: Vec<&str> = Vec::with_capacity(entries.len());
-    for (key, _) in entries {
-        if seen.contains(&key.as_str()) {
-            return true;
-        }
-        seen.push(key);
-    }
-    false
+    let mut seen: HashSet<&str> = HashSet::with_capacity(entries.len());
+    !entries.iter().all(|(key, _)| seen.insert(key))
 }
 
 #[cfg(test)]
@@ -429,24 +404,35 @@ mod tests {
     }
 
     #[test]
-    fn deeply_nested_values_are_refused_before_the_parser_recurses() {
-        // Each of these opens one parser frame per level, and the parser
-        // recurses as it reads: reaching it at all overflows the stack, which
-        // aborts the process rather than unwinding. The block cap allows
-        // thousands of levels, so the depth check has to come first.
+    fn deeply_nested_values_are_refused_without_overflowing_the_stack() {
+        // Every one of these opens a level per token, and the block cap allows
+        // thousands of them. Reaching a recursive parse at that depth overflows
+        // the stack, which aborts the process rather than unwinding, so the
+        // depth is bounded against the tree as it is built. Counting the source
+        // text instead cannot work: YAML opens a level with `- `, with `? `,
+        // with `: `, with a flow bracket and with indentation, and a guess that
+        // misses one of them is a guess that crashes.
         let depth = MAX_NESTING_DEPTH + 5;
-        let flow = format!("key: {}{}", "[".repeat(depth), "]".repeat(depth));
-        assert_eq!(parse_frontmatter(&flow), None);
+        for block in [
+            format!("key: {}{}", "[".repeat(depth), "]".repeat(depth)),
+            format!("{}x\n", "- ".repeat(1_000)),
+            format!("{}x\n", "? ".repeat(4_000)),
+            format!("{}x\n", "? : ".repeat(2_000)),
+            format!("{}x\n", ": ".repeat(4_000)),
+        ] {
+            assert_eq!(parse_frontmatter(&block), None, "{}", &block[..12]);
+        }
 
-        let block_sequence = format!("{}x\n", "- ".repeat(1_000));
-        assert_eq!(parse_frontmatter(&block_sequence), None);
-
+        // Bounding the tree rather than the text is also what keeps ordinary
+        // blocks out of the refusal: nesting a note might really use, deep
+        // indentation, and a block scalar holding indented content all open
+        // far fewer levels than they have columns.
+        assert!(parse_frontmatter("outer:\n  middle:\n    inner: value\ntitle: Note\n").is_some());
         let indented = format!("{}deep: value\n", " ".repeat(depth + 1));
-        assert_eq!(parse_frontmatter(&indented), None);
-
-        // A block that nests normally still parses.
-        let shallow = "outer:\n  middle:\n    inner: value\ntitle: Note\n";
-        assert!(parse_frontmatter(shallow).is_some());
+        assert!(parse_frontmatter(&indented).is_some());
+        let scalar = format!("snippet: |\n{}code\ntitle: T\n", " ".repeat(70));
+        let parsed = parse_frontmatter(&scalar).expect("a block scalar is one level deep");
+        assert_eq!(parsed.title.as_deref(), Some("T"));
     }
 
     #[test]

--- a/src-tauri/src/vault/frontmatter.rs
+++ b/src-tauri/src/vault/frontmatter.rs
@@ -83,10 +83,7 @@ pub fn split_frontmatter(content: &str) -> (Option<String>, usize) {
 /// Parse the inner text of a frontmatter block. `None` when the YAML is
 /// malformed, is not a mapping, or carries nothing worth showing.
 pub(crate) fn parse_frontmatter(inner: &str) -> Option<Frontmatter> {
-    let entries = match parse_mapping(inner)? {
-        Value::Mapping(entries) => entries,
-        _ => return None,
-    };
+    let entries = parse_mapping(inner)?;
 
     let mut out = Frontmatter::default();
     for (key, value) in &entries {
@@ -242,7 +239,7 @@ impl EventReceiver for Builder {
     }
 }
 
-fn parse_mapping(inner: &str) -> Option<Value> {
+fn parse_mapping(inner: &str) -> Option<Vec<(String, Value)>> {
     // Events are pulled one at a time rather than through `Parser::load`,
     // which recurses once per nesting level as it reads: a block deep enough
     // overflows the stack, and that aborts the process instead of unwinding.
@@ -261,17 +258,13 @@ fn parse_mapping(inner: &str) -> Option<Value> {
             return None;
         }
     }
-    if !builder.stack.is_empty() {
-        return None;
+    // A collection left open would have errored above rather than reaching
+    // `StreamEnd`, and the root mapping's duplicate keys were checked as it
+    // closed, so the only thing left to ask is whether the root is a mapping.
+    match builder.root? {
+        Value::Mapping(entries) => Some(entries),
+        _ => None,
     }
-    let root = builder.root?;
-    let Value::Mapping(entries) = &root else {
-        return None;
-    };
-    if has_duplicate_key(entries) {
-        return None;
-    }
-    Some(root)
 }
 
 /// js-yaml throws on a duplicate mapping key, so a block carrying one shows
@@ -448,6 +441,40 @@ mod tests {
             parse("---\ntitle: Note\nnested:\n  a: 1\n  a: 2\n---\n"),
             None
         );
+    }
+
+    #[test]
+    fn a_field_whose_value_is_a_collection_of_collections_is_dropped() {
+        // Neither a mapping nor a nested sequence has a string to show, so
+        // `tags` yields nothing and `links` is not a displayable field.
+        let fm = parse("---\ntags:\n  nested: value\nlinks: [[a], [b]]\ntitle: T\n---\n").unwrap();
+        assert!(fm.tags.is_empty());
+        assert_eq!(fm.extra, vec![]);
+        assert_eq!(fm.title.as_deref(), Some("T"));
+
+        // A sequence mixing the two keeps only the parts that render.
+        let mixed = parse("---\nlinks: [a, [b], c]\n---\n").unwrap();
+        assert_eq!(mixed.extra, vec![("links".to_string(), "a, c".to_string())]);
+    }
+
+    #[test]
+    fn a_collection_in_key_position_yields_nothing() {
+        assert_eq!(parse("---\n? [a, b]\n: value\n---\n"), None);
+    }
+
+    #[test]
+    fn a_second_document_in_the_block_yields_nothing() {
+        assert_eq!(parse("---\ntitle: One\n...\ntitle: Two\n---\n"), None);
+    }
+
+    #[test]
+    fn an_unbalanced_event_stream_is_refused() {
+        // The parser cannot emit one, so this drives the receiver directly:
+        // the contract is that a close without a matching open rejects the
+        // document rather than being read as an empty collection.
+        let mut builder = Builder::default();
+        builder.on_event(Event::MappingEnd);
+        assert!(builder.rejected);
     }
 
     #[test]

--- a/src-tauri/src/vault/graph.rs
+++ b/src-tauri/src/vault/graph.rs
@@ -1,0 +1,302 @@
+//! The views derived from resolved links: the workspace graph, backlinks per
+//! note, and the links that go nowhere.
+
+use std::collections::{BTreeSet, HashMap};
+
+use serde::Serialize;
+
+use super::note::Note;
+use super::resolve::{compare_paths, dir_of, stem_of, Resolver};
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphNode {
+    /// Absolute file path, the unique node id.
+    pub id: String,
+    /// File name without its extension.
+    pub label: String,
+    /// Number of distinct neighbours, in either direction.
+    pub degree: usize,
+    /// True when no resolved link points into or out of this file.
+    pub orphan: bool,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphEdge {
+    pub source: String,
+    pub target: String,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Backlink {
+    pub source: String,
+    pub line: u32,
+    pub snippet: String,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnresolvedLink {
+    pub source: String,
+    /// Target as written, with `|alias` and `#heading` already removed.
+    pub target: String,
+    pub line: u32,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct Graph {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+    /// Undirected adjacency, indexed by note id.
+    pub neighbors: Vec<BTreeSet<usize>>,
+    /// Inbound links, indexed by note id.
+    pub backlinks: Vec<Vec<Backlink>>,
+    pub unresolved: Vec<UnresolvedLink>,
+    /// Notes with no outgoing resolved link.
+    pub dead_ends: Vec<String>,
+}
+
+pub(crate) fn build(notes: &[Note], resolver: &Resolver) -> Graph {
+    let mut neighbors: Vec<BTreeSet<usize>> = vec![BTreeSet::new(); notes.len()];
+    let mut backlinks: Vec<Vec<Backlink>> = (0..notes.len()).map(|_| Vec::new()).collect();
+    let mut edges: Vec<GraphEdge> = Vec::new();
+    let mut unresolved: Vec<UnresolvedLink> = Vec::new();
+    let mut has_outgoing = vec![false; notes.len()];
+    let mut seen_edges: BTreeSet<(usize, usize)> = BTreeSet::new();
+    // Resolution depends only on the target and the linking file's directory,
+    // and a target naming a path is matched by scanning every indexed path, so
+    // hub-heavy vaults stay linear in unique targets rather than links times
+    // files.
+    let mut resolved: HashMap<(&str, &str), Option<usize>> = HashMap::new();
+
+    for (source, note) in notes.iter().enumerate() {
+        for link in &note.links {
+            let key = (link.target.as_str(), dir_of(&note.path));
+            let hit = *resolved
+                .entry(key)
+                .or_insert_with(|| resolver.resolve(&link.target, Some(&note.path)));
+            let Some(target) = hit else {
+                unresolved.push(UnresolvedLink {
+                    source: note.path.clone(),
+                    target: link.target.clone(),
+                    line: link.line,
+                });
+                continue;
+            };
+            if target == source {
+                continue;
+            }
+            has_outgoing[source] = true;
+
+            // A line can hold several links to the same note, which would
+            // otherwise surface as duplicate backlink rows sharing a snippet.
+            let already = backlinks[target]
+                .iter()
+                .any(|back| back.source == note.path && back.line == link.line);
+            if !already {
+                backlinks[target].push(Backlink {
+                    source: note.path.clone(),
+                    line: link.line,
+                    snippet: link.snippet.clone(),
+                });
+            }
+
+            neighbors[source].insert(target);
+            neighbors[target].insert(source);
+            if seen_edges.insert((source, target)) {
+                edges.push(GraphEdge {
+                    source: note.path.clone(),
+                    target: notes[target].path.clone(),
+                });
+            }
+        }
+    }
+
+    for rows in &mut backlinks {
+        rows.sort_by(|a, b| compare_paths(&a.source, &b.source).then_with(|| a.line.cmp(&b.line)));
+    }
+
+    let nodes = notes
+        .iter()
+        .enumerate()
+        .map(|(id, note)| {
+            let degree = neighbors[id].len();
+            GraphNode {
+                id: note.path.clone(),
+                label: stem_of(&note.path).to_string(),
+                degree,
+                orphan: degree == 0,
+            }
+        })
+        .collect();
+
+    let dead_ends = notes
+        .iter()
+        .enumerate()
+        .filter(|(id, _)| !has_outgoing[*id])
+        .map(|(_, note)| note.path.clone())
+        .collect();
+
+    Graph {
+        nodes,
+        edges,
+        neighbors,
+        backlinks,
+        unresolved,
+        dead_ends,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::note::extract_note;
+
+    fn graph_of(files: &[(&str, &str)]) -> (Vec<Note>, Graph) {
+        let notes: Vec<Note> = files
+            .iter()
+            .map(|(path, body)| extract_note(path, body))
+            .collect();
+        let paths: Vec<String> = notes.iter().map(|note| note.path.clone()).collect();
+        let aliases: Vec<Vec<String>> = notes.iter().map(|note| note.aliases.clone()).collect();
+        let resolver = Resolver::build(&paths, &aliases);
+        let graph = build(&notes, &resolver);
+        (notes, graph)
+    }
+
+    fn edge_pairs(graph: &Graph) -> Vec<(String, String)> {
+        graph
+            .edges
+            .iter()
+            .map(|e| (e.source.clone(), e.target.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn one_node_per_file_labelled_by_stem() {
+        let (_, graph) = graph_of(&[("/w/A.md", ""), ("/w/sub/B.md", "")]);
+        assert_eq!(graph.nodes.len(), 2);
+        assert_eq!(graph.nodes[0].label, "A");
+        assert_eq!(graph.nodes[1].label, "B");
+    }
+
+    #[test]
+    fn a_resolved_link_becomes_one_directed_edge() {
+        let (_, graph) = graph_of(&[("/w/A.md", "see [[B]]\n"), ("/w/B.md", "")]);
+        assert_eq!(
+            edge_pairs(&graph),
+            vec![("/w/A.md".to_string(), "/w/B.md".to_string())]
+        );
+    }
+
+    #[test]
+    fn aliases_and_headings_do_not_change_the_edge() {
+        let (_, graph) = graph_of(&[("/w/A.md", "see [[B#Top|the other]]\n"), ("/w/B.md", "")]);
+        assert_eq!(edge_pairs(&graph).len(), 1);
+    }
+
+    #[test]
+    fn broken_and_self_links_are_dropped() {
+        let (_, graph) = graph_of(&[("/w/A.md", "[[Missing]] and [[A]]\n")]);
+        assert!(graph.edges.is_empty());
+        assert_eq!(graph.unresolved.len(), 1);
+        assert_eq!(graph.unresolved[0].target, "Missing");
+        assert_eq!(graph.unresolved[0].line, 1);
+    }
+
+    #[test]
+    fn parallel_links_collapse_but_the_reverse_edge_survives() {
+        let (_, graph) = graph_of(&[
+            ("/w/A.md", "[[B]] and again [[B]]\n"),
+            ("/w/B.md", "back to [[A]]\n"),
+        ]);
+        assert_eq!(
+            edge_pairs(&graph),
+            vec![
+                ("/w/A.md".to_string(), "/w/B.md".to_string()),
+                ("/w/B.md".to_string(), "/w/A.md".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn degree_counts_distinct_neighbours_in_either_direction() {
+        let (_, graph) = graph_of(&[
+            ("/w/A.md", "[[B]] [[C]]\n"),
+            ("/w/B.md", "[[A]]\n"),
+            ("/w/C.md", ""),
+            ("/w/D.md", ""),
+        ]);
+        assert_eq!(graph.nodes[0].degree, 2);
+        assert_eq!(graph.nodes[1].degree, 1);
+        assert_eq!(graph.nodes[2].degree, 1);
+        assert_eq!(graph.nodes[3].degree, 0);
+        assert!(graph.nodes[3].orphan);
+        assert!(!graph.nodes[2].orphan);
+    }
+
+    #[test]
+    fn backlinks_list_inbound_links_once_per_source_line() {
+        let (_, graph) = graph_of(&[
+            (
+                "/w/A.md",
+                "[[Target]] twice [[Target]]\nand again [[Target]]\n",
+            ),
+            ("/w/Target.md", "self [[Target]]\n"),
+        ]);
+        let rows = &graph.backlinks[1];
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].source, "/w/A.md");
+        assert_eq!(rows[0].line, 1);
+        assert_eq!(rows[1].line, 2);
+        assert!(rows[0].snippet.contains("[[Target]]"));
+        // The self-link contributes nothing.
+        assert!(graph.backlinks[1]
+            .iter()
+            .all(|r| r.source != "/w/Target.md"));
+    }
+
+    #[test]
+    fn backlinks_are_ordered_by_source_then_line() {
+        let (_, graph) = graph_of(&[
+            ("/w/b.md", "[[T]]\n"),
+            ("/w/A.md", "\n[[T]]\n"),
+            ("/w/T.md", ""),
+        ]);
+        let rows = &graph.backlinks[2];
+        assert_eq!(
+            rows.iter().map(|r| r.source.as_str()).collect::<Vec<_>>(),
+            vec!["/w/A.md", "/w/b.md"]
+        );
+    }
+
+    #[test]
+    fn the_resolution_memo_keeps_per_directory_answers_apart() {
+        // Both notes write the same target; each must reach its own neighbour.
+        let (_, graph) = graph_of(&[
+            ("/w/a/Note.md", "[[Shared]]\n"),
+            ("/w/a/Shared.md", ""),
+            ("/w/b/Note.md", "[[Shared]]\n"),
+            ("/w/b/Shared.md", ""),
+        ]);
+        assert_eq!(
+            edge_pairs(&graph),
+            vec![
+                ("/w/a/Note.md".to_string(), "/w/a/Shared.md".to_string()),
+                ("/w/b/Note.md".to_string(), "/w/b/Shared.md".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn dead_ends_are_notes_with_no_outgoing_resolved_link() {
+        let (_, graph) = graph_of(&[
+            ("/w/A.md", "[[B]]\n"),
+            ("/w/B.md", "[[Missing]]\n"),
+            ("/w/C.md", ""),
+        ]);
+        assert_eq!(graph.dead_ends, vec!["/w/B.md", "/w/C.md"]);
+    }
+}

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -34,7 +34,9 @@ pub struct Vault {
     /// Every frontmatter field name in the workspace, derived with the graph
     /// so the palette does not recompute it per keystroke.
     pub(super) field_names: BTreeSet<String>,
-    pub(super) status: ScanStatus,
+    pub(super) walk_status: ScanStatus,
+    /// Set when an update was turned away at the file cap.
+    refused_at_cap: bool,
     max_files: usize,
     max_depth: usize,
 }
@@ -64,7 +66,8 @@ impl Vault {
             resolver: Resolver::default(),
             graph: Graph::default(),
             field_names: BTreeSet::new(),
-            status,
+            walk_status: status,
+            refused_at_cap: false,
             max_files,
             max_depth,
         };
@@ -103,10 +106,10 @@ impl Vault {
             match existing {
                 Some(index) => self.notes[index] = note,
                 None => {
+                    // Growing past the cap the walk enforces would leave the
+                    // index reporting a complete scan it no longer has.
                     if self.notes.len() >= self.max_files {
-                        // Growing past the cap the walk enforces would leave the
-                        // index reporting a complete scan it no longer has.
-                        self.status = ScanStatus::file_limit(self.max_files);
+                        self.refused_at_cap = true;
                         continue;
                     }
                     let at = self
@@ -154,8 +157,21 @@ impl Vault {
                 return false;
             }
         }
-        std::fs::symlink_metadata(path)
-            .is_ok_and(|meta| meta.is_file() && meta.len() <= SCAN_MAX_FILE_BYTES)
+        // `symlink_metadata` reports the link itself, so `is_file` already
+        // refuses a symlinked note the way the walk does.
+        let Ok(meta) = std::fs::symlink_metadata(path) else {
+            return false;
+        };
+        if !meta.is_file() || meta.len() > SCAN_MAX_FILE_BYTES {
+            return false;
+        }
+        // A symlink further up the path is invisible to that check, and the
+        // watcher follows links, so a linked directory would otherwise deliver
+        // events for files outside the workspace entirely.
+        let Some(root) = &self.canonical_root else {
+            return false;
+        };
+        std::fs::canonicalize(path).is_ok_and(|resolved| resolved.starts_with(root))
     }
 
     /// Rebuild the resolver and the derived views from the notes already in
@@ -170,6 +186,17 @@ impl Vault {
             .iter()
             .flat_map(|note| note.fields.keys().cloned())
             .collect();
+    }
+
+    /// What the walk reported, unless a later file was turned away at the cap.
+    /// That stays reported until a rebuild, because the index cannot know
+    /// whether a subsequent deletion made room for the file it refused; a
+    /// `vault_refresh` is what answers that.
+    pub(super) fn status(&self) -> ScanStatus {
+        if self.refused_at_cap {
+            return ScanStatus::file_limit(self.max_files);
+        }
+        self.walk_status.clone()
     }
 
     pub(super) fn id_of(&self, path: &str) -> Option<usize> {

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -1,0 +1,191 @@
+//! The [`Vault`] itself: building the note set from a workspace root and
+//! keeping it current as files change.
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+
+use super::canvas::{self, Canvas};
+use super::graph::{self, Graph};
+use super::note::{self, Note};
+use super::resolve::{compare_paths, Resolver};
+use crate::commands::walk::{
+    scan_files, ScanStatus, SCAN_MAX_FILE_BYTES, WALK_MAX_DEPTH, WALK_MAX_FILES, WALK_SKIP_DIRS,
+};
+
+/// Markdown and canvas files both belong to the index; everything else is an
+/// attachment the index only ever points at.
+fn is_indexable(path: &Path) -> bool {
+    crate::is_markdown_file(path) || crate::is_canvas_file(path)
+}
+
+#[derive(Debug)]
+pub struct Vault {
+    pub(super) root: PathBuf,
+    /// The root as the filesystem reports it. Watcher events arrive resolved
+    /// (a verbatim `\\?\C:\…` prefix on Windows, symlinks followed on macOS),
+    /// so without this an incremental update would match nothing.
+    canonical_root: Option<PathBuf>,
+    /// Sorted by path, so an incremental update inserts in place instead of
+    /// replaying the walk.
+    pub(super) notes: Vec<Note>,
+    pub(super) canvases: HashMap<String, Canvas>,
+    pub(super) resolver: Resolver,
+    pub(super) graph: Graph,
+    /// Every frontmatter field name in the workspace, derived with the graph
+    /// so the palette does not recompute it per keystroke.
+    pub(super) field_names: BTreeSet<String>,
+    pub(super) status: ScanStatus,
+    max_files: usize,
+    max_depth: usize,
+}
+
+impl Vault {
+    /// Index every markdown and canvas file under `root`, within the shared
+    /// walk caps.
+    pub fn build(root: &Path) -> Result<Self, String> {
+        Self::build_capped(root, WALK_MAX_FILES, WALK_MAX_DEPTH)
+    }
+
+    /// Body of [`Vault::build`] with the caps as parameters, so the truncation
+    /// branches are testable without creating `WALK_MAX_FILES` real files.
+    pub fn build_capped(root: &Path, max_files: usize, max_depth: usize) -> Result<Self, String> {
+        let mut notes = Vec::new();
+        let mut canvases = HashMap::new();
+        let status = scan_files(root, is_indexable, max_files, max_depth, |path, content| {
+            let path = path.to_string_lossy().to_string();
+            notes.push(index_file(&path, content, &mut canvases));
+        })?;
+
+        let mut vault = Vault {
+            canonical_root: std::fs::canonicalize(root).ok(),
+            root: root.to_path_buf(),
+            notes,
+            canvases,
+            resolver: Resolver::default(),
+            graph: Graph::default(),
+            field_names: BTreeSet::new(),
+            status,
+            max_files,
+            max_depth,
+        };
+        vault.notes.sort_by(|a, b| compare_paths(&a.path, &b.path));
+        vault.rebuild_derived();
+        Ok(vault)
+    }
+
+    /// Re-index only the paths that changed. Files that vanished are dropped,
+    /// new ones are inserted in place; nothing else is read from disk.
+    pub fn apply_changes(&mut self, paths: &[PathBuf]) {
+        let mut touched = false;
+        for path in paths {
+            let Some(path) = self.inside_root(path) else {
+                continue;
+            };
+            let existing = self.id_of(&path.to_string_lossy());
+            let key = match existing {
+                Some(index) => self.notes[index].path.clone(),
+                None => path.to_string_lossy().to_string(),
+            };
+
+            let content = self.walkable(&path).then(|| std::fs::read_to_string(&path));
+            let Some(Ok(content)) = content else {
+                // A path the walker would have skipped, a deletion, or a file
+                // that went away mid-update: none of them belong in the index.
+                if let Some(index) = existing {
+                    self.notes.remove(index);
+                    self.canvases.remove(&key);
+                    touched = true;
+                }
+                continue;
+            };
+
+            let note = index_file(&key, &content, &mut self.canvases);
+            match existing {
+                Some(index) => self.notes[index] = note,
+                None => {
+                    if self.notes.len() >= self.max_files {
+                        // Growing past the cap the walk enforces would leave the
+                        // index reporting a complete scan it no longer has.
+                        self.status = ScanStatus::file_limit(self.max_files);
+                        continue;
+                    }
+                    let at = self
+                        .notes
+                        .partition_point(|other| compare_paths(&other.path, &key).is_lt());
+                    self.notes.insert(at, note);
+                }
+            }
+            touched = true;
+        }
+
+        if touched {
+            self.rebuild_derived();
+        }
+    }
+
+    /// `path` respelled the way the index spells it, or `None` when it lies
+    /// outside the root. Watcher events arrive against the canonical root, and
+    /// two spellings of one file must not index twice.
+    fn inside_root(&self, path: &Path) -> Option<PathBuf> {
+        let relative = path
+            .strip_prefix(&self.root)
+            .ok()
+            .or_else(|| path.strip_prefix(self.canonical_root.as_ref()?).ok())?;
+        Some(self.root.join(relative).components().collect())
+    }
+
+    /// Whether the walk would have visited `path`. `apply_changes` reads files
+    /// the walk never offered it, so the same gates have to hold here: no
+    /// hidden or noisy directories, no symlinks out of the workspace, and no
+    /// file past the size cap.
+    fn walkable(&self, path: &Path) -> bool {
+        if !is_indexable(path) {
+            return false;
+        }
+        let Ok(relative) = path.strip_prefix(&self.root) else {
+            return false;
+        };
+        if relative.components().count() > self.max_depth {
+            return false;
+        }
+        for component in relative.components() {
+            let name = component.as_os_str().to_string_lossy();
+            if name.starts_with('.') || WALK_SKIP_DIRS.contains(&name.as_ref()) {
+                return false;
+            }
+        }
+        std::fs::symlink_metadata(path)
+            .is_ok_and(|meta| meta.is_file() && meta.len() <= SCAN_MAX_FILE_BYTES)
+    }
+
+    /// Rebuild the resolver and the derived views from the notes already in
+    /// memory. Linear in links, and the only work an incremental update repeats.
+    fn rebuild_derived(&mut self) {
+        let paths: Vec<String> = self.notes.iter().map(|note| note.path.clone()).collect();
+        let aliases: Vec<Vec<String>> = self.notes.iter().map(|n| n.aliases.clone()).collect();
+        self.resolver = Resolver::build(&paths, &aliases);
+        self.graph = graph::build(&self.notes, &self.resolver);
+        self.field_names = self
+            .notes
+            .iter()
+            .flat_map(|note| note.fields.keys().cloned())
+            .collect();
+    }
+
+    pub(super) fn id_of(&self, path: &str) -> Option<usize> {
+        let wanted = Path::new(path);
+        self.notes
+            .iter()
+            .position(|note| Path::new(&note.path) == wanted)
+    }
+}
+
+fn index_file(path: &str, content: &str, canvases: &mut HashMap<String, Canvas>) -> Note {
+    if crate::is_canvas_file(Path::new(path)) {
+        let (note, canvas) = canvas::extract_canvas(path, content);
+        canvases.insert(path.to_string(), canvas);
+        return note;
+    }
+    canvases.remove(path);
+    note::extract_note(path, content)
+}

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -24,7 +24,7 @@ pub struct Vault {
     /// The root as the filesystem reports it. Watcher events arrive resolved
     /// (a verbatim `\\?\C:\…` prefix on Windows, symlinks followed on macOS),
     /// so without this an incremental update would match nothing.
-    canonical_root: Option<PathBuf>,
+    canonical_root: PathBuf,
     /// Sorted by path, so an incremental update inserts in place instead of
     /// replaying the walk.
     pub(super) notes: Vec<Note>,
@@ -59,7 +59,7 @@ impl Vault {
         })?;
 
         let mut vault = Vault {
-            canonical_root: std::fs::canonicalize(root).ok(),
+            canonical_root: std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf()),
             root: root.to_path_buf(),
             notes,
             canvases,
@@ -81,7 +81,7 @@ impl Vault {
     pub fn apply_changes(&mut self, paths: &[PathBuf]) {
         let mut touched = false;
         for path in paths {
-            let Some(path) = self.inside_root(path) else {
+            let Some((path, relative)) = self.inside_root(path) else {
                 continue;
             };
             let existing = self.id_of(&path.to_string_lossy());
@@ -90,7 +90,9 @@ impl Vault {
                 None => path.to_string_lossy().to_string(),
             };
 
-            let content = self.walkable(&path).then(|| std::fs::read_to_string(&path));
+            let content = self
+                .walkable(&path, &relative)
+                .then(|| std::fs::read_to_string(&path));
             let Some(Ok(content)) = content else {
                 // A path the walker would have skipped, a deletion, or a file
                 // that went away mid-update: none of them belong in the index.
@@ -129,26 +131,21 @@ impl Vault {
     /// `path` respelled the way the index spells it, or `None` when it lies
     /// outside the root. Watcher events arrive against the canonical root, and
     /// two spellings of one file must not index twice.
-    fn inside_root(&self, path: &Path) -> Option<PathBuf> {
+    fn inside_root(&self, path: &Path) -> Option<(PathBuf, PathBuf)> {
         let relative = path
             .strip_prefix(&self.root)
-            .ok()
-            .or_else(|| path.strip_prefix(self.canonical_root.as_ref()?).ok())?;
-        Some(self.root.join(relative).components().collect())
+            .or_else(|_| path.strip_prefix(&self.canonical_root))
+            .ok()?;
+        let relative: PathBuf = relative.components().collect();
+        Some((self.root.join(&relative), relative))
     }
 
     /// Whether the walk would have visited `path`. `apply_changes` reads files
     /// the walk never offered it, so the same gates have to hold here: no
     /// hidden or noisy directories, no symlinks out of the workspace, and no
     /// file past the size cap.
-    fn walkable(&self, path: &Path) -> bool {
-        if !is_indexable(path) {
-            return false;
-        }
-        let Ok(relative) = path.strip_prefix(&self.root) else {
-            return false;
-        };
-        if relative.components().count() > self.max_depth {
+    fn walkable(&self, path: &Path, relative: &Path) -> bool {
+        if !is_indexable(path) || relative.components().count() > self.max_depth {
             return false;
         }
         for component in relative.components() {
@@ -168,10 +165,7 @@ impl Vault {
         // A symlink further up the path is invisible to that check, and the
         // watcher follows links, so a linked directory would otherwise deliver
         // events for files outside the workspace entirely.
-        let Some(root) = &self.canonical_root else {
-            return false;
-        };
-        std::fs::canonicalize(path).is_ok_and(|resolved| resolved.starts_with(root))
+        std::fs::canonicalize(path).is_ok_and(|resolved| resolved.starts_with(&self.canonical_root))
     }
 
     /// Rebuild the resolver and the derived views from the notes already in

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -35,6 +35,7 @@ mod tests;
 pub use index::Vault;
 // Borrowed by `commands/metadata.rs` and `commands/wikilinks.rs` so the tag
 // rules and the snippet cap have one definition while both still ship.
+pub use frontmatter::split_frontmatter;
 pub use note::snippet_for;
 pub use tags::inline_tags;
 // Their tests name the caps; the code paths only reach them through the

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -1,0 +1,45 @@
+//! The workspace index: one owner for every wikilink, backlink, alias, tag
+//! and canvas card under a root.
+//!
+//! Pure Rust with no `tauri::State` and no `AppHandle`, so a headless process
+//! can build and query a [`Vault`] in-process.
+//!
+//! - [`index`] owns the [`Vault`] itself: the walk, the note set, and keeping
+//!   it current as files change.
+//! - [`snapshot`] and [`queries`] are what callers read: one payload per
+//!   workspace, plus the per-note lookups the payload deliberately omits.
+//! - [`note`], [`frontmatter`], [`tags`] and [`canvas`] extract one file;
+//!   [`resolve`] and [`graph`] turn the whole set into links and backlinks;
+//!   [`query`] parses the palette's filter grammar.
+//! - [`commands`] is the thin Tauri wrapper that adds the grant check and the
+//!   managed store.
+
+pub mod commands;
+
+mod canvas;
+mod frontmatter;
+mod graph;
+mod index;
+mod note;
+mod queries;
+mod query;
+mod resolve;
+mod snapshot;
+mod tags;
+
+#[cfg(test)]
+mod test_support;
+#[cfg(test)]
+mod tests;
+
+pub use index::Vault;
+// Borrowed by `commands/metadata.rs` and `commands/wikilinks.rs` so the tag
+// rules and the snippet cap have one definition while both still ship.
+pub use note::snippet_for;
+pub use tags::inline_tags;
+// Their tests name the caps; the code paths only reach them through the
+// functions above.
+#[cfg(test)]
+pub use note::MAX_SNIPPET_CHARS;
+#[cfg(test)]
+pub use tags::{MAX_INLINE_TAGS_PER_FILE, MAX_TAG_CHARS};

--- a/src-tauri/src/vault/note.rs
+++ b/src-tauri/src/vault/note.rs
@@ -11,9 +11,6 @@ pub const MAX_SNIPPET_CHARS: usize = 200;
 pub(crate) struct Link {
     /// Target as written, with `|alias` and `#heading` removed.
     pub target: String,
-    pub heading: Option<String>,
-    pub alias: Option<String>,
-    pub embed: bool,
     /// 1-based, as the backlinks panel shows it.
     pub line: u32,
     pub snippet: String,
@@ -72,16 +69,18 @@ pub(crate) fn extract_note(path: &str, content: &str) -> Note {
         tags,
         fields,
         aliases,
-        links: parse_links(content),
+        links: parse_links(content, body_start),
     }
 }
 
 /// Every `[[target]]` and `![[embed]]` outside fenced code, in source order.
-fn parse_links(content: &str) -> Vec<Link> {
+/// The frontmatter block is skipped the way the tag scan skips it: the
+/// renderer shows those lines as a table, never as links.
+fn parse_links(content: &str, body_start: usize) -> Vec<Link> {
     let mut links = Vec::new();
     let mut in_fence = false;
 
-    for (idx, line) in content.lines().enumerate() {
+    for (idx, line) in content.lines().enumerate().skip(body_start) {
         let trimmed_start = line.trim_start();
         if trimmed_start.starts_with("```") || trimmed_start.starts_with("~~~") {
             in_fence = !in_fence;
@@ -116,39 +115,31 @@ fn push_line_links(line: &str, line_number: u32, out: &mut Vec<Link>) {
         }
 
         let inner: String = chars[start..close].iter().collect();
-        if let Some(link) = parse_link_inner(&inner) {
+        if let Some(target) = link_target(&inner) {
             out.push(Link {
-                embed: i > 0 && chars[i - 1] == '!',
+                target,
                 line: line_number,
                 snippet: snippet_for(line),
-                ..link
             });
         }
         i = close + 2;
     }
 }
 
-/// Split `name#heading|alias` into its parts. `None` when no target survives.
-fn parse_link_inner(inner: &str) -> Option<Link> {
-    let (target_with_heading, alias) = match inner.split_once('|') {
-        Some((target, alias)) => (target.trim(), alias.trim()),
-        None => (inner.trim(), ""),
+/// The note `name#heading|alias` points at. The heading and the alias are
+/// display concerns the renderer splits out for itself; the index only needs
+/// to know which file the link reaches.
+fn link_target(inner: &str) -> Option<String> {
+    let target_with_heading = match inner.split_once('|') {
+        Some((target, _)) => target,
+        None => inner,
     };
-    let (target, heading) = match target_with_heading.split_once('#') {
-        Some((target, heading)) => (target.trim(), heading.trim()),
-        None => (target_with_heading, ""),
+    let target = match target_with_heading.split_once('#') {
+        Some((target, _)) => target,
+        None => target_with_heading,
     };
-    if target.is_empty() {
-        return None;
-    }
-    Some(Link {
-        target: target.to_string(),
-        heading: (!heading.is_empty()).then(|| heading.to_string()),
-        alias: (!alias.is_empty()).then(|| alias.to_string()),
-        embed: false,
-        line: 0,
-        snippet: String::new(),
-    })
+    let target = target.trim();
+    (!target.is_empty()).then(|| target.to_string())
 }
 
 pub fn snippet_for(line: &str) -> String {
@@ -165,31 +156,31 @@ pub fn snippet_for(line: &str) -> String {
 mod tests {
     use super::*;
 
+    fn parse_links_from_start(content: &str) -> Vec<Link> {
+        parse_links(content, 0)
+    }
+
     fn targets(content: &str) -> Vec<String> {
-        parse_links(content)
+        parse_links_from_start(content)
             .into_iter()
             .map(|link| link.target)
             .collect()
     }
 
     #[test]
-    fn links_carry_target_heading_alias_and_line() {
-        let links = parse_links("intro\nsee [[Target#Section|the alias]] here\n");
+    fn a_link_carries_its_target_line_and_snippet() {
+        let links = parse_links_from_start("intro\nsee [[Target#Section|the alias]] here\n");
         assert_eq!(links.len(), 1);
+        // The heading and the alias are display concerns the renderer splits
+        // out for itself, so the index keeps only the file the link reaches.
         assert_eq!(links[0].target, "Target");
-        assert_eq!(links[0].heading.as_deref(), Some("Section"));
-        assert_eq!(links[0].alias.as_deref(), Some("the alias"));
         assert_eq!(links[0].line, 2);
-        assert!(!links[0].embed);
         assert!(links[0].snippet.starts_with("see [[Target"));
     }
 
     #[test]
-    fn an_exclamation_marks_an_embed() {
-        let links = parse_links("![[Board]] and [[Plain]]\n");
-        assert_eq!(links.len(), 2);
-        assert!(links[0].embed);
-        assert!(!links[1].embed);
+    fn an_embed_reaches_the_same_target_as_a_plain_link() {
+        assert_eq!(targets("![[Board]] and [[Board]]\n"), ["Board", "Board"]);
     }
 
     #[test]
@@ -225,9 +216,19 @@ mod tests {
     }
 
     #[test]
+    fn a_link_written_in_frontmatter_is_not_an_edge() {
+        // Those lines render as a table, so the renderer makes no link there
+        // and neither does the index.
+        let note = extract_note("/w/a.md", "---\nsee: \"[[Elsewhere]]\"\n---\n\n[[Real]]\n");
+        assert_eq!(note.links.len(), 1);
+        assert_eq!(note.links[0].target, "Real");
+        assert_eq!(note.links[0].line, 5);
+    }
+
+    #[test]
     fn long_lines_are_truncated_in_the_snippet() {
         let line = format!("{}[[Target]]{}", "x".repeat(150), "y".repeat(150));
-        let links = parse_links(&line);
+        let links = parse_links_from_start(&line);
         assert!(links[0].snippet.ends_with('…'));
         assert!(links[0].snippet.chars().count() <= MAX_SNIPPET_CHARS + 1);
     }

--- a/src-tauri/src/vault/note.rs
+++ b/src-tauri/src/vault/note.rs
@@ -1,0 +1,281 @@
+//! Per-note extraction: what one file contributes to the index.
+
+use std::collections::BTreeMap;
+
+use super::frontmatter::{parse_frontmatter, split_frontmatter};
+use super::tags::{add_tags, inline_tags};
+
+pub const MAX_SNIPPET_CHARS: usize = 200;
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct Link {
+    /// Target as written, with `|alias` and `#heading` removed.
+    pub target: String,
+    pub heading: Option<String>,
+    pub alias: Option<String>,
+    pub embed: bool,
+    /// 1-based, as the backlinks panel shows it.
+    pub line: u32,
+    pub snippet: String,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct Note {
+    pub path: String,
+    pub title: Option<String>,
+    /// Frontmatter and inline tags, normalized, deduplicated and sorted.
+    pub tags: Vec<String>,
+    /// Frontmatter fields by lowercased name, `tags` excluded.
+    pub fields: BTreeMap<String, String>,
+    pub aliases: Vec<String>,
+    pub links: Vec<Link>,
+}
+
+pub(crate) fn extract_note(path: &str, content: &str) -> Note {
+    let (block, body_start) = split_frontmatter(content);
+    let parsed = block.as_deref().and_then(parse_frontmatter);
+
+    let mut tags: Vec<String> = Vec::new();
+    for tag in inline_tags(content.lines().skip(body_start)) {
+        add_tags(&tag, &mut tags);
+    }
+
+    let mut fields: BTreeMap<String, String> = BTreeMap::new();
+    let mut title = None;
+    let mut aliases = Vec::new();
+    if let Some(parsed) = parsed {
+        for tag in &parsed.tags {
+            add_tags(tag, &mut tags);
+        }
+        if let Some(value) = &parsed.title {
+            fields.insert("title".to_string(), value.clone());
+        }
+        if let Some(value) = &parsed.author {
+            fields.insert("author".to_string(), value.clone());
+        }
+        if let Some(value) = &parsed.date {
+            fields.insert("date".to_string(), value.clone());
+        }
+        // Extras land last, so a `Title:` key lowercases onto `title` exactly
+        // as it does in the renderer's index.
+        for (key, value) in &parsed.extra {
+            fields.insert(key.to_lowercase(), value.clone());
+        }
+        title = parsed.title;
+        aliases = parsed.aliases;
+    }
+    tags.sort();
+
+    Note {
+        path: path.to_string(),
+        title,
+        tags,
+        fields,
+        aliases,
+        links: parse_links(content),
+    }
+}
+
+/// Every `[[target]]` and `![[embed]]` outside fenced code, in source order.
+fn parse_links(content: &str) -> Vec<Link> {
+    let mut links = Vec::new();
+    let mut in_fence = false;
+
+    for (idx, line) in content.lines().enumerate() {
+        let trimmed_start = line.trim_start();
+        if trimmed_start.starts_with("```") || trimmed_start.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        push_line_links(line, (idx + 1) as u32, &mut links);
+    }
+
+    links
+}
+
+fn push_line_links(line: &str, line_number: u32, out: &mut Vec<Link>) {
+    let chars: Vec<char> = line.chars().collect();
+    let mut i = 0;
+    while i + 1 < chars.len() {
+        if chars[i] != '[' || chars[i + 1] != '[' {
+            i += 1;
+            continue;
+        }
+        // The inner text may not span a `]`, matching the renderer's pattern,
+        // so `[[a]b]]` is text rather than a link to `a]b`.
+        let start = i + 2;
+        let Some(close) = (start..chars.len()).find(|&j| chars[j] == ']') else {
+            break;
+        };
+        if close + 1 >= chars.len() || chars[close + 1] != ']' || close == start {
+            i += 1;
+            continue;
+        }
+
+        let inner: String = chars[start..close].iter().collect();
+        if let Some(link) = parse_link_inner(&inner) {
+            out.push(Link {
+                embed: i > 0 && chars[i - 1] == '!',
+                line: line_number,
+                snippet: snippet_for(line),
+                ..link
+            });
+        }
+        i = close + 2;
+    }
+}
+
+/// Split `name#heading|alias` into its parts. `None` when no target survives.
+fn parse_link_inner(inner: &str) -> Option<Link> {
+    let (target_with_heading, alias) = match inner.split_once('|') {
+        Some((target, alias)) => (target.trim(), alias.trim()),
+        None => (inner.trim(), ""),
+    };
+    let (target, heading) = match target_with_heading.split_once('#') {
+        Some((target, heading)) => (target.trim(), heading.trim()),
+        None => (target_with_heading, ""),
+    };
+    if target.is_empty() {
+        return None;
+    }
+    Some(Link {
+        target: target.to_string(),
+        heading: (!heading.is_empty()).then(|| heading.to_string()),
+        alias: (!alias.is_empty()).then(|| alias.to_string()),
+        embed: false,
+        line: 0,
+        snippet: String::new(),
+    })
+}
+
+pub fn snippet_for(line: &str) -> String {
+    let trimmed = line.trim();
+    if trimmed.chars().count() <= MAX_SNIPPET_CHARS {
+        return trimmed.to_string();
+    }
+    let mut out: String = trimmed.chars().take(MAX_SNIPPET_CHARS).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn targets(content: &str) -> Vec<String> {
+        parse_links(content)
+            .into_iter()
+            .map(|link| link.target)
+            .collect()
+    }
+
+    #[test]
+    fn links_carry_target_heading_alias_and_line() {
+        let links = parse_links("intro\nsee [[Target#Section|the alias]] here\n");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "Target");
+        assert_eq!(links[0].heading.as_deref(), Some("Section"));
+        assert_eq!(links[0].alias.as_deref(), Some("the alias"));
+        assert_eq!(links[0].line, 2);
+        assert!(!links[0].embed);
+        assert!(links[0].snippet.starts_with("see [[Target"));
+    }
+
+    #[test]
+    fn an_exclamation_marks_an_embed() {
+        let links = parse_links("![[Board]] and [[Plain]]\n");
+        assert_eq!(links.len(), 2);
+        assert!(links[0].embed);
+        assert!(!links[1].embed);
+    }
+
+    #[test]
+    fn several_links_on_one_line_are_all_found() {
+        assert_eq!(
+            targets("[[One]] then [[Two]] then [[Three]]\n"),
+            ["One", "Two", "Three"]
+        );
+    }
+
+    #[test]
+    fn fenced_code_holds_no_links() {
+        assert_eq!(
+            targets("before [[Real]]\n```\n[[Fenced]]\n```\nafter [[Also]]\n"),
+            ["Real", "Also"]
+        );
+    }
+
+    #[test]
+    fn unclosed_empty_and_bracketed_targets_are_not_links() {
+        assert_eq!(targets("an [[Unclosed link\nthen [[Closed]]\n"), ["Closed"]);
+        assert_eq!(
+            targets("empty [[]] blank [[   ]] real [[Real]]\n"),
+            ["Real"]
+        );
+        // The renderer's pattern refuses a `]` inside, so this is plain text.
+        assert!(targets("[[a]b]]\n").is_empty());
+    }
+
+    #[test]
+    fn a_heading_only_target_is_not_a_link() {
+        assert!(targets("see [[#Section]]\n").is_empty());
+    }
+
+    #[test]
+    fn long_lines_are_truncated_in_the_snippet() {
+        let line = format!("{}[[Target]]{}", "x".repeat(150), "y".repeat(150));
+        let links = parse_links(&line);
+        assert!(links[0].snippet.ends_with('…'));
+        assert!(links[0].snippet.chars().count() <= MAX_SNIPPET_CHARS + 1);
+    }
+
+    #[test]
+    fn a_note_merges_frontmatter_and_inline_tags() {
+        let note = extract_note(
+            "/w/a.md",
+            "---\ntitle: Note\ntags: [Work, ideas]\n---\n\nbody #Work/Urgent and #42\n",
+        );
+        assert_eq!(note.tags, vec!["ideas", "work", "work/urgent"]);
+        assert_eq!(note.title.as_deref(), Some("Note"));
+        assert_eq!(note.fields.get("title").map(String::as_str), Some("Note"));
+        assert!(!note.fields.contains_key("tags"));
+    }
+
+    #[test]
+    fn frontmatter_tags_do_not_leak_into_the_inline_scan() {
+        // The body scan starts after the closing fence, so a `#` in the block
+        // is not read as a tag.
+        let note = extract_note("/w/a.md", "---\nnote: see #notatag\n---\n\nbody #real\n");
+        assert_eq!(note.tags, vec!["real"]);
+    }
+
+    #[test]
+    fn a_note_without_frontmatter_still_indexes() {
+        let note = extract_note("/w/a.md", "# Title\n\nlinks to [[Other]] #tag\n");
+        assert_eq!(note.tags, vec!["tag"]);
+        assert!(note.title.is_none());
+        assert!(note.fields.is_empty());
+        assert_eq!(note.links.len(), 1);
+    }
+
+    #[test]
+    fn aliases_are_kept_for_the_resolver() {
+        let note = extract_note("/w/a.md", "---\naliases: [Alt, Second]\n---\n");
+        assert_eq!(note.aliases, vec!["Alt", "Second"]);
+        assert_eq!(
+            note.fields.get("aliases").map(String::as_str),
+            Some("Alt, Second")
+        );
+    }
+
+    #[test]
+    fn an_oversized_block_leaves_the_note_indexed_for_inline_tags() {
+        let content = format!("---\nbig: {}\n---\nbody #kept\n", "x".repeat(9000));
+        let note = extract_note("/w/a.md", &content);
+        assert!(note.fields.is_empty());
+        assert_eq!(note.tags, vec!["kept"]);
+    }
+}

--- a/src-tauri/src/vault/queries.rs
+++ b/src-tauri/src/vault/queries.rs
@@ -1,0 +1,94 @@
+//! The per-note lookups the snapshot deliberately leaves out, so its payload
+//! stays proportional to the file count rather than the link count.
+
+use serde::Serialize;
+
+use super::canvas::Canvas;
+use super::graph::Backlink;
+use super::index::Vault;
+use super::query::{self, Filter};
+use super::tags;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryResult {
+    pub filters: Vec<Filter>,
+    /// The query minus its filters.
+    pub text: String,
+    /// Paths satisfying every filter, or every indexed path when there are none.
+    pub paths: Vec<String>,
+}
+
+impl Vault {
+    /// Inbound links to `path`, with the snippet of the line each came from.
+    pub fn backlinks(&self, path: &str) -> &[Backlink] {
+        match self.id_of(path) {
+            Some(id) => &self.graph.backlinks[id],
+            None => &[],
+        }
+    }
+
+    /// Resolve several targets at once, as linked from `from`. One call per
+    /// rendered document rather than one per link.
+    pub fn resolve_many(&self, from: Option<&str>, targets: &[String]) -> Vec<Option<&str>> {
+        targets
+            .iter()
+            .map(|target| {
+                self.resolver
+                    .resolve(target, from)
+                    .map(|id| self.resolver.path(id))
+            })
+            .collect()
+    }
+
+    /// Directly connected notes, in either direction.
+    pub fn neighbors(&self, path: &str) -> Vec<&str> {
+        let Some(id) = self.id_of(path) else {
+            return Vec::new();
+        };
+        self.graph.neighbors[id]
+            .iter()
+            .map(|&other| self.notes[other].path.as_str())
+            .collect()
+    }
+
+    /// Parse a palette query and return the notes it selects.
+    pub fn query(&self, raw: &str) -> QueryResult {
+        let parsed = query::parse_query(raw, &self.field_names);
+        let paths = self
+            .notes
+            .iter()
+            .filter(|note| query::matches_filters(note, &parsed.filters))
+            .map(|note| note.path.clone())
+            .collect();
+        QueryResult {
+            filters: parsed.filters,
+            text: parsed.text,
+            paths,
+        }
+    }
+
+    /// Files carrying `tag` or one of its nested children (`work/urgent`).
+    pub fn paths_with_tag(&self, tag: &str) -> Vec<&str> {
+        let wanted = tags::normalize_tag(tag);
+        if wanted.is_empty() {
+            return Vec::new();
+        }
+        let nested = format!("{wanted}/");
+        self.notes
+            .iter()
+            .filter(|note| {
+                note.tags
+                    .iter()
+                    .any(|t| t == &wanted || t.starts_with(&nested))
+            })
+            .map(|note| note.path.as_str())
+            .collect()
+    }
+
+    /// The parsed board of an indexed `.canvas` file.
+    pub fn canvas(&self, path: &str) -> Option<&Canvas> {
+        let id = self.id_of(path)?;
+        self.canvases.get(&self.notes[id].path)
+    }
+}

--- a/src-tauri/src/vault/query.rs
+++ b/src-tauri/src/vault/query.rs
@@ -1,0 +1,227 @@
+//! Metadata filters in a palette query: `tag:foo`, `status:draft`,
+//! `project:"side quest"`. Field syntax follows Obsidian's so notes migrating
+//! from it keep working. Whatever is left after the filters is plain search
+//! text and still goes through the caller's fuzzy matcher.
+
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::Serialize;
+
+use super::note::Note;
+use super::tags::normalize_tag;
+
+const TAG_FIELDS: [&str; 2] = ["tag", "tags"];
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Filter {
+    /// Lowercased field name; `tag` and `tags` match the tag set.
+    pub field: String,
+    /// Lowercased value, unquoted.
+    pub value: String,
+}
+
+#[derive(Debug, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ParsedQuery {
+    pub filters: Vec<Filter>,
+    /// The query minus its filters, trimmed.
+    pub text: String,
+}
+
+/// ASCII `\w` on purpose: the renderer's pattern is JavaScript's, where `\w`
+/// does not include letters outside ASCII.
+fn filter_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| Regex::new(r#"([A-Za-z][0-9A-Za-z_-]*):("[^"]*"|\S+)"#).unwrap())
+}
+
+/// Split `query` into metadata filters and leftover search text. `fields` is
+/// the set of frontmatter field names the workspace actually uses: a
+/// `word:value` term naming anything else (a pasted `C:\notes\x`, a
+/// `Section:Overview` heading) stays plain text instead of filtering the
+/// results down to nothing.
+pub(crate) fn parse_query(query: &str, fields: &BTreeSet<String>) -> ParsedQuery {
+    let mut filters = Vec::new();
+    let mut rest = String::with_capacity(query.len());
+    let mut cursor = 0;
+
+    for caps in filter_pattern().captures_iter(query) {
+        let whole = caps.get(0).expect("group 0 always matches");
+        let field = caps[1].to_lowercase();
+        let raw_value = &caps[2];
+        // A value with only an opening quote keeps its text; the renderer
+        // drops its last character instead, which is no use mid-typing.
+        let value = raw_value
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .unwrap_or(raw_value)
+            .trim();
+
+        let usable =
+            !value.is_empty() && (TAG_FIELDS.contains(&field.as_str()) || fields.contains(&field));
+        if !usable {
+            continue;
+        }
+
+        rest.push_str(&query[cursor..whole.start()]);
+        // Removing a filter from the middle would otherwise join the words on
+        // either side of it into one.
+        rest.push(' ');
+        cursor = whole.end();
+        filters.push(Filter {
+            field,
+            value: value.to_lowercase(),
+        });
+    }
+    rest.push_str(&query[cursor..]);
+
+    ParsedQuery {
+        filters,
+        text: rest.split_whitespace().collect::<Vec<_>>().join(" "),
+    }
+}
+
+fn matches_filter(note: &Note, filter: &Filter) -> bool {
+    if TAG_FIELDS.contains(&filter.field.as_str()) {
+        let wanted = normalize_tag(&filter.value);
+        let nested = format!("{wanted}/");
+        return note
+            .tags
+            .iter()
+            .any(|tag| tag == &wanted || tag.starts_with(&nested));
+    }
+    // Substring, so `project:glyph` still finds "Glyph Docs".
+    note.fields
+        .get(&filter.field)
+        .is_some_and(|value| value.to_lowercase().contains(&filter.value))
+}
+
+/// Whether `note` satisfies every filter (AND, like Obsidian).
+pub(crate) fn matches_filters(note: &Note, filters: &[Filter]) -> bool {
+    filters.iter().all(|filter| matches_filter(note, filter))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::note::extract_note;
+
+    fn fields(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    fn filter(field: &str, value: &str) -> Filter {
+        Filter {
+            field: field.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn a_filter_is_lifted_out_of_the_search_text() {
+        let parsed = parse_query("tag:work notes", &fields(&[]));
+        assert_eq!(parsed.filters, vec![filter("tag", "work")]);
+        assert_eq!(parsed.text, "notes");
+    }
+
+    #[test]
+    fn a_filter_removed_from_the_middle_leaves_one_space() {
+        let parsed = parse_query("weekly tag:work notes", &fields(&[]));
+        assert_eq!(parsed.text, "weekly notes");
+    }
+
+    #[test]
+    fn only_fields_the_workspace_uses_become_filters() {
+        let known = parse_query("status:draft", &fields(&["status"]));
+        assert_eq!(known.filters, vec![filter("status", "draft")]);
+        assert_eq!(known.text, "");
+
+        let unknown = parse_query("Section:Overview", &fields(&["status"]));
+        assert!(unknown.filters.is_empty());
+        assert_eq!(unknown.text, "Section:Overview");
+    }
+
+    #[test]
+    fn a_pasted_windows_path_stays_plain_text() {
+        let parsed = parse_query(r"C:\notes\x", &fields(&["status"]));
+        assert!(parsed.filters.is_empty());
+        assert_eq!(parsed.text, r"C:\notes\x");
+    }
+
+    #[test]
+    fn quoted_values_may_hold_spaces() {
+        let parsed = parse_query("project:\"side quest\" left", &fields(&["project"]));
+        assert_eq!(parsed.filters, vec![filter("project", "side quest")]);
+        assert_eq!(parsed.text, "left");
+    }
+
+    #[test]
+    fn fields_and_values_are_lowercased() {
+        let parsed = parse_query("Status:Draft", &fields(&["status"]));
+        assert_eq!(parsed.filters, vec![filter("status", "draft")]);
+    }
+
+    #[test]
+    fn a_bare_colon_and_an_empty_quoted_value_stay_plain_text() {
+        for query in ["just: text", "project:\"\" left"] {
+            let parsed = parse_query(query, &fields(&["project"]));
+            assert!(parsed.filters.is_empty(), "{query}");
+        }
+    }
+
+    #[test]
+    fn a_query_without_filters_is_untouched() {
+        let parsed = parse_query("weekly review", &fields(&["status"]));
+        assert!(parsed.filters.is_empty());
+        assert_eq!(parsed.text, "weekly review");
+    }
+
+    #[test]
+    fn several_filters_are_all_lifted() {
+        let parsed = parse_query("tag:work status:draft rest", &fields(&["status"]));
+        assert_eq!(
+            parsed.filters,
+            vec![filter("tag", "work"), filter("status", "draft")]
+        );
+        assert_eq!(parsed.text, "rest");
+    }
+
+    #[test]
+    fn no_filters_matches_everything() {
+        let note = extract_note("/w/a.md", "plain body\n");
+        assert!(matches_filters(&note, &[]));
+    }
+
+    #[test]
+    fn tag_filters_match_nested_children() {
+        let note = extract_note("/w/a.md", "body #work/urgent\n");
+        assert!(matches_filters(&note, &[filter("tag", "work")]));
+        assert!(matches_filters(&note, &[filter("tags", "work/urgent")]));
+        assert!(!matches_filters(&note, &[filter("tag", "wor")]));
+        assert!(!matches_filters(&note, &[filter("tag", "home")]));
+    }
+
+    #[test]
+    fn field_filters_match_case_insensitive_substrings() {
+        let note = extract_note("/w/a.md", "---\nproject: Glyph Docs\n---\n");
+        assert!(matches_filters(&note, &[filter("project", "glyph")]));
+        assert!(!matches_filters(&note, &[filter("project", "other")]));
+        assert!(!matches_filters(&note, &[filter("status", "draft")]));
+    }
+
+    #[test]
+    fn every_filter_must_match() {
+        let note = extract_note("/w/a.md", "---\nstatus: draft\n---\n\nbody #work\n");
+        assert!(matches_filters(
+            &note,
+            &[filter("tag", "work"), filter("status", "draft")]
+        ));
+        assert!(!matches_filters(
+            &note,
+            &[filter("tag", "home"), filter("status", "draft")]
+        ));
+    }
+}

--- a/src-tauri/src/vault/resolve.rs
+++ b/src-tauri/src/vault/resolve.rs
@@ -1,0 +1,345 @@
+//! Resolves a `[[wikilink]]` target to an indexed note. Match is
+//! case-insensitive on the filename stem, with `.md` stripped; a target
+//! carrying a separator matches a path suffix instead. When several files
+//! share a stem, the one in the linking file's directory wins.
+
+use std::collections::HashMap;
+
+/// A leading dot is part of the name, so `.hidden` keeps it.
+pub(crate) fn stem_of(path: &str) -> &str {
+    let name = path.rsplit(['/', '\\']).next().unwrap_or(path);
+    match name.rfind('.') {
+        Some(dot) if dot > 0 => &name[..dot],
+        _ => name,
+    }
+}
+
+pub(crate) fn dir_of(path: &str) -> &str {
+    match path.rfind(['/', '\\']) {
+        Some(idx) => &path[..idx],
+        None => "",
+    }
+}
+
+/// Deterministic path ordering that does not depend on the host's locale.
+pub(crate) fn compare_paths(a: &str, b: &str) -> std::cmp::Ordering {
+    a.to_lowercase()
+        .cmp(&b.to_lowercase())
+        .then_with(|| a.cmp(b))
+}
+
+/// Split a raw target on its first `#`. An empty heading is no heading.
+pub(crate) fn split_heading(raw: &str) -> (&str, Option<&str>) {
+    match raw.split_once('#') {
+        Some((target, heading)) => {
+            let heading = heading.trim();
+            (target, (!heading.is_empty()).then_some(heading))
+        }
+        None => (raw, None),
+    }
+}
+
+fn normalize_target(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    let Some(cut) = trimmed.len().checked_sub(3) else {
+        return trimmed;
+    };
+    if trimmed.is_char_boundary(cut) && trimmed[cut..].eq_ignore_ascii_case(".md") {
+        return &trimmed[..cut];
+    }
+    trimmed
+}
+
+/// Strip a trailing extension, but only one that is not itself a path segment.
+fn without_extension(path: &str) -> &str {
+    let name_start = path.rfind(['/', '\\']).map_or(0, |idx| idx + 1);
+    match path[name_start..].rfind('.') {
+        Some(dot) if dot > 0 => &path[..name_start + dot],
+        _ => path,
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct Resolver {
+    /// Every indexed path, in walker order; the index into this vector is a
+    /// note's id everywhere else in the module.
+    paths: Vec<String>,
+    /// Lowercased, forward-slashed, extension-less paths, for suffix matching.
+    suffix_keys: Vec<String>,
+    by_stem: HashMap<String, Vec<usize>>,
+    by_alias: HashMap<String, Vec<usize>>,
+}
+
+impl Resolver {
+    pub(crate) fn build(paths: &[String], aliases: &[Vec<String>]) -> Self {
+        let mut resolver = Resolver {
+            paths: paths.to_vec(),
+            suffix_keys: paths
+                .iter()
+                .map(|path| without_extension(path).replace('\\', "/").to_lowercase())
+                .collect(),
+            ..Resolver::default()
+        };
+        for (id, path) in paths.iter().enumerate() {
+            resolver
+                .by_stem
+                .entry(stem_of(path).to_lowercase())
+                .or_default()
+                .push(id);
+        }
+        for (id, note_aliases) in aliases.iter().enumerate() {
+            for alias in note_aliases {
+                let key = alias.trim().to_lowercase();
+                if key.is_empty() {
+                    continue;
+                }
+                resolver.by_alias.entry(key).or_default().push(id);
+            }
+        }
+        resolver
+    }
+
+    pub(crate) fn path(&self, id: usize) -> &str {
+        &self.paths[id]
+    }
+
+    /// The note `raw_target` names, resolved as if linked from `from`.
+    pub(crate) fn resolve(&self, raw_target: &str, from: Option<&str>) -> Option<usize> {
+        let (target, _) = split_heading(raw_target);
+        let cleaned = normalize_target(target);
+        if cleaned.is_empty() || self.paths.is_empty() {
+            return None;
+        }
+        let lower = cleaned.to_lowercase();
+
+        let candidates = if lower.contains('/') || lower.contains('\\') {
+            let suffix = format!("/{}", lower.replace('\\', "/"));
+            self.suffix_keys
+                .iter()
+                .enumerate()
+                .filter(|(_, key)| key.ends_with(&suffix))
+                .map(|(id, _)| id)
+                .collect()
+        } else {
+            // A bare name matches a filename, never a directory.
+            self.by_stem.get(&lower).cloned().unwrap_or_default()
+        };
+
+        // Aliases are the last resort, so a file actually named `target` still
+        // wins over another file that merely lists it under `aliases:`.
+        let candidates = if candidates.is_empty() {
+            self.by_alias.get(&lower).cloned().unwrap_or_default()
+        } else {
+            candidates
+        };
+
+        self.pick(candidates, from)
+    }
+
+    fn pick(&self, mut candidates: Vec<usize>, from: Option<&str>) -> Option<usize> {
+        match candidates.len() {
+            0 => return None,
+            1 => return Some(candidates[0]),
+            _ => {}
+        }
+
+        if let Some(from) = from {
+            let current_dir = dir_of(from);
+            if let Some(&same_dir) = candidates
+                .iter()
+                .find(|&&id| dir_of(&self.paths[id]) == current_dir)
+            {
+                return Some(same_dir);
+            }
+        }
+
+        // Stable fallback: shortest path, then by name. Counted in chars
+        // and compared case-first, so the answer does not move with the host's
+        // locale the way the renderer's `localeCompare` does.
+        candidates.sort_by(|&a, &b| {
+            let (a, b) = (&self.paths[a], &self.paths[b]);
+            a.chars()
+                .count()
+                .cmp(&b.chars().count())
+                .then_with(|| a.to_lowercase().cmp(&b.to_lowercase()))
+                .then_with(|| a.cmp(b))
+        });
+        Some(candidates[0])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn files() -> Vec<String> {
+        [
+            "/workspace/Index.md",
+            "/workspace/Notes/Cooking.md",
+            "/workspace/Notes/Travel.md",
+            "/workspace/Archive/Travel.md",
+        ]
+        .map(String::from)
+        .to_vec()
+    }
+
+    fn resolver(paths: &[String]) -> Resolver {
+        Resolver::build(paths, &vec![Vec::new(); paths.len()])
+    }
+
+    fn resolved(target: &str, from: Option<&str>) -> Option<String> {
+        let paths = files();
+        let resolver = resolver(&paths);
+        resolver
+            .resolve(target, from)
+            .map(|id| resolver.path(id).to_string())
+    }
+
+    #[test]
+    fn stems_and_directories() {
+        assert_eq!(stem_of("/a/b/Note.md"), "Note");
+        assert_eq!(stem_of("Note.markdown"), "Note");
+        assert_eq!(stem_of("Note"), "Note");
+        assert_eq!(stem_of("/a/.hidden"), ".hidden");
+        assert_eq!(dir_of("/a/b/Note.md"), "/a/b");
+        assert_eq!(dir_of("C:\\a\\Note.md"), "C:\\a");
+        assert_eq!(dir_of("Note.md"), "");
+    }
+
+    #[test]
+    fn headings_split_off_the_target() {
+        assert_eq!(split_heading("note"), ("note", None));
+        assert_eq!(split_heading("note#section"), ("note", Some("section")));
+        assert_eq!(split_heading("note#  "), ("note", None));
+    }
+
+    #[test]
+    fn nothing_resolves_in_an_empty_workspace() {
+        assert_eq!(resolver(&[]).resolve("Note", None), None);
+    }
+
+    #[test]
+    fn stems_match_case_insensitively() {
+        assert_eq!(
+            resolved("cooking", None).as_deref(),
+            Some("/workspace/Notes/Cooking.md")
+        );
+        assert_eq!(
+            resolved("INDEX", None).as_deref(),
+            Some("/workspace/Index.md")
+        );
+    }
+
+    #[test]
+    fn a_trailing_md_is_stripped() {
+        assert_eq!(
+            resolved("Cooking.md", None).as_deref(),
+            Some("/workspace/Notes/Cooking.md")
+        );
+        assert_eq!(
+            resolved("Cooking.MD", None).as_deref(),
+            Some("/workspace/Notes/Cooking.md")
+        );
+    }
+
+    #[test]
+    fn an_unknown_target_resolves_to_nothing() {
+        assert_eq!(resolved("Missing", None), None);
+        assert_eq!(resolved("   ", None), None);
+    }
+
+    #[test]
+    fn a_heading_does_not_change_the_target() {
+        assert_eq!(
+            resolved("Cooking#Recipes", None).as_deref(),
+            Some("/workspace/Notes/Cooking.md")
+        );
+    }
+
+    #[test]
+    fn colliding_names_prefer_the_linking_file_directory() {
+        assert_eq!(
+            resolved("Travel", Some("/workspace/Archive/today.md")).as_deref(),
+            Some("/workspace/Archive/Travel.md")
+        );
+        assert_eq!(
+            resolved("Travel", Some("/workspace/Notes/today.md")).as_deref(),
+            Some("/workspace/Notes/Travel.md")
+        );
+    }
+
+    #[test]
+    fn without_a_same_directory_candidate_the_shortest_path_wins() {
+        assert_eq!(
+            resolved("Travel", Some("/workspace/Other/today.md")).as_deref(),
+            Some("/workspace/Notes/Travel.md")
+        );
+        assert_eq!(
+            resolved("Travel", None).as_deref(),
+            Some("/workspace/Notes/Travel.md")
+        );
+    }
+
+    #[test]
+    fn a_target_with_a_separator_matches_a_path_suffix() {
+        assert_eq!(
+            resolved("Notes/Travel", None).as_deref(),
+            Some("/workspace/Notes/Travel.md")
+        );
+        assert_eq!(
+            resolved("Archive/Travel", None).as_deref(),
+            Some("/workspace/Archive/Travel.md")
+        );
+    }
+
+    #[test]
+    fn a_dotfile_keeps_its_whole_name_in_a_nested_target() {
+        // The renderer strips a leading dot as if it were an extension, which
+        // would make `.hidden` match any path ending in a directory separator.
+        let paths = [
+            "/w/notes/.hidden".to_string(),
+            "/w/notes/Real.md".to_string(),
+        ];
+        let resolver = resolver(&paths);
+        assert_eq!(
+            resolver
+                .resolve("notes/.hidden", None)
+                .map(|id| resolver.path(id)),
+            Some("/w/notes/.hidden")
+        );
+    }
+
+    #[test]
+    fn a_forward_slash_target_matches_backslash_paths() {
+        let paths = ["C:\\ws\\Index.md", "C:\\ws\\Notes\\Ingredients.md"].map(String::from);
+        let resolver = resolver(&paths);
+        for target in ["Notes/Ingredients", "Notes\\Ingredients"] {
+            assert_eq!(
+                resolver.resolve(target, None).map(|id| resolver.path(id)),
+                Some("C:\\ws\\Notes\\Ingredients.md")
+            );
+        }
+    }
+
+    #[test]
+    fn aliases_resolve_only_when_no_file_is_named_that() {
+        let paths = files();
+        let mut aliases = vec![Vec::new(); paths.len()];
+        // Index.md answers to "Home", and Archive/Travel.md claims the name of
+        // a real note, which must not win over that note's own file.
+        aliases[0] = vec!["Home".to_string()];
+        aliases[3] = vec!["Cooking".to_string()];
+        let resolver = Resolver::build(&paths, &aliases);
+
+        assert_eq!(
+            resolver.resolve("home", None).map(|id| resolver.path(id)),
+            Some("/workspace/Index.md")
+        );
+        assert_eq!(
+            resolver
+                .resolve("Cooking", None)
+                .map(|id| resolver.path(id)),
+            Some("/workspace/Notes/Cooking.md")
+        );
+    }
+}

--- a/src-tauri/src/vault/resolve.rs
+++ b/src-tauri/src/vault/resolve.rs
@@ -322,6 +322,23 @@ mod tests {
     }
 
     #[test]
+    fn a_blank_alias_is_not_a_key() {
+        // `aliases: ["", "  "]` would otherwise make every empty target
+        // resolve to that note.
+        let paths = files();
+        let mut aliases = vec![Vec::new(); paths.len()];
+        aliases[0] = vec![String::new(), "   ".to_string(), "Home".to_string()];
+        let resolver = Resolver::build(&paths, &aliases);
+
+        assert_eq!(resolver.resolve("", None), None);
+        assert_eq!(resolver.resolve("   ", None), None);
+        assert_eq!(
+            resolver.resolve("home", None).map(|id| resolver.path(id)),
+            Some("/workspace/Index.md")
+        );
+    }
+
+    #[test]
     fn aliases_resolve_only_when_no_file_is_named_that() {
         let paths = files();
         let mut aliases = vec![Vec::new(); paths.len()];

--- a/src-tauri/src/vault/snapshot.rs
+++ b/src-tauri/src/vault/snapshot.rs
@@ -1,0 +1,102 @@
+//! What the UI reads on workspace open and after a watcher refresh.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use super::graph::{GraphEdge, GraphNode, UnresolvedLink};
+use super::index::Vault;
+use super::tags;
+use crate::commands::walk::ScanStatus;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NoteSummary {
+    pub path: String,
+    pub title: Option<String>,
+    pub tags: Vec<String>,
+    pub fields: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TagCount {
+    pub tag: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphView<'a> {
+    pub nodes: &'a [GraphNode],
+    pub edges: &'a [GraphEdge],
+}
+
+/// What the UI reads on workspace open and after a watcher refresh. Snippets
+/// are not in here: they arrive per note through [`Vault::backlinks`], which
+/// keeps this payload proportional to the file count rather than the link
+/// count.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultSnapshot<'a> {
+    pub files: Vec<&'a str>,
+    /// Notes carrying at least one tag or frontmatter field.
+    pub notes: Vec<NoteSummary>,
+    pub graph: GraphView<'a>,
+    pub tag_counts: Vec<TagCount>,
+    /// Every frontmatter field name used anywhere in the workspace.
+    pub field_names: Vec<&'a str>,
+    pub unresolved: &'a [UnresolvedLink],
+    pub dead_ends: &'a [String],
+    pub status: &'a ScanStatus,
+}
+
+impl Vault {
+    pub fn snapshot(&self) -> VaultSnapshot<'_> {
+        VaultSnapshot {
+            files: self.notes.iter().map(|note| note.path.as_str()).collect(),
+            notes: self
+                .notes
+                .iter()
+                .filter(|note| !note.tags.is_empty() || !note.fields.is_empty())
+                .map(|note| NoteSummary {
+                    path: note.path.clone(),
+                    title: note.title.clone(),
+                    tags: note.tags.clone(),
+                    fields: note.fields.clone(),
+                })
+                .collect(),
+            graph: GraphView {
+                nodes: &self.graph.nodes,
+                edges: &self.graph.edges,
+            },
+            tag_counts: self.tag_counts(),
+            field_names: self.field_names.iter().map(String::as_str).collect(),
+            unresolved: &self.graph.unresolved,
+            dead_ends: &self.graph.dead_ends,
+            status: &self.status,
+        }
+    }
+
+    /// Every tag in the workspace, most frequent first, ties broken by name. A
+    /// nested tag counts toward each of its ancestors once per file, so a
+    /// parent's count matches the list [`Vault::paths_with_tag`] returns.
+    fn tag_counts(&self) -> Vec<TagCount> {
+        let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+        for note in &self.notes {
+            let mut in_file: BTreeSet<String> = BTreeSet::new();
+            for tag in &note.tags {
+                in_file.extend(tags::with_ancestors(tag));
+            }
+            for tag in in_file {
+                *counts.entry(tag).or_insert(0) += 1;
+            }
+        }
+        let mut out: Vec<TagCount> = counts
+            .into_iter()
+            .map(|(tag, count)| TagCount { tag, count })
+            .collect();
+        out.sort_by(|a, b| b.count.cmp(&a.count).then_with(|| a.tag.cmp(&b.tag)));
+        out
+    }
+}

--- a/src-tauri/src/vault/snapshot.rs
+++ b/src-tauri/src/vault/snapshot.rs
@@ -48,7 +48,7 @@ pub struct VaultSnapshot<'a> {
     pub field_names: Vec<&'a str>,
     pub unresolved: &'a [UnresolvedLink],
     pub dead_ends: &'a [String],
-    pub status: &'a ScanStatus,
+    pub status: ScanStatus,
 }
 
 impl Vault {
@@ -74,7 +74,7 @@ impl Vault {
             field_names: self.field_names.iter().map(String::as_str).collect(),
             unresolved: &self.graph.unresolved,
             dead_ends: &self.graph.dead_ends,
-            status: &self.status,
+            status: self.status(),
         }
     }
 

--- a/src-tauri/src/vault/tags.rs
+++ b/src-tauri/src/vault/tags.rs
@@ -1,0 +1,189 @@
+//! Tag rules for the vault index: what counts as a tag in note text, how a
+//! written tag normalizes, and how tags roll up into counts.
+
+/// Note content is untrusted and every tag reaches the frontend, so a single
+/// crafted `a/a/a/…` tag can't expand into thousands of tree levels.
+pub const MAX_TAG_CHARS: usize = 64;
+/// Bounds the inline scan only. Frontmatter tags arrive inside the 8 KB block,
+/// which bounds them already.
+pub const MAX_INLINE_TAGS_PER_FILE: usize = 100;
+
+/// `#Project/Alpha` and `project/alpha` are the same tag. The separator is
+/// collapsed and trimmed so `work/` and `work//urgent` can't open a blank
+/// level in the tag tree.
+pub(crate) fn normalize_tag(tag: &str) -> String {
+    let without_hash = tag.trim().trim_start_matches('#');
+    let lowered = without_hash.to_lowercase();
+
+    let mut out = String::with_capacity(lowered.len());
+    let mut last_was_sep = false;
+    for c in lowered.chars() {
+        if c == '/' {
+            if !last_was_sep {
+                out.push(c);
+            }
+            last_was_sep = true;
+            continue;
+        }
+        last_was_sep = false;
+        out.push(c);
+    }
+    out.trim_matches('/').to_string()
+}
+
+/// Add every tag in `raw` to `into`. A plain scalar (`tags: work, ideas`)
+/// reaches the index as one string, so it is split the way Obsidian does
+/// instead of indexing "work, ideas" as a single tag.
+pub(crate) fn add_tags(raw: &str, into: &mut Vec<String>) {
+    for part in raw.split([',', ' ', '\t', '\n', '\r']) {
+        let tag = normalize_tag(part);
+        if !tag.is_empty() && tag.chars().count() <= MAX_TAG_CHARS && !into.contains(&tag) {
+            into.push(tag);
+        }
+    }
+}
+
+fn is_tag_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '-' || c == '/'
+}
+
+/// Inline `#tag` tokens in one line of body text, lowercased. A tag opens at
+/// the start of a line or after whitespace, so `mid#word` is not one.
+fn push_line_tags(line: &str, out: &mut Vec<String>) {
+    let chars: Vec<char> = line.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] != '#' || (i > 0 && !chars[i - 1].is_whitespace()) {
+            i += 1;
+            continue;
+        }
+        let start = i + 1;
+        let mut end = start;
+        while end < chars.len() && is_tag_char(chars[end]) {
+            end += 1;
+        }
+        let tag: String = chars[start..end].iter().collect();
+        // A digits-only run is an issue reference (`#42`), not a tag.
+        let usable = !tag.is_empty()
+            && tag.chars().count() <= MAX_TAG_CHARS
+            && tag.chars().any(|c| !c.is_ascii_digit());
+        if usable {
+            out.push(tag.to_lowercase());
+        }
+        i = end;
+    }
+}
+
+/// Inline tags across a note body, sorted, deduplicated, and capped. `body` is
+/// the note's lines with any frontmatter block already skipped.
+pub fn inline_tags<'a>(body: impl Iterator<Item = &'a str>) -> Vec<String> {
+    let mut tags: Vec<String> = Vec::new();
+    let mut in_fence = false;
+    for line in body {
+        let trimmed_start = line.trim_start();
+        if trimmed_start.starts_with("```") || trimmed_start.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        push_line_tags(line, &mut tags);
+    }
+    tags.sort();
+    tags.dedup();
+    tags.truncate(MAX_INLINE_TAGS_PER_FILE);
+    tags
+}
+
+/// `project/glyph/ui` also belongs to `project/glyph` and to `project`.
+pub(crate) fn with_ancestors(tag: &str) -> Vec<String> {
+    let parts: Vec<&str> = tag.split('/').collect();
+    (1..=parts.len()).map(|i| parts[..i].join("/")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_strips_hashes_and_lowercases() {
+        assert_eq!(normalize_tag("  #Project  "), "project");
+        assert_eq!(normalize_tag("##Deep"), "deep");
+        assert_eq!(normalize_tag("Work/Urgent"), "work/urgent");
+    }
+
+    #[test]
+    fn normalize_collapses_and_trims_separators() {
+        assert_eq!(normalize_tag("#work//urgent"), "work/urgent");
+        assert_eq!(normalize_tag("#work/"), "work");
+        assert_eq!(normalize_tag("#/work/"), "work");
+        assert_eq!(normalize_tag("#"), "");
+        assert_eq!(normalize_tag("///"), "");
+    }
+
+    #[test]
+    fn add_tags_splits_a_plain_scalar() {
+        let mut out = Vec::new();
+        add_tags("work, ideas  drafts", &mut out);
+        assert_eq!(out, vec!["work", "ideas", "drafts"]);
+    }
+
+    #[test]
+    fn add_tags_drops_empty_and_oversized_entries() {
+        let mut out = Vec::new();
+        add_tags(&format!("ok, {}", "x".repeat(MAX_TAG_CHARS + 1)), &mut out);
+        add_tags("  ,  ", &mut out);
+        assert_eq!(out, vec!["ok"]);
+
+        let mut exact = Vec::new();
+        add_tags(&"y".repeat(MAX_TAG_CHARS), &mut exact);
+        assert_eq!(exact.len(), 1);
+    }
+
+    #[test]
+    fn add_tags_does_not_repeat_a_tag() {
+        let mut out = Vec::new();
+        add_tags("work", &mut out);
+        add_tags("#Work", &mut out);
+        assert_eq!(out, vec!["work"]);
+    }
+
+    #[test]
+    fn inline_tags_ignore_fenced_code() {
+        let body = "before #kept\n```\n#fenced\n```\nafter #also\n";
+        assert_eq!(inline_tags(body.lines()), vec!["also", "kept"]);
+    }
+
+    #[test]
+    fn inline_tags_ignore_issue_references_and_mid_word_hashes() {
+        let body = "closes #42 for mid#word but keeps #real and #v2\n";
+        assert_eq!(inline_tags(body.lines()), vec!["real", "v2"]);
+    }
+
+    #[test]
+    fn inline_tags_keep_nesting_and_lowercase() {
+        let body = "#Work/Urgent and #work/urgent\n";
+        assert_eq!(inline_tags(body.lines()), vec!["work/urgent"]);
+    }
+
+    #[test]
+    fn inline_tags_stop_at_the_per_file_cap() {
+        let body: String = (0..MAX_INLINE_TAGS_PER_FILE + 20)
+            .map(|i| format!("#tag{i:04}\n"))
+            .collect();
+        assert_eq!(inline_tags(body.lines()).len(), MAX_INLINE_TAGS_PER_FILE);
+    }
+
+    #[test]
+    fn inline_tags_reject_a_run_over_the_character_cap() {
+        let body = format!("#{} #short\n", "z".repeat(MAX_TAG_CHARS + 1));
+        assert_eq!(inline_tags(body.lines()), vec!["short"]);
+    }
+
+    #[test]
+    fn ancestors_expand_every_level() {
+        assert_eq!(with_ancestors("a/b/c"), vec!["a", "a/b", "a/b/c"]);
+        assert_eq!(with_ancestors("solo"), vec!["solo"]);
+    }
+}

--- a/src-tauri/src/vault/test_support.rs
+++ b/src-tauri/src/vault/test_support.rs
@@ -1,0 +1,80 @@
+//! The shared fixture vault. `src-tauri/fixtures/vault/` is a real workspace
+//! checked into the repo and copied into a temp directory per test, so a test
+//! may create, edit and delete inside it. `fixtures/vault-frontmatter.json`
+//! carries the frontmatter expectations that `src/lib/frontmatter.test.ts`
+//! asserts too, which is what keeps the two parsers in step.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tauri::test::{mock_app, MockRuntime};
+use tauri::Manager;
+
+use crate::grants::GrantRegistry;
+use crate::vault::commands::VaultStore;
+
+pub(crate) fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures")
+}
+
+/// An empty temp directory, unique per test.
+pub(crate) fn unique_tmp(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "glyph_vault_{}_{}_{}",
+        name,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A writable copy of the fixture vault.
+pub(crate) fn fixture_vault(name: &str) -> PathBuf {
+    let dir = unique_tmp(name);
+    copy_tree(&fixtures_dir().join("vault"), &dir);
+    dir
+}
+
+fn copy_tree(from: &Path, to: &Path) {
+    fs::create_dir_all(to).unwrap();
+    for entry in fs::read_dir(from).unwrap().flatten() {
+        let target = to.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_tree(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+
+/// A mock app carrying a grant for `dir` plus an empty vault store, so the
+/// command surface runs without a real window manager.
+pub(crate) fn app_with_workspace(dir: &Path) -> tauri::App<MockRuntime> {
+    let app = mock_app();
+    app.manage(GrantRegistry::default());
+    app.manage(VaultStore::default());
+    app.state::<GrantRegistry>().grant_workspace(dir).unwrap();
+    app
+}
+
+/// A mock app with no grant at all, for the denial tests.
+pub(crate) fn app_without_grants() -> tauri::App<MockRuntime> {
+    let app = mock_app();
+    app.manage(GrantRegistry::default());
+    app.manage(VaultStore::default());
+    app
+}
+
+/// Fixture paths as the index spells them, relative to `root`.
+pub(crate) fn in_vault(root: &Path, relative: &str) -> String {
+    relative
+        .split('/')
+        .fold(root.to_path_buf(), |path, segment| path.join(segment))
+        .to_string_lossy()
+        .to_string()
+}

--- a/src-tauri/src/vault/tests.rs
+++ b/src-tauri/src/vault/tests.rs
@@ -432,6 +432,56 @@ fn an_incremental_update_refuses_a_symlinked_note() {
     fs::remove_dir_all(&outside).unwrap();
 }
 
+// The walk refuses a symlink structurally: it never descends into a linked
+// directory. `walkable` stats only the leaf, which a link further up the path
+// is invisible to, and the watcher follows links, so events for a linked
+// directory arrive spelled as if they were inside the workspace.
+#[cfg(unix)]
+#[test]
+fn an_incremental_update_refuses_a_note_under_a_symlinked_directory() {
+    let root = fixture_vault("incremental_symlink_dir");
+    let outside = unique_tmp("incremental_symlink_dir_target");
+    fs::write(outside.join("secret.md"), "top secret #classified\n").unwrap();
+
+    let mut vault = build(&root);
+    let linked = root.join("archive");
+    std::os::unix::fs::symlink(&outside, &linked).unwrap();
+    vault.apply_changes(&[linked.join("secret.md")]);
+
+    assert!(vault.paths_with_tag("classified").is_empty());
+    assert_eq!(vault.snapshot().files.len(), 8);
+    assert_matches_rebuild(&vault, &root);
+
+    fs::remove_dir_all(&root).unwrap();
+    fs::remove_dir_all(&outside).unwrap();
+}
+
+#[test]
+fn one_workspace_caches_one_index_however_the_root_is_spelled() {
+    // The store key cannot be the caller's string: a renderer that asked for
+    // `<ws>`, `<ws>/.` and `<ws>/./.` would otherwise cache a full index under
+    // each and grow the map without bound.
+    let root = fixture_vault("cmd_root_spellings");
+    let app = app_with_workspace(&root);
+    let (grants, store) = (app.state::<GrantRegistry>(), app.state::<VaultStore>());
+    let base = root.to_string_lossy().to_string();
+
+    for spelling in [base.clone(), format!("{base}/."), format!("{base}/./.")] {
+        vault_snapshot(spelling, grants.clone(), store.clone()).unwrap();
+    }
+    assert_eq!(store.0.lock().unwrap().len(), 1);
+
+    // A directory inside the workspace is readable but is not a workspace, so
+    // it gets no index of its own.
+    let inside = vault_snapshot(in_vault(&root, "Notes"), grants.clone(), store.clone());
+    assert!(inside.is_err());
+    assert_eq!(store.0.lock().unwrap().len(), 1);
+
+    vault_forget(base, store.clone()).unwrap();
+    assert!(store.0.lock().unwrap().is_empty());
+    fs::remove_dir_all(&root).unwrap();
+}
+
 #[test]
 fn growing_past_the_file_cap_is_reported_rather_than_indexed() {
     let root = fixture_vault("incremental_cap");

--- a/src-tauri/src/vault/tests.rs
+++ b/src-tauri/src/vault/tests.rs
@@ -1,0 +1,851 @@
+//! Tests that span the vault's siblings or drive its command surface. The
+//! per-sibling rules live in each sibling's own test module.
+
+use std::fs;
+use std::path::Path;
+
+use serde_json::{json, Value};
+use tauri::Manager;
+
+use super::commands::*;
+use super::frontmatter::{parse_frontmatter, split_frontmatter};
+use super::test_support::*;
+use super::Vault;
+use crate::grants::GrantRegistry;
+
+fn build(root: &Path) -> Vault {
+    Vault::build(root).unwrap()
+}
+
+fn relative(root: &Path, path: &str) -> String {
+    path.strip_prefix(&root.to_string_lossy().to_string())
+        .unwrap_or(path)
+        .trim_start_matches(['/', '\\'])
+        .replace('\\', "/")
+}
+
+fn resolve_one(vault: &Vault, from: Option<&str>, target: &str) -> Option<String> {
+    vault.resolve_many(from, &[target.to_string()])[0].map(str::to_string)
+}
+
+// ---------------------------------------------------------------- the index
+
+#[test]
+fn the_fixture_vault_indexes_markdown_and_canvas() {
+    let root = fixture_vault("index_all");
+    let vault = build(&root);
+    let snapshot = vault.snapshot();
+    let files: Vec<String> = snapshot
+        .files
+        .iter()
+        .map(|path| relative(&root, path))
+        .collect();
+
+    assert_eq!(
+        files,
+        vec![
+            "Aliased.md",
+            "Archive/Old Note.md",
+            "Archive/Travel.md",
+            "Board.canvas",
+            "Broken.md",
+            "Index.md",
+            "Notes/Cooking.md",
+            "Notes/Travel.md",
+        ]
+    );
+    assert!(!snapshot.status.truncated);
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn resolution_across_the_fixture_vault() {
+    let root = fixture_vault("resolve");
+    let vault = build(&root);
+    let index = in_vault(&root, "Index.md");
+    let archive = in_vault(&root, "Archive/Travel.md");
+
+    let cases: [(Option<&str>, &str, Option<&str>); 8] = [
+        // Case-insensitive stem, `.md` stripped, heading and alias ignored.
+        (None, "cooking", Some("Notes/Cooking.md")),
+        (None, "Cooking.MD", Some("Notes/Cooking.md")),
+        (None, "Cooking#Recipes", Some("Notes/Cooking.md")),
+        // A nested target matches a path suffix.
+        (None, "Notes/Travel", Some("Notes/Travel.md")),
+        // Colliding stems: the linking file's own directory wins, otherwise
+        // the shortest path does.
+        (Some(archive.as_str()), "Travel", Some("Archive/Travel.md")),
+        (Some(index.as_str()), "Travel", Some("Notes/Travel.md")),
+        // An alias resolves once nothing is named that.
+        (None, "Second Name", Some("Aliased.md")),
+        (None, "Missing Note", None),
+    ];
+
+    for (from, target, expected) in cases {
+        let got = resolve_one(&vault, from, target).map(|p| relative(&root, &p));
+        assert_eq!(got.as_deref(), expected, "resolving {target}");
+    }
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn tags_follow_the_documented_rules() {
+    let root = fixture_vault("tags");
+    let vault = build(&root);
+    let snapshot = vault.snapshot();
+
+    let cooking = snapshot
+        .notes
+        .iter()
+        .find(|note| note.path.ends_with("Cooking.md"))
+        .expect("Cooking is indexed");
+    // Frontmatter list plus the inline tag; the fenced tag, the issue
+    // reference and the mid-word hash contribute nothing.
+    assert_eq!(cooking.tags, vec!["food", "food/baking", "kitchen"]);
+
+    // A nested tag counts toward each ancestor, once per file.
+    let counts: Vec<(&str, usize)> = snapshot
+        .tag_counts
+        .iter()
+        .map(|c| (c.tag.as_str(), c.count))
+        .collect();
+    assert!(counts.contains(&("food", 1)));
+    assert!(counts.contains(&("food/baking", 1)));
+    assert!(counts.contains(&("archive", 1)));
+
+    let with_food: Vec<String> = vault
+        .paths_with_tag("food")
+        .into_iter()
+        .map(|p| relative(&root, p))
+        .collect();
+    assert_eq!(with_food, vec!["Notes/Cooking.md"]);
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn frontmatter_matches_the_shared_expectation() {
+    // The same file drives `src/lib/frontmatter.test.ts`. When one parser
+    // changes, that test and this one disagree with it together.
+    let expected: Value = serde_json::from_str(
+        &fs::read_to_string(fixtures_dir().join("vault-frontmatter.json")).unwrap(),
+    )
+    .unwrap();
+    let vault_dir = fixtures_dir().join("vault");
+
+    for (name, want) in expected.as_object().unwrap() {
+        let content = fs::read_to_string(vault_dir.join(name)).unwrap();
+        let parsed = split_frontmatter(&content)
+            .0
+            .as_deref()
+            .and_then(parse_frontmatter);
+
+        let Some(want) = want.as_object() else {
+            assert!(parsed.is_none(), "{name} should carry no frontmatter");
+            continue;
+        };
+        let parsed = parsed.unwrap_or_else(|| panic!("{name} should parse"));
+
+        for key in ["title", "author", "date"] {
+            let got = match key {
+                "title" => &parsed.title,
+                "author" => &parsed.author,
+                _ => &parsed.date,
+            };
+            assert_eq!(
+                got.as_deref(),
+                want.get(key).and_then(Value::as_str),
+                "{name}.{key}"
+            );
+        }
+        let want_tags: Vec<&str> = want
+            .get("tags")
+            .and_then(Value::as_array)
+            .map(|v| v.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        assert_eq!(parsed.tags, want_tags, "{name}.tags");
+
+        let got_extra: Vec<Value> = parsed.extra.iter().map(|(k, v)| json!([k, v])).collect();
+        assert_eq!(&Value::Array(got_extra), &want["extra"], "{name}.extra");
+    }
+}
+
+#[test]
+fn the_graph_and_backlinks_read_from_resolved_links() {
+    let root = fixture_vault("graph");
+    let vault = build(&root);
+    let snapshot = vault.snapshot();
+
+    // Index links Cooking twice (plain and with a heading); one edge only.
+    let index_edges: Vec<String> = snapshot
+        .graph
+        .edges
+        .iter()
+        .filter(|e| e.source.ends_with("Index.md"))
+        .map(|e| relative(&root, &e.target))
+        .collect();
+    assert_eq!(
+        index_edges,
+        vec![
+            "Notes/Cooking.md",
+            "Notes/Travel.md",
+            "Aliased.md",
+            "Board.canvas"
+        ]
+    );
+
+    // Broken.md points nowhere, so it is an orphan and a dead end.
+    let broken = snapshot
+        .graph
+        .nodes
+        .iter()
+        .find(|n| n.id.ends_with("Broken.md"))
+        .unwrap();
+    assert_eq!(broken.degree, 0);
+    assert!(broken.orphan);
+    assert!(snapshot.dead_ends.iter().any(|p| p.ends_with("Broken.md")));
+    assert_eq!(
+        snapshot
+            .unresolved
+            .iter()
+            .filter(|u| u.source.ends_with("Broken.md"))
+            .count(),
+        2
+    );
+
+    // One row per source line: Index links Cooking on two lines, the board on
+    // one, and the two links sharing Index's second line collapse into it.
+    let backlinks = vault.backlinks(&in_vault(&root, "Notes/Cooking.md"));
+    assert_eq!(backlinks.len(), 3);
+    assert!(backlinks
+        .iter()
+        .all(|b| b.source.ends_with("Index.md") || b.source.ends_with("Board.canvas")));
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn a_canvas_board_is_indexed_and_links_its_file_cards() {
+    let root = fixture_vault("canvas");
+    let vault = build(&root);
+    let board = in_vault(&root, "Board.canvas");
+
+    let canvas = vault.canvas(&board).expect("the board is indexed");
+    // The card without geometry is dropped, and so is the edge to a card that
+    // does not exist.
+    assert_eq!(canvas.nodes.len(), 4);
+    assert_eq!(canvas.edges.len(), 1);
+
+    let neighbors: Vec<String> = vault
+        .neighbors(&board)
+        .into_iter()
+        .map(|p| relative(&root, p))
+        .collect();
+    assert_eq!(neighbors, vec!["Index.md", "Notes/Cooking.md"]);
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn queries_filter_on_tags_and_fields() {
+    let root = fixture_vault("query");
+    let vault = build(&root);
+
+    let tagged = vault.query("tag:food recipes");
+    assert_eq!(tagged.text, "recipes");
+    assert_eq!(
+        tagged
+            .paths
+            .iter()
+            .map(|p| relative(&root, p))
+            .collect::<Vec<_>>(),
+        vec!["Notes/Cooking.md"]
+    );
+
+    // `project` is a field the fixture uses, so it filters.
+    let field = vault.query("project:glyph");
+    assert_eq!(
+        field
+            .paths
+            .iter()
+            .map(|p| relative(&root, p))
+            .collect::<Vec<_>>(),
+        vec!["Archive/Old Note.md"]
+    );
+
+    // `section` is not, so it stays plain text and nothing is filtered out.
+    let plain = vault.query("Section:Overview");
+    assert!(plain.filters.is_empty());
+    assert_eq!(plain.text, "Section:Overview");
+    assert_eq!(plain.paths.len(), 8);
+    fs::remove_dir_all(&root).unwrap();
+}
+
+// -------------------------------------------------------- incremental updates
+
+/// An incremental update must land the index exactly where a rebuild from disk
+/// would, so a long-lived session never drifts from a fresh open.
+fn assert_matches_rebuild(vault: &Vault, root: &Path) {
+    let fresh = build(root);
+    let (a, b) = (vault.snapshot(), fresh.snapshot());
+    assert_eq!(
+        serde_json::to_value(&a).unwrap(),
+        serde_json::to_value(&b).unwrap()
+    );
+}
+
+#[test]
+fn creating_editing_deleting_and_renaming_update_the_index_in_place() {
+    let root = fixture_vault("incremental");
+    let mut vault = build(&root);
+
+    // Create.
+    let added = root.join("Notes").join("Added.md");
+    fs::write(&added, "---\ntags: [fresh]\n---\n\nLinks [[Index]].\n").unwrap();
+    vault.apply_changes(std::slice::from_ref(&added));
+    assert_eq!(
+        resolve_one(&vault, None, "Added").map(|p| relative(&root, &p)),
+        Some("Notes/Added.md".to_string())
+    );
+    assert_eq!(vault.paths_with_tag("fresh").len(), 1);
+    assert_matches_rebuild(&vault, &root);
+
+    // Edit: the tag goes, a new outgoing link arrives.
+    fs::write(&added, "Now links [[Cooking]] instead.\n").unwrap();
+    vault.apply_changes(std::slice::from_ref(&added));
+    assert!(vault.paths_with_tag("fresh").is_empty());
+    assert!(vault
+        .backlinks(&in_vault(&root, "Notes/Cooking.md"))
+        .iter()
+        .any(|b| b.source.ends_with("Added.md")));
+    assert_matches_rebuild(&vault, &root);
+
+    // Rename, which arrives as the two paths that changed.
+    let renamed = root.join("Notes").join("Renamed.md");
+    fs::rename(&added, &renamed).unwrap();
+    vault.apply_changes(&[added.clone(), renamed.clone()]);
+    assert_eq!(resolve_one(&vault, None, "Added"), None);
+    assert!(resolve_one(&vault, None, "Renamed").is_some());
+    assert_matches_rebuild(&vault, &root);
+
+    // Delete.
+    fs::remove_file(&renamed).unwrap();
+    vault.apply_changes(&[renamed]);
+    assert_eq!(resolve_one(&vault, None, "Renamed"), None);
+    assert_matches_rebuild(&vault, &root);
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn changes_outside_the_root_or_to_other_file_types_are_ignored() {
+    let root = fixture_vault("ignored_changes");
+    let outside = unique_tmp("ignored_outside");
+    let stray = outside.join("Elsewhere.md");
+    fs::write(&stray, "[[Index]]\n").unwrap();
+    let attachment = root.join("photo.png");
+    fs::write(&attachment, "not markdown").unwrap();
+
+    let mut vault = build(&root);
+    let before = serde_json::to_value(vault.snapshot()).unwrap();
+    vault.apply_changes(&[stray, attachment]);
+    assert_eq!(serde_json::to_value(vault.snapshot()).unwrap(), before);
+
+    fs::remove_dir_all(&root).unwrap();
+    fs::remove_dir_all(&outside).unwrap();
+}
+
+#[test]
+fn a_watcher_event_against_the_canonical_root_still_lands() {
+    // `watch_directory` watches the canonicalized root, so notify reports
+    // paths with a verbatim prefix on Windows and with symlinks resolved on
+    // macOS. The index is keyed on the caller's spelling of the root, and one
+    // file must not arrive under two of them.
+    let root = fixture_vault("canonical_event");
+    let mut vault = build(&root);
+    let canonical = fs::canonicalize(&root).unwrap();
+
+    let added = canonical.join("Notes").join("Watched.md");
+    fs::write(&added, "body #watched\n").unwrap();
+    vault.apply_changes(&[added]);
+
+    assert_eq!(vault.snapshot().files.len(), 9);
+    assert_eq!(vault.paths_with_tag("watched").len(), 1);
+    // Spelled the way the rest of the index spells it, so tab paths match.
+    assert!(vault
+        .snapshot()
+        .files
+        .iter()
+        .all(|path| path.starts_with(&root.to_string_lossy().to_string())));
+    assert_matches_rebuild(&vault, &root);
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn an_incremental_update_honours_every_filter_the_walk_applies() {
+    let root = fixture_vault("incremental_filters");
+    let mut vault = build(&root);
+    let before = serde_json::to_value(vault.snapshot()).unwrap();
+
+    // A hidden file, a note inside a skipped directory, and a file past the
+    // size cap: the walk offers none of them, so neither does an update.
+    let hidden = root.join(".secret.md");
+    fs::write(&hidden, "hidden #private\n").unwrap();
+    let skipped = root.join("node_modules").join("pkg");
+    fs::create_dir_all(&skipped).unwrap();
+    let vendored = skipped.join("README.md");
+    fs::write(&vendored, "vendored #noise\n").unwrap();
+    let oversized = root.join("huge.md");
+    fs::write(
+        &oversized,
+        "x".repeat(crate::commands::walk::SCAN_MAX_FILE_BYTES as usize + 1),
+    )
+    .unwrap();
+
+    vault.apply_changes(&[hidden, vendored, oversized]);
+
+    assert_eq!(serde_json::to_value(vault.snapshot()).unwrap(), before);
+    assert_matches_rebuild(&vault, &root);
+    fs::remove_dir_all(&root).unwrap();
+}
+
+// A symlink is a way out of the granted workspace. The walk refuses to follow
+// one; an incremental update reads files the walk never offered it, so it has
+// to refuse them too or a link planted in a shared vault leaks its target's
+// content through tags, fields and backlink snippets.
+#[cfg(unix)]
+#[test]
+fn an_incremental_update_refuses_a_symlinked_note() {
+    let root = fixture_vault("incremental_symlink");
+    let outside = unique_tmp("incremental_symlink_target");
+    let secret = outside.join("secret.md");
+    fs::write(&secret, "top secret #classified\n").unwrap();
+
+    let mut vault = build(&root);
+    let planted = root.join("leak.md");
+    std::os::unix::fs::symlink(&secret, &planted).unwrap();
+    vault.apply_changes(&[planted]);
+
+    assert!(vault.paths_with_tag("classified").is_empty());
+    assert_eq!(vault.snapshot().files.len(), 8);
+    assert_matches_rebuild(&vault, &root);
+
+    fs::remove_dir_all(&root).unwrap();
+    fs::remove_dir_all(&outside).unwrap();
+}
+
+#[test]
+fn growing_past_the_file_cap_is_reported_rather_than_indexed() {
+    let root = fixture_vault("incremental_cap");
+    let mut vault = Vault::build_capped(&root, 8, 32).unwrap();
+    assert!(!vault.snapshot().status.truncated);
+
+    let added = root.join("Ninth.md");
+    fs::write(&added, "one too many\n").unwrap();
+    vault.apply_changes(&[added]);
+
+    let snapshot = vault.snapshot();
+    assert_eq!(snapshot.files.len(), 8);
+    assert!(snapshot.status.truncated);
+    assert_eq!(snapshot.status.reason, Some("fileLimit"));
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn a_file_that_vanishes_between_the_event_and_the_read_is_dropped() {
+    let root = fixture_vault("vanished");
+    let mut vault = build(&root);
+    let gone = root.join("Notes").join("Cooking.md");
+    fs::remove_file(&gone).unwrap();
+
+    vault.apply_changes(&[gone]);
+
+    assert_eq!(resolve_one(&vault, None, "Cooking"), None);
+    assert_eq!(vault.snapshot().files.len(), 7);
+    fs::remove_dir_all(&root).unwrap();
+}
+
+// -------------------------------------------------------------- caps and abuse
+
+#[test]
+fn the_file_cap_truncates_and_says_so() {
+    let root = fixture_vault("file_cap");
+    let vault = Vault::build_capped(&root, 3, 32).unwrap();
+    let snapshot = vault.snapshot();
+
+    assert_eq!(snapshot.files.len(), 3);
+    assert!(snapshot.status.truncated);
+    assert_eq!(snapshot.status.reason, Some("fileLimit"));
+    assert_eq!(snapshot.status.limit, Some(3));
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn the_depth_cap_truncates_and_says_so() {
+    let root = fixture_vault("depth_cap");
+    let vault = Vault::build_capped(&root, 10_000, 1).unwrap();
+    let snapshot = vault.snapshot();
+
+    // Only the top level survives; the reason names the cap that cut it.
+    assert!(snapshot.files.iter().all(|p| !p.contains("Notes")));
+    assert!(snapshot.status.truncated);
+    assert_eq!(snapshot.status.reason, Some("depthLimit"));
+    assert_eq!(snapshot.status.limit, Some(1));
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn building_a_vault_over_a_file_is_an_error() {
+    let root = fixture_vault("not_a_dir");
+    let result = Vault::build(&root.join("Index.md"));
+    assert!(result.is_err());
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn hostile_notes_are_bounded_rather_than_indexed() {
+    let root = unique_tmp("hostile");
+    // A huge frontmatter block, a deeply nested one, one tag past the
+    // character cap, and far more tags than a file may contribute.
+    fs::write(
+        root.join("huge.md"),
+        format!("---\nbig: {}\n---\n\nbody #kept\n", "x".repeat(9000)),
+    )
+    .unwrap();
+    fs::write(
+        root.join("nested.md"),
+        format!(
+            "---\nkey: {}{}\n---\n\nbody\n",
+            "[".repeat(200),
+            "]".repeat(200)
+        ),
+    )
+    .unwrap();
+    let many: String = (0..500).map(|i| format!("#tag{i:04} ")).collect();
+    fs::write(
+        root.join("many.md"),
+        format!("#{} {many}\n", "z".repeat(200)),
+    )
+    .unwrap();
+
+    let vault = build(&root);
+    let snapshot = vault.snapshot();
+
+    let note = |name: &str| {
+        snapshot
+            .notes
+            .iter()
+            .find(|n| n.path.ends_with(name))
+            .unwrap()
+    };
+    assert!(note("huge.md").fields.is_empty());
+    assert_eq!(note("huge.md").tags, vec!["kept"]);
+    assert!(snapshot
+        .notes
+        .iter()
+        .all(|n| !n.path.ends_with("nested.md")));
+    assert_eq!(
+        note("many.md").tags.len(),
+        super::tags::MAX_INLINE_TAGS_PER_FILE
+    );
+    assert!(note("many.md")
+        .tags
+        .iter()
+        .all(|tag| tag.chars().count() <= super::tags::MAX_TAG_CHARS));
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+// A symlink is a way out of the granted workspace, so the walker must not
+// follow it. Unix-only: a symlink on Windows needs elevation or Developer Mode.
+#[cfg(unix)]
+#[test]
+fn symlinked_notes_are_not_indexed() {
+    let root = unique_tmp("symlink");
+    let outside = unique_tmp("symlink_target");
+    fs::write(outside.join("Secret.md"), "secret #private\n").unwrap();
+    fs::write(root.join("Real.md"), "body\n").unwrap();
+    std::os::unix::fs::symlink(outside.join("Secret.md"), root.join("Linked.md")).unwrap();
+    // A loop back onto the root must not hang the walk either.
+    std::os::unix::fs::symlink(&root, root.join("loop")).unwrap();
+
+    let vault = build(&root);
+    let files: Vec<String> = vault
+        .snapshot()
+        .files
+        .iter()
+        .map(|p| relative(&root, p))
+        .collect();
+    assert_eq!(files, vec!["Real.md"]);
+
+    fs::remove_dir_all(&root).unwrap();
+    fs::remove_dir_all(&outside).unwrap();
+}
+
+// ------------------------------------------------------------ command surface
+
+#[test]
+fn the_snapshot_command_returns_the_index_for_a_granted_root() {
+    let root = fixture_vault("cmd_snapshot");
+    let app = app_with_workspace(&root);
+    let snapshot = vault_snapshot(
+        root.to_string_lossy().to_string(),
+        app.state::<GrantRegistry>(),
+        app.state::<VaultStore>(),
+    )
+    .unwrap();
+
+    assert_eq!(snapshot["files"].as_array().unwrap().len(), 8);
+    assert!(snapshot["graph"]["nodes"].is_array());
+    assert_eq!(snapshot["status"]["truncated"], json!(false));
+    // camelCase keys reach the frontend, not Rust's snake_case.
+    assert!(snapshot.get("tagCounts").is_some());
+    assert!(snapshot.get("fieldNames").is_some());
+    assert!(snapshot.get("deadEnds").is_some());
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn every_path_command_is_denied_without_a_grant() {
+    let root = fixture_vault("cmd_denied");
+    let app = app_without_grants();
+    let path = root.to_string_lossy().to_string();
+    let (grants, store) = (app.state::<GrantRegistry>(), app.state::<VaultStore>());
+
+    let errors: Vec<String> = vec![
+        vault_snapshot(path.clone(), grants.clone(), store.clone()).unwrap_err(),
+        vault_refresh(path.clone(), grants.clone(), store.clone()).unwrap_err(),
+        vault_backlinks(path.clone(), path.clone(), grants.clone(), store.clone()).unwrap_err(),
+        vault_resolve(path.clone(), None, vec![], grants.clone(), store.clone()).unwrap_err(),
+        vault_neighbors(path.clone(), path.clone(), grants.clone(), store.clone()).unwrap_err(),
+        vault_query(path.clone(), "tag:x".into(), grants.clone(), store.clone()).unwrap_err(),
+        vault_paths_with_tag(path.clone(), "x".into(), grants.clone(), store.clone()).unwrap_err(),
+        vault_canvas(path.clone(), path.clone(), grants.clone(), store.clone()).unwrap_err(),
+    ];
+
+    for error in &errors {
+        assert!(
+            error.starts_with("path is outside the allowed workspaces and files:"),
+            "unexpected error: {error}"
+        );
+    }
+    // A denied call must not have left an index behind for that root.
+    assert!(store.0.lock().unwrap().is_empty());
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn the_targeted_commands_answer_from_the_cached_index() {
+    let root = fixture_vault("cmd_targeted");
+    let app = app_with_workspace(&root);
+    let (grants, store) = (app.state::<GrantRegistry>(), app.state::<VaultStore>());
+    let path = root.to_string_lossy().to_string();
+
+    let resolved = vault_resolve(
+        path.clone(),
+        Some(in_vault(&root, "Index.md")),
+        vec!["Cooking".into(), "Nowhere".into()],
+        grants.clone(),
+        store.clone(),
+    )
+    .unwrap();
+    assert!(resolved[0].as_deref().unwrap().ends_with("Cooking.md"));
+    assert_eq!(resolved[1], None);
+
+    let backlinks = vault_backlinks(
+        path.clone(),
+        in_vault(&root, "Notes/Cooking.md"),
+        grants.clone(),
+        store.clone(),
+    )
+    .unwrap();
+    assert_eq!(backlinks.as_array().unwrap().len(), 3);
+
+    let tagged =
+        vault_paths_with_tag(path.clone(), "food".into(), grants.clone(), store.clone()).unwrap();
+    assert_eq!(tagged.len(), 1);
+
+    let canvas = vault_canvas(
+        path.clone(),
+        in_vault(&root, "Board.canvas"),
+        grants.clone(),
+        store.clone(),
+    )
+    .unwrap();
+    assert_eq!(canvas.unwrap()["nodes"].as_array().unwrap().len(), 4);
+
+    let neighbors = vault_neighbors(
+        path.clone(),
+        in_vault(&root, "Board.canvas"),
+        grants.clone(),
+        store.clone(),
+    )
+    .unwrap();
+    assert_eq!(neighbors.len(), 2);
+
+    let query = vault_query(
+        path.clone(),
+        "tag:food recipes".into(),
+        grants.clone(),
+        store.clone(),
+    )
+    .unwrap();
+    assert_eq!(query["text"], json!("recipes"));
+    assert_eq!(query["paths"].as_array().unwrap().len(), 1);
+    assert_eq!(query["filters"][0]["field"], json!("tag"));
+
+    // A path that is not indexed answers empty rather than reading the disk.
+    let missing = vault_backlinks(path, "/elsewhere/secret.md".into(), grants, store).unwrap();
+    assert_eq!(missing, json!([]));
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn two_open_roots_keep_separate_indexes() {
+    let first = fixture_vault("cmd_root_a");
+    let second = unique_tmp("cmd_root_b");
+    fs::write(second.join("Only.md"), "body #other\n").unwrap();
+
+    let app = app_with_workspace(&first);
+    app.state::<GrantRegistry>()
+        .grant_workspace(&second)
+        .unwrap();
+    let (grants, store) = (app.state::<GrantRegistry>(), app.state::<VaultStore>());
+
+    let a = vault_snapshot(
+        first.to_string_lossy().to_string(),
+        grants.clone(),
+        store.clone(),
+    )
+    .unwrap();
+    let b = vault_snapshot(
+        second.to_string_lossy().to_string(),
+        grants.clone(),
+        store.clone(),
+    )
+    .unwrap();
+
+    assert_eq!(a["files"].as_array().unwrap().len(), 8);
+    assert_eq!(b["files"].as_array().unwrap().len(), 1);
+    assert_eq!(store.0.lock().unwrap().len(), 2);
+
+    // Closing one workspace releases only its index.
+    vault_forget(first.to_string_lossy().to_string(), store.clone()).unwrap();
+    assert_eq!(store.0.lock().unwrap().len(), 1);
+
+    fs::remove_dir_all(&first).unwrap();
+    fs::remove_dir_all(&second).unwrap();
+}
+
+#[test]
+fn refresh_rebuilds_a_cached_index_from_disk() {
+    let root = fixture_vault("cmd_refresh");
+    let app = app_with_workspace(&root);
+    let (grants, store) = (app.state::<GrantRegistry>(), app.state::<VaultStore>());
+    let path = root.to_string_lossy().to_string();
+
+    vault_snapshot(path.clone(), grants.clone(), store.clone()).unwrap();
+    fs::write(root.join("Late.md"), "arrived after the first scan\n").unwrap();
+
+    // The cached index has not seen the new file; a refresh has.
+    let cached = vault_snapshot(path.clone(), grants.clone(), store.clone()).unwrap();
+    assert_eq!(cached["files"].as_array().unwrap().len(), 8);
+    let refreshed = vault_refresh(path.clone(), grants.clone(), store.clone()).unwrap();
+    assert_eq!(refreshed["files"].as_array().unwrap().len(), 9);
+    let after = vault_snapshot(path, grants, store).unwrap();
+    assert_eq!(after["files"].as_array().unwrap().len(), 9);
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn watcher_changes_reach_the_stored_index() {
+    let root = fixture_vault("cmd_watcher");
+    let app = app_with_workspace(&root);
+    let (grants, store) = (app.state::<GrantRegistry>(), app.state::<VaultStore>());
+    let path = root.to_string_lossy().to_string();
+    vault_snapshot(path.clone(), grants.clone(), store.clone()).unwrap();
+
+    let added = root.join("Watched.md");
+    fs::write(&added, "body #watched\n").unwrap();
+    apply_changes(&store, &path, &[added]);
+
+    let snapshot = vault_snapshot(path, grants, store).unwrap();
+    assert_eq!(snapshot["files"].as_array().unwrap().len(), 9);
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn watcher_changes_for_an_unopened_root_are_a_no_op() {
+    let root = fixture_vault("cmd_watcher_unknown");
+    let app = app_with_workspace(&root);
+    let store = app.state::<VaultStore>();
+
+    apply_changes(&store, "/never/opened", &[root.join("Index.md")]);
+    forget(&store, "/never/opened");
+
+    assert!(store.0.lock().unwrap().is_empty());
+    fs::remove_dir_all(&root).unwrap();
+}
+
+// ------------------------------------------------------------------ timing
+
+/// Reports how long indexing a thousand notes takes against the scans it
+/// replaces. Ignored by default; run with
+/// `cargo test -p glyph --lib vault::tests::index_1k_notes_timing -- --ignored --nocapture`.
+#[test]
+#[ignore = "timing, not a pass/fail assertion"]
+fn index_1k_notes_timing() {
+    use std::time::Instant;
+
+    let root = unique_tmp("timing");
+    for i in 0..1_000 {
+        fs::write(
+            root.join(format!("note{i:04}.md")),
+            format!(
+                "---\ntitle: Note {i}\ntags: [bench, bench/group{}]\n---\n\n# Note {i}\n\nLinks [[note{:04}]] and [[note{:04}]] plus #inline{}.\n",
+                i % 10,
+                (i + 1) % 1_000,
+                (i + 500) % 1_000,
+                i % 7
+            ),
+        )
+        .unwrap();
+    }
+
+    let app = app_with_workspace(&root);
+    let path = root.to_string_lossy().to_string();
+
+    let started = Instant::now();
+    let old_links = crate::commands::wikilinks::scan_wikilinks(
+        path.clone(),
+        app.state::<crate::grants::GrantRegistry>(),
+    )
+    .unwrap();
+    let old_meta =
+        crate::commands::metadata::scan_metadata(path.clone(), app.state::<GrantRegistry>())
+            .unwrap();
+    let old = started.elapsed();
+
+    let started = Instant::now();
+    let vault = build(&root);
+    let new = started.elapsed();
+
+    let started = Instant::now();
+    let snapshot = serde_json::to_string(&vault.snapshot()).unwrap();
+    let serialized = started.elapsed();
+
+    println!(
+        "scan_wikilinks + scan_metadata: {old:?} ({} refs, {} files)",
+        old_links.refs.len(),
+        old_meta.files.len()
+    );
+    println!(
+        "vault build:                    {new:?} ({} notes)",
+        vault.snapshot().files.len()
+    );
+    println!(
+        "snapshot serialize:             {serialized:?} ({} bytes)",
+        snapshot.len()
+    );
+
+    fs::remove_dir_all(&root).unwrap();
+}

--- a/src-tauri/src/vault/tests.rs
+++ b/src-tauri/src/vault/tests.rs
@@ -483,6 +483,56 @@ fn one_workspace_caches_one_index_however_the_root_is_spelled() {
 }
 
 #[test]
+fn queries_about_a_path_the_index_does_not_hold_answer_empty() {
+    let root = fixture_vault("unknown_path_queries");
+    let vault = build(&root);
+    let stranger = "/elsewhere/secret.md";
+
+    assert!(vault.neighbors(stranger).is_empty());
+    assert!(vault.backlinks(stranger).is_empty());
+    assert!(vault.canvas(stranger).is_none());
+    // A tag that normalizes to nothing selects nothing rather than everything.
+    assert!(vault.paths_with_tag("#").is_empty());
+    assert!(vault.paths_with_tag("///").is_empty());
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn an_incremental_update_respects_the_depth_cap() {
+    let root = fixture_vault("incremental_depth");
+    let mut vault = Vault::build_capped(&root, 10_000, 1).unwrap();
+    let before = serde_json::to_value(vault.snapshot()).unwrap();
+
+    // The walk stopped at the top level, so a note one directory down is not
+    // one the walk would have offered.
+    let deep = root.join("Notes").join("Deep.md");
+    fs::write(&deep, "body #deep\n").unwrap();
+    vault.apply_changes(&[deep]);
+
+    assert_eq!(serde_json::to_value(vault.snapshot()).unwrap(), before);
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
+fn watcher_changes_tolerate_a_poisoned_store() {
+    // The watcher thread has nowhere to report an error, so a poisoned lock
+    // leaves the index as it was rather than panicking the callback.
+    let root = fixture_vault("cmd_poisoned");
+    let app = app_with_workspace(&root);
+    let store = app.state::<VaultStore>();
+    let path = root.to_string_lossy().to_string();
+
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _guard = store.0.lock().unwrap();
+        panic!("poison");
+    }));
+
+    apply_changes(&store, &path, &[root.join("Index.md")]);
+    forget(&store, &path);
+    fs::remove_dir_all(&root).unwrap();
+}
+
+#[test]
 fn growing_past_the_file_cap_is_reported_rather_than_indexed() {
     let root = fixture_vault("incremental_cap");
     let mut vault = Vault::build_capped(&root, 8, 32).unwrap();

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -4,14 +4,15 @@ use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Manager, Runtime, State};
 
 use crate::grants::GrantRegistry;
+use crate::vault::commands::VaultStore;
 
 pub struct FileWatcherState(pub Arc<Mutex<HashMap<String, RecommendedWatcher>>>);
 
-/// A directory watch should fire when a markdown file or a sub-directory is
+/// A directory watch should fire when an indexed file or a sub-directory is
 /// added, removed, renamed, or modified. Everything else (e.g. attribute-only
-/// changes, non-markdown sibling files) is filtered out so the frontend isn't
-/// flooded with refreshes. Extracted as a pure helper so we can test the
-/// filter without booting a Tauri app.
+/// changes, sibling attachments) is filtered out so the frontend isn't flooded
+/// with refreshes. Extracted as a pure helper so we can test the filter
+/// without booting a Tauri app.
 pub fn is_relevant_directory_change(event: &Event) -> bool {
     matches!(
         event.kind,
@@ -19,7 +20,7 @@ pub fn is_relevant_directory_change(event: &Event) -> bool {
     ) && event
         .paths
         .iter()
-        .any(|p| crate::is_markdown_file(p) || p.is_dir())
+        .any(|p| crate::is_markdown_file(p) || crate::is_canvas_file(p) || p.is_dir())
 }
 
 /// A file watch should fire when the watched file's content changes. Editors
@@ -36,11 +37,11 @@ pub fn is_relevant_file_change(event: &Event) -> bool {
 fn forward_watch_event(
     res: Result<Event, notify::Error>,
     is_relevant: fn(&Event) -> bool,
-    emit: impl FnOnce(),
+    emit: impl FnOnce(&Event),
 ) {
     if let Ok(event) = res {
         if is_relevant(&event) {
-            emit();
+            emit(&event);
         }
     }
 }
@@ -81,7 +82,7 @@ pub fn watch_file<R: Runtime>(
     let app_handle = app.clone();
     let watched_path = path.clone();
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
-        forward_watch_event(res, is_relevant_file_change, || {
+        forward_watch_event(res, is_relevant_file_change, |_| {
             let _ = app_handle.emit("file-changed", &watched_path);
         });
     })
@@ -120,7 +121,12 @@ pub fn watch_directory<R: Runtime>(
     let app_handle = app.clone();
     let watched_path = path.clone();
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
-        forward_watch_event(res, is_relevant_directory_change, || {
+        forward_watch_event(res, is_relevant_directory_change, |event| {
+            // Re-index before the frontend hears about the change, so the
+            // snapshot it asks for next is already current.
+            if let Some(store) = app_handle.try_state::<VaultStore>() {
+                crate::vault::commands::apply_changes(&store, &watched_path, &event.paths);
+            }
             let _ = app_handle.emit("directory-changed", &watched_path);
         });
     })
@@ -252,7 +258,7 @@ mod tests {
                 vec![PathBuf::from("/watch/note.md")],
             )),
             is_relevant_file_change,
-            || fired = true,
+            |_| fired = true,
         );
         assert!(fired);
     }
@@ -266,7 +272,7 @@ mod tests {
                 vec![PathBuf::from("/watch/note.md")],
             )),
             is_relevant_file_change,
-            || fired = true,
+            |_| fired = true,
         );
         assert!(!fired);
     }
@@ -277,7 +283,7 @@ mod tests {
         forward_watch_event(
             Err(notify::Error::generic("backend failure")),
             is_relevant_file_change,
-            || fired = true,
+            |_| fired = true,
         );
         assert!(!fired);
     }
@@ -305,6 +311,16 @@ mod tests {
         let e = event(
             EventKind::Modify(ModifyKind::Any),
             vec![PathBuf::from("/p/notes.md")],
+        );
+        assert!(is_relevant_directory_change(&e));
+    }
+
+    #[test]
+    fn relevant_when_a_canvas_board_changes() {
+        // Boards are in the index too, so an edit to one has to reach it.
+        let e = event(
+            EventKind::Modify(ModifyKind::Any),
+            vec![PathBuf::from("/p/board.canvas")],
         );
         assert!(is_relevant_directory_change(&e));
     }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -172,6 +172,8 @@ mod tests {
         let app = mock_app();
         app.manage(FileWatcherState(Arc::new(Mutex::new(HashMap::new()))));
         app.manage(GrantRegistry::default());
+        // The directory watcher re-indexes through the store before it emits.
+        app.manage(VaultStore::default());
         app
     }
 
@@ -633,6 +635,50 @@ mod tests {
 
         let count = wait_for_event(&fired, Duration::from_secs(10));
         assert!(count > 0, "expected at least one directory-changed emit");
+        // The index for this root is built lazily by the command surface, so
+        // an event arriving before that has nothing to update and must not
+        // panic the watcher thread.
+        assert!(app.state::<VaultStore>().0.lock().unwrap().is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_watched_directory_re_indexes_before_it_emits() {
+        let dir = unique_tmp("watch_dir_reindex");
+        let path = dir.to_string_lossy().to_string();
+        std::fs::write(
+            dir.join("first.md"),
+            "links [[second]]
+",
+        )
+        .unwrap();
+
+        let app = mock_app_with_state();
+        grant_dir(&app, &dir);
+        let fired = count_event(&app, "directory-changed");
+        let store = app.state::<VaultStore>();
+        store.0.lock().unwrap().insert(
+            std::fs::canonicalize(&dir).unwrap(),
+            crate::vault::Vault::build(&dir).unwrap(),
+        );
+        watch_directory(
+            path.clone(),
+            app.handle().clone(),
+            app.state::<GrantRegistry>(),
+        )
+        .unwrap();
+
+        std::fs::write(dir.join("second.md"), "# second").unwrap();
+        assert!(wait_for_event(&fired, Duration::from_secs(10)) > 0);
+
+        // Asserted without waiting: the re-index runs before the emit, so the
+        // event the frontend just saw already implies a current index. Polling
+        // here would pass even if that order were reversed.
+        let indexed = store.0.lock().unwrap()[&std::fs::canonicalize(&dir).unwrap()]
+            .snapshot()
+            .files
+            .len();
+        assert_eq!(indexed, 2);
         let _ = std::fs::remove_dir_all(&dir);
     }
     #[test]

--- a/src-tauri/src/window_events.rs
+++ b/src-tauri/src/window_events.rs
@@ -15,10 +15,15 @@ pub fn handle_window_event(window: &Window, event: &WindowEvent) {
     if matches!(event, WindowEvent::Destroyed) {
         if let Some(registry) = window.try_state::<windows::WindowRegistry>() {
             let label = window.label();
-            crate::watcher::drop_watches(
-                window.app_handle(),
-                &registry.exclusively_owned_paths(label),
-            );
+            let owned = registry.exclusively_owned_paths(label);
+            crate::watcher::drop_watches(window.app_handle(), &owned);
+            // The index outlives its watches otherwise, holding every note's
+            // tags, fields and links for the rest of the session.
+            if let Some(store) = window.try_state::<crate::vault::commands::VaultStore>() {
+                for path in &owned {
+                    crate::vault::commands::forget(&store, path);
+                }
+            }
             registry.remove(label);
         }
         #[cfg(desktop)]

--- a/src/lib/frontmatter.test.ts
+++ b/src/lib/frontmatter.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseFrontmatter } from "./frontmatter";
 
@@ -81,5 +83,40 @@ describe("parseFrontmatter", () => {
     expect(result?.author).toBeUndefined();
     expect(result?.date).toBeUndefined();
     expect(result?.extra).toEqual([["slug", "x"]]);
+  });
+});
+
+// The Rust index parses the same blocks in `src-tauri/src/vault/frontmatter.rs`.
+// Both sides are held to `vault-frontmatter.json`, so a change to either parser
+// fails here and in `vault::tests::frontmatter_matches_the_shared_expectation`
+// together instead of drifting apart unnoticed.
+describe("the shared fixture vault", () => {
+  // Vitest runs from the package root, where its config lives.
+  const fixtures = path.join(process.cwd(), "src-tauri", "fixtures");
+  const expected: Record<
+    string,
+    {
+      title?: string;
+      author?: string;
+      date?: string;
+      tags?: string[];
+      extra: [string, string][];
+    } | null
+  > = JSON.parse(readFileSync(path.join(fixtures, "vault-frontmatter.json"), "utf-8"));
+
+  it.each(Object.keys(expected))("parses %s the way the Rust index does", (name) => {
+    const content = readFileSync(path.join(fixtures, "vault", name), "utf-8");
+    const parsed = parseFrontmatter(content);
+    const want = expected[name];
+
+    if (want === null) {
+      expect(parsed).toBeNull();
+      return;
+    }
+    expect(parsed?.title).toBe(want.title);
+    expect(parsed?.author).toBe(want.author);
+    expect(parsed?.date).toBe(want.date);
+    expect(parsed?.tags ?? []).toEqual(want.tags ?? []);
+    expect(parsed?.extra).toEqual(want.extra);
   });
 });


### PR DESCRIPTION
## Summary

First of two PRs for #223, moving the workspace link index out of the webview and into Rust so the UI and the headless MCP server (#301) read one implementation instead of two.

This one adds the index and its command surface. Nothing in the frontend reads it yet: the app still runs on `scan_wikilinks` and `scan_metadata`, so the change is additive and the TypeScript modules it replaces are untouched. The consumer switch and their deletion are the second PR.

`src-tauri/src/vault/` is pure Rust with no `tauri::State` and no `AppHandle` anywhere in the core, which is what lets a headless process build and query it in-process.

| Module | Owns |
| --- | --- |
| `index.rs` | the `Vault`: the walk, the note set, incremental updates |
| `snapshot.rs` | the per-root payload the UI reads on open and after a refresh |
| `queries.rs` | backlinks, resolve, neighbours, query, tag lookup, canvas |
| `frontmatter.rs` | FAILSAFE YAML through `yaml-rust2`'s event parser |
| `note.rs` | title, tags and outgoing links per file |
| `resolve.rs` | stem, nested-suffix and `aliases:` keys, plus the tie-breaks |
| `graph.rs` | edges, degree, orphan, backlinks, unresolved links, dead ends |
| `canvas.rs` | JSON Canvas cards and edges |
| `tags.rs` | the tag rules and their caps |
| `query.rs` | the palette's filter grammar |
| `commands.rs` | nine Tauri commands, each gated |

### Why `yaml-rust2`, and why its event parser

`serde_yaml` is archived; `serde_yaml_ng` and `serde_norway` last shipped in 2024; `saphyr` is still 0.0.x. `yaml-rust2` 0.12 is maintained and is the stable face of the same parser.

The event API matters more than the crate choice. `Event::Scalar` carries the scalar's **source text**, so building the field map from the event stream *is* FAILSAFE, with nothing to un-coerce. Going through `YamlLoader` and the `Yaml` value type would coerce to `Integer` / `Boolean` / `Real` first and lose `1.0` versus `1.00`, and `true` versus `True`, which is exactly what the renderer must not do.

New crates in the tree: `arraydeque` and `hashlink` (a thin wrapper over `hashbrown`, already present). `encoding_rs`, its one optional dependency, was already there.

### Performance

Three release runs indexing a thousand notes, against the two scans this replaces, on the same machine (`cargo test --release --lib vault::tests::index_1k_notes_timing -- --ignored --nocapture`):

```
scan_wikilinks + scan_metadata:  129 / 134 / 124 ms
vault build:                      69 /  71 /  72 ms
snapshot serialize:              1.9 / 1.8 / 2.3 ms   (914 KB)
```

Roughly half the time while doing strictly more work: the old pair returns raw refs and raw frontmatter blocks, the new build additionally resolves every link and derives the graph, backlinks, the unresolved list and the canvas boards.

## Changes

- `src-tauri/src/vault/`: the index, its derived views, and nine Tauri commands (`vault_snapshot`, `vault_refresh`, `vault_forget`, `vault_backlinks`, `vault_resolve`, `vault_neighbors`, `vault_query`, `vault_paths_with_tag`, `vault_canvas`), registered in `lib.rs` with a `VaultStore` managed alongside the grant registry.
- `src-tauri/fixtures/vault/`: a real workspace checked into the repo, copied to a temp directory per test. `vault-frontmatter.json` beside it carries the frontmatter expectation asserted from **both** Rust and `src/lib/frontmatter.test.ts`, so the one parser that necessarily stays duplicated cannot drift unnoticed.
- `src-tauri/src/watcher.rs`: the directory watcher re-indexes the paths that changed before it tells the frontend to refresh, so no edit costs a full rescan. Its relevance filter now also passes `.canvas` files, which the index covers and which previously could never reach it.
- `src-tauri/src/window_events.rs`: a closing window releases its index next to its watches.
- `src-tauri/src/commands/{walk,metadata,wikilinks}.rs`: the walker takes a file predicate so the vault can visit canvases too, and the tag rules and snippet cap now have one definition that the two scan commands borrow rather than a second copy each. `split_frontmatter` was a third copy that disagreed with the vault's about trailing whitespace on the delimiter and about where the 8 KB budget starts; `scan_metadata` borrows the shared one now, so one file cannot have two answers.
- `docs/security/threat-model.md`: the new gated commands and their checks.

### Scope notes

- **Watcher-driven incremental updates landed here rather than in the second PR.** Leaving `Vault::apply_changes` unwired would have been dead code, which the strict clippy gate rejects. The index maintains itself now; the second PR only switches consumers.
- **The heading index is not in this PR**, and neither are a link's heading, alias and embed flag. #223 lists them, but nothing reads them: heading slicing for embeds is rendering-time work that stays in `headingSection.ts`, and the renderer splits a link's alias and heading out for itself. A per-file heading parse on every build and every incremental update would have been pure cost. They return with their consumers, in #301 and #711.
- **Three TypeScript parsers stay, deliberately.** `frontmatter.ts` also renders the open document's frontmatter table and feeds both exporters; `headingSection.ts` slices content the embed already loaded; `canvas/parse.ts` backs the interactive canvas editor. None of them is resolution, tag rules, graph building, or the query grammar, so none falls under the acceptance criterion that forbids a parallel implementation. The shared fixture is the guard on the one real duplicate.
- **`list_markdown_files` stays**, so the plugin API (`ctx.workspace.listFiles`) and the site exporter are untouched and no satellite repo needs a matching release.

## Risk classification

- [x] Asynchronous ordering / races
- [x] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [x] Filesystem / IPC surface
- [x] Untrusted rendering (Markdown, plugins, links)
- [x] Bundle size / startup

### Invariants at stake and evidence

**INV-5 (all external input is untrusted) and INV-6 (the backend is the boundary).** Every command routes through `with_vault`, which calls `grants.ensure_workspace(root)` before any filesystem access; `vault_refresh` checks before `Vault::build`. The second path argument of `vault_backlinks` / `vault_neighbors` / `vault_canvas` / `vault_resolve` is only ever compared against in-memory strings, so an ungranted path returns empty rather than content. Covered by `every_path_command_is_denied_without_a_grant` (all eight gated commands, and asserts a denied call leaves no index behind) and `the_targeted_commands_answer_from_the_cached_index`.

Note frontmatter is untrusted note content, and the index now parses it in-process rather than shipping the raw block to the renderer's YAML parser. Two consequences are handled:

- **The parser recurses once per nesting level, and a Rust stack overflow aborts the process rather than unwinding**, so it would have taken every unsaved tab in every window with it (INV-1). The 8 KB block cap allows thousands of levels. Events are pulled one at a time through the parser's own iterative state machine and the depth is bounded against the tree as it is built, which is exact; counting the source text instead is a second YAML parser that has to agree with the first about what opens a level, and YAML opens one with `- `, with `? `, with `: `, with a flow bracket and with indentation. `deeply_nested_values_are_refused_without_overflowing_the_stack` covers all five and asserts that ordinary nesting, deep indentation and a block scalar still parse.
- Block size, tag length, tags per file and value nesting are all bounded: `hostile_notes_are_bounded_rather_than_indexed`.
- The store is keyed on the canonical root and gated with `ensure_workspace` rather than `ensure_readable`. A readable check also accepts every directory inside a workspace, so a renderer could have cached a full index per subdirectory, and per spelling of the same one, without bound: `one_workspace_caches_one_index_however_the_root_is_spelled`.

**INV-7 (partial results are explicit).** `ScanStatus` survives the move unchanged and rides on every snapshot: `the_file_cap_truncates_and_says_so`, `the_depth_cap_truncates_and_says_so`, and the camel-case assertion in `the_snapshot_command_returns_the_index_for_a_granted_root`. An incremental update cannot quietly grow the index past the cap the walk enforces: `growing_past_the_file_cap_is_reported_rather_than_indexed`. A refusal stays reported until a rebuild: the index cannot know whether a later deletion made room for the file it turned away, and `vault_refresh` is what answers that.

`apply_changes` reads files the walk never offered it, so it re-applies the same gates rather than calling `read_to_string` directly. Without that, a symlink planted in a shared vault would surface its target's content through tags, fields and backlink snippets, and `node_modules/**.md` and dotfiles would drift into the index until the next full refresh. The walk refuses a symlink structurally, by never descending into a linked directory, so checking only the leaf leaves a symlinked *directory* invisible; the resolved path has to stay inside the workspace. Covered by `an_incremental_update_refuses_a_symlinked_note` and `an_incremental_update_refuses_a_note_under_a_symlinked_directory` (both Unix), `an_incremental_update_honours_every_filter_the_walk_applies`, and `symlinked_notes_are_not_indexed` for the walk itself.

**INV-3 (stale results never win).** The store is built outside its lock, so a full workspace walk no longer blocks every other root's queries or the watcher thread behind it; a concurrent build of the same root loses the race and is discarded rather than replacing an index that has since taken watcher updates. `vault_refresh` stores before it reads back, under one lock, so a watcher update landing mid-walk is not reported as absent. `refresh_rebuilds_a_cached_index_from_disk` and `watcher_changes_reach_the_stored_index` cover the two paths; `two_open_roots_keep_separate_indexes` covers the isolation.

**INV-4 (owners flush before they die).** A closing window releases its index beside its watches in `handle_window_event`; nothing else would, and the index holds every note's tags, fields and links for the rest of the session. `watcher_changes_for_an_unopened_root_are_a_no_op` covers the unknown-root path, and `two_open_roots_keep_separate_indexes` asserts releasing one root leaves the other.

**Incremental updates must not diverge from a rebuild.** `assert_matches_rebuild` compares the whole snapshot against a fresh `Vault::build` after every create, edit, rename and delete, and after each of the filter cases above. A file that vanishes between the watcher event and the read is dropped rather than failing the update: `a_file_that_vanishes_between_the_event_and_the_read_is_dropped`.

**Path spelling.** `watch_directory` watches the canonicalized root, so notify reports verbatim `\\?\C:\…` paths on Windows and symlink-resolved paths on macOS, while the index is keyed on the caller's spelling. Both are accepted and respelled into one, so a file cannot index twice and tab paths keep matching: `a_watcher_event_against_the_canonical_root_still_lands`.

**Bundle size / startup.** Two small new crates (above); no frontend bundle change, since the only TypeScript touched is a test file.

**Untrusted rendering** is checked because the index parses note content; no rendering path changes in this PR.

## Testing

`pnpm typecheck && pnpm check && pnpm test` and `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green: 698 Rust tests and 3789 frontend tests.

Parity with the TypeScript modules this replaces is asserted case by case, in the module beside the code: the twelve `wikilinkResolver.test.ts` cases and the resolution-shaped cases from `graph.test.ts` in `resolve.rs` and `graph.rs`, the fifteen `metadata.test.ts` cases in `tags.rs`, the fourteen `frontmatter.test.ts` cases in `frontmatter.rs`, the fourteen `metadataQuery.test.ts` cases in `query.rs`, and the twenty `canvas/parse.test.ts` cases in `canvas.rs`.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Screenshots

No user-visible change in this PR; the index has no frontend consumer until the second one.

Part of #223
