### PR TITLE
fix(export): prune pages a website export no longer produces

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -92,6 +92,18 @@ jobs:
           xvfb-run --auto-servernum ./src-tauri/target/release/glyph export "$PWD/samples" --format site --out /tmp/csp-smoke
           test -f /tmp/csp-smoke/index.html
           test "$(find /tmp/csp-smoke -maxdepth 1 -name '*.html' | wc -l)" -ge 3
+          # A repeat export prunes what it no longer produces, and only that.
+          # This is the only place the prune runs over real IPC and a real
+          # export-dir grant.
+          cp -r "$PWD/samples" /tmp/prune-ws
+          xvfb-run --auto-servernum ./src-tauri/target/release/glyph export /tmp/prune-ws --format site --out /tmp/prune-out
+          test -f /tmp/prune-out/Scratchpad.html
+          test -f /tmp/prune-out/.glyph/site-manifest.json
+          touch /tmp/prune-out/CNAME
+          rm /tmp/prune-ws/Scratchpad.md
+          xvfb-run --auto-servernum ./src-tauri/target/release/glyph export /tmp/prune-ws --format site --out /tmp/prune-out
+          test ! -f /tmp/prune-out/Scratchpad.html
+          test -f /tmp/prune-out/CNAME
           # A document export renders the live DOM, so it exercises the
           # render-readiness gate the site export never touches.
           xvfb-run --auto-servernum ./src-tauri/target/release/glyph export "$PWD/samples/Index.md" --format html --out /tmp/doc-smoke.html

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -30,7 +30,7 @@ the missing remainder is rejected.
 | ----- | ----- | ------ |
 | workspace | folder, recursive | read, write, watch |
 | file | exact path | read, write (autosave), watch |
-| export dir | folder, recursive | write only |
+| export dir | folder, recursive | write, and delete what a previous export into that folder recorded |
 | export file | exact path | write only |
 
 Grants are minted only from backend-observed events, never from a bare
@@ -80,6 +80,7 @@ and files: <path>`), which never echoes the grant list.
 | `read_file`, `get_file_metadata`, `read_directory`, `list_markdown_files`, `scan_wikilinks`, `scan_metadata` | readable |
 | `write_file`, `write_binary_file`, `create_dir_all` | writable |
 | `copy_file` | source readable and destination writable |
+| `prune_export_dir` | the output directory must be writable, and each entry read back from its manifest must be plain path segments whose parent still canonicalizes inside that directory (so a hand-edited manifest cannot delete outside the export) |
 | `watch_file`, `watch_directory` | readable (unwatch stays open; it only drops a watcher) |
 | `create_note`, `create_canvas`, `create_folder` | `root` must be a granted workspace and the target directory canonicalizes inside it |
 | `rename_path`, `duplicate_path`, `move_path`, `delete_path` | `root` must be a granted workspace and the entry itself canonicalizes strictly inside it (a trailing `..`, the root itself, or a symlink resolving outside is refused; `duplicate_path` refuses a folder containing a symlink rather than copying its target) |

--- a/samples/README.md
+++ b/samples/README.md
@@ -432,6 +432,8 @@ With the `samples/` folder open, `File → Export → Website…` turns this who
 glyph export samples/ --format site --out ./site
 ```
 
+Exporting into the same folder twice keeps it in step with the workspace: a page whose note was deleted or renamed is removed, so the old URL stops resolving. Only the previous export's own files are pruned, tracked in a `.glyph/site-manifest.json` the export writes into the output folder, so anything else you keep there (a `CNAME`, a `.nojekyll`) survives. Keep that manifest with the published site: delete or ignore it and the next export starts fresh and prunes nothing.
+
 ### Wikilink autocomplete
 
 In the editor or split view, typing `[[` opens a popup with workspace files. Keep typing to filter, press **Tab** or **Enter** to insert; the closing `]]` is added for you. Open this file in split view (`Cmd+E` cycles modes) and try typing `[[Co` to see it.

--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
+use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 use std::time::UNIX_EPOCH;
 use tauri::State;
