### PR TITLE
feat(graph): focus a node on click, open it on a second press

### DIFF
--- a/samples/Graph View.md
+++ b/samples/Graph View.md
@@ -36,8 +36,8 @@ the `samples/` folder and try it on this very workspace.
 
 | Action | How |
 | --- | --- |
-| Focus a note | Click its node (the view centres on it and its neighbours stay lit) |
-| Open a note | Double-click its node |
+| Focus a note | Click or tap its node (the view centres on it and its neighbours stay lit) |
+| Open a note | Click or tap the focused node again, or double-click it |
 | Highlight a note's neighbours | Hover it (the rest dim, arrows show link direction) |
 | Clear the focus | Click the background |
 | Pan | Drag the background |

--- a/samples/Graph View.md
+++ b/samples/Graph View.md
@@ -36,8 +36,10 @@ the `samples/` folder and try it on this very workspace.
 
 | Action | How |
 | --- | --- |
-| Open a note | Click its node |
+| Focus a note | Click its node (the view centres on it and its neighbours stay lit) |
+| Open a note | Double-click its node |
 | Highlight a note's neighbours | Hover it (the rest dim, arrows show link direction) |
+| Clear the focus | Click the background |
 | Pan | Drag the background |
 | Zoom | Scroll or pinch |
 | Re-centre | **Reset view** button (top-right) |

--- a/samples/README.md
+++ b/samples/README.md
@@ -420,7 +420,7 @@ When you have the `samples/` folder open, the **Backlinks** section under the fi
 
 ### Graph view
 
-With the `samples/` folder open, press `Cmd/Ctrl+G` (or View → Open Graph) to see this workspace as a graph: every note is a node, every wikilink an edge. Hover a node to highlight its neighbours, click one to focus it and pull the view in around it, double-click to open that note, drag to pan, and scroll to zoom. `Missing` targets never appear (broken links are dropped), and notes nothing links to render muted.
+With the `samples/` folder open, press `Cmd/Ctrl+G` (or View → Open Graph) to see this workspace as a graph: every note is a node, every wikilink an edge. Hover a node to highlight its neighbours, click one to focus it and pull the view in around it, click the focused node again to open that note, drag to pan, and scroll to zoom. `Missing` targets never appear (broken links are dropped), and notes nothing links to render muted.
 
 This workspace is wired to make the graph worth a look: [[Index]] and [[Graph View]] act as hubs, the cooking notes ([[Notes/Cooking]], [[Ingredients]], [[Techniques]]) form a tight cluster, and `Scratchpad` sits off on its own as a muted orphan. The [[Graph View]] note is a full walkthrough of the feature.
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -420,7 +420,7 @@ When you have the `samples/` folder open, the **Backlinks** section under the fi
 
 ### Graph view
 
-With the `samples/` folder open, press `Cmd/Ctrl+G` (or View → Open Graph) to see this workspace as a graph: every note is a node, every wikilink an edge. Hover a node to highlight its neighbours, click one to open that note, drag to pan, and scroll to zoom. `Missing` targets never appear (broken links are dropped), and notes nothing links to render muted.
+With the `samples/` folder open, press `Cmd/Ctrl+G` (or View → Open Graph) to see this workspace as a graph: every note is a node, every wikilink an edge. Hover a node to highlight its neighbours, click one to focus it and pull the view in around it, double-click to open that note, drag to pan, and scroll to zoom. `Missing` targets never appear (broken links are dropped), and notes nothing links to render muted.
 
 This workspace is wired to make the graph worth a look: [[Index]] and [[Graph View]] act as hubs, the cooking notes ([[Notes/Cooking]], [[Ingredients]], [[Techniques]]) form a tight cluster, and `Scratchpad` sits off on its own as a muted orphan. The [[Graph View]] note is a full walkthrough of the feature.
 

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -69,7 +69,7 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
   if (!activeTab) return null;
 
   // Graph tabs have no document; they render the workspace graph and open
