### PR TITLE
fix(bundle): ship the license inside the app, not as a mount-time gate

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,7 +41,9 @@
     "publisher": "hamidfzm",
     "copyright": "Copyright (c) 2026 hamidfzm",
     "license": "MIT",
-    "licenseFile": "../LICENSE",
+    "resources": {
+      "../LICENSE": "LICENSE"
+    },
     "category": "Productivity",
     "longDescription": "A modern markdown viewer and editor with GFM support, syntax highlighting, Mermaid and D2 diagrams, live file watching, table of contents sidebar, cloud sync, JavaScript plugins, and platform-native styling.",
     "icon": [


### PR DESCRIPTION
## Summary

The `dmg` leg of the Release Smoke Test has failed on every v0.23.0 run:

```
hdiutil: attach canceled
```

preceded by the full MIT text. The DMG carries a software license agreement, so macOS shows Agree/Disagree and refuses to mount until someone clicks through. A non-interactive attach cannot, so the check dies.

The cause is `licenseFile`, added in #700. That PR was stamping packaging metadata, and its stated goals were the Windows Manufacturer, the deb and rpm `License` field, `LSApplicationCategoryType`, and the Linux desktop `Categories`. `licenseFile` is not a metadata field: Tauri hands it to the DMG bundler as the SLA. The install-time wall came along uninvited.

## Why not just delete it

Because that swings too far. MIT's condition is that the notice be **included in copies**, not agreed to, so the click-through buys no compliance. But `resources` was unset and the app has no About screen, which meant the macOS build carried the license text nowhere except that agreement. Removing `licenseFile` on its own would have shipped a macOS artifact with no notice at all.

So the text becomes a bundled resource instead. It now travels inside every artifact rather than only the disk image, and the disk image mounts without asking anything.

## Changes

```diff
   "license": "MIT",
-  "licenseFile": "../LICENSE",
+  "resources": {
+    "../LICENSE": "LICENSE"
+  },
```

- `license` is untouched and still what the release workflow reads (`jq -r '.bundle.license'`) for the deb and rpm `License` field.
- Nothing else in the repo referenced `licenseFile`.
- The WiX MSI loses the license page it gained in #700, returning to its pre-#700 behavior.

## Risk classification

- [x] No risk areas touched

Packaging configuration only. No runtime code, no IPC surface, no persisted format.

## Testing

`pnpm tauri info` accepts the config, and typecheck plus the frontend suite pass.

The Linux leg of this PR's build runs `--bundles deb`, which exercises the same resource-copy step, so a malformed map or an unresolvable `../LICENSE` fails the build here. The DMG itself is `--no-bundle` on pull requests, so the mount is proven at the next release.

**Known gap:** the Release Smoke Test for v0.23.0 stays red, since it mounts the already-published DMG. It goes green from v0.24.0 onward.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