@@ -84,6 +85,102 @@ pub fn copy_file(
     fs::copy(&src, &dest)
         .map(|_| ())
         .map_err(|e| format!("Failed to copy file: {e}"))
+}
+
+/// Where an exported site records what it wrote, so the next export into the
+/// same directory knows which of its own files to remove. Site-relative, POSIX
+/// style, matching the paths the exporter hands us.
+const SITE_MANIFEST_REL: &str = ".glyph/site-manifest.json";
+
+/// Resolve a manifest entry inside `out_dir`, refusing anything that could
+/// escape it. The manifest lives in the output directory, so a hand-edited one
+/// is untrusted input (INV-5): every segment must be a plain name, and the
+/// resolved parent must still be inside the output tree after symlinks.
+fn manifest_entry_path(out_dir: &Path, rel: &str) -> Option<PathBuf> {
+    let mut path = out_dir.to_path_buf();
+    for segment in rel.split(['/', '\\']) {
+        let mut components = Path::new(segment).components();
+        match (components.next(), components.next()) {
+            (Some(Component::Normal(name)), None) => path.push(name),
+            _ => return None,
+        }
+    }
+    // Delete through the canonicalized parent, not the path as joined: an
+    // intermediate component swapped for a symlink between the check and the
+    // unlink would otherwise escape the directory that was checked.
+    let parent = path.parent()?.canonicalize().ok()?;
+    let name = path.file_name()?;
+    parent.starts_with(out_dir).then(|| parent.join(name))
+}
+
+/// Fold a manifest entry for comparison: separators unified, case ignored. A
+/// rename that only changes case writes the same file on Windows and macOS, so
+/// comparing verbatim would prune the page the current export just wrote.
+fn manifest_entry_key(rel: &str) -> String {
+    rel.replace('\\', "/").to_lowercase()
+}
+
+/// Remove `from` and each parent up to (but never including) `out_dir`, for as
+/// long as they are empty. `remove_dir` refuses a non-empty directory, which is
+/// exactly the stopping condition.
+fn prune_empty_dirs(from: &Path, out_dir: &Path) {
+    let mut dir = from.to_path_buf();
+    while dir != out_dir && fs::remove_dir(&dir).is_ok() {
+        dir.pop();
+    }
+}
+
+/// Delete the files a previous website export left in `out_dir` that this one
+/// did not write, then record what the output directory now holds of Glyph's.
+/// Returns how many files were removed.
+///
+/// Pruning is against the previous export's own manifest, never against the
+/// whole directory, so anything the user keeps beside the generated site (a
+/// `CNAME`, a `.nojekyll`) is untouched. The manifest is trusted only to name
+/// Glyph's output: every entry it claims is confined to `out_dir`, and that
+/// confinement, not the manifest's contents, is the boundary.
+#[tauri::command]
+pub fn prune_export_dir(
+    out_dir: String,
+    written: Vec<String>,
+    grants: State<'_, GrantRegistry>,
+) -> Result<usize, String> {
+    let out_dir = grants.ensure_writable(&out_dir)?;
+    let manifest = out_dir.join(SITE_MANIFEST_REL);
+    let previous: Vec<String> = fs::read_to_string(&manifest)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default();
+
+    let keep: HashSet<String> = written.iter().map(|rel| manifest_entry_key(rel)).collect();
+    let mut claimed = written;
+    let mut removed = 0;
+    for rel in previous
+        .iter()
+        .filter(|rel| !keep.contains(&manifest_entry_key(rel)))
+    {
+        let Some(path) = manifest_entry_path(&out_dir, rel) else {
+            continue;
+        };
+        if fs::remove_file(&path).is_ok() {
+            removed += 1;
+            if let Some(parent) = path.parent() {
+                prune_empty_dirs(parent, &out_dir);
+            }
+        } else if path.exists() {
+            // Read-only, locked by another process, or a directory: keep
+            // claiming it so a later export prunes it. Dropping it here would
+            // orphan the file in the output for good.
+            claimed.push(rel.clone());
+        }
+    }
+
+    if let Some(parent) = manifest.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {e}"))?;
+    }
+    let json = serde_json::to_string(&claimed).map_err(|e| format!("Failed to serialize: {e}"))?;
+    fs::write(&manifest, json).map_err(|e| format!("Failed to write file: {e}"))?;
+    Ok(removed)
 }
 
 #[tauri::command]