-  // clicked notes as document tabs.
+  // its notes as document tabs.
   if (activeTab.kind === "graph") {
     return (
       // Keyed by root so a workspace change remounts rather than swapping the

--- a/src/components/graph/GraphView.test.tsx
+++ b/src/components/graph/GraphView.test.tsx
@@ -1,13 +1,24 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import { useZoomApi } from "@/contexts/ZoomContext";
 import { ZoomProvider } from "@/contexts/ZoomProvider";
+import { DOUBLE_CLICK_MS } from "@/hooks/useGraphFocus";
 import type { WikilinkRef } from "@/lib/backlinks";
 import { buildWorkspaceGraph, type WorkspaceGraph } from "@/lib/graph";
-import { fitCameraToNodes, worldToScreen } from "@/lib/graphCanvas";
+import {
+  type Camera,
+  centerCameraOn,
+  FOCUS_SCALE,
+  fitCameraToNodes,
+  MAX_SCALE,
+  worldToScreen,
+  zoomCameraAt,
+} from "@/lib/graphCanvas";
 import type { GraphLayout, LayoutNode } from "@/lib/graphSimulation";
 import { clearGraphView, loadGraphView } from "@/lib/graphViewStore";
+import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
+import { restoreRaf, stubRaf } from "@/test/raf";
 import { GraphView } from "./GraphView";
 
 // Shared spies/captures between the test and the hoisted mock factory.
@@ -61,6 +72,23 @@ const FIT = fitCameraToNodes(FIT_NODES, VIEWPORT);
 const NODE_A = worldToScreen(FIT, VIEWPORT, 0, 0);
 const EMPTY = { x: 40, y: 40 };
 
+// The alpha `drawGraph` dims to outside the highlighted neighbourhood. Matches
+// the value asserted in graphDraw.test.ts.
+const ALPHA_DIMMED = 0.18;
+
+// A third, unlinked note, so focusing "a" leaves something outside its
+// neighbourhood to dim. The two-file fixture above cannot show dimming: a and b
+// are neighbours, so focusing either highlights the whole graph.
+const TRIO_FILES = [...FILES, "/v/c.md"];
+const TRIO_FIT_NODES: LayoutNode[] = buildWorkspaceGraph(TRIO_FILES, REFS).nodes.map((n, i) => ({
+  ...n,
+  x: i * 100,
+  y: 0,
+}));
+const TRIO_FIT = fitCameraToNodes(TRIO_FIT_NODES, VIEWPORT);
+const TRIO_NODE_A = worldToScreen(TRIO_FIT, VIEWPORT, 0, 0);
+const TRIO_NODE_C = worldToScreen(TRIO_FIT, VIEWPORT, 200, 0);
+
 function stubContext() {
   return {
     setTransform: vi.fn(),
@@ -84,12 +112,19 @@ function stubContext() {
 }
 
 let ctx: ReturnType<typeof stubContext>;
+/** Every alpha written during the draws since it was last emptied. */
+let alphas: number[];
 
 beforeEach(() => {
   hoisted.reheat.mockClear();
   hoisted.layoutRef.current = null;
   hoisted.reseeded.value = true;
   ctx = stubContext();
+  alphas = [];
+  Object.defineProperty(ctx, "globalAlpha", {
+    set: (value: number) => alphas.push(value),
+    get: () => 1,
+  });
   HTMLCanvasElement.prototype.getContext = vi.fn(
     () => ctx,
   ) as unknown as typeof HTMLCanvasElement.prototype.getContext;
@@ -111,13 +146,27 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
+  restoreRaf();
+  restoreMatchMedia();
 });
 
-function renderGraph(onOpenFile = vi.fn()) {
+function renderGraph(onOpenFile = vi.fn(), files = FILES) {
   const utils = render(
-    <GraphView workspaceFiles={FILES} wikilinkRefs={REFS} onOpenFile={onOpenFile} />,
+    <GraphView workspaceFiles={files} wikilinkRefs={REFS} onOpenFile={onOpenFile} />,
   );
   return { ...utils, onOpenFile, canvas: screen.getByRole("img", { name: "Workspace graph" }) };
+}
+
+/** A press and release that never travels, i.e. a click. */
+function click(canvas: HTMLElement, point: { x: number; y: number }, clickCount = 1) {
+  fireEvent.pointerDown(canvas, { pointerId: 1, clientX: point.x, clientY: point.y });
+  fireEvent.pointerUp(canvas, {
+    pointerId: 1,
+    clientX: point.x,
+    clientY: point.y,
+    detail: clickCount,
+  });
 }
 
 /** Scale + x-translation of the most recent world-transform draw call. */
@@ -153,17 +202,17 @@ describe("GraphView", () => {
     expect(tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
   });
 
-  it("opens the clicked node's file", () => {
+  it("opens the clicked node's file on a double click", () => {
     const { canvas, onOpenFile } = renderGraph();
-    fireEvent.pointerDown(canvas, { pointerId: 1, clientX: NODE_A.x, clientY: NODE_A.y });
-    fireEvent.pointerUp(canvas, { pointerId: 1, clientX: NODE_A.x, clientY: NODE_A.y });
+    click(canvas, NODE_A, 1);
+    click(canvas, NODE_A, 2);
     expect(onOpenFile).toHaveBeenCalledWith("/v/a.md");
   });
 
   it("does not open a file when clicking empty space", () => {
     const { canvas, onOpenFile } = renderGraph();
-    fireEvent.pointerDown(canvas, { pointerId: 1, clientX: EMPTY.x, clientY: EMPTY.y });
-    fireEvent.pointerUp(canvas, { pointerId: 1, clientX: EMPTY.x, clientY: EMPTY.y });
+    click(canvas, EMPTY, 1);
+    click(canvas, EMPTY, 2);
     expect(onOpenFile).not.toHaveBeenCalled();
   });
 
@@ -236,7 +285,12 @@ describe("GraphView", () => {
     const { canvas, onOpenFile } = renderGraph();
     fireEvent.pointerDown(canvas, { pointerId: 1, clientX: NODE_A.x, clientY: NODE_A.y });
     fireEvent.pointerMove(canvas, { pointerId: 1, clientX: NODE_A.x + 2, clientY: NODE_A.y + 1 });
-    fireEvent.pointerUp(canvas, { pointerId: 1, clientX: NODE_A.x + 2, clientY: NODE_A.y + 1 });
+    fireEvent.pointerUp(canvas, {
+      pointerId: 1,
+      clientX: NODE_A.x + 2,
+      clientY: NODE_A.y + 1,
+      detail: 2,
+    });
     expect(onOpenFile).toHaveBeenCalledWith("/v/a.md");
   });
 
@@ -262,7 +316,12 @@ describe("GraphView", () => {
     expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx + 80);
     // Clicking the now-shifted node still resolves it (press uses the manual camera).
     fireEvent.pointerDown(canvas, { pointerId: 3, clientX: NODE_A.x + 80, clientY: NODE_A.y });
-    fireEvent.pointerUp(canvas, { pointerId: 3, clientX: NODE_A.x + 80, clientY: NODE_A.y });
+    fireEvent.pointerUp(canvas, {
+      pointerId: 3,
+      clientX: NODE_A.x + 80,
+      clientY: NODE_A.y,
+      detail: 2,
+    });
     expect(onOpenFile).toHaveBeenCalledWith("/v/a.md");
   });
 
@@ -454,5 +513,114 @@ describe("GraphView view state across a tab switch", () => {
 
     renderInRoot("/other");
     expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
+  });
+});
+
+describe("GraphView node focus", () => {
+  it("focuses a node on a single click instead of opening it", () => {
+    const { canvas, onOpenFile } = renderGraph();
+    click(canvas, NODE_A, 1);
+    expect(onOpenFile).not.toHaveBeenCalled();
+    // Focusing takes manual control, so auto-fit stops re-framing over the node.
+    expect(screen.getByRole("button", { name: "Reset view" })).toBeEnabled();
+  });
+
+  it("centres the camera on the focused node, instantly under reduced motion", () => {
+    stubMatchMedia(true);
+    vi.useFakeTimers();
+    const { canvas } = renderGraph();
+    click(canvas, NODE_A, 1);
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS);
+    });
+    const target = centerCameraOn(0, 0, FOCUS_SCALE);
+    expect(lastWorldTransform().scale).toBeCloseTo(target.scale);
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + target.dx);
+  });
+
+  it("animates the focus camera over frames when motion is allowed", () => {
+    stubMatchMedia(false);
+    vi.useFakeTimers();
+    const raf = stubRaf();
+    const { canvas } = renderGraph();
+    click(canvas, NODE_A, 1);
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS);
+    });
+    // The tween is scheduled but no frame has run, so the framing has not moved.
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
+    act(() => {
+      raf.settle();
+    });
+    const target = centerCameraOn(0, 0, FOCUS_SCALE);
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + target.dx);
+  });
+
+  it("keeps the focus camera within the maximum zoom", () => {
+    stubMatchMedia(true);
+    vi.useFakeTimers();
+    const { canvas } = renderGraph();
+    // Wheel all the way in; the camera clamps at MAX_SCALE well before the last step.
+    let zoomed: Camera = FIT;
+    for (let i = 0; i < 4; i += 1) {
+      fireEvent.wheel(canvas, { deltaY: -800, clientX: 400, clientY: 300 });
+      zoomed = zoomCameraAt(zoomed, 400, 300, Math.exp(1.2), VIEWPORT);
+    }
+    expect(zoomed.scale).toBe(MAX_SCALE);
+
+    click(canvas, worldToScreen(zoomed, VIEWPORT, 0, 0), 1);
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS);
+    });
+    expect(lastWorldTransform().scale).toBeCloseTo(MAX_SCALE);
+  });
+
+  it("opens on a double click without ever animating a focus", () => {
+    stubMatchMedia(true);
+    vi.useFakeTimers();
+    const { canvas, onOpenFile } = renderGraph();
+    click(canvas, NODE_A, 1);
+    click(canvas, NODE_A, 2);
+    expect(onOpenFile).toHaveBeenCalledWith("/v/a.md");
+
+    const framing = lastWorldTransform();
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS * 4);
+    });
+    expect(lastWorldTransform()).toEqual(framing);
+  });
+
+  it("keeps the focused neighbourhood highlighted after the cursor moves away", () => {
+    const { canvas } = renderGraph(vi.fn(), TRIO_FILES);
+    click(canvas, TRIO_NODE_A, 1);
+    // Hovering the unlinked note previews its own neighbourhood on top.
+    fireEvent.pointerMove(canvas, { pointerId: 2, clientX: TRIO_NODE_C.x, clientY: TRIO_NODE_C.y });
+    alphas.length = 0;
+    fireEvent.pointerLeave(canvas);
+    expect(alphas).toContain(ALPHA_DIMMED);
+  });
+
+  it("clears the focus when the background is clicked", () => {
+    const { canvas } = renderGraph(vi.fn(), TRIO_FILES);
+    click(canvas, TRIO_NODE_A, 1);
+    expect(alphas).toContain(ALPHA_DIMMED);
+
+    alphas.length = 0;
+    click(canvas, EMPTY, 1);
+    expect(alphas).not.toContain(ALPHA_DIMMED);
+  });
+
+  it("clears the focus and returns to auto-fit on Reset view", () => {
+    const { canvas } = renderGraph(vi.fn(), TRIO_FILES);
+    click(canvas, TRIO_NODE_A, 1);
+    const reset = screen.getByRole("button", { name: "Reset view" });
+    expect(reset).toBeEnabled();
+    expect(alphas).toContain(ALPHA_DIMMED);
+
+    alphas.length = 0;
+    fireEvent.click(reset);
+    expect(alphas).not.toContain(ALPHA_DIMMED);
+    expect(reset).toBeDisabled();
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + TRIO_FIT.dx);
   });
 });

--- a/src/components/graph/GraphView.test.tsx
+++ b/src/components/graph/GraphView.test.tsx
@@ -597,6 +597,38 @@ describe("GraphView node focus", () => {
     expect(lastWorldTransform()).toEqual(framing);
   });
 
