### PR TITLE
fix(export): publish files linked from a page, not just embedded media

### DIFF
--- a/src/lib/export/site/exportSite.test.ts
+++ b/src/lib/export/site/exportSite.test.ts
@@ -138,6 +138,14 @@ describe("exportSite", () => {
     expect(fs.copies).toEqual([{ src: "/ws/img/shot.png", dest: "/out/img/shot.png" }]);
   });
 
+  it("copies a linked file into the output tree so the link resolves", async () => {
+    const fs = mockFs({ "/ws/notes.md": "[the report](./docs/report.pdf)" });
+    const result = await exportSite({ root: "/ws", outDir: "/out" });
+    expect(result.assets).toBe(1);
+    expect(fs.copies).toEqual([{ src: "/ws/docs/report.pdf", dest: "/out/docs/report.pdf" }]);
+    expect(fs.writes.get("/out/notes.html")).toContain('href="docs/report.pdf"');
+  });
+
   it("inlines mermaid diagrams and restores the app theme afterwards", async () => {
     const fs = mockFs({ "/ws/d.md": "```mermaid\ngraph TD; A-->B;\n```" });
     await exportSite({ root: "/ws", outDir: "/out" });

--- a/src/lib/export/site/exportSite.ts
+++ b/src/lib/export/site/exportSite.ts
@@ -59,8 +59,8 @@ function siteDir(rel: string): string {
  * Export a folder workspace as a browsable static site: one page per markdown
  * file (structure preserved; the root index.*, else the root README.*, owns
  * index.html), a shared style.css collected from the live document, per-page
- * nav and outline, rewritten wikilinks/relative links, copied image assets,
- * and inline Mermaid SVGs. Rendering is headless (no React mount), so every
+ * nav and outline, rewritten wikilinks/relative links, copied images, media
+ * and linked files, and inline Mermaid SVGs. Rendering is headless (no React mount), so every
  * file exports with the same fidelity regardless of what is open in the app.
  */
 export async function exportSite({
@@ -209,8 +209,8 @@ export async function exportSite({
         await invoke("copy_file", { src, dest: outPath(outDir, destRel) });
         copied++;
       } catch (err) {
-        // A referenced image that is missing on disk renders nothing in the
-        // app; the exported page gets the same broken reference instead of
+        // A reference to something missing on disk is already broken in the
+        // app; the exported page carries a broken reference too, rather than
         // the whole export failing on it.
         console.error(`Failed to copy asset ${src}:`, err);
       }

--- a/src/lib/export/site/rewriteUrls.test.ts
+++ b/src/lib/export/site/rewriteUrls.test.ts
@@ -95,10 +95,68 @@ describe("rehypeSiteUrls links", () => {
     expect(html).toContain('href="../index.html"');
   });
 
-  it("leaves relative links to non-markdown files untouched", async () => {
+  it("copies a linked non-markdown file and points the link at the copy", async () => {
+    const ctx = makeCtx("/ws/guide/intro.md", "guide/intro.html");
+    const html = await render("[the report](./report.pdf)", ctx);
+    expect(html).toContain('href="report.pdf"');
+    expect(ctx.assets.get("/ws/guide/report.pdf")).toBe("guide/report.pdf");
+  });
+
+  it("keeps the fragment on a linked non-markdown file", async () => {
     const ctx = makeCtx("/ws/other.md", "other.html");
-    const html = await render("[raw data](./data.csv)", ctx);
-    expect(html).toContain('href="./data.csv"');
+    const html = await render("[page 3](./report.pdf#page=3)", ctx);
+    expect(html).toContain('href="report.pdf#page=3"');
+  });
+
+  it("leaves a linked file above the workspace alone rather than publishing it", async () => {
+    const ctx = makeCtx("/ws/other.md", "other.html");
+    const html = await render("[secret](../private/notes.pdf)", ctx);
+    expect(html).toContain('href="../private/notes.pdf"');
+    expect(ctx.assets.size).toBe(0);
+  });
+
+  it("shares one copy between a link and an image pointing at the same file", async () => {
+    const ctx = makeCtx("/ws/other.md", "other.html");
+    const html = await render("![p](./pic.png) and [p](./pic.png)", ctx);
+    expect(html).toContain('href="pic.png"');
+    expect(html).toContain('src="pic.png"');
+    expect(ctx.assets.size).toBe(1);
+  });
+
+  it("keeps a query string on a linked file out of the resolved path", async () => {
+    const ctx = makeCtx("/ws/other.md", "other.html");
+    const html = await render("[cache-busted](./file.zip?v=2)", ctx);
+    expect(html).toContain('href="file.zip?v=2"');
+    expect(ctx.assets.get("/ws/file.zip")).toBe("file.zip");
+  });
+
+  it("leaves links to folders alone", async () => {
+    const ctx = makeCtx("/ws/guide/intro.md", "guide/intro.html");
+    const html = await render("[trailing](./downloads/) [up](..) [here](.)", ctx);
+    expect(html).toContain('href="./downloads/"');
+    expect(html).toContain('href=".."');
+    expect(html).toContain('href="."');
+    expect(ctx.assets.size).toBe(0);
+  });
+
+  it("sends a linked file that would overwrite a generated file to assets/", async () => {
+    // Assets are copied after the pages are written, so mirroring a workspace
+    // index.html, page, or style.css onto its own path would overwrite it.
+    const ctx = makeCtx("/ws/README.md", "index.html");
+    const html = await render(
+      "[old home](./index.html) [old page](./other.html) [css](./style.css)",
+      ctx,
+    );
+    expect(html).toContain('href="assets/index.html"');
+    expect(html).toContain('href="assets/other.html"');
+    expect(html).toContain('href="assets/style.css"');
+  });
+
+  it("percent-encodes spaces in a rewritten link", async () => {
+    const ctx = makeCtx("/ws/other.md", "other.html");
+    const html = await render("[the report](<./my docs/q1 report.pdf>)", ctx);
+    expect(html).toContain('href="my%20docs/q1%20report.pdf"');
+    expect(ctx.assets.get("/ws/my docs/q1 report.pdf")).toBe("my docs/q1 report.pdf");
   });
 
   it("ignores anchors without an href", async () => {

--- a/src/lib/export/site/rewriteUrls.ts
+++ b/src/lib/export/site/rewriteUrls.ts
@@ -6,9 +6,10 @@ import { decodeHref, encodeHref, headingSlug, relativeHref, relFromRoot } from "
 
 // Rehype plugin that makes one rendered page navigable inside the exported
 // site: wikilink anchors point at the target's generated .html, relative
-// markdown links swap .md for .html, and local images and media are redirected
-// to the copy the exporter will place in the output tree. Runs after sanitize,
-// so the wikilink data-* attributes it reads are already allowlisted.
+// markdown links swap .md for .html, and local images, media and linked files
+// are redirected to the copy the exporter will place in the output tree. Runs
+// after sanitize, so the wikilink data-* attributes it reads are already
+// allowlisted.
 //
 // It also forces the playback attributes the viewer's media components apply,
 // which a static pipeline has no other place to add: without controls, and with
@@ -32,7 +33,7 @@ export interface SiteUrlContext {
   pages: Map<string, string>;
   /**
    * Absolute asset path -> site-relative copy destination. Shared across the
-   * whole export so every page referencing the same image agrees on one copy.
+   * whole export so every page referencing the same file agrees on one copy.
    */
   assets: Map<string, string>;
 }
@@ -48,24 +49,44 @@ function lookupPage(pages: Map<string, string>, abs: string): string | undefined
   return undefined;
 }
 
+/** Site files the exporter writes itself, beyond the generated pages. */
+const SITE_FILES = ["index.html", "style.css", "site.js", "robots.txt"];
+
+/**
+ * Whether the exporter writes `dest` itself. Page paths are compared
+ * case-insensitively, matching how sitePagePlan dedupes them.
+ */
+function isGeneratedPath(ctx: SiteUrlContext, dest: string): boolean {
+  const lower = dest.toLowerCase();
+  if (SITE_FILES.includes(lower)) return true;
+  for (const page of ctx.pages.values()) {
+    if (page.toLowerCase() === lower) return true;
+  }
+  return false;
+}
+
 /**
  * Reserve a site-relative destination for `abs`. Assets inside the workspace
- * keep their relative location; anything outside lands in assets/ with a
- * numeric suffix on basename collisions.
+ * keep their relative location; anything outside, or anything that would land
+ * on a file the exporter generates, goes to assets/ with a numeric suffix on
+ * basename collisions.
  */
 function assetDestination(ctx: SiteUrlContext, abs: string): string {
   const existing = ctx.assets.get(abs);
   if (existing) return existing;
-  let dest: string;
-  if (isPathInside(abs, ctx.root)) {
-    dest = relFromRoot(ctx.root, abs);
-  } else {
-    const name = basename(abs);
-    dest = `assets/${name}`;
-    const taken = new Set(ctx.assets.values());
-    for (let n = 1; taken.has(dest); n++) {
-      dest = `assets/${name.replace(/(\.[^.]*)?$/, `-${n}$1`)}`;
-    }
+  const mirrored = isPathInside(abs, ctx.root) ? relFromRoot(ctx.root, abs) : null;
+  // Assets are copied after the pages are written, so mirroring a workspace
+  // file onto a path the exporter generates (a stray index.html, a workspace
+  // style.css) would silently overwrite it. Those go to assets/ instead.
+  if (mirrored !== null && !isGeneratedPath(ctx, mirrored)) {
+    ctx.assets.set(abs, mirrored);
+    return mirrored;
+  }
+  const name = basename(abs);
+  let dest = `assets/${name}`;
+  const taken = new Set(ctx.assets.values());
+  for (let n = 1; taken.has(dest) || isGeneratedPath(ctx, dest); n++) {
+    dest = `assets/${name.replace(/(\.[^.]*)?$/, `-${n}$1`)}`;
   }
   ctx.assets.set(abs, dest);
   return dest;
@@ -87,13 +108,24 @@ function rewriteAnchor(ctx: SiteUrlContext, props: Record<string, unknown>): voi
 
   const href = props.href;
   if (typeof href !== "string" || !isRelativeLocalHref(href)) return;
-  const [target, fragment] = href.split("#");
-  if (!isMarkdownFile(target)) return;
+  // The query and fragment ride along untouched; only the path resolves.
+  const [, target, suffix] = href.match(/^([^?#]*)(.*)$/) as RegExpMatchArray;
+  const lastSegment = target.split("/").pop();
+  // A folder, not a file: nothing to copy, and the href already points at
+  // whatever the site serves there.
+  if (lastSegment === "" || lastSegment === "." || lastSegment === "..") return;
   // micromark percent-encodes destinations; decode to get the on-disk path.
   const abs = normalizeRelativePath(ctx.filePath, decodeHref(target));
+  if (!isMarkdownFile(target)) {
+    // Anything above the root keeps its original href: a link is easier to
+    // write carelessly than an embed, so it does not publish what it names.
+    if (!isPathInside(abs, ctx.root)) return;
+    props.href = encodeHref(relativeHref(ctx.pageRel, assetDestination(ctx, abs))) + suffix;
+    return;
+  }
   const page = lookupPage(ctx.pages, abs);
   if (!page) return; // outside the workspace; leave the original link alone
-  props.href = encodeHref(relativeHref(ctx.pageRel, page)) + (fragment ? `#${fragment}` : "");
+  props.href = encodeHref(relativeHref(ctx.pageRel, page)) + suffix;
 }
 
 function rewriteImage(ctx: SiteUrlContext, props: Record<string, unknown>): void {


### PR DESCRIPTION
## Summary

A markdown link to a local file that is not markdown survived into the exported site unchanged, and the file it pointed at was never copied, so the published page carried a dead link. `[report](report.pdf)` rendered as `href="report.pdf"` next to no `report.pdf`.

Embedded media never had this problem: `rewriteUrls.ts` already copies the target of `img`, SVG `image`, `video`, `audio` and `source` through `assetDestination`, but `rewriteAnchor` returned early unless the href was markdown. So an image beside a PDF published fine while the PDF beside it did not.

`rewriteAnchor` now routes non-markdown local hrefs through the same `assetDestination` the media paths use, so the file ships beside the page and the link resolves. This covers `--export site` and `glyph serve` alike, since both run the same pipeline.

## Changes

- `rewriteAnchor`: a relative local link to a non-markdown file inside the workspace is registered as an asset and rewritten to point at the copy.
- `assetDestination`: a workspace file is no longer mirrored onto a path the exporter generates. Assets are copied *after* the pages are written, so `[old home](./index.html)` or `[css](./style.css)` in a workspace that also contains those files would have silently overwritten the generated page or stylesheet. Those fall through to `assets/` with the existing collision suffixes, and the suffix loop skips generated paths too.
- Link parsing splits the query and fragment off before resolving, so `[page 3](report.pdf#page=3)` and `[dl](file.zip?v=2)` both resolve to the real file and keep their suffix. Previously the whole `?v=2` went into the path and came back percent-encoded in the href.
- A target whose last segment is empty, `.` or `..` is a folder and is left alone, so `[back](..)` still resolves to the site root instead of becoming a dead rewritten href.
- Tests in `rewriteUrls.test.ts` for the copy, the fragment, the query string, the outside-the-root refusal, folder links, the generated-path collisions, spaces in the path, and a link and an image sharing one copy. `exportSite.test.ts` gains the end-to-end case: a linked PDF is copied and the page's href points at it.

### Two decisions the issue asked for

- **Links pointing outside the workspace are left alone.** `assetDestination` would have copied them into `assets/`, which is what embedded images do today, but a link is easier to write carelessly than an embed, so `[x](../../private/notes.pdf)` keeps its original href and publishes nothing.
- **Any local file type inside the workspace is copyable**, matching the media paths, rather than an attachment-extension allowlist that would silently drop legitimate types. Note this includes dotfiles and dot-directories: `[x](./.git/config)` publishes that file. That was already true for `![](./.git/config)` before this change, so the behavior is not new, but the link spelling makes it easier to hit.

## Risk classification

- [x] Untrusted rendering (Markdown, plugins, links)
- [x] Filesystem / IPC surface

### Invariants at stake and evidence

**INV-5 (all external input is untrusted).** The href is document-supplied and now decides which in-workspace file gets published. Resolution reuses the existing `normalizeRelativePath` + `decodeHref` pair the image path already uses, and the result is clamped with `isPathInside(abs, ctx.root)` before any copy is registered, so a `../` chain cannot pull a file out of the workspace into the site. Evidence: "leaves a linked file above the workspace alone rather than publishing it" asserts both the untouched href and an empty asset map. Escape attempts that fail by construction: `normalizeRelativePath` collapses `..` before the clamp, and prefix confusion (`../ws-secrets/x.pdf` against root `/ws`) is rejected because `isPathInside` requires a separator.

**INV-6 (the backend is the boundary).** No new IPC surface: copying reuses `copy_file` and its `ensure_readable` / `ensure_writable` grant checks. Only the set of files the exporter asks it to copy changes.

**INV-1 (user edits are never silently discarded)**, in the export's own output: the generated-path guard above is what keeps a copied asset from overwriting a page the same export just wrote.

## Testing

`pnpm typecheck && pnpm check && pnpm test` all green (3790 tests). No Rust changes.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Closes #709