@@ -665,6 +762,267 @@ mod tests {
         assert!(result.unwrap_err().contains("Failed to copy file"));
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    fn app_with_export_dir(dir: &Path) -> tauri::App<MockRuntime> {
+        let app = app_with_grants();
+        app.state::<GrantRegistry>().grant_export_dir(dir).unwrap();
+        app
+    }
+
+    /// An output directory with a previous export's manifest already in place.
+    fn out_dir_with_manifest(name: &str, previous: &[&str]) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("glyph_test_{name}_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join(".glyph")).unwrap();
+        fs::write(
+            dir.join(SITE_MANIFEST_REL),
+            serde_json::to_string(previous).unwrap(),
+        )
+        .unwrap();
+        dir
+    }
+
+    fn prune(dir: &Path, written: &[&str]) -> Result<usize, String> {
+        let app = app_with_export_dir(dir);
+        prune_export_dir(
+            dir.to_string_lossy().to_string(),
+            written.iter().map(|s| s.to_string()).collect(),
+            app.state::<GrantRegistry>(),
+        )
+    }
+
+    #[test]
+    fn prune_export_dir_removes_only_files_the_previous_export_wrote() {
+        let dir = out_dir_with_manifest("prune_stale", &["index.html", "guide.html"]);
+        fs::write(dir.join("index.html"), "home").unwrap();
+        fs::write(dir.join("guide.html"), "stale").unwrap();
+        // Not Glyph's file: a static host's marker the user keeps beside the site.
+        fs::write(dir.join("CNAME"), "example.com").unwrap();
+
+        let removed = prune(&dir, &["index.html"]).unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(!dir.join("guide.html").exists());
+        assert!(dir.join("index.html").exists());
+        assert!(dir.join("CNAME").exists());
+        // The manifest now describes this export, so the next one prunes against it.
+        let manifest = fs::read_to_string(dir.join(SITE_MANIFEST_REL)).unwrap();
+        assert_eq!(manifest, r#"["index.html"]"#);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn prune_export_dir_removes_directories_a_pruned_page_leaves_empty() {
+        let dir = out_dir_with_manifest("prune_dirs", &["guide/intro.html"]);
+        fs::create_dir_all(dir.join("guide")).unwrap();
+        fs::write(dir.join("guide/intro.html"), "gone").unwrap();
+
+        assert_eq!(prune(&dir, &[]).unwrap(), 1);
+
+        assert!(!dir.join("guide").exists());
+        assert!(dir.exists(), "the output directory itself is never removed");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn prune_export_dir_deletes_nothing_without_a_previous_manifest() {
+        let dir =
+            std::env::temp_dir().join(format!("glyph_test_prune_first_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("keep.txt"), "not ours").unwrap();
+
+        assert_eq!(prune(&dir, &["index.html"]).unwrap(), 0);
+
+        assert!(dir.join("keep.txt").exists());
+        assert!(dir.join(SITE_MANIFEST_REL).exists());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn prune_export_dir_ignores_a_malformed_manifest() {
+        let dir = std::env::temp_dir().join(format!("glyph_test_prune_bad_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join(".glyph")).unwrap();
+        fs::write(dir.join(SITE_MANIFEST_REL), "{ not json").unwrap();
+        fs::write(dir.join("index.html"), "home").unwrap();
+
+        assert_eq!(prune(&dir, &["index.html"]).unwrap(), 0);
+
+        assert!(dir.join("index.html").exists());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn prune_export_dir_refuses_manifest_entries_that_escape_the_output_directory() {
+        let outer =
+            std::env::temp_dir().join(format!("glyph_test_prune_escape_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&outer);
+        let dir = outer.join("site");
+        fs::create_dir_all(dir.join(".glyph")).unwrap();
+        let victim = outer.join("secret.txt");
+        fs::write(&victim, "keep").unwrap();
+        // A hand-edited manifest is untrusted input, whatever shape it takes.
+        let escapes = vec![
+            "../secret.txt".to_string(),
+            "..\\secret.txt".to_string(),
+            victim.to_string_lossy().to_string(),
+            "./index.html".to_string(),
+            "".to_string(),
+        ];
+        fs::write(
+            dir.join(SITE_MANIFEST_REL),
+            serde_json::to_string(&escapes).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(prune(&dir, &[]).unwrap(), 0);
+
+        assert!(victim.exists());
+
+        let _ = fs::remove_dir_all(&outer);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn prune_export_dir_refuses_an_entry_reached_through_a_junction() {
+        let outer =
+            std::env::temp_dir().join(format!("glyph_test_prune_junc_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&outer);
+        let dir = outer.join("site");
+        let elsewhere = outer.join("elsewhere");
+        fs::create_dir_all(dir.join(".glyph")).unwrap();
+        fs::create_dir_all(&elsewhere).unwrap();
+        let victim = elsewhere.join("secret.txt");
+        fs::write(&victim, "keep").unwrap();
+        // Junctions are the Windows escape vector symlinks are on unix, and
+        // unlike symlinks they need no privilege to create.
+        let output = std::process::Command::new("cmd")
+            .arg("/C")
+            .arg("mklink")
+            .arg("/J")
+            .arg(dir.join("out"))
+            .arg(&elsewhere)
+            .output()
+            .expect("cmd should run");
+        assert!(output.status.success(), "mklink /J failed");
+        fs::write(
+            dir.join(SITE_MANIFEST_REL),
+            serde_json::to_string(&["out/secret.txt"]).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(prune(&dir, &[]).unwrap(), 0);
+
+        assert!(victim.exists());
+
+        let _ = fs::remove_dir_all(&outer);
+    }
+
+    #[test]
+    fn prune_export_dir_keeps_the_page_a_case_only_rename_rewrote() {
+        // Windows and macOS write `Guide.html` and `guide.html` to one file,
+        // so pruning the old spelling would delete the page just written.
+        let dir = out_dir_with_manifest("prune_case", &["Guide.html"]);
+        fs::write(dir.join("guide.html"), "the current page").unwrap();
+
+        assert_eq!(prune(&dir, &["guide.html"]).unwrap(), 0);
+
+        assert_eq!(
+            fs::read_to_string(dir.join("guide.html")).unwrap(),
+            "the current page"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn prune_export_dir_keeps_claiming_a_file_it_could_not_remove() {
+        // A directory stands in for the read-only or locked file the removal
+        // fails on: dropping the claim would orphan it in the output for good.
+        let dir = out_dir_with_manifest("prune_stuck", &["stuck"]);
+        fs::create_dir_all(dir.join("stuck")).unwrap();
+        fs::write(dir.join("stuck/inside.txt"), "blocks the removal").unwrap();
+
+        assert_eq!(prune(&dir, &[]).unwrap(), 0);
+
+        assert!(dir.join("stuck").exists());
+        let manifest = fs::read_to_string(dir.join(SITE_MANIFEST_REL)).unwrap();
+        assert_eq!(manifest, r#"["stuck"]"#);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn prune_export_dir_hands_its_manifest_to_the_next_export() {
+        let dir =
+            std::env::temp_dir().join(format!("glyph_test_prune_chain_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("index.html"), "home").unwrap();
+        fs::write(dir.join("guide.html"), "guide").unwrap();
+
+        assert_eq!(prune(&dir, &["index.html", "guide.html"]).unwrap(), 0);
+        // Second export: guide.md is gone, so its page is no longer written.
+        assert_eq!(prune(&dir, &["index.html"]).unwrap(), 1);
+
+        assert!(!dir.join("guide.html").exists());
+        assert!(dir.join("index.html").exists());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_export_dir_refuses_an_entry_reached_through_a_symlinked_directory() {
+        let outer =
+            std::env::temp_dir().join(format!("glyph_test_prune_link_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&outer);
+        let dir = outer.join("site");
+        let elsewhere = outer.join("elsewhere");
+        fs::create_dir_all(dir.join(".glyph")).unwrap();
+        fs::create_dir_all(&elsewhere).unwrap();
+        let victim = elsewhere.join("secret.txt");
+        fs::write(&victim, "keep").unwrap();
+        std::os::unix::fs::symlink(&elsewhere, dir.join("out")).unwrap();
+        fs::write(
+            dir.join(SITE_MANIFEST_REL),
+            serde_json::to_string(&["out/secret.txt"]).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(prune(&dir, &[]).unwrap(), 0);
+
+        assert!(victim.exists());
+
+        let _ = fs::remove_dir_all(&outer);
+    }
+
+    #[test]
+    fn prune_export_dir_denied_without_a_grant() {
+        let dir =
+            std::env::temp_dir().join(format!("glyph_test_prune_denied_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join(".glyph")).unwrap();
+        fs::write(dir.join(SITE_MANIFEST_REL), r#"["index.html"]"#).unwrap();
+        fs::write(dir.join("index.html"), "home").unwrap();
+
+        let app = app_with_grants();
+        let result = prune_export_dir(
+            dir.to_string_lossy().to_string(),
+            vec![],
+            app.state::<GrantRegistry>(),
+        );
+
+        assert!(result.is_err());
+        assert!(dir.join("index.html").exists());
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/commands/serve.rs
+++ b/src-tauri/src/commands/serve.rs
@@ -93,7 +93,7 @@ pub fn serve_ready<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), St
 /// A build failed. Whatever was exported last stays on disk and keeps being
 /// served, so a browser is left showing a site rather than nothing. It is not
 /// necessarily the previous site in full: the export writes pages in place,
-/// so a failure part way through leaves new and old pages mixed (see #707).
+/// so a failure part way through leaves new and old pages mixed.
 #[tauri::command]
 pub fn serve_failed<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,

--- a/src-tauri/src/grants.rs
+++ b/src-tauri/src/grants.rs
@@ -19,7 +19,8 @@ struct Grants {
     workspaces: HashSet<PathBuf>,
     /// Explicitly opened loose files: exact-path read, write (autosave), watch.
     files: HashSet<PathBuf>,
-    /// Approved export destination folders: recursive write only.
+    /// Approved export destination folders: recursive write, plus the prune
+    /// a repeat website export performs over its own previous output.
     export_dirs: HashSet<PathBuf>,
     /// Approved single-file export targets: exact-path write only.
     export_files: HashSet<PathBuf>,
@@ -93,7 +94,9 @@ impl GrantRegistry {
         Ok(canonical)
     }
 
-    /// Export grants are write-only and deliberately do not count as readable.
+    /// Export grants deliberately do not count as readable: a compromised
+    /// renderer cannot read back what an export wrote. (`prune_export_dir`
+    /// reads its own manifest in Rust, never through this check.)
     pub fn ensure_readable(&self, path: &str) -> Result<PathBuf, String> {
         let requested = Path::new(path);
         let canonical = canonicalize_lenient(requested)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -261,6 +261,7 @@ pub fn run() {
             commands::file::write_binary_file,
             commands::file::create_dir_all,
             commands::file::copy_file,
+            commands::file::prune_export_dir,
             commands::file::get_file_metadata,
             commands::file::get_initial_file,
             #[cfg(desktop)]

--- a/src/hooks/useCliExport.test.ts
+++ b/src/hooks/useCliExport.test.ts
@@ -42,7 +42,7 @@ const HOOK_ARGS = { entries: [], content: "# Notes" };
 
 beforeEach(() => {
   vi.mocked(invoke).mockReset();
-  exportSiteMock.mockReset().mockResolvedValue({ pages: 3, assets: 1 });
+  exportSiteMock.mockReset().mockResolvedValue({ pages: 3, assets: 1, removed: 0 });
   runCliDocumentExportMock.mockReset().mockResolvedValue({ path: "/ws/notes.pdf", settled: true });
   settings.loaded = true;
   resetCliExportRequestCache();
@@ -123,6 +123,17 @@ describe("useCliExport", () => {
     expect(invokeCalls("finish_cli_export")[0][1]).toEqual({
       code: 0,
       message: "Exported 3 pages and 1 assets to /out",
+    });
+  });
+
+  it("names the stale files a repeat export removed", async () => {
+    exportSiteMock.mockResolvedValue({ pages: 3, assets: 1, removed: 2 });
+    stubRequest(SITE_REQUEST);
+    renderHook(() => useCliExport(HOOK_ARGS));
+    await waitFor(() => expect(invokeCalls("finish_cli_export")).toHaveLength(1));
+    expect(invokeCalls("finish_cli_export")[0][1]).toEqual({
+      code: 0,
+      message: "Exported 3 pages and 1 assets to /out, removing 2 stale files",
     });
   });
 

--- a/src/hooks/useCliExport.ts
+++ b/src/hooks/useCliExport.ts
@@ -64,7 +64,10 @@ export function useCliExport({ entries, content }: UseCliExportOptions): void {
             remarkPlugins,
             rehypePlugins,
           });
-          message = `Exported ${result.pages} pages and ${result.assets} assets to ${request.output}`;
+          // Deletions are named, never silent: the export removes files a
+          // previous run into the same directory left behind.
+          const pruned = result.removed > 0 ? `, removing ${result.removed} stale files` : "";
+          message = `Exported ${result.pages} pages and ${result.assets} assets to ${request.output}${pruned}`;
         } else {
           const { runCliDocumentExport } = await import("@/lib/export/cliDocumentExport");
           const { path, settled } = await runCliDocumentExport(request, () => ({

--- a/src/hooks/useCliServe.ts
+++ b/src/hooks/useCliServe.ts
@@ -28,8 +28,8 @@ export function resetCliServeRunner(): void {
  * last is still on disk and still being served, so the browser keeps showing
  * a site rather than nothing. That site is not guaranteed to be the previous
  * one in full, because the export writes pages in place as it goes, so a
- * failure part way through leaves a mixture (see #707). On every launch that
- * is not `glyph serve` this is a no-op.
+ * failure part way through leaves a mixture. On every launch that is not
+ * `glyph serve` this is a no-op.
  */
 export function useCliServe(): void {
   const { ready, themes, remarkPlugins, rehypePlugins } = useExportReadiness();

--- a/src/lib/export/site/exportSite.test.ts
+++ b/src/lib/export/site/exportSite.test.ts
@@ -13,10 +13,12 @@ interface FakeFs {
   writes: Map<string, string>;
   dirs: string[];
   copies: Array<{ src: string; dest: string }>;
+  /** Site-relative paths handed to the pruner, one entry per export. */
+  pruned: string[][];
 }
 
-function mockFs(files: Record<string, string>): FakeFs {
-  const fs: FakeFs = { writes: new Map(), dirs: [], copies: [] };
+function mockFs(files: Record<string, string>, removed = 0): FakeFs {
+  const fs: FakeFs = { writes: new Map(), dirs: [], copies: [], pruned: [] };
   vi.mocked(invoke).mockImplementation((cmd: string, args?: unknown) => {
     const a = (args ?? {}) as Record<string, string>;
     switch (cmd) {
@@ -36,6 +38,9 @@ function mockFs(files: Record<string, string>): FakeFs {
       case "copy_file":
         fs.copies.push({ src: a.src, dest: a.dest });
         return Promise.resolve(undefined);
+      case "prune_export_dir":
+        fs.pruned.push((a as unknown as { written: string[] }).written);
+        return Promise.resolve(removed);
       case "get_file_metadata":
         return a.path in files
           ? Promise.resolve({ name: "", path: a.path, size: 1, modified: 0 })
@@ -99,7 +104,7 @@ describe("exportSite", () => {
       onProgress: (done, total) => progress.push([done, total]),
     });
 
-    expect(result).toEqual({ pages: 2, assets: 0 });
+    expect(result).toEqual({ pages: 2, assets: 0, removed: 0 });
     expect([...fs.writes.keys()].sort()).toEqual([
       "/out/guide/intro.html",
       "/out/index.html",
@@ -385,6 +390,84 @@ describe("exportSite", () => {
     expect(fs.copies).toEqual([{ src: "/ws/ok.png", dest: "/out/ok.png" }]);
     expect(error).toHaveBeenCalled();
     error.mockRestore();
+  });
+
+  it("hands the pruner every file it wrote, and reports what was removed", async () => {
+    const fs = mockFs(
+      {
+        "/ws/README.md": "# Home",
+        "/ws/guide/intro.md": "# Intro\n\n![shot](./shot.png)",
+        "/ws/.glyph/site.json": JSON.stringify({ robots: "none" }),
+        "/ws/guide/shot.png": "<binary>",
+      },
+      2,
+    );
+
+    const result = await exportSite({ root: "/ws", outDir: "/out" });
+
+    expect(result.removed).toBe(2);
+    expect(fs.pruned).toHaveLength(1);
+    expect([...fs.pruned[0]].sort()).toEqual([
+      "guide/intro.html",
+      "guide/shot.png",
+      "index.html",
+      "robots.txt",
+      "site.js",
+      "style.css",
+    ]);
+  });
+
+  it("keeps an asset that failed to copy out of the pruner's list", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fs = mockFs({ "/ws/notes.md": "![gone](./missing.png)" });
+    const base = vi.mocked(invoke).getMockImplementation()!;
+    vi.mocked(invoke).mockImplementation((cmd, args) => {
+      if (cmd === "copy_file") return Promise.reject(new Error("os error 2"));
+      return base(cmd, args);
+    });
+
+    await exportSite({ root: "/ws", outDir: "/out" });
+
+    // Claiming it would make the next export believe it owns a file that is
+    // not there, and a later real copy of the same name would go unpruned.
+    expect(fs.pruned[0]).not.toContain("missing.png");
+    error.mockRestore();
+  });
+
+  it("still reports a successful export when the prune fails", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fs = mockFs({ "/ws/README.md": "# A" });
+    const base = vi.mocked(invoke).getMockImplementation()!;
+    vi.mocked(invoke).mockImplementation((cmd, args) => {
+      if (cmd === "prune_export_dir") return Promise.reject(new Error("locked"));
+      return base(cmd, args);
+    });
+
+    // Every page and asset is on disk; only the cleanup failed.
+    const result = await exportSite({ root: "/ws", outDir: "/out" });
+
+    expect(result).toEqual({ pages: 1, assets: 0, removed: 0 });
+    expect(fs.writes.has("/out/index.html")).toBe(true);
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  it("does not prune when the export fails part way through", async () => {
+    const fs = mockFs({ "/ws/a.md": "# A" });
+    const base = vi.mocked(invoke).getMockImplementation()!;
+    vi.mocked(invoke).mockImplementation((cmd, args) => {
+      const a = (args ?? {}) as Record<string, string>;
+      if (cmd === "write_file" && a.path === "/out/style.css") {
+        return Promise.reject(new Error("disk full"));
+      }
+      return base(cmd, args);
+    });
+
+    await expect(exportSite({ root: "/ws", outDir: "/out" })).rejects.toThrow(/disk full/);
+
+    // Pruning a half-written site against its own list would delete the pages
+    // the previous, complete export left serving.
+    expect(fs.pruned).toEqual([]);
   });
 
   it("rejects when the workspace has no markdown files", async () => {

--- a/src/lib/export/site/exportSite.ts
+++ b/src/lib/export/site/exportSite.ts
@@ -40,6 +40,8 @@ export interface ExportSiteOptions {
 export interface ExportSiteResult {
   pages: number;
   assets: number;
+  /** Files a previous export into the same directory wrote and this one did not. */
+  removed: number;
 }
 
 const MERMAID_FENCE = /^(```|~~~)mermaid\b/m;
@@ -62,6 +64,11 @@ function siteDir(rel: string): string {
  * nav and outline, rewritten wikilinks/relative links, copied image assets,
  * and inline Mermaid SVGs. Rendering is headless (no React mount), so every
  * file exports with the same fidelity regardless of what is open in the app.
+ *
+ * Exporting again into the same directory prunes what the previous export
+ * wrote and this one did not, so a deleted or renamed note leaves no page
+ * behind. Only Glyph's own output is pruned; anything else in the directory
+ * (a CNAME, a .nojekyll) is left alone.
  */
 export async function exportSite({
   root,
@@ -113,6 +120,10 @@ export async function exportSite({
   if (socialImageAbs !== null && socialImageRel !== null) {
     assets.set(socialImageAbs, socialImageRel);
   }
+  // Every site-relative path this export puts on disk, in write order. Handed
+  // to the pruner at the end so the files a previous export left behind for
+  // content that no longer exists are removed.
+  const written: string[] = [];
   const madeDirs = new Set<string>();
   const ensureDir = async (rel: string) => {
     const dir = siteDir(rel);
@@ -159,10 +170,12 @@ export async function exportSite({
     });
     await ensureDir(rel);
     await invoke("write_file", { path: outPath(outDir, rel), content: html });
+    written.push(rel);
   };
 
   let done = 0;
   let copied = 0;
+  let removed = 0;
   let usedMermaid = false;
   try {
     for (const { file, content, rel: pageRel } of jobs) {
@@ -208,6 +221,7 @@ export async function exportSite({
       try {
         await invoke("copy_file", { src, dest: outPath(outDir, destRel) });
         copied++;
+        written.push(destRel);
       } catch (err) {
         // A referenced image that is missing on disk renders nothing in the
         // app; the exported page gets the same broken reference instead of
@@ -224,16 +238,30 @@ export async function exportSite({
       path: outPath(outDir, "style.css"),
       content: `${collectStyles()}\n${siteChromeCss()}\n${theme.css}`,
     });
+    written.push("style.css");
     await invoke("write_file", { path: outPath(outDir, "site.js"), content: siteChromeScript() });
+    written.push("site.js");
     if (config.robots !== null) {
       await invoke("write_file", {
         path: outPath(outDir, "robots.txt"),
         content: robotsTxt(config.robots),
       });
+      written.push("robots.txt");
+    }
+
+    // Last, so a failed export leaves the previous build's files (and its
+    // manifest) alone rather than pruning against a half-written site.
+    try {
+      removed = await invoke<number>("prune_export_dir", { outDir, written });
+    } catch (err) {
+      // Cleanup, not part of producing the site: the pages and assets are all
+      // on disk, so a failure here leaves stale files behind rather than
+      // failing an export that succeeded.
+      console.error("Failed to prune stale files from the export:", err);
     }
   } finally {
     if (usedMermaid) await restoreMermaidTheme(dark);
   }
 
-  return { pages: done, assets: copied };
+  return { pages: done, assets: copied, removed };
 }


### PR DESCRIPTION
## Summary

The website export wrote files but never removed the ones a previous export left behind, so an output directory exported into more than once accumulated pages for content that no longer exists. Deleting `guide.md` and exporting again left `guide.html` serving at its own URL; a rename left the old URL live beside the new one. Only the navigation reflected the current workspace, which made the removal look like it had worked.

`exportSite` now records every site-relative path it writes and hands the list to a new `prune_export_dir` command, which deletes what the previous export's manifest claims and this one did not write.

Pruning is against that manifest, never against the whole directory. Wiping anything in the output directory the export did not produce would delete a `CNAME`, a `.nojekyll`, or whatever else a static host needs; deleting only what a previous export is known to have written keeps the blast radius to files Glyph created. The manifest lives at `.glyph/site-manifest.json` in the output directory, so it survives between one-shot `--export site` runs as well as `glyph serve` rebuilds, and one mechanism covers both.

## Changes

- `src/lib/export/site/exportSite.ts`: collects the site-relative path of every page, copied asset, `style.css`, `site.js` and `robots.txt` it writes, then calls `prune_export_dir` as the last step of a successful export. An asset whose copy failed is deliberately not claimed. The result gains a `removed` count.
- `src-tauri/src/commands/file.rs`: new `prune_export_dir(out_dir, written)`. Reads the previous manifest, deletes the entries this export did not write, removes directories a pruned page left empty, writes the new manifest, and returns how many files it removed.
- `src/hooks/useCliExport.ts`: the CLI success line names what was removed (`Exported 12 pages and 3 assets to ./site, removing 2 stale files`), so deleting is never silent.
- `src/hooks/useCliServe.ts` and `src-tauri/src/commands/serve.rs`: drop the now-stale `#707` pointers in the partial-build comments. A failed rebuild still leaves a mixture; that is about atomicity, not pruning.
- `docs/security/threat-model.md`, `src-tauri/src/grants.rs`: the export-dir grant now also authorizes deleting what a previous export into that folder recorded, and `prune_export_dir` joins the gated-command table.
- `samples/README.md`: the website-export section documents the repeat-export behavior and the manifest, including that dropping the manifest silently disables pruning.
- `.github/workflows/ci-build.yml`: the headless export smoke now exports twice into one directory, with a note deleted in between, and asserts the stale page is gone while a `CNAME` beside it survives. This is the only place the prune runs over real IPC with a real export-dir grant.

## Risk classification

- [x] Persistence / data loss
- [x] Filesystem / IPC surface
- [x] Migrations / persisted-format changes

### Invariants at stake and evidence

**INV-5 (all external input is untrusted).** The manifest lives in the output directory, so a hand-edited one is untrusted input to a command that deletes files. `manifest_entry_path` accepts an entry only if every `/`- or `\`-separated segment is a single `Component::Normal` (so `..`, `.`, a leading `/`, and a Windows drive prefix are all refused), and it resolves through the canonicalized parent, which both enforces containment and closes the check-to-unlink window an intermediate symlink would otherwise open. Covered by `prune_export_dir_refuses_manifest_entries_that_escape_the_output_directory` (five shapes: `../`, `..\`, an absolute path, `./`, and empty), plus a symlinked-directory case on Unix and the equivalent junction case on Windows.

The manifest is trusted only to name Glyph's own output. That confinement, not the manifest's contents, is the boundary, and the docstring says so: a manifest that travelled with a directory (a cloned Pages repo, say) can name any file inside that directory. Nothing escapes it, and a renderer able to write the manifest already holds recursive write on the same folder.

**INV-6 (the backend is the boundary).** `prune_export_dir` calls `grants.ensure_writable` before touching disk, so the output directory must carry an export grant minted from a backend-observed event (the CLI `--out` argument or the native destination picker). Denial test: `prune_export_dir_denied_without_a_grant` asserts both the error and that the file survives.

**INV-1 (user edits are never silently discarded).** Nothing in the workspace is touched; only generated output is.
- `prune_export_dir_removes_only_files_the_previous_export_wrote`: a `CNAME` beside the site survives.
- `prune_export_dir_deletes_nothing_without_a_previous_manifest`: the first export into a populated directory removes nothing.
- `prune_export_dir_keeps_the_page_a_case_only_rename_rewrote`: entries are compared with separators unified and case folded, because `Guide.html` and `guide.html` are one file on Windows and macOS. Without this the fix reintroduced #707's own rename case, deleting the page the same export had just written.
- `prune_export_dir_keeps_claiming_a_file_it_could_not_remove`: a removal that fails (read-only, locked by another process, a directory) keeps its manifest claim, so a later export can still prune it instead of orphaning it in the output forever.

**INV-7 (partial results are explicit).** Pruning is cleanup, not part of producing the site, so its failure no longer fails a completed export: the pages and assets are already on disk. It logs and reports `removed: 0` instead, mirroring how a failed asset copy is already tolerated ("still reports a successful export when the prune fails"). The CLI names the removals rather than deleting silently.

**INV-3 (stale results never win).** Pruning runs only after a complete export, and `useCliServe` serializes rebuilds. "does not prune when the export fails part way through" asserts the pruner is never called, so a half-written site cannot delete against the previous complete one.

**Adversarial matrix.** Missing manifest, malformed manifest, an export that fails part way, a prune that fails, an asset that failed to copy, a case-only rename, a removal that fails, two exports in sequence (`prune_export_dir_hands_its_manifest_to_the_next_export`), and inside-versus-outside-grant paths are all covered.

**Persisted format.** `.glyph/site-manifest.json` is new. Its absence is the first-run case and prunes nothing, so an output directory from an older Glyph simply starts tracking from the next export.

## Testing

`pnpm typecheck && pnpm check && pnpm test` green (3790 tests), `cargo test` green (593 tests), `cargo clippy --all-targets -- -D warnings` clean.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Closes #707