+  it("focuses from a camera restored across a tab switch, not from the fit", () => {
+    stubMatchMedia(true);
+    vi.useFakeTimers();
+    // Pan, leave the tab, come back: the camera is restored and manual.
+    const tabs = { workspace: { root: "/ws" } } as unknown as TabsContextValue;
+    const graph = (
+      <TabsContext.Provider value={tabs}>
+        <GraphView workspaceFiles={FILES} wikilinkRefs={REFS} onOpenFile={vi.fn()} />
+      </TabsContext.Provider>
+    );
+    const first = render(graph);
+    const canvas = screen.getByRole("img", { name: "Workspace graph" });
+    fireEvent.pointerDown(canvas, { pointerId: 1, clientX: EMPTY.x, clientY: EMPTY.y });
+    fireEvent.pointerMove(canvas, { pointerId: 1, clientX: EMPTY.x + 60, clientY: EMPTY.y });
+    fireEvent.pointerUp(canvas, { pointerId: 1, clientX: EMPTY.x + 60, clientY: EMPTY.y });
+    first.unmount();
+    render(graph);
+
+    // The node sits 60px right of where it was, because the camera came back panned.
+    const restored = screen.getByRole("img", { name: "Workspace graph" });
+    click(restored, { x: NODE_A.x + 60, y: NODE_A.y });
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS);
+    });
+    // The click only lands on the node if the camera really came back panned,
+    // and the zoom only reaches FOCUS_SCALE if the focus ran.
+    const target = centerCameraOn(0, 0, FOCUS_SCALE);
+    expect(lastWorldTransform().scale).toBeCloseTo(target.scale);
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + target.dx);
+    clearGraphView("/ws");
+  });
+
   it("keeps the focused neighbourhood highlighted after the cursor moves away", () => {
     const { canvas } = renderGraph(vi.fn(), TRIO_FILES);
     click(canvas, TRIO_NODE_A, 1);

--- a/src/components/graph/GraphView.test.tsx
+++ b/src/components/graph/GraphView.test.tsx
@@ -627,6 +627,15 @@ describe("GraphView node focus", () => {
     expect(onOpenFile).not.toHaveBeenCalled();
   });
 
+  it("ignores a cancel that has no matching press", () => {
+    const { canvas, onOpenFile } = renderGraph();
+    click(canvas, NODE_A);
+    // A cancel for a pointer that never pressed must not touch the focus state.
+    fireEvent.pointerCancel(canvas, { pointerId: 99, clientX: NODE_A.x, clientY: NODE_A.y });
+    expect(onOpenFile).not.toHaveBeenCalled();
+    expect(hoisted.reheat).not.toHaveBeenCalled();
+  });
+
   it("releases a node whose drag is cancelled", () => {
     const { canvas } = renderGraph();
     fireEvent.pointerDown(canvas, { pointerId: 1, clientX: NODE_A.x, clientY: NODE_A.y });

--- a/src/components/graph/GraphView.test.tsx
+++ b/src/components/graph/GraphView.test.tsx
@@ -15,6 +15,7 @@ import {
   worldToScreen,
   zoomCameraAt,
 } from "@/lib/graphCanvas";
+import { ALPHA_DIMMED } from "@/lib/graphDraw";
 import type { GraphLayout, LayoutNode } from "@/lib/graphSimulation";
 import { clearGraphView, loadGraphView } from "@/lib/graphViewStore";
 import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
@@ -71,10 +72,6 @@ const FIT_NODES: LayoutNode[] = buildWorkspaceGraph(FILES, REFS).nodes.map((n, i
 const FIT = fitCameraToNodes(FIT_NODES, VIEWPORT);
 const NODE_A = worldToScreen(FIT, VIEWPORT, 0, 0);
 const EMPTY = { x: 40, y: 40 };
-
-// The alpha `drawGraph` dims to outside the highlighted neighbourhood. Matches
-// the value asserted in graphDraw.test.ts.
-const ALPHA_DIMMED = 0.18;
 
 // A third, unlinked note, so focusing "a" leaves something outside its
 // neighbourhood to dim. The two-file fixture above cannot show dimming: a and b
@@ -158,8 +155,9 @@ function renderGraph(onOpenFile = vi.fn(), files = FILES) {
   return { ...utils, onOpenFile, canvas: screen.getByRole("img", { name: "Workspace graph" }) };
 }
 
-/** A press and release that never travels, i.e. a click. */
-function click(canvas: HTMLElement, point: { x: number; y: number }, clickCount = 1) {
+// Chromium reports no click count on pointerup (the Pointer Events spec leaves
+// `detail` 0 there), so 0 is the realistic default for Windows and Android.
+function click(canvas: HTMLElement, point: { x: number; y: number }, clickCount = 0) {
   fireEvent.pointerDown(canvas, { pointerId: 1, clientX: point.x, clientY: point.y });
   fireEvent.pointerUp(canvas, {
     pointerId: 1,
@@ -202,7 +200,15 @@ describe("GraphView", () => {
     expect(tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
   });
 
-  it("opens the clicked node's file on a double click", () => {
+  it("opens the clicked node's file on a second press, with no click count", () => {
+    const { canvas, onOpenFile } = renderGraph();
+    click(canvas, NODE_A);
+    expect(onOpenFile).not.toHaveBeenCalled();
+    click(canvas, NODE_A);
+    expect(onOpenFile).toHaveBeenCalledWith("/v/a.md");
+  });
+
+  it("opens the clicked node's file on a reported double click", () => {
     const { canvas, onOpenFile } = renderGraph();
     click(canvas, NODE_A, 1);
     click(canvas, NODE_A, 2);
@@ -211,8 +217,8 @@ describe("GraphView", () => {
 
   it("does not open a file when clicking empty space", () => {
     const { canvas, onOpenFile } = renderGraph();
-    click(canvas, EMPTY, 1);
-    click(canvas, EMPTY, 2);
+    click(canvas, EMPTY);
+    click(canvas, EMPTY);
     expect(onOpenFile).not.toHaveBeenCalled();
   });
 
@@ -292,6 +298,7 @@ describe("GraphView", () => {
       detail: 2,
     });
     expect(onOpenFile).toHaveBeenCalledWith("/v/a.md");
+    expect(hoisted.reheat).not.toHaveBeenCalled();
   });
 
   it("keeps panning on a continued background drag", () => {
@@ -608,6 +615,58 @@ describe("GraphView node focus", () => {
     alphas.length = 0;
     click(canvas, EMPTY, 1);
     expect(alphas).not.toContain(ALPHA_DIMMED);
+  });
+
+  it("never treats a cancelled gesture as a click", () => {
+    const { canvas, onOpenFile } = renderGraph();
+    click(canvas, NODE_A);
+
+    // A cancel on the focused node would otherwise read as the opening press.
+    fireEvent.pointerDown(canvas, { pointerId: 2, clientX: NODE_A.x, clientY: NODE_A.y });
+    fireEvent.pointerCancel(canvas, { pointerId: 2, clientX: NODE_A.x, clientY: NODE_A.y });
+    expect(onOpenFile).not.toHaveBeenCalled();
+  });
+
+  it("releases a node whose drag is cancelled", () => {
+    const { canvas } = renderGraph();
+    fireEvent.pointerDown(canvas, { pointerId: 1, clientX: NODE_A.x, clientY: NODE_A.y });
+    fireEvent.pointerMove(canvas, { pointerId: 1, clientX: NODE_A.x + 60, clientY: NODE_A.y });
+    const dragged = hoisted.layoutRef.current?.nodes.find((n) => n.id === "/v/a.md");
+    expect(Number.isFinite(dragged?.fx)).toBe(true);
+
+    fireEvent.pointerCancel(canvas, { pointerId: 1, clientX: NODE_A.x + 60, clientY: NODE_A.y });
+    expect(dragged?.fx).toBeNull();
+  });
+
+  it("stops a running focus move when the next gesture takes the camera", () => {
+    stubMatchMedia(true);
+    vi.useFakeTimers();
+    const { canvas } = renderGraph();
+    click(canvas, NODE_A);
+
+    // Panning inside the window must win: the deferred move never lands.
+    fireEvent.pointerDown(canvas, { pointerId: 2, clientX: EMPTY.x, clientY: EMPTY.y });
+    fireEvent.pointerMove(canvas, { pointerId: 2, clientX: EMPTY.x + 50, clientY: EMPTY.y });
+    fireEvent.pointerUp(canvas, { pointerId: 2, clientX: EMPTY.x + 50, clientY: EMPTY.y });
+    const panned = lastWorldTransform();
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS * 4);
+    });
+    expect(lastWorldTransform()).toEqual(panned);
+  });
+
+  it("stops a running focus move when the wheel takes the camera", () => {
+    stubMatchMedia(true);
+    vi.useFakeTimers();
+    const { canvas } = renderGraph();
+    click(canvas, NODE_A);
+
+    fireEvent.wheel(canvas, { deltaY: -200, clientX: 400, clientY: 300 });
+    const zoomed = lastWorldTransform();
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS * 4);
+    });
+    expect(lastWorldTransform()).toEqual(zoomed);
   });
 
   it("clears the focus and returns to auto-fit on Reset view", () => {

--- a/src/components/graph/GraphView.tsx
+++ b/src/components/graph/GraphView.tsx
@@ -2,16 +2,18 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FitIcon } from "@/components/icons/FitIcon";
 import { useWorkspaceRoot } from "@/contexts/TabsContext";
-import { useZoomApi, type ZoomHandlers } from "@/contexts/ZoomContext";
 import { useElementSize } from "@/hooks/useElementSize";
 import { useGraphCamera } from "@/hooks/useGraphCamera";
+import { useGraphFocus } from "@/hooks/useGraphFocus";
 import { useGraphPointer } from "@/hooks/useGraphPointer";
 import { useGraphSimulation } from "@/hooks/useGraphSimulation";
+import { useGraphZoomCommands } from "@/hooks/useGraphZoomCommands";
 import { useIsDarkMode } from "@/hooks/useIsDarkMode";
 import type { WikilinkRef } from "@/lib/backlinks";
 import { buildWorkspaceGraph } from "@/lib/graph";
 import { type Camera, fitCameraToNodes } from "@/lib/graphCanvas";
 import { drawGraph, readGraphTheme } from "@/lib/graphDraw";
+import type { LayoutNode } from "@/lib/graphSimulation";
 import { loadGraphView, saveGraphView } from "@/lib/graphViewStore";
 
 interface GraphViewProps {
@@ -20,9 +22,6 @@ interface GraphViewProps {
   /** Open the clicked note inside its workspace. */
   onOpenFile: (path: string) => void;
 }
-
-// Zoom factor per Zoom In / Zoom Out command (keyboard / menu).
-const HOTKEY_ZOOM_FACTOR = 1.2;
 
 // Force-directed picture of the active workspace: every markdown file is a
 // node, every resolved wikilink an edge. Heavy lifting is delegated — model
@@ -37,7 +36,6 @@ export function GraphView({ workspaceFiles, wikilinkRefs, onOpenFile }: GraphVie
   const { t } = useTranslation("common");
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { ref: containerRef, size: viewport } = useElementSize<HTMLDivElement>();
-  const registerZoomTarget = useZoomApi()?.registerTarget;
   const graph = useMemo(
     () => buildWorkspaceGraph(workspaceFiles, wikilinkRefs),
     [workspaceFiles, wikilinkRefs],
@@ -89,6 +87,26 @@ export function GraphView({ workspaceFiles, wikilinkRefs, onOpenFile }: GraphVie
     setAutoFit(false);
   }, [camera, layout, viewport]);
 
+  const { focusedId, focusNode, clearFocus } = useGraphFocus({
+    camera,
+    cameraNow,
+    takeManualControl,
+  });
+
+  // Clearing beats the deferred camera move to the punch, so the first press of
+  // a double click never animates on its way to the note.
+  const handleNodeClick = useCallback(
+    (node: LayoutNode, clickCount: number) => {
+      if (clickCount < 2) {
+        focusNode(node);
+        return;
+      }
+      clearFocus();
+      onOpenFile(node.id);
+    },
+    [clearFocus, focusNode, onOpenFile],
+  );
+
   const { hovered, dragging, clearHover, handlePointerDown, handlePointerMove, handlePointerUp } =
     useGraphPointer({
       canvasRef,
@@ -98,11 +116,16 @@ export function GraphView({ workspaceFiles, wikilinkRefs, onOpenFile }: GraphVie
       cameraNow,
       takeManualControl,
       reheat,
-      onOpenFile,
+      onNodeClick: handleNodeClick,
+      onBackgroundClick: clearFocus,
     });
 
+  // Hover previews on top of the focus and falls back to it on leave; both ride
+  // the single highlight input `drawGraph` already dims around.
+  const highlightId = hovered?.id ?? focusedId;
+
   // Redraw on every change that affects pixels: layout motion (version),
-  // camera, hover, viewport size, theme.
+  // camera, highlight, viewport size, theme.
   // biome-ignore lint/correctness/useExhaustiveDependencies: `version` is the redraw trigger — d3 mutates layout node positions in place, so neither the layout reference nor a manual camera changes between animation frames
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -116,45 +139,18 @@ export function GraphView({ workspaceFiles, wikilinkRefs, onOpenFile }: GraphVie
       dpr,
       camera: effectiveCamera,
       theme,
-      hoveredId: hovered?.id ?? null,
+      hoveredId: highlightId,
       neighbors: graph.neighbors,
     });
-  }, [layout, version, effectiveCamera, hovered?.id, viewport, theme, graph.neighbors]);
+  }, [layout, version, effectiveCamera, highlightId, viewport, theme, graph.neighbors]);
 
   const refit = useCallback(() => {
+    clearFocus();
     autoFitRef.current = true;
     setAutoFit(true);
-  }, []);
+  }, [clearFocus]);
 
-  // Route the Zoom In/Out/Actual-Size commands to the camera while the graph is
-  // the active surface, anchored on the viewport centre. Wheel zoom is wired
-  // separately above. The handlers read the latest camera/viewport through a
-  // ref so registration happens once per mount, not on every camera frame.
-  const zoomImplRef = useRef<() => ZoomHandlers>(() => ({
-    zoomIn: () => {},
-    zoomOut: () => {},
-    zoomReset: () => {},
-  }));
-  zoomImplRef.current = () => {
-    const zoomCenter = (factor: number) => {
-      takeManualControl();
-      camera.zoomAt(viewport.width / 2, viewport.height / 2, factor, viewport);
-    };
-    return {
-      zoomIn: () => zoomCenter(HOTKEY_ZOOM_FACTOR),
-      zoomOut: () => zoomCenter(1 / HOTKEY_ZOOM_FACTOR),
-      zoomReset: refit,
-    };
-  };
-  useEffect(() => {
-    if (!registerZoomTarget) return;
-    registerZoomTarget({
-      zoomIn: () => zoomImplRef.current().zoomIn(),
-      zoomOut: () => zoomImplRef.current().zoomOut(),
-      zoomReset: () => zoomImplRef.current().zoomReset(),
-    });
-    return () => registerZoomTarget(null);
-  }, [registerZoomTarget]);
+  useGraphZoomCommands({ camera, viewport, takeManualControl, refit });
 
   if (graph.nodes.length === 0) {
     return (

--- a/src/components/graph/GraphView.tsx
+++ b/src/components/graph/GraphView.tsx
@@ -19,7 +19,7 @@ import { loadGraphView, saveGraphView } from "@/lib/graphViewStore";
 interface GraphViewProps {
   workspaceFiles: readonly string[];
   wikilinkRefs: readonly WikilinkRef[];
-  /** Open the clicked note inside its workspace. */
+  /** Open a note from the graph, inside its workspace. */
   onOpenFile: (path: string) => void;
 }
 
@@ -87,38 +87,51 @@ export function GraphView({ workspaceFiles, wikilinkRefs, onOpenFile }: GraphVie
     setAutoFit(false);
   }, [camera, layout, viewport]);
 
-  const { focusedId, focusNode, clearFocus } = useGraphFocus({
+  const { focusedId, focusNode, clearFocus, cancelMove } = useGraphFocus({
     camera,
     cameraNow,
     takeManualControl,
+    layout,
   });
 
-  // Clearing beats the deferred camera move to the punch, so the first press of
-  // a double click never animates on its way to the note.
+  // A second press on the node already in focus is what opens it. Chromium
+  // follows the Pointer Events spec and reports no click count on pointerup, and
+  // touch reports none anywhere, so `clickCount` alone would never reach 2 on
+  // Windows or Android. Clearing first beats the deferred camera move to the
+  // punch, so opening never animates.
   const handleNodeClick = useCallback(
     (node: LayoutNode, clickCount: number) => {
-      if (clickCount < 2) {
+      const opening = clickCount >= 2 || focusedId === node.id;
+      if (!opening) {
         focusNode(node);
         return;
       }
       clearFocus();
       onOpenFile(node.id);
     },
-    [clearFocus, focusNode, onOpenFile],
+    [clearFocus, focusNode, focusedId, onOpenFile],
   );
 
-  const { hovered, dragging, clearHover, handlePointerDown, handlePointerMove, handlePointerUp } =
-    useGraphPointer({
-      canvasRef,
-      layout,
-      viewport,
-      camera,
-      cameraNow,
-      takeManualControl,
-      reheat,
-      onNodeClick: handleNodeClick,
-      onBackgroundClick: clearFocus,
-    });
+  const {
+    hovered,
+    dragging,
+    clearHover,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handlePointerCancel,
+  } = useGraphPointer({
+    canvasRef,
+    layout,
+    viewport,
+    camera,
+    cameraNow,
+    takeManualControl,
+    reheat,
+    onNodeClick: handleNodeClick,
+    onBackgroundClick: clearFocus,
+    onCameraInterrupt: cancelMove,
+  });
 
   // Hover previews on top of the focus and falls back to it on leave; both ride
   // the single highlight input `drawGraph` already dims around.
@@ -173,7 +186,7 @@ export function GraphView({ workspaceFiles, wikilinkRefs, onOpenFile }: GraphVie
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
         onPointerLeave={clearHover}
       />
       <button

--- a/src/hooks/useGraphFocus.test.ts
+++ b/src/hooks/useGraphFocus.test.ts
@@ -1,25 +1,31 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
 import { type Camera, centerCameraOn, DEFAULT_CAMERA, FOCUS_SCALE } from "@/lib/graphCanvas";
-import type { LayoutNode } from "@/lib/graphSimulation";
+import type { GraphLayout, LayoutNode } from "@/lib/graphSimulation";
 import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
 import { DOUBLE_CLICK_MS, useGraphFocus } from "./useGraphFocus";
 
+function node(id: string, x?: number, y?: number): LayoutNode {
+  return { id, label: id, degree: 0, orphan: true, x, y };
+}
+
+function layoutOf(...nodes: LayoutNode[]): GraphLayout {
+  return { nodes, links: [], simulation: null } as unknown as GraphLayout;
+}
+
 // Reduced motion makes the spring snap in one step, so the camera write lands
-// synchronously with the timer instead of over animation frames.
-function setup() {
+// with the timer instead of over animation frames.
+function setup(layout: GraphLayout) {
   stubMatchMedia(true);
   const set = vi.fn();
   const takeManualControl = vi.fn();
   const camera = { camera: DEFAULT_CAMERA, pan: vi.fn(), zoomAt: vi.fn(), set };
-  const view = renderHook(() =>
-    useGraphFocus({ camera, cameraNow: () => DEFAULT_CAMERA, takeManualControl }),
+  const view = renderHook(
+    ({ live }: { live: GraphLayout }) =>
+      useGraphFocus({ camera, cameraNow: () => DEFAULT_CAMERA, takeManualControl, layout: live }),
+    { initialProps: { live: layout } },
   );
   return { view, set, takeManualControl };
-}
-
-function node(id: string, x?: number, y?: number): LayoutNode {
-  return { id, label: id, degree: 0, orphan: true, x, y };
 }
 
 // The tween arrives at its target by arithmetic, so a target of -0 lands as 0.
@@ -39,9 +45,10 @@ afterEach(() => {
 describe("useGraphFocus", () => {
   it("frames a node that carries no coordinates at the origin", () => {
     vi.useFakeTimers();
-    const { view, set, takeManualControl } = setup();
+    const a = node("a");
+    const { view, set, takeManualControl } = setup(layoutOf(a));
 
-    act(() => view.result.current.focusNode(node("a")));
+    act(() => view.result.current.focusNode(a));
     expect(view.result.current.focusedId).toBe("a");
     expect(takeManualControl).toHaveBeenCalled();
 
@@ -53,9 +60,10 @@ describe("useGraphFocus", () => {
 
   it("holds the camera until the double-click window has passed", () => {
     vi.useFakeTimers();
-    const { view, set } = setup();
+    const a = node("a", 40, 25);
+    const { view, set } = setup(layoutOf(a));
 
-    act(() => view.result.current.focusNode(node("a", 40, 25)));
+    act(() => view.result.current.focusNode(a));
     act(() => {
       vi.advanceTimersByTime(DOUBLE_CLICK_MS - 1);
     });
@@ -69,24 +77,56 @@ describe("useGraphFocus", () => {
 
   it("frames where a still-settling node ended up, not where it was pressed", () => {
     vi.useFakeTimers();
-    const { view, set } = setup();
-    const settling = node("a", 40, 25);
+    const a = node("a", 40, 25);
+    const { view, set } = setup(layoutOf(a));
 
-    act(() => view.result.current.focusNode(settling));
+    act(() => view.result.current.focusNode(a));
     // d3 mutates positions in place while the layout keeps cooling.
-    settling.x = 180;
-    settling.y = -60;
+    a.x = 180;
+    a.y = -60;
     act(() => {
       vi.advanceTimersByTime(DOUBLE_CLICK_MS);
     });
     expectLastCamera(set, centerCameraOn(180, -60, FOCUS_SCALE));
   });
 
+  it("follows a re-index that replaces the node objects", () => {
+    vi.useFakeTimers();
+    const pressed = node("a", 40, 25);
+    const { view, set } = setup(layoutOf(pressed));
+
+    act(() => view.result.current.focusNode(pressed));
+    // A watcher-driven re-index builds a fresh layout; the pressed object is
+    // abandoned at its old coordinates.
+    act(() => view.rerender({ live: layoutOf(node("a", -15, 90)) }));
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS);
+    });
+    expectLastCamera(set, centerCameraOn(-15, 90, FOCUS_SCALE));
+  });
+
+  it("drops a focus whose note has left the graph", () => {
+    vi.useFakeTimers();
+    const a = node("a", 40, 25);
+    const { view, set } = setup(layoutOf(a, node("b", 100, 0)));
+
+    act(() => view.result.current.focusNode(a));
+    // The note is deleted or renamed, so it is gone from the next index.
+    act(() => view.rerender({ live: layoutOf(node("b", 100, 0)) }));
+    expect(view.result.current.focusedId).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS);
+    });
+    expect(set).not.toHaveBeenCalled();
+  });
+
   it("cancels a pending camera move when the focus is cleared", () => {
     vi.useFakeTimers();
-    const { view, set } = setup();
+    const a = node("a", 40, 25);
+    const { view, set } = setup(layoutOf(a));
 
-    act(() => view.result.current.focusNode(node("a", 40, 25)));
+    act(() => view.result.current.focusNode(a));
     act(() => view.result.current.clearFocus());
     expect(view.result.current.focusedId).toBeNull();
 
@@ -96,11 +136,26 @@ describe("useGraphFocus", () => {
     expect(set).not.toHaveBeenCalled();
   });
 
+  it("cancels the camera move but keeps the highlight", () => {
+    vi.useFakeTimers();
+    const a = node("a", 40, 25);
+    const { view, set } = setup(layoutOf(a));
+
+    act(() => view.result.current.focusNode(a));
+    act(() => view.result.current.cancelMove());
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS * 4);
+    });
+    expect(set).not.toHaveBeenCalled();
+    expect(view.result.current.focusedId).toBe("a");
+  });
+
   it("cancels a pending camera move when the view unmounts", () => {
     vi.useFakeTimers();
-    const { view, set } = setup();
+    const a = node("a", 40, 25);
+    const { view, set } = setup(layoutOf(a));
 
-    act(() => view.result.current.focusNode(node("a", 40, 25)));
+    act(() => view.result.current.focusNode(a));
     view.unmount();
     act(() => {
       vi.advanceTimersByTime(DOUBLE_CLICK_MS * 4);
@@ -110,10 +165,12 @@ describe("useGraphFocus", () => {
 
   it("retargets to the node of a second focus without moving to the first", () => {
     vi.useFakeTimers();
-    const { view, set } = setup();
+    const a = node("a", 40, 25);
+    const b = node("b", -80, 10);
+    const { view, set } = setup(layoutOf(a, b));
 
-    act(() => view.result.current.focusNode(node("a", 40, 25)));
-    act(() => view.result.current.focusNode(node("b", -80, 10)));
+    act(() => view.result.current.focusNode(a));
+    act(() => view.result.current.focusNode(b));
     expect(view.result.current.focusedId).toBe("b");
 
     act(() => {

--- a/src/hooks/useGraphFocus.test.ts
+++ b/src/hooks/useGraphFocus.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
+import { type Camera, centerCameraOn, DEFAULT_CAMERA, FOCUS_SCALE } from "@/lib/graphCanvas";
+import type { LayoutNode } from "@/lib/graphSimulation";
+import { restoreMatchMedia, stubMatchMedia } from "@/test/matchMedia";
+import { DOUBLE_CLICK_MS, useGraphFocus } from "./useGraphFocus";
+
+// Reduced motion makes the spring snap in one step, so the camera write lands
+// synchronously with the timer instead of over animation frames.
+function setup() {
+  stubMatchMedia(true);
+  const set = vi.fn();
+  const takeManualControl = vi.fn();
+  const camera = { camera: DEFAULT_CAMERA, pan: vi.fn(), zoomAt: vi.fn(), set };
+  const view = renderHook(() =>
+    useGraphFocus({ camera, cameraNow: () => DEFAULT_CAMERA, takeManualControl }),
+  );
+  return { view, set, takeManualControl };
+}
+
+function node(id: string, x?: number, y?: number): LayoutNode {
+  return { id, label: id, degree: 0, orphan: true, x, y };
+}
+
+// The tween arrives at its target by arithmetic, so a target of -0 lands as 0.
+// `toHaveBeenCalledWith` tells those apart; comparing the fields does not.
+function expectLastCamera(set: Mock, expected: Camera) {
+  const actual = set.mock.calls.at(-1)?.[0] as Camera;
+  expect(actual.scale).toBeCloseTo(expected.scale);
+  expect(actual.dx).toBeCloseTo(expected.dx);
+  expect(actual.dy).toBeCloseTo(expected.dy);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  restoreMatchMedia();
+});
+
+describe("useGraphFocus", () => {
+  it("frames a node that carries no coordinates at the origin", () => {
+    vi.useFakeTimers();
+    const { view, set, takeManualControl } = setup();
+
+    act(() => view.result.current.focusNode(node("a")));
+    expect(view.result.current.focusedId).toBe("a");
+    expect(takeManualControl).toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS);
+    });
+    expectLastCamera(set, centerCameraOn(0, 0, FOCUS_SCALE));
+  });
+
+  it("holds the camera until the double-click window has passed", () => {
+    vi.useFakeTimers();
+    const { view, set } = setup();
+
+    act(() => view.result.current.focusNode(node("a", 40, 25)));
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS - 1);
+    });
+    expect(set).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expectLastCamera(set, centerCameraOn(40, 25, FOCUS_SCALE));
+  });
+
+  it("frames where a still-settling node ended up, not where it was pressed", () => {
+    vi.useFakeTimers();
+    const { view, set } = setup();
+    const settling = node("a", 40, 25);
+
+    act(() => view.result.current.focusNode(settling));
+    // d3 mutates positions in place while the layout keeps cooling.
+    settling.x = 180;
+    settling.y = -60;
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS);
+    });
+    expectLastCamera(set, centerCameraOn(180, -60, FOCUS_SCALE));
+  });
+
+  it("cancels a pending camera move when the focus is cleared", () => {
+    vi.useFakeTimers();
+    const { view, set } = setup();
+
+    act(() => view.result.current.focusNode(node("a", 40, 25)));
+    act(() => view.result.current.clearFocus());
+    expect(view.result.current.focusedId).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS * 4);
+    });
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending camera move when the view unmounts", () => {
+    vi.useFakeTimers();
+    const { view, set } = setup();
+
+    act(() => view.result.current.focusNode(node("a", 40, 25)));
+    view.unmount();
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS * 4);
+    });
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("retargets to the node of a second focus without moving to the first", () => {
+    vi.useFakeTimers();
+    const { view, set } = setup();
+
+    act(() => view.result.current.focusNode(node("a", 40, 25)));
+    act(() => view.result.current.focusNode(node("b", -80, 10)));
+    expect(view.result.current.focusedId).toBe("b");
+
+    act(() => {
+      vi.advanceTimersByTime(DOUBLE_CLICK_MS);
+    });
+    expect(set).toHaveBeenCalledTimes(1);
+    expectLastCamera(set, centerCameraOn(-80, 10, FOCUS_SCALE));
+  });
+});

--- a/src/hooks/useGraphFocus.ts
+++ b/src/hooks/useGraphFocus.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { GraphCameraApi } from "@/hooks/useGraphCamera";
 import { type Camera, centerCameraOn, FOCUS_SCALE, lerpCamera } from "@/lib/graphCanvas";
-import type { LayoutNode } from "@/lib/graphSimulation";
+import type { GraphLayout, LayoutNode } from "@/lib/graphSimulation";
 import { createSpringAnimation, type SpringAnimation } from "@/lib/spring";
 
-// The camera move waits out this window, so the first press of a double click
-// never starts an animation on its way to opening the note.
-export const DOUBLE_CLICK_MS = 280;
+// Windows' default double-click time, and the longest of the platform defaults.
+// The camera move waits it out so a double click never starts an animation on
+// its way to opening the note; the highlight still lands on the first press.
+export const DOUBLE_CLICK_MS = 500;
 
 interface UseGraphFocusOptions {
   camera: GraphCameraApi;
@@ -14,6 +15,7 @@ interface UseGraphFocusOptions {
   cameraNow: () => Camera;
   /** Switch the view from auto-fit to the user's own camera. */
   takeManualControl: () => void;
+  layout: GraphLayout;
 }
 
 export interface GraphFocusApi {
@@ -21,6 +23,8 @@ export interface GraphFocusApi {
   focusedId: string | null;
   focusNode: (node: LayoutNode) => void;
   clearFocus: () => void;
+  /** Drop a pending or running camera move, keeping the highlight. */
+  cancelMove: () => void;
 }
 
 /**
@@ -32,16 +36,20 @@ export function useGraphFocus({
   camera,
   cameraNow,
   takeManualControl,
+  layout,
 }: UseGraphFocusOptions): GraphFocusApi {
   const [focusedId, setFocusedId] = useState<string | null>(null);
   const timerRef = useRef(0);
   const animationRef = useRef<SpringAnimation | null>(null);
-  // The deferred move reads the camera when it fires, not when it was scheduled:
-  // a wheel zoom inside the double-click window would otherwise make it jump.
+  // The deferred move reads the camera and the layout when it fires, not when it
+  // was scheduled, so a zoom or a re-index inside the window cannot strand it.
   const cameraNowRef = useRef(cameraNow);
   cameraNowRef.current = cameraNow;
+  const layoutRef = useRef(layout);
+  layoutRef.current = layout;
+  const setCamera = camera.set;
 
-  const cancelPending = useCallback(() => {
+  const cancelMove = useCallback(() => {
     window.clearTimeout(timerRef.current);
     timerRef.current = 0;
     animationRef.current?.stop();
@@ -50,32 +58,40 @@ export function useGraphFocus({
 
   const focusNode = useCallback(
     (node: LayoutNode) => {
-      cancelPending();
+      cancelMove();
       takeManualControl();
       setFocusedId(node.id);
       timerRef.current = window.setTimeout(() => {
         timerRef.current = 0;
-        // d3 mutates node positions in place, so read them here: a layout still
-        // settling would have moved the node on since the press.
+        // Re-resolve by id: a re-index swaps every node object, and d3 moves the
+        // survivors on as the layout keeps settling.
+        const target = layoutRef.current.nodes.find((n) => n.id === node.id);
+        if (!target) return;
         const from = cameraNowRef.current();
-        const to = centerCameraOn(node.x ?? 0, node.y ?? 0, Math.max(from.scale, FOCUS_SCALE));
+        const to = centerCameraOn(target.x ?? 0, target.y ?? 0, Math.max(from.scale, FOCUS_SCALE));
         const animation = createSpringAnimation({
           initial: 0,
-          onFrame: (progress) => camera.set(lerpCamera(from, to, progress)),
+          onFrame: (progress) => setCamera(lerpCamera(from, to, progress)),
         });
         animationRef.current = animation;
         animation.animateTo(1);
       }, DOUBLE_CLICK_MS);
     },
-    [camera, cancelPending, takeManualControl],
+    [cancelMove, setCamera, takeManualControl],
   );
 
   const clearFocus = useCallback(() => {
-    cancelPending();
+    cancelMove();
     setFocusedId(null);
-  }, [cancelPending]);
+  }, [cancelMove]);
 
-  useEffect(() => cancelPending, [cancelPending]);
+  // A focused note can leave the graph (deleted, renamed, unindexed). Its id
+  // would then dim the whole graph with nothing lit, so drop it.
+  useEffect(() => {
+    setFocusedId((id) => (id !== null && !layout.nodes.some((n) => n.id === id) ? null : id));
+  }, [layout]);
 
-  return { focusedId, focusNode, clearFocus };
+  useEffect(() => cancelMove, [cancelMove]);
+
+  return { focusedId, focusNode, clearFocus, cancelMove };
 }

--- a/src/hooks/useGraphFocus.ts
+++ b/src/hooks/useGraphFocus.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { GraphCameraApi } from "@/hooks/useGraphCamera";
+import { type Camera, centerCameraOn, FOCUS_SCALE, lerpCamera } from "@/lib/graphCanvas";
+import type { LayoutNode } from "@/lib/graphSimulation";
+import { createSpringAnimation, type SpringAnimation } from "@/lib/spring";
+
+// The camera move waits out this window, so the first press of a double click
+// never starts an animation on its way to opening the note.
+export const DOUBLE_CLICK_MS = 280;
+
+interface UseGraphFocusOptions {
+  camera: GraphCameraApi;
+  /** The camera under the cursor right now, read inside event handlers. */
+  cameraNow: () => Camera;
+  /** Switch the view from auto-fit to the user's own camera. */
+  takeManualControl: () => void;
+}
+
+export interface GraphFocusApi {
+  /** Node held in focus; its neighbourhood stays highlighted until cleared. */
+  focusedId: string | null;
+  focusNode: (node: LayoutNode) => void;
+  clearFocus: () => void;
+}
+
+/**
+ * Sticky focus for a graph node: the highlight lands at once, the camera follows
+ * only after the double-click window, so clearing in between never animates.
+ * `createSpringAnimation` snaps rather than tweens under reduced motion.
+ */
+export function useGraphFocus({
+  camera,
+  cameraNow,
+  takeManualControl,
+}: UseGraphFocusOptions): GraphFocusApi {
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const timerRef = useRef(0);
+  const animationRef = useRef<SpringAnimation | null>(null);
+  // The deferred move reads the camera when it fires, not when it was scheduled:
+  // a wheel zoom inside the double-click window would otherwise make it jump.
+  const cameraNowRef = useRef(cameraNow);
+  cameraNowRef.current = cameraNow;
+
+  const cancelPending = useCallback(() => {
+    window.clearTimeout(timerRef.current);
+    timerRef.current = 0;
+    animationRef.current?.stop();
+    animationRef.current = null;
+  }, []);
+
+  const focusNode = useCallback(
+    (node: LayoutNode) => {
+      cancelPending();
+      takeManualControl();
+      setFocusedId(node.id);
+      timerRef.current = window.setTimeout(() => {
+        timerRef.current = 0;
+        // d3 mutates node positions in place, so read them here: a layout still
+        // settling would have moved the node on since the press.
+        const from = cameraNowRef.current();
+        const to = centerCameraOn(node.x ?? 0, node.y ?? 0, Math.max(from.scale, FOCUS_SCALE));
+        const animation = createSpringAnimation({
+          initial: 0,
+          onFrame: (progress) => camera.set(lerpCamera(from, to, progress)),
+        });
+        animationRef.current = animation;
+        animation.animateTo(1);
+      }, DOUBLE_CLICK_MS);
+    },
+    [camera, cancelPending, takeManualControl],
+  );
+
+  const clearFocus = useCallback(() => {
+    cancelPending();
+    setFocusedId(null);
+  }, [cancelPending]);
+
+  useEffect(() => cancelPending, [cancelPending]);
+
+  return { focusedId, focusNode, clearFocus };
+}

--- a/src/hooks/useGraphPointer.ts
+++ b/src/hooks/useGraphPointer.ts
@@ -37,13 +37,16 @@ interface UseGraphPointerOptions {
   /** Switch the view from auto-fit to the user's own camera. */
   takeManualControl: () => void;
   reheat: (alpha?: number) => void;
-  onOpenFile: (path: string) => void;
+  /** A click on a node, with the native click count (1 = single, 2 = double). */
+  onNodeClick: (node: LayoutNode, clickCount: number) => void;
+  onBackgroundClick: () => void;
 }
 
 /**
  * The graph canvas gesture state machine: hover, background pan, node drag (pin
- * plus reheat), click-to-open, and wheel zoom. A press only becomes a drag once
- * it travels past the click slop, so a click never nudges the camera.
+ * plus reheat), click reporting, and wheel zoom. A press only becomes a drag
+ * once it travels past the click slop, so a click never nudges the camera. What
+ * a click means (focus versus open) is the caller's decision, not this hook's.
  */
 export function useGraphPointer({
   canvasRef,
@@ -53,7 +56,8 @@ export function useGraphPointer({
   cameraNow,
   takeManualControl,
   reheat,
-  onOpenFile,
+  onNodeClick,
+  onBackgroundClick,
 }: UseGraphPointerOptions) {
   const [hovered, setHovered] = useState<{ id: string; x: number; y: number } | null>(null);
   const pointer = useRef<ActivePointer | null>(null);
@@ -121,8 +125,10 @@ export function useGraphPointer({
       pointer.current = null;
       if (!drag || drag.id !== event.pointerId) return;
       if (!drag.moved) {
-        // A press that never became a drag is a click: open the node's note.
-        if (drag.node) onOpenFile(drag.node.id);
+        // A press that never became a drag is a click; `detail` is the native
+        // click count, which separates a double click's second press.
+        if (drag.node) onNodeClick(drag.node, event.detail);
+        else onBackgroundClick();
         return;
       }
       if (drag.node) {
@@ -131,7 +137,7 @@ export function useGraphPointer({
         reheat(0.1);
       }
     },
-    [onOpenFile, reheat],
+    [onBackgroundClick, onNodeClick, reheat],
   );
 
   // Wheel must be a native non-passive listener to preventDefault scrolling.

--- a/src/hooks/useGraphPointer.ts
+++ b/src/hooks/useGraphPointer.ts
@@ -37,9 +37,11 @@ interface UseGraphPointerOptions {
   /** Switch the view from auto-fit to the user's own camera. */
   takeManualControl: () => void;
   reheat: (alpha?: number) => void;
-  /** A click on a node, with the native click count (1 = single, 2 = double). */
+  /** A click on a node, with the native click count (0 where the engine omits it). */
   onNodeClick: (node: LayoutNode, clickCount: number) => void;
   onBackgroundClick: () => void;
+  /** A new gesture is taking the camera, so any animation on it must stop. */
+  onCameraInterrupt: () => void;
 }
 
 /**
@@ -58,6 +60,7 @@ export function useGraphPointer({
   reheat,
   onNodeClick,
   onBackgroundClick,
+  onCameraInterrupt,
 }: UseGraphPointerOptions) {
   const [hovered, setHovered] = useState<{ id: string; x: number; y: number } | null>(null);
   const pointer = useRef<ActivePointer | null>(null);
@@ -72,6 +75,7 @@ export function useGraphPointer({
 
   const handlePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLCanvasElement>) => {
+      onCameraInterrupt();
       const point = localPoint(event);
       const cam = cameraNow();
       const hit = hitTestNode(layout.nodes, cam, viewport, point.x, point.y);
@@ -85,7 +89,7 @@ export function useGraphPointer({
       };
       event.currentTarget.setPointerCapture(event.pointerId);
     },
-    [cameraNow, layout.nodes, localPoint, viewport],
+    [cameraNow, layout.nodes, localPoint, onCameraInterrupt, viewport],
   );
 
   const handlePointerMove = useCallback(
@@ -119,25 +123,45 @@ export function useGraphPointer({
     [camera, cameraNow, layout.nodes, localPoint, reheat, takeManualControl, viewport],
   );
 
+  // Release a dragged node back into the flow and let its neighbours relax.
+  const releaseDraggedNode = useCallback(
+    (drag: ActivePointer) => {
+      if (!drag.moved || !drag.node) return;
+      releaseNode(drag.node);
+      reheat(0.1);
+    },
+    [reheat],
+  );
+
   const handlePointerUp = useCallback(
     (event: ReactPointerEvent<HTMLCanvasElement>) => {
       const drag = pointer.current;
       pointer.current = null;
       if (!drag || drag.id !== event.pointerId) return;
       if (!drag.moved) {
-        // A press that never became a drag is a click; `detail` is the native
-        // click count, which separates a double click's second press.
+        // A press that never became a drag is a click. `detail` is the native
+        // click count where the engine supplies one; Chromium follows the
+        // Pointer Events spec and leaves it 0 here, so the caller cannot lean
+        // on it alone.
         if (drag.node) onNodeClick(drag.node, event.detail);
         else onBackgroundClick();
         return;
       }
-      if (drag.node) {
-        // Release the dragged node back into the flow and let neighbours relax.
-        releaseNode(drag.node);
-        reheat(0.1);
-      }
+      releaseDraggedNode(drag);
     },
-    [onBackgroundClick, onNodeClick, reheat],
+    [onBackgroundClick, onNodeClick, releaseDraggedNode],
+  );
+
+  // A cancelled gesture (the browser taking over a touch, a lost capture) is
+  // never a click: it only has to put a dragged node back.
+  const handlePointerCancel = useCallback(
+    (event: ReactPointerEvent<HTMLCanvasElement>) => {
+      const drag = pointer.current;
+      pointer.current = null;
+      if (!drag || drag.id !== event.pointerId) return;
+      releaseDraggedNode(drag);
+    },
+    [releaseDraggedNode],
   );
 
   // Wheel must be a native non-passive listener to preventDefault scrolling.
@@ -146,13 +170,14 @@ export function useGraphPointer({
     if (!canvas) return;
     const handleWheel = (event: WheelEvent) => {
       event.preventDefault();
+      onCameraInterrupt();
       takeManualControl();
       const point = localPoint(event);
       camera.zoomAt(point.x, point.y, Math.exp(-event.deltaY * WHEEL_ZOOM_SPEED), viewport);
     };
     canvas.addEventListener("wheel", handleWheel, { passive: false });
     return () => canvas.removeEventListener("wheel", handleWheel);
-  }, [camera, canvasRef, localPoint, takeManualControl, viewport]);
+  }, [camera, canvasRef, localPoint, onCameraInterrupt, takeManualControl, viewport]);
 
   return {
     hovered,
@@ -162,6 +187,7 @@ export function useGraphPointer({
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handlePointerCancel,
     /** Clear hover when the cursor leaves the canvas. */
     clearHover: () => setHovered(null),
   };

--- a/src/hooks/useGraphZoomCommands.ts
+++ b/src/hooks/useGraphZoomCommands.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+import { useZoomApi, type ZoomHandlers } from "@/contexts/ZoomContext";
+import type { GraphCameraApi } from "@/hooks/useGraphCamera";
+import type { Viewport } from "@/lib/graphCanvas";
+
+// Zoom factor per Zoom In / Zoom Out command (keyboard / menu).
+const HOTKEY_ZOOM_FACTOR = 1.2;
+
+interface UseGraphZoomCommandsOptions {
+  camera: GraphCameraApi;
+  viewport: Viewport;
+  /** Switch the view from auto-fit to the user's own camera. */
+  takeManualControl: () => void;
+  /** Re-frame the graph and return it to auto-fit (the Reset view action). */
+  refit: () => void;
+}
+
+/**
+ * Routes the Zoom In/Out/Actual-Size commands to the graph camera while the
+ * graph is the active surface, anchored on the viewport centre. Wheel zoom is
+ * wired separately in `useGraphPointer`. The handlers read the latest
+ * camera/viewport through a ref, so registration happens once per mount rather
+ * than on every camera frame.
+ */
+export function useGraphZoomCommands({
+  camera,
+  viewport,
+  takeManualControl,
+  refit,
+}: UseGraphZoomCommandsOptions): void {
+  const registerZoomTarget = useZoomApi()?.registerTarget;
+  const zoomImplRef = useRef<() => ZoomHandlers>(() => ({
+    zoomIn: () => {},
+    zoomOut: () => {},
+    zoomReset: () => {},
+  }));
+  zoomImplRef.current = () => {
+    const zoomCenter = (factor: number) => {
+      takeManualControl();
+      camera.zoomAt(viewport.width / 2, viewport.height / 2, factor, viewport);
+    };
+    return {
+      zoomIn: () => zoomCenter(HOTKEY_ZOOM_FACTOR),
+      zoomOut: () => zoomCenter(1 / HOTKEY_ZOOM_FACTOR),
+      zoomReset: refit,
+    };
+  };
+
+  useEffect(() => {
+    if (!registerZoomTarget) return;
+    registerZoomTarget({
+      zoomIn: () => zoomImplRef.current().zoomIn(),
+      zoomOut: () => zoomImplRef.current().zoomOut(),
+      zoomReset: () => zoomImplRef.current().zoomReset(),
+    });
+    return () => registerZoomTarget(null);
+  }, [registerZoomTarget]);
+}

--- a/src/lib/graphCanvas.test.ts
+++ b/src/lib/graphCanvas.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   type Camera,
+  centerCameraOn,
   DEFAULT_CAMERA,
   fitCameraToNodes,
   hitTestNode,
+  lerpCamera,
   MAX_SCALE,
   MIN_SCALE,
   nodeRadius,
@@ -160,5 +162,36 @@ describe("hitTestNode", () => {
     const n: LayoutNode = { id: "a", label: "a", degree: 0, orphan: true };
     // Origin maps to the viewport centre (400, 300) under the default camera.
     expect(hitTestNode([n], DEFAULT_CAMERA, VIEWPORT, 400, 300)?.id).toBe("a");
+  });
+});
+
+describe("centerCameraOn", () => {
+  it("puts the world point at the viewport centre", () => {
+    const screen = worldToScreen(centerCameraOn(120, -45, 2), VIEWPORT, 120, -45);
+    expect(screen).toEqual({ x: 400, y: 300 });
+  });
+
+  it("clamps the scale to the zoom limits", () => {
+    expect(centerCameraOn(0, 0, MAX_SCALE * 4).scale).toBe(MAX_SCALE);
+    expect(centerCameraOn(0, 0, MIN_SCALE / 4).scale).toBe(MIN_SCALE);
+  });
+
+  it("keeps the point centred at a clamped scale", () => {
+    const camera = centerCameraOn(50, 50, MAX_SCALE * 4);
+    expect(worldToScreen(camera, VIEWPORT, 50, 50)).toEqual({ x: 400, y: 300 });
+  });
+});
+
+describe("lerpCamera", () => {
+  const from: Camera = { dx: 0, dy: 0, scale: 1 };
+  const to: Camera = { dx: 100, dy: -40, scale: 2 };
+
+  it("returns the endpoints at t = 0 and t = 1", () => {
+    expect(lerpCamera(from, to, 0)).toEqual(from);
+    expect(lerpCamera(from, to, 1)).toEqual(to);
+  });
+
+  it("interpolates every field", () => {
+    expect(lerpCamera(from, to, 0.5)).toEqual({ dx: 50, dy: -20, scale: 1.5 });
   });
 });

--- a/src/lib/graphCanvas.ts
+++ b/src/lib/graphCanvas.ts
@@ -124,6 +124,24 @@ export function fitCameraToNodes(
   return { scale, dx: -centreX * scale, dy: -centreY * scale };
 }
 
+/** Scale a focused node is framed at, close enough for its labels to read. */
+export const FOCUS_SCALE = 1.6;
+
+/** Camera that puts the world point (x, y) at the centre of the viewport. */
+export function centerCameraOn(x: number, y: number, scale: number): Camera {
+  const clamped = Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale));
+  return { scale: clamped, dx: -x * clamped, dy: -y * clamped };
+}
+
+/** Camera `t` of the way from `from` to `to`, driving the focus tween. */
+export function lerpCamera(from: Camera, to: Camera, t: number): Camera {
+  return {
+    dx: from.dx + (to.dx - from.dx) * t,
+    dy: from.dy + (to.dy - from.dy) * t,
+    scale: from.scale + (to.scale - from.scale) * t,
+  };
+}
+
 /**
  * Topmost node under the screen point (nodes drawn later win), or null.
  * `slop` widens the target in screen px so small nodes stay clickable when

--- a/src/lib/graphCanvas.ts
+++ b/src/lib/graphCanvas.ts
@@ -27,8 +27,6 @@ const FIT_MAX_SCALE = 1.6;
 // Breathing room (screen px) left around the graph when fitting.
 const FIT_PADDING = 48;
 
-/** Labels are unreadable clutter when zoomed far out; hide them below this. */
-
 export function panCamera(camera: Camera, dx: number, dy: number): Camera {
   return { ...camera, dx: camera.dx + dx, dy: camera.dy + dy };
 }

--- a/src/lib/graphDraw.test.ts
+++ b/src/lib/graphDraw.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { WikilinkRef } from "./backlinks";
 import { buildWorkspaceGraph } from "./graph";
 import { DEFAULT_CAMERA } from "./graphCanvas";
-import { drawGraph, readGraphTheme } from "./graphDraw";
+import { ALPHA_DIMMED, drawGraph, readGraphTheme } from "./graphDraw";
 import { createGraphLayout, type GraphLayout, type LayoutNode } from "./graphSimulation";
 
 const VIEWPORT = { width: 800, height: 600 };
@@ -239,6 +239,6 @@ describe("drawGraph", () => {
     expect(fills).toContain("node");
     expect(fills).not.toContain("orphan");
     // The c–d edge doesn't touch the hovered node, so it draws at the dimmed alpha.
-    expect(alphas).toContain(0.18);
+    expect(alphas).toContain(ALPHA_DIMMED);
   });
 });

--- a/src/lib/graphDraw.ts
+++ b/src/lib/graphDraw.ts
@@ -6,7 +6,8 @@ import { type Camera, nodeRadius, type Viewport } from "./graphCanvas";
 import type { GraphLayout, LayoutNode } from "./graphSimulation";
 
 const LABEL_MIN_SCALE = 0.7;
-const ALPHA_DIMMED = 0.18;
+/** Alpha everything outside the highlighted neighbourhood draws at. */
+export const ALPHA_DIMMED = 0.18;
 const ALPHA_EDGE = 0.55;
 
 export interface GraphTheme {


### PR DESCRIPTION
## Summary

Clicking a node in the graph used to yank you straight out of it into a document tab, so there was no way to click a node just to look at what it connects to. A single click now focuses a node: the camera centres on it and its neighbourhood stays highlighted while the rest of the graph dims. Opening the note is a deliberate second action.

Closes #733

## Changes

- **Focus on click, open on a second press.** `useGraphPointer` no longer opens files; it reports `onNodeClick(node, clickCount)` and `onBackgroundClick()`, and `GraphView` decides what a click means. A second press on the node already in focus opens it, and a reported click count of 2 or more opens it too.
- **`drawGraph` is unchanged.** Focus rides its existing highlight input as `hovered?.id ?? focusedId`, so hover still previews a neighbourhood on top of the focus and the focus survives the cursor leaving, without a second dimming pass.
- **New `useGraphFocus`** owns the focus state, the deferred camera move, and its cancellation. The move animates one 0..1 progress scalar through the existing `lib/spring`, lerping between two cameras, so it is one animation loop and one camera write per frame. `createSpringAnimation` already snaps instead of tweening under reduced motion, so that costs no extra wiring.
- **New `centerCameraOn` and `lerpCamera`** in `lib/graphCanvas`, next to `fitCameraToNodes` and sharing its centring math. Focus never zooms out from a closer camera and clamps at `MAX_SCALE`.
- **`useGraphZoomCommands`** extracts the Zoom In/Out/Actual-Size registration out of `GraphView`, which had grown past the file-size cap. Pure move, already covered by the existing zoom test.
- `ALPHA_DIMMED` is exported from `graphDraw` so tests assert the real constant rather than re-declaring `0.18`.
- `samples/README.md` and `samples/Graph View.md` describe the new gesture.

### The click count does not work on Chromium or touch

The first implementation read the click count from `PointerEvent.detail` on pointerup. That is wrong: the Pointer Events spec leaves `detail` at 0 for `pointerdown`/`pointerup`, Chromium follows it, and touch reports no count on any engine. Verified in Chromium 152 with real trusted events:

```
pointerdown:0  pointerup:0  click:1
pointerdown:0  pointerup:0  click:2  dblclick:2
```

Glyph runs on WebView2 on Windows and Android WebView, so `clickCount >= 2` could never be true there and **the graph would have had no way to open a note at all** on those platforms. WebKit happens to carry the count, which is why it looked fine on macOS and Linux.

The second commit replaces that with the already-focused rule, which is engine-independent and works by tap. Four related defects went with it, each with a regression test:

- A `pointercancel` was routed through the click path, so a cancelled gesture on the focused node would have opened it. Cancel now has its own handler and only releases a dragged node.
- The running camera tween fought any concurrent pan, wheel, or node drag for its whole flight; a node grabbed mid-tween was pinned against a camera that had moved under it. A new gesture now stops the move.
- The deferred move held a `LayoutNode` object, so a watcher-driven re-index inside the window centred on an abandoned copy. It now resolves the node by id against the live layout.
- A focused note that left the graph (deleted, renamed, unindexed) left a dangling id that dimmed the whole view with nothing lit.

The window was also 280 ms, shorter than the 500 ms platform double-click time, so a normal-speed double click started the animation the deferral exists to prevent. It is 500 ms now.

## Risk classification

- [x] Asynchronous ordering / races
- [x] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [x] Accessibility
- [ ] Persistence / data loss
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Bundle size / startup

### Invariants at stake and evidence

**INV-3: stale results never win.** The deferred camera move is a pending operation that can outlive the state it was scheduled from. Every way it can go stale is covered in `useGraphFocus.test.ts`:

- fires after the layout kept settling: "frames where a still-settling node ended up, not where it was pressed"
- fires after a re-index replaced every node object: "follows a re-index that replaces the node objects"
- fires after the focused note left the graph: "drops a focus whose note has left the graph" (no camera write, focus cleared)
- fires after the focus was cleared or retargeted: "cancels a pending camera move when the focus is cleared", "retargets to the node of a second focus without moving to the first"
- fires after the user took the camera by hand: `GraphView.test.tsx` "stops a running focus move when the next gesture takes the camera" and "...when the wheel takes the camera"

**INV-4: owners flush before they die.** The only pending work is a cosmetic camera animation, so unmount cancels rather than flushes, which is the correct choice here. Covered by "cancels a pending camera move when the view unmounts".

**Accessibility.** Opening a note now takes two presses rather than one. It is deliberately *not* double-click-only: a second single press on the focused node opens it with no timing requirement, which is easier than a timed double click for motor impairments and is the only thing that works by tap. There is still no keyboard route to a graph node; that is pre-existing and out of scope for this issue.

## Testing

Automated gates only, on Windows. Not manually exercised on any platform, so all three boxes are left unchecked.

- `pnpm typecheck`, `pnpm check`, `pnpm test` (3812 tests), `cargo clippy --all-targets -- -D warnings`: all green.
- `pnpm test:coverage`: no uncovered lines in any file this diff touches.
- The Chromium `detail` behaviour above was probed in a real browser with trusted events, not asserted from the spec.
- The two load-bearing behaviours were mutation-tested: reverting the already-focused rule fails "opens the clicked node's file on a second press, with no click count", and reverting the focus highlight fails the two neighbourhood-dimming tests.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not captured: the change is an interaction on an existing canvas, and a still frame does not show the difference between a focus and an open.
