### PR TITLE
chore(release): give breaking changes their own notes section

### DIFF
--- a/.claude/rules/sibling-repos.md
+++ b/.claude/rules/sibling-repos.md
@@ -6,7 +6,9 @@ The main repo is `hamidfzm/glyph`. Every satellite (Homebrew tap, Scoop bucket, 
 
 - **Clone all satellites into `../glyph-md/<repo>`**, a `glyph-md/` directory **adjacent to this repo** (i.e. next to the `glyph` checkout), not inside a worktree or a temp dir. Make cross-repo changes there so the working copies persist between sessions instead of re-cloning each time.
 
-- **Clone over HTTPS with the gh token, push over SSH.** SSH auth isn't loaded in the Bash tool, so clone with `$(gh auth token)`, then reset `origin` to the SSH URL for pushing (SSH works from PowerShell). Never commit a remote URL with the token baked in.
+- **Clone over HTTPS with the gh token, push over SSH.** Clone with `$(gh auth token)`, then reset `origin` to the SSH URL for pushing. Never commit a remote URL with the token baked in.
+
+  On Windows, also point the clone at the OpenSSH that owns the agent. Git for Windows ships its own `ssh.exe`, which cannot reach the Windows `ssh-agent` service, so a push fails `Permission denied (publickey)` even while `ssh -T git@github.com` authenticates fine from the same shell. The `glyph` checkout already sets this; a fresh satellite clone does not inherit it.
 
   ```bash
   mkdir -p ../glyph-md && cd ../glyph-md
@@ -15,6 +17,7 @@ The main repo is `hamidfzm/glyph`. Every satellite (Homebrew tap, Scoop bucket, 
     [ -d "$r/.git" ] && (cd "$r" && git pull --ff-only) && continue
     git clone "https://x-access-token:${TOKEN}@github.com/glyph-md/$r.git" "$r"
     git -C "$r" remote set-url origin "git@github.com:glyph-md/$r.git"  # scrub token; push over SSH
+    git -C "$r" config core.sshCommand "C:/Windows/System32/OpenSSH/ssh.exe"  # Windows only
   done
   ```
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,12 @@
 changelog:
   categories:
+    # First, because a reader who upgrades without noticing it is the one this
+    # section exists for. GitHub groups by label only, so the `!` in a
+    # conventional-commit subject (`feat(cli)!:`) does not reach the notes on
+    # its own; the PR needs the `breaking` label.
+    - title: "💥 Breaking Changes"
+      labels:
+        - breaking
     - title: "🚀 Features"
       labels:
         - enhancement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,7 @@ committed; regenerate them only when the Tauri CLI requires it.
 ## Conventions
 
 - **Commits**: [Conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`)
+- **Breaking changes**: mark the commit `feat(scope)!:` **and** label the PR `breaking`. The `!` on its own changes nothing in the release notes: GitHub groups them by label, and `.github/release.yml` keys the "💥 Breaking Changes" section off that label. A PR carrying both `breaking` and `enhancement` appears only under Breaking Changes, because the first matching category wins.
 - **No co-authored-by** lines in commits
 - **Package manager**: pnpm only (not npm/yarn)
 - **Linting (TS)**: Biome (configured in `biome.json`); run `pnpm lint`
@@ -281,6 +282,8 @@ Run the **Create Release** workflow from GitHub Actions (`create-release.yml`) w
 The release workflow builds all platforms and publishes to Homebrew, Chocolatey, Scoop, AUR, PPA, the Debian apt repo, and the Fedora/RHEL dnf repo.
 
 Do **not** create releases manually with `gh release create` or push tags by hand. Use the workflow.
+
+**A release with a Breaking Changes section needs an upgrade note written by hand.** The generated bullet is only the PR title, which tells nobody what to change. Prepend a short before/after block to the published notes with `gh release edit vX.Y.Z --notes-file <file>`; [v0.23.0](https://github.com/hamidfzm/glyph/releases/tag/v0.23.0) is the worked example.
 
 **Wait for CI to pass on `main` before triggering Create Release.** The release workflow assumes the latest commit is green; running it on a red `main` produces broken artifacts that get published to every package manager simultaneously. Check the CI badge or `gh run list --branch main --limit 1` first.
 

--- a/scripts/release-changelog.sh
+++ b/scripts/release-changelog.sh
@@ -26,6 +26,7 @@ usage() {
 # The test fails if the two drift apart. "*" is the catch-all, matching that
 # file's own last category.
 CATEGORIES=(
+  '💥 Breaking Changes|breaking'
   '🚀 Features|enhancement'
   '🐛 Bug Fixes|bug'
   '🔒 Security|security'


### PR DESCRIPTION
## Summary

GitHub's generated release notes group PRs by **label**, so the `!` in a conventional-commit subject reaches nobody. v0.23.0 shipped `feat(cli)!: add a serve subcommand, and make export one too` (#708) listed under Features like any other entry, and a reader upgrading from v0.22.1 got no signal that `glyph <path> --export <fmt>` had stopped working. Follow-up to #710, which surfaced the gap.

## Changes

- `.github/release.yml`: new **💥 Breaking Changes** category keyed off a `breaking` label, listed **first** so the section a reader most needs is the one they hit first. First match wins in GitHub's grouping, so a PR labelled both `breaking` and `enhancement` appears only under Breaking Changes.
- Created the `breaking` label ("Changes existing behavior in a way users must act on") and applied it retroactively to #708.
- `CONTRIBUTING.md`, two additions:
  - Conventions: mark the commit `feat(scope)!:` **and** label the PR `breaking`, with the reason the `!` alone does nothing.
  - Releases: a release with that section still needs a hand-written upgrade note, because the generated bullet is only the PR title.
- Out of band, not in this diff: [v0.23.0's notes](https://github.com/hamidfzm/glyph/releases/tag/v0.23.0) now open with the before/after block for the `export` flip, which is the worked example CONTRIBUTING points at.

### Also here: a rules correction

Batched rather than split into its own PR. The sibling-repos contributor rule claimed satellite pushes need PowerShell because "SSH auth isn't loaded in the Bash tool". That is wrong, and it cost time this session: the agent is running and `ssh -T git@github.com` authenticates from either shell. What fails is git's transport. Git for Windows ships its own `ssh.exe`, which cannot reach the Windows `ssh-agent` service, so a push from a clone with no `core.sshCommand` dies `Permission denied (publickey)`.

This checkout sets `core.sshCommand` to `C:/Windows/System32/OpenSSH/ssh.exe`, which is why pushes work here and not in a fresh satellite clone. The clone loop in the rule now sets it too.

## Risk classification

- [x] No risk areas touched

Configuration and documentation only. No runtime code, no workflow logic; `release.yml` is read by GitHub when it generates notes, not by any job in this repo.

## Testing

Parsed `.github/release.yml` and asserted the category order and that `breaking` is the first category's only label. The category itself is exercised the next time a release is generated with a `breaking`-labelled PR in range.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
