### PR TITLE
fix(paths): keep a dotfile name whole in stem()

### DIFF
--- a/src/components/layout/FileTree.menu.test.tsx
+++ b/src/components/layout/FileTree.menu.test.tsx
@@ -125,6 +125,20 @@ describe("FileTree context menu", () => {
     expect(onOpenFile).not.toHaveBeenCalled();
   });
 
+  it("preselects the whole name when renaming a dotfile", async () => {
+    const dotfile: DirEntry = {
+      name: ".gitignore",
+      path: "/root/.gitignore",
+      isDirectory: false,
+      modified: 0,
+    };
+    renderFileTree({ nodes: new Map([["/root", [dotfile]]]) });
+
+    fireEvent.contextMenu(screen.getByText(".gitignore"));
+    fireEvent.click(screen.getByText("Rename"));
+    expect(await screen.findByRole("textbox")).toHaveValue(".gitignore");
+  });
+
   it("duplicates an entry via 'Make a copy'", () => {
     const { props } = renderFileTree();
     fireEvent.contextMenu(screen.getByText("post.md"));

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -50,6 +50,14 @@ describe("stem", () => {
   it("returns a name without an extension unchanged", () => {
     expect(stem("Folder")).toBe("Folder");
   });
+
+  it("keeps a dotfile whole, since its leading dot is not an extension", () => {
+    expect(stem(".gitignore")).toBe(".gitignore");
+  });
+
+  it("drops a real extension from a dotfile", () => {
+    expect(stem(".env.local")).toBe(".env");
+  });
 });
 
 describe("displayName", () => {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -19,9 +19,10 @@ export function lastSegment(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
 }
 
-/** File name with its extension removed; a name without one is unchanged. */
+/** File name with its extension removed; a name without one is unchanged. A
+ *  leading dot is part of the name, so `.gitignore` has no extension to drop. */
 export function stem(name: string): string {
-  return name.replace(/\.[^.]+$/, "");
+  return name.replace(/(?!^)\.[^.]+$/, "");
 }
 
 /** Human-readable file name from a plain path or a mobile picker URI


### PR DESCRIPTION
## Summary

`stem()` in `src/lib/paths.ts` treated a leading dot as an extension separator, so `stem(".gitignore")` returned the empty string. Its only caller is the sidebar's inline rename box, which preselects the name portion when the box opens, so renaming any dotfile opened with nothing preselected.

The fix anchors the extension match past index 0, so a leading dot is part of the name rather than a separator. No lookbehind, so there is no minimum WebView version concern.

## Changes

- `stem()` now uses `/(?!^)\.[^.]+$/`, leaving `.gitignore` whole while still reducing `.env.local` to `.env`. Existing behaviour is unchanged for `note.md`, `archive.tar.gz`, and extensionless names.
- Added `paths.test.ts` cases for a bare dotfile and a dotfile with a real extension.
- Added a `FileTree.menu.test.tsx` case asserting the rename box for `.gitignore` opens preselected with `.gitignore`.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

None. The change only affects the default text a rename input opens with; the rename call itself is unchanged and still passes whatever the user commits.

## Testing

Gates run on Windows: `pnpm typecheck`, `pnpm check`, `pnpm test` (407 files, 3785 tests, all passing). No Rust touched, so clippy was not run.

Automated only, no manual app run.

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux
