### PR TITLE
feat(graph): keep the camera and layout across tab switches

### DIFF
--- a/samples/Graph View.md
+++ b/samples/Graph View.md
@@ -45,6 +45,10 @@ the `samples/` folder and try it on this very workspace.
 The graph stays live: create or delete a note, or edit a wikilink, and the map
 re-shapes on the next save, with no manual refresh.
 
+Where you left the view is remembered for the session, so switching to a note
+and back returns to the same framing and layout instead of re-settling from
+scratch. Closing the graph tab forgets it, and so does restarting Glyph.
+
 ## Related
 
 - [[Index]] is the workspace entry point.

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -72,7 +72,10 @@ export function TabContent({ searchOpen, onSearchClose }: TabContentProps) {
   // clicked notes as document tabs.
   if (activeTab.kind === "graph") {
     return (
+      // Keyed by root so a workspace change remounts rather than swapping the
+      // key underneath hooks that seed from it once.
       <GraphView
+        key={activeTab.root}
         workspaceFiles={workspaceFiles}
         wikilinkRefs={wikilinkRefs}
         onOpenFile={handleOpenWikilink}

--- a/src/components/graph/GraphView.test.tsx
+++ b/src/components/graph/GraphView.test.tsx
@@ -14,6 +14,9 @@ import { GraphView } from "./GraphView";
 const hoisted = vi.hoisted(() => ({
   reheat: vi.fn(),
   layoutRef: { current: null as GraphLayout | null },
+  // Whether the mock layout resumed the stored shape. False means d3 replayed
+  // it, which is when a restored camera would frame the wrong coordinates.
+  reseeded: { value: true },
 }));
 
 // Deterministic stand-in for the d3 layout: node i sits at world (i * 100, 0).
@@ -36,6 +39,7 @@ vi.mock("@/hooks/useGraphSimulation", () => {
         layout = { nodes, links, simulation: null } as unknown as GraphLayout;
         cache.set(graph, layout);
       }
+      layout.reseeded = hoisted.reseeded.value;
       hoisted.layoutRef.current = layout;
       return { layout, version: 1, settled: true, reheat: hoisted.reheat };
     },
@@ -84,6 +88,7 @@ let ctx: ReturnType<typeof stubContext>;
 beforeEach(() => {
   hoisted.reheat.mockClear();
   hoisted.layoutRef.current = null;
+  hoisted.reseeded.value = true;
   ctx = stubContext();
   HTMLCanvasElement.prototype.getContext = vi.fn(
     () => ctx,
@@ -345,7 +350,10 @@ describe("GraphView", () => {
 describe("GraphView view state across a tab switch", () => {
   const ROOT = "/ws";
 
-  afterEach(() => clearGraphView(ROOT));
+  afterEach(() => {
+    clearGraphView(ROOT);
+    clearGraphView("/other");
+  });
 
   // Built here rather than via `renderInWorkspace` so a re-index can rerender
   // the same tree: rerendering without the provider would remount the view.
@@ -403,6 +411,20 @@ describe("GraphView view state across a tab switch", () => {
     expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
   });
 
+  it("re-fits instead of restoring the camera when the layout replayed", () => {
+    const first = renderInRoot();
+    pan(first.canvas, 60);
+    first.unmount();
+
+    // Too few nodes came back seeded (a large re-index while the tab was in the
+    // background), so d3 replayed the layout around the origin. Restoring the
+    // manual camera would frame empty space.
+    hoisted.reseeded.value = false;
+    renderInRoot();
+    expect(screen.getByRole("button", { name: "Reset view" })).toBeDisabled();
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
+  });
+
   it("starts fresh once the graph tab's state is cleared", () => {
     const first = renderInRoot();
     pan(first.canvas, 60);
@@ -432,6 +454,5 @@ describe("GraphView view state across a tab switch", () => {
 
     renderInRoot("/other");
     expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
-    clearGraphView("/other");
   });
 });

--- a/src/components/graph/GraphView.test.tsx
+++ b/src/components/graph/GraphView.test.tsx
@@ -1,11 +1,13 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TabsContext, type TabsContextValue } from "@/contexts/TabsContext";
 import { useZoomApi } from "@/contexts/ZoomContext";
 import { ZoomProvider } from "@/contexts/ZoomProvider";
 import type { WikilinkRef } from "@/lib/backlinks";
 import { buildWorkspaceGraph, type WorkspaceGraph } from "@/lib/graph";
 import { fitCameraToNodes, worldToScreen } from "@/lib/graphCanvas";
 import type { GraphLayout, LayoutNode } from "@/lib/graphSimulation";
+import { clearGraphView, loadGraphView } from "@/lib/graphViewStore";
 import { GraphView } from "./GraphView";
 
 // Shared spies/captures between the test and the hoisted mock factory.
@@ -296,6 +298,9 @@ describe("GraphView", () => {
           <button type="button" onClick={() => api?.actions.zoomIn()}>
             cmd-zoom-in
           </button>
+          <button type="button" onClick={() => api?.actions.zoomOut()}>
+            cmd-zoom-out
+          </button>
           <button type="button" onClick={() => api?.actions.zoomReset()}>
             cmd-zoom-reset
           </button>
@@ -316,6 +321,9 @@ describe("GraphView", () => {
     expect(reset).toBeEnabled();
     expect(lastWorldTransform().scale).toBeGreaterThan(FIT.scale);
 
+    fireEvent.click(screen.getByText("cmd-zoom-out"));
+    expect(lastWorldTransform().scale).toBeCloseTo(FIT.scale);
+
     fireEvent.click(screen.getByText("cmd-zoom-reset"));
     expect(reset).toBeDisabled();
     expect(lastWorldTransform().scale).toBeCloseTo(FIT.scale);
@@ -329,5 +337,101 @@ describe("GraphView", () => {
     expect(() =>
       fireEvent.pointerMove(canvas, { pointerId: 1, clientX: NODE_A.x, clientY: NODE_A.y }),
     ).not.toThrow();
+  });
+});
+
+// The graph tab unmounts whenever another tab is active, so these render inside
+// a workspace: the root is the key its view state is stored under.
+describe("GraphView view state across a tab switch", () => {
+  const ROOT = "/ws";
+
+  afterEach(() => clearGraphView(ROOT));
+
+  // Built here rather than via `renderInWorkspace` so a re-index can rerender
+  // the same tree: rerendering without the provider would remount the view.
+  function graphIn(root: string, files: readonly string[] = FILES) {
+    const tabs = { workspace: { root } } as unknown as TabsContextValue;
+    return (
+      <TabsContext.Provider value={tabs}>
+        <GraphView workspaceFiles={files} wikilinkRefs={REFS} onOpenFile={vi.fn()} />
+      </TabsContext.Provider>
+    );
+  }
+
+  function renderInRoot(root = ROOT) {
+    const utils = render(graphIn(root));
+    return { ...utils, canvas: screen.getByRole("img", { name: "Workspace graph" }) };
+  }
+
+  function pan(canvas: HTMLElement, dx: number) {
+    fireEvent.pointerDown(canvas, { pointerId: 1, clientX: EMPTY.x, clientY: EMPTY.y });
+    fireEvent.pointerMove(canvas, { pointerId: 1, clientX: EMPTY.x + dx, clientY: EMPTY.y });
+    fireEvent.pointerUp(canvas, { pointerId: 1, clientX: EMPTY.x + dx, clientY: EMPTY.y });
+  }
+
+  it("comes back to the same camera, with no re-fit in between", () => {
+    const first = renderInRoot();
+    pan(first.canvas, 60);
+    const panned = lastWorldTransform();
+    expect(panned.tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx + 60);
+    first.unmount();
+
+    renderInRoot();
+    expect(lastWorldTransform().tx).toBeCloseTo(panned.tx);
+    expect(screen.getByRole("button", { name: "Reset view" })).toBeEnabled();
+  });
+
+  it("comes back still auto-fitting when the camera was never touched", () => {
+    const first = renderInRoot();
+    expect(screen.getByRole("button", { name: "Reset view" })).toBeDisabled();
+    first.unmount();
+
+    renderInRoot();
+    expect(screen.getByRole("button", { name: "Reset view" })).toBeDisabled();
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
+  });
+
+  it("stays auto-fit across a switch that follows a reset", () => {
+    const first = renderInRoot();
+    pan(first.canvas, 60);
+    fireEvent.click(screen.getByRole("button", { name: "Reset view" }));
+    expect(loadGraphView(ROOT)?.autoFit).toBe(true);
+    first.unmount();
+
+    renderInRoot();
+    expect(screen.getByRole("button", { name: "Reset view" })).toBeDisabled();
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
+  });
+
+  it("starts fresh once the graph tab's state is cleared", () => {
+    const first = renderInRoot();
+    pan(first.canvas, 60);
+    first.unmount();
+
+    // What closing the graph tab does.
+    clearGraphView(ROOT);
+    renderInRoot();
+    expect(screen.getByRole("button", { name: "Reset view" })).toBeDisabled();
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
+  });
+
+  it("keeps the camera through a re-index", () => {
+    const { canvas, rerender } = renderInRoot();
+    pan(canvas, 60);
+    const panned = lastWorldTransform();
+
+    // The watcher re-indexes the workspace, so the graph and layout are rebuilt.
+    rerender(graphIn(ROOT, [...FILES, "/v/c.md"]));
+    expect(lastWorldTransform().tx).toBeCloseTo(panned.tx);
+  });
+
+  it("keeps one workspace's camera out of another's", () => {
+    const first = renderInRoot();
+    pan(first.canvas, 60);
+    first.unmount();
+
+    renderInRoot("/other");
+    expect(lastWorldTransform().tx).toBeCloseTo(VIEWPORT.width / 2 + FIT.dx);
+    clearGraphView("/other");
   });
 });

--- a/src/components/graph/GraphView.tsx
+++ b/src/components/graph/GraphView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FitIcon } from "@/components/icons/FitIcon";
+import { useWorkspaceRoot } from "@/contexts/TabsContext";
 import { useZoomApi, type ZoomHandlers } from "@/contexts/ZoomContext";
 import { useElementSize } from "@/hooks/useElementSize";
 import { useGraphCamera } from "@/hooks/useGraphCamera";
@@ -11,6 +12,7 @@ import type { WikilinkRef } from "@/lib/backlinks";
 import { buildWorkspaceGraph } from "@/lib/graph";
 import { type Camera, fitCameraToNodes } from "@/lib/graphCanvas";
 import { drawGraph, readGraphTheme } from "@/lib/graphDraw";
+import { loadGraphView, saveGraphView } from "@/lib/graphViewStore";
 
 interface GraphViewProps {
   workspaceFiles: readonly string[];
@@ -40,18 +42,24 @@ export function GraphView({ workspaceFiles, wikilinkRefs, onOpenFile }: GraphVie
     () => buildWorkspaceGraph(workspaceFiles, wikilinkRefs),
     [workspaceFiles, wikilinkRefs],
   );
-  const { layout, version, reheat } = useGraphSimulation(graph);
-  const camera = useGraphCamera();
+  // The graph tab unmounts whenever another tab is active, so its camera,
+  // auto-fit flag and layout live in a store keyed by workspace root.
+  const persistKey = useWorkspaceRoot();
+  const { layout, version, reheat } = useGraphSimulation(graph, { persistKey });
+  const camera = useGraphCamera(persistKey);
   const isDark = useIsDarkMode();
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-read CSS variables when the theme flips
   const theme = useMemo(() => readGraphTheme(document.documentElement), [isDark]);
 
   // Auto-fit follows the live layout until the user takes manual control.
-  const [autoFit, setAutoFit] = useState(true);
-  const autoFitRef = useRef(true);
+  const [autoFit, setAutoFit] = useState(
+    () => (persistKey ? loadGraphView(persistKey)?.autoFit : undefined) ?? true,
+  );
+  const autoFitRef = useRef(autoFit);
   useEffect(() => {
     autoFitRef.current = autoFit;
-  }, [autoFit]);
+    if (persistKey) saveGraphView(persistKey, { autoFit });
+  }, [autoFit, persistKey]);
 
   // The camera actually used to draw and hit-test: a live fit while auto-fit is
   // on, the user's camera once they take over. Recomputed as the layout moves

--- a/src/components/graph/GraphView.tsx
+++ b/src/components/graph/GraphView.tsx
@@ -52,8 +52,11 @@ export function GraphView({ workspaceFiles, wikilinkRefs, onOpenFile }: GraphVie
   const theme = useMemo(() => readGraphTheme(document.documentElement), [isDark]);
 
   // Auto-fit follows the live layout until the user takes manual control.
+  // Only honour a stored auto-fit when the layout actually resumed the shape it
+  // was saved against; a layout that replayed from scratch would leave a manual
+  // camera framing empty space.
   const [autoFit, setAutoFit] = useState(
-    () => (persistKey ? loadGraphView(persistKey)?.autoFit : undefined) ?? true,
+    () => (persistKey && layout.reseeded ? loadGraphView(persistKey)?.autoFit : undefined) ?? true,
   );
   const autoFitRef = useRef(autoFit);
   useEffect(() => {

--- a/src/hooks/useGraphCamera.test.ts
+++ b/src/hooks/useGraphCamera.test.ts
@@ -1,9 +1,13 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { DEFAULT_CAMERA, MAX_SCALE } from "@/lib/graphCanvas";
+import { clearGraphView, loadGraphView, saveGraphView } from "@/lib/graphViewStore";
 import { useGraphCamera } from "./useGraphCamera";
 
 const VIEWPORT = { width: 800, height: 600 };
+const ROOT = "/ws";
+
+afterEach(() => clearGraphView(ROOT));
 
 describe("useGraphCamera", () => {
   it("starts at the default camera", () => {
@@ -43,5 +47,37 @@ describe("useGraphCamera", () => {
     expect(result.current.pan).toBe(first.pan);
     expect(result.current.zoomAt).toBe(first.zoomAt);
     expect(result.current.set).toBe(first.set);
+  });
+});
+
+describe("useGraphCamera persistence", () => {
+  it("starts from the stored camera for its workspace", () => {
+    const stored = { dx: 12, dy: -8, scale: 2 };
+    saveGraphView(ROOT, { camera: stored });
+    const { result } = renderHook(() => useGraphCamera(ROOT));
+    expect(result.current.camera).toEqual(stored);
+  });
+
+  it("writes every change through to the store", () => {
+    const { result } = renderHook(() => useGraphCamera(ROOT));
+    act(() => result.current.pan(10, 20));
+    expect(loadGraphView(ROOT)?.camera).toEqual({ dx: 10, dy: 20, scale: 1 });
+  });
+
+  it("survives an unmount and remount on the same key", () => {
+    const first = renderHook(() => useGraphCamera(ROOT));
+    act(() => first.result.current.pan(30, 40));
+    first.unmount();
+
+    const second = renderHook(() => useGraphCamera(ROOT));
+    expect(second.result.current.camera).toEqual({ dx: 30, dy: 40, scale: 1 });
+  });
+
+  it("stores nothing without a key, and ignores another workspace's camera", () => {
+    saveGraphView(ROOT, { camera: { dx: 99, dy: 99, scale: 4 } });
+    const { result } = renderHook(() => useGraphCamera());
+    act(() => result.current.pan(1, 1));
+    expect(result.current.camera).toEqual({ dx: 1, dy: 1, scale: 1 });
+    expect(loadGraphView(ROOT)?.camera).toEqual({ dx: 99, dy: 99, scale: 4 });
   });
 });

--- a/src/hooks/useGraphCamera.ts
+++ b/src/hooks/useGraphCamera.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   type Camera,
   DEFAULT_CAMERA,
@@ -6,6 +6,7 @@ import {
   type Viewport,
   zoomCameraAt,
 } from "@/lib/graphCanvas";
+import { loadGraphView, saveGraphView } from "@/lib/graphViewStore";
 
 export interface GraphCameraApi {
   camera: Camera;
@@ -17,9 +18,18 @@ export interface GraphCameraApi {
   set: (camera: Camera) => void;
 }
 
-/** Pan/zoom camera state for the graph view; the math lives in lib/graphCanvas. */
-export function useGraphCamera(): GraphCameraApi {
-  const [camera, setCamera] = useState<Camera>(DEFAULT_CAMERA);
+/**
+ * Pan/zoom camera state for the graph view; the math lives in lib/graphCanvas.
+ * `persistKey` (the workspace root) keeps the camera alive across the graph
+ * tab's unmount, so switching away and back does not snap the view around.
+ */
+export function useGraphCamera(persistKey?: string): GraphCameraApi {
+  const [camera, setCamera] = useState<Camera>(
+    () => (persistKey ? loadGraphView(persistKey)?.camera : undefined) ?? DEFAULT_CAMERA,
+  );
+  useEffect(() => {
+    if (persistKey) saveGraphView(persistKey, { camera });
+  }, [persistKey, camera]);
   const pan = useCallback((dx: number, dy: number) => {
     setCamera((c) => panCamera(c, dx, dy));
   }, []);

--- a/src/hooks/useGraphSimulation.test.ts
+++ b/src/hooks/useGraphSimulation.test.ts
@@ -2,8 +2,12 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WikilinkRef } from "@/lib/backlinks";
 import { buildWorkspaceGraph } from "@/lib/graph";
-import { RESEED_ALPHA } from "@/lib/graphSimulation";
-import { clearGraphView, loadGraphView, saveGraphView } from "@/lib/graphViewStore";
+import {
+  clearGraphView,
+  loadGraphView,
+  pruneGraphViews,
+  saveGraphView,
+} from "@/lib/graphViewStore";
 import { useGraphSimulation } from "./useGraphSimulation";
 
 const { reducedMotion } = vi.hoisted(() => ({ reducedMotion: { value: false } }));
@@ -198,7 +202,8 @@ describe("useGraphSimulation persistence", () => {
     expect(result.current.layout.nodes.map((n) => ({ x: n.x, y: n.y }))).toEqual(
       FILES.map((_, i) => ({ x: i * 40, y: i * -20 })),
     );
-    expect(result.current.layout.simulation.alpha()).toBeLessThanOrEqual(RESEED_ALPHA);
+    expect(result.current.layout.reseeded).toBe(true);
+    expect(result.current.layout.simulation.alpha()).toBeLessThan(1);
     unmount();
   });
 
@@ -222,6 +227,33 @@ describe("useGraphSimulation persistence", () => {
     const { result, unmount } = renderHook(() => useGraphSimulation(graph, FAST));
     await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
     expect(loadGraphView(ROOT)).toBeUndefined();
+    unmount();
+  });
+
+  it("stops writing once unmounted, so a prune after a close stays clean", async () => {
+    const graph = buildWorkspaceGraph(FILES, REFS);
+    const { unmount } = renderHook(() =>
+      useGraphSimulation(graph, { ticksPerFrame: 1, persistKey: ROOT }),
+    );
+    // The close path prunes from an effect, which runs after the commit that
+    // unmounted the view. Nothing may write after that, or the entry returns.
+    unmount();
+    pruneGraphViews(new Set());
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    expect(loadGraphView(ROOT)).toBeUndefined();
+  });
+
+  it("reports no reseed when too few nodes carry a stored position", () => {
+    // One seeded node out of three is below the half-coverage rule, so d3
+    // replays the layout and the stored camera must not be trusted.
+    saveGraphView(ROOT, { positions: new Map([[FILES[0], { x: 10, y: 10 }]]) });
+    const graph = buildWorkspaceGraph(FILES, REFS);
+    const { result, unmount } = renderHook(() =>
+      useGraphSimulation(graph, { ...FAST, persistKey: ROOT }),
+    );
+    expect(result.current.layout.reseeded).toBe(false);
+    expect(result.current.layout.simulation.alpha()).toBe(1);
     unmount();
   });
 });

--- a/src/hooks/useGraphSimulation.test.ts
+++ b/src/hooks/useGraphSimulation.test.ts
@@ -2,6 +2,8 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WikilinkRef } from "@/lib/backlinks";
 import { buildWorkspaceGraph } from "@/lib/graph";
+import { RESEED_ALPHA } from "@/lib/graphSimulation";
+import { clearGraphView, loadGraphView, saveGraphView } from "@/lib/graphViewStore";
 import { useGraphSimulation } from "./useGraphSimulation";
 
 const { reducedMotion } = vi.hoisted(() => ({ reducedMotion: { value: false } }));
@@ -176,6 +178,50 @@ describe("useGraphSimulation", () => {
     // Reheat un-settles the simulation and runs at least one more frame.
     await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
     expect(result.current.version).toBeGreaterThan(versionWhenSettled);
+    unmount();
+  });
+});
+
+describe("useGraphSimulation persistence", () => {
+  const ROOT = "/ws";
+  afterEach(() => clearGraphView(ROOT));
+
+  it("seeds a fresh mount from the stored positions and reheats gently", () => {
+    const graph = buildWorkspaceGraph(FILES, REFS);
+    const positions = new Map(FILES.map((id, i) => [id, { x: i * 40, y: i * -20 }]));
+    saveGraphView(ROOT, { positions });
+
+    const { result, unmount } = renderHook(() =>
+      useGraphSimulation(graph, { ...FAST, persistKey: ROOT }),
+    );
+    // Every node arrives pre-placed, so the layout resumes instead of replaying.
+    expect(result.current.layout.nodes.map((n) => ({ x: n.x, y: n.y }))).toEqual(
+      FILES.map((_, i) => ({ x: i * 40, y: i * -20 })),
+    );
+    expect(result.current.layout.simulation.alpha()).toBeLessThanOrEqual(RESEED_ALPHA);
+    unmount();
+  });
+
+  it("writes the ticked positions through to the store", async () => {
+    const graph = buildWorkspaceGraph(FILES, REFS);
+    const { result, unmount } = renderHook(() =>
+      useGraphSimulation(graph, { ...FAST, persistKey: ROOT }),
+    );
+    await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
+
+    const stored = loadGraphView(ROOT)?.positions;
+    expect([...(stored?.keys() ?? [])]).toEqual(FILES);
+    for (const node of result.current.layout.nodes) {
+      expect(stored?.get(node.id)).toEqual({ x: node.x, y: node.y });
+    }
+    unmount();
+  });
+
+  it("keeps positions out of the store without a key", async () => {
+    const graph = buildWorkspaceGraph(FILES, REFS);
+    const { result, unmount } = renderHook(() => useGraphSimulation(graph, FAST));
+    await waitFor(() => expect(result.current.settled).toBe(true), { timeout: 5000 });
+    expect(loadGraphView(ROOT)).toBeUndefined();
     unmount();
   });
 });

--- a/src/hooks/useGraphSimulation.ts
+++ b/src/hooks/useGraphSimulation.ts
@@ -8,6 +8,7 @@ import {
   type NodePosition,
   tickLayout,
 } from "@/lib/graphSimulation";
+import { loadGraphView, saveGraphView } from "@/lib/graphViewStore";
 import { useReducedMotion } from "./useReducedMotion";
 
 export interface UseGraphSimulationOptions {
@@ -15,6 +16,9 @@ export interface UseGraphSimulationOptions {
   ticksPerFrame?: number;
   /** Hard cap on total steps per layout pass. */
   maxTicks?: number;
+  /** Workspace root to seed positions from and write them back to, so a layout
+   *  outlives the graph tab's mount. Omitted, positions live for this mount. */
+  persistKey?: string;
 }
 
 export interface GraphSimulationState {
@@ -49,7 +53,15 @@ export function useGraphSimulation(
   const ticksPerFrame = options?.ticksPerFrame ?? DEFAULT_TICKS_PER_FRAME;
   const maxTicks = options?.maxTicks ?? LAYOUT_MAX_TICKS;
   const reducedMotion = useReducedMotion();
-  const previousPositions = useRef<Map<string, NodePosition> | null>(null);
+  const persistKey = options?.persistKey;
+  // A restored snapshot makes a return to the tab reheat gently, the way a
+  // watcher-driven re-index already does.
+  const previousPositions = useRef<ReadonlyMap<string, NodePosition> | null>(
+    persistKey ? (loadGraphView(persistKey)?.positions ?? null) : null,
+  );
+  // Read through a ref so the rAF loop is not rebuilt when the key changes.
+  const persistKeyRef = useRef(persistKey);
+  persistKeyRef.current = persistKey;
   const [version, setVersion] = useState(0);
   const [settled, setSettled] = useState(false);
   // rAF handle + whether a loop is in flight, so reheat can resume a settled
@@ -78,7 +90,10 @@ export function useGraphSimulation(
     const step = () => {
       const done = tickLayout(layout, ticksPerFrame);
       budgetRef.current -= ticksPerFrame;
-      previousPositions.current = capturePositions(layout);
+      const positions = capturePositions(layout);
+      previousPositions.current = positions;
+      // Written through here, not on unmount, so no cleanup ordering matters.
+      if (persistKeyRef.current) saveGraphView(persistKeyRef.current, { positions });
       const finished = done || budgetRef.current <= 0;
       if (paintEveryFrameRef.current || finished) setVersion((v) => v + 1);
       if (finished) {

--- a/src/hooks/useGraphSimulation.ts
+++ b/src/hooks/useGraphSimulation.ts
@@ -55,11 +55,12 @@ export function useGraphSimulation(
   const reducedMotion = useReducedMotion();
   const persistKey = options?.persistKey;
   // A restored snapshot makes a return to the tab reheat gently, the way a
-  // watcher-driven re-index already does.
-  const previousPositions = useRef<ReadonlyMap<string, NodePosition> | null>(
-    persistKey ? (loadGraphView(persistKey)?.positions ?? null) : null,
-  );
-  // Read through a ref so the rAF loop is not rebuilt when the key changes.
+  // watcher-driven re-index already does. `undefined` means "not seeded yet",
+  // so the store is read once rather than on every render.
+  const previousPositions = useRef<ReadonlyMap<string, NodePosition> | null | undefined>(undefined);
+  if (previousPositions.current === undefined) {
+    previousPositions.current = persistKey ? (loadGraphView(persistKey)?.positions ?? null) : null;
+  }
   const persistKeyRef = useRef(persistKey);
   persistKeyRef.current = persistKey;
   const [version, setVersion] = useState(0);
@@ -92,7 +93,7 @@ export function useGraphSimulation(
       budgetRef.current -= ticksPerFrame;
       const positions = capturePositions(layout);
       previousPositions.current = positions;
-      // Written through here, not on unmount, so no cleanup ordering matters.
+      // Written through as it changes rather than queued for unmount.
       if (persistKeyRef.current) saveGraphView(persistKeyRef.current, { positions });
       const finished = done || budgetRef.current <= 0;
       if (paintEveryFrameRef.current || finished) setVersion((v) => v + 1);

--- a/src/hooks/useTabs.graph.test.tsx
+++ b/src/hooks/useTabs.graph.test.tsx
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearGraphView, loadGraphView, saveGraphView } from "@/lib/graphViewStore";
 import { getWorkspaceSession } from "@/lib/workspaceSession";
 import {
   defaultOptions,
@@ -23,6 +24,7 @@ beforeEach(resetTabsMocks);
 
 afterEach(() => {
   vi.restoreAllMocks();
+  clearGraphView("/p/ws");
 });
 
 describe("useTabs graph tabs", () => {
@@ -273,25 +275,30 @@ describe("useTabs graph tabs", () => {
     expect(result.current.indexStatus.wikilinks.truncated).toBe(false);
   });
 
-  it("closeWorkspace closes the graph tab", async () => {
+  it("closeWorkspace closes the graph tab and drops its view state", async () => {
     const result = await openWorkspace();
     act(() => result.current.openGraph());
+    saveGraphView("/p/ws", { autoFit: false });
     await act(async () => {
       await result.current.closeWorkspace();
     });
     expect(result.current.tabs).toHaveLength(0);
     expect(result.current.activeTabId).toBeNull();
+    expect(loadGraphView("/p/ws")).toBeUndefined();
   });
 
-  it("closing the graph tab keeps the workspace open", async () => {
+  it("closing the graph tab keeps the workspace open and forgets the view", async () => {
     const result = await openWorkspace();
     act(() => result.current.openGraph());
     const graphId = result.current.activeTabId as string;
+    saveGraphView("/p/ws", { autoFit: false });
     await act(async () => {
       await result.current.closeTab(graphId);
     });
     expect(result.current.tabs).toHaveLength(0);
     expect(result.current.workspace?.root).toBe("/p/ws");
+    // Reopening from the menu must start auto-fit, not a stale camera.
+    expect(loadGraphView("/p/ws")).toBeUndefined();
   });
 
   it("persists graph tabs after the workspace entry and restores them", async () => {

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { ask } from "@tauri-apps/plugin-dialog";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDocumentEdits } from "@/hooks/useDocumentEdits";
 import { useDocumentSave } from "@/hooks/useDocumentSave";
@@ -17,7 +17,7 @@ import type { WorkspaceNotice } from "@/hooks/useWorkspaceNotice";
 import { useWorkspaceSession, type WorkspaceSessionApi } from "@/hooks/useWorkspaceSession";
 import { useWorkspaceTree } from "@/hooks/useWorkspaceTree";
 import { isCliExportProcess } from "@/lib/cliExport";
-import { clearGraphView } from "@/lib/graphViewStore";
+import { pruneGraphViews } from "@/lib/graphViewStore";
 import { basename, isPathInside } from "@/lib/paths";
 import { EDITOR_MODE, type EditorMode } from "@/lib/settings";
 import { type FileTab, type PersistedTab, removeTabs } from "@/lib/tabs";
@@ -307,10 +307,6 @@ export function useTabs(options: UseTabsOptions) {
           if (!tab) continue;
           if (tab.kind === "file") {
             invoke("unwatch_file", { path: tab.file.path }).catch(() => {});
-          } else {
-            // Closing the graph drops its remembered view, so reopening it from
-            // the menu starts auto-fit rather than restoring a stale camera.
-            clearGraphView(tab.root);
           }
           forgetScroll(id);
           forgetHistory(id);
@@ -381,6 +377,18 @@ export function useTabs(options: UseTabsOptions) {
     forgetHistory,
     refreshWorkspace,
   });
+
+  // Reconciled after the commit, not at the close call sites: a close runs while
+  // the graph is still mounted and its animation loop is still writing
+  // positions, so a clear issued there would be undone by the next frame. This
+  // covers every removal path, including a workspace switch.
+  useEffect(() => {
+    const roots = new Set<string>();
+    for (const tab of tabs) {
+      if (tab.kind === "graph") roots.add(tab.root);
+    }
+    pruneGraphViews(roots);
+  }, [tabs]);
 
   return {
     tabs,

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -17,6 +17,7 @@ import type { WorkspaceNotice } from "@/hooks/useWorkspaceNotice";
 import { useWorkspaceSession, type WorkspaceSessionApi } from "@/hooks/useWorkspaceSession";
 import { useWorkspaceTree } from "@/hooks/useWorkspaceTree";
 import { isCliExportProcess } from "@/lib/cliExport";
+import { clearGraphView } from "@/lib/graphViewStore";
 import { basename, isPathInside } from "@/lib/paths";
 import { EDITOR_MODE, type EditorMode } from "@/lib/settings";
 import { type FileTab, type PersistedTab, removeTabs } from "@/lib/tabs";
@@ -306,6 +307,10 @@ export function useTabs(options: UseTabsOptions) {
           if (!tab) continue;
           if (tab.kind === "file") {
             invoke("unwatch_file", { path: tab.file.path }).catch(() => {});
+          } else {
+            // Closing the graph drops its remembered view, so reopening it from
+            // the menu starts auto-fit rather than restoring a stale camera.
+            clearGraphView(tab.root);
           }
           forgetScroll(id);
           forgetHistory(id);

--- a/src/hooks/useWorkspaceLifecycle.ts
+++ b/src/hooks/useWorkspaceLifecycle.ts
@@ -5,7 +5,6 @@ import type { OpenFileOptions } from "@/hooks/useOpenDocument";
 import type { WorkspaceNotice } from "@/hooks/useWorkspaceNotice";
 import type { WorkspaceSessionApi } from "@/hooks/useWorkspaceSession";
 import { isCliExportProcess } from "@/lib/cliExport";
-import { clearGraphView } from "@/lib/graphViewStore";
 import { isMarkdownFile } from "@/lib/markdownExtensions";
 import { isPathInside } from "@/lib/paths";
 import { pickFolder, pickNewWorkspace } from "@/lib/pickers";
@@ -77,7 +76,6 @@ export function useWorkspaceLifecycle({
         const removedIds = new Set<string>();
         for (const tab of prev.tabs) {
           if (tab.kind === "graph") {
-            clearGraphView(tab.root);
             removedIds.add(tab.id);
           } else if (isPathInside(tab.file.path, root)) {
             invoke("unwatch_file", { path: tab.file.path }).catch(() => {});

--- a/src/hooks/useWorkspaceLifecycle.ts
+++ b/src/hooks/useWorkspaceLifecycle.ts
@@ -5,6 +5,7 @@ import type { OpenFileOptions } from "@/hooks/useOpenDocument";
 import type { WorkspaceNotice } from "@/hooks/useWorkspaceNotice";
 import type { WorkspaceSessionApi } from "@/hooks/useWorkspaceSession";
 import { isCliExportProcess } from "@/lib/cliExport";
+import { clearGraphView } from "@/lib/graphViewStore";
 import { isMarkdownFile } from "@/lib/markdownExtensions";
 import { isPathInside } from "@/lib/paths";
 import { pickFolder, pickNewWorkspace } from "@/lib/pickers";
@@ -76,6 +77,7 @@ export function useWorkspaceLifecycle({
         const removedIds = new Set<string>();
         for (const tab of prev.tabs) {
           if (tab.kind === "graph") {
+            clearGraphView(tab.root);
             removedIds.add(tab.id);
           } else if (isPathInside(tab.file.path, root)) {
             invoke("unwatch_file", { path: tab.file.path }).catch(() => {});

--- a/src/lib/graphSimulation.ts
+++ b/src/lib/graphSimulation.ts
@@ -34,6 +34,10 @@ export interface GraphLayout {
   nodes: LayoutNode[];
   links: LayoutLink[];
   simulation: Simulation<LayoutNode, SimulationLinkDatum<LayoutNode>>;
+  /** True when enough nodes arrived pre-placed to resume the previous shape
+   *  rather than replay the layout. A camera saved against that shape is only
+   *  meaningful when this holds. */
+  reseeded: boolean;
 }
 
 export interface NodePosition {
@@ -48,7 +52,7 @@ export const LAYOUT_MAX_TICKS = 300;
 // When most nodes carry a seeded position (an incremental update from the
 // folder watcher, not a fresh open), reheat gently instead of replaying the
 // whole layout, so the existing shape stays put.
-export const RESEED_ALPHA = 0.3;
+const RESEED_ALPHA = 0.3;
 
 export function createGraphLayout(
   graph: WorkspaceGraph,
@@ -84,12 +88,13 @@ export function createGraphLayout(
     .force("collide", forceCollide(16))
     .stop();
 
-  if (nodes.length > 0 && seeded >= nodes.length / 2) {
+  const reseeded = nodes.length > 0 && seeded >= nodes.length / 2;
+  if (reseeded) {
     simulation.alpha(RESEED_ALPHA);
   }
 
   // forceLink swapped each link's string endpoints for node references.
-  return { nodes, links: links as unknown as LayoutLink[], simulation };
+  return { nodes, links: links as unknown as LayoutLink[], simulation, reseeded };
 }
 
 /**

--- a/src/lib/graphSimulation.ts
+++ b/src/lib/graphSimulation.ts
@@ -48,7 +48,7 @@ export const LAYOUT_MAX_TICKS = 300;
 // When most nodes carry a seeded position (an incremental update from the
 // folder watcher, not a fresh open), reheat gently instead of replaying the
 // whole layout, so the existing shape stays put.
-const RESEED_ALPHA = 0.3;
+export const RESEED_ALPHA = 0.3;
 
 export function createGraphLayout(
   graph: WorkspaceGraph,

--- a/src/lib/graphViewStore.test.ts
+++ b/src/lib/graphViewStore.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_CAMERA } from "./graphCanvas";
+import { clearGraphView, loadGraphView, saveGraphView } from "./graphViewStore";
+
+const ROOT = "/vault";
+
+afterEach(() => clearGraphView(ROOT));
+
+describe("graphViewStore", () => {
+  it("has nothing for a key that was never written", () => {
+    expect(loadGraphView(ROOT)).toBeUndefined();
+  });
+
+  it("round-trips a saved slice", () => {
+    saveGraphView(ROOT, { camera: DEFAULT_CAMERA, autoFit: false });
+    expect(loadGraphView(ROOT)).toEqual({ camera: DEFAULT_CAMERA, autoFit: false });
+  });
+
+  it("merges a patch instead of replacing the entry", () => {
+    const positions = new Map([["a.md", { x: 1, y: 2 }]]);
+    saveGraphView(ROOT, { positions });
+    saveGraphView(ROOT, { camera: DEFAULT_CAMERA, autoFit: false });
+
+    // The camera write must not drop the positions the simulation stored.
+    expect(loadGraphView(ROOT)).toEqual({ positions, camera: DEFAULT_CAMERA, autoFit: false });
+  });
+
+  it("keeps workspaces apart", () => {
+    saveGraphView(ROOT, { autoFit: false });
+    expect(loadGraphView("/other")).toBeUndefined();
+  });
+
+  it("forgets a cleared key", () => {
+    saveGraphView(ROOT, { autoFit: false });
+    clearGraphView(ROOT);
+    expect(loadGraphView(ROOT)).toBeUndefined();
+  });
+});

--- a/src/lib/graphViewStore.test.ts
+++ b/src/lib/graphViewStore.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { DEFAULT_CAMERA } from "./graphCanvas";
-import { clearGraphView, loadGraphView, saveGraphView } from "./graphViewStore";
+import { clearGraphView, loadGraphView, pruneGraphViews, saveGraphView } from "./graphViewStore";
 
 const ROOT = "/vault";
 
-afterEach(() => clearGraphView(ROOT));
+afterEach(() => {
+  clearGraphView(ROOT);
+  clearGraphView("/other");
+});
 
 describe("graphViewStore", () => {
   it("has nothing for a key that was never written", () => {
@@ -33,6 +36,21 @@ describe("graphViewStore", () => {
   it("forgets a cleared key", () => {
     saveGraphView(ROOT, { autoFit: false });
     clearGraphView(ROOT);
+    expect(loadGraphView(ROOT)).toBeUndefined();
+  });
+
+  it("prunes the entries whose graph tab is gone and keeps the rest", () => {
+    saveGraphView(ROOT, { autoFit: false });
+    saveGraphView("/other", { autoFit: false });
+
+    pruneGraphViews(new Set([ROOT]));
+    expect(loadGraphView(ROOT)).toEqual({ autoFit: false });
+    expect(loadGraphView("/other")).toBeUndefined();
+  });
+
+  it("empties the store when no graph tab is left", () => {
+    saveGraphView(ROOT, { autoFit: false });
+    pruneGraphViews(new Set());
     expect(loadGraphView(ROOT)).toBeUndefined();
   });
 });

--- a/src/lib/graphViewStore.ts
+++ b/src/lib/graphViewStore.ts
@@ -1,0 +1,31 @@
+// Module-level store of graph view state, keyed by workspace root. `TabContent`
+// renders the graph only while its tab is active, so switching to a document tab
+// unmounts the whole subtree; without shared state the camera, the auto-fit flag
+// and the settled layout would all be rebuilt from scratch on every return.
+// One entry per workspace, cleared when the graph tab closes or the workspace
+// changes, so no eviction is needed. Session-only: nothing reaches disk.
+
+import type { Camera } from "./graphCanvas";
+import type { NodePosition } from "./graphSimulation";
+
+export interface GraphViewState {
+  camera: Camera;
+  /** False once the user has taken the camera by hand. */
+  autoFit: boolean;
+  positions: ReadonlyMap<string, NodePosition>;
+}
+
+const states = new Map<string, Partial<GraphViewState>>();
+
+export function loadGraphView(key: string): Partial<GraphViewState> | undefined {
+  return states.get(key);
+}
+
+/** Merge a slice in, so the simulation and the view can write independently. */
+export function saveGraphView(key: string, patch: Partial<GraphViewState>): void {
+  states.set(key, { ...states.get(key), ...patch });
+}
+
+export function clearGraphView(key: string): void {
+  states.delete(key);
+}

--- a/src/lib/graphViewStore.ts
+++ b/src/lib/graphViewStore.ts
@@ -2,8 +2,8 @@
 // renders the graph only while its tab is active, so switching to a document tab
 // unmounts the whole subtree; without shared state the camera, the auto-fit flag
 // and the settled layout would all be rebuilt from scratch on every return.
-// One entry per workspace, cleared when the graph tab closes or the workspace
-// changes, so no eviction is needed. Session-only: nothing reaches disk.
+// One entry per open graph tab, so no eviction is needed. Session-only: nothing
+// reaches disk.
 
 import type { Camera } from "./graphCanvas";
 import type { NodePosition } from "./graphSimulation";
@@ -26,6 +26,19 @@ export function saveGraphView(key: string, patch: Partial<GraphViewState>): void
   states.set(key, { ...states.get(key), ...patch });
 }
 
+/**
+ * Drop every entry whose graph tab is gone. Reconciling against the live tabs
+ * beats clearing at the close call site: a close runs while the view is still
+ * mounted and its animation loop is still writing positions, so a clear issued
+ * there is undone by the next frame.
+ */
+export function pruneGraphViews(keep: ReadonlySet<string>): void {
+  for (const key of states.keys()) {
+    if (!keep.has(key)) states.delete(key);
+  }
+}
+
+/** Test seam: drop a single entry without reconciling the whole store. */
 export function clearGraphView(key: string): void {
   states.delete(key);
 }


### PR DESCRIPTION
## Summary

The graph view forgot everything the moment you left its tab. `TabContent` renders `<GraphView>` only while the graph tab is active, so switching to a note unmounted the whole subtree and took the camera, the auto-fit flag, and the seeded d3 positions with it. Coming back replayed the full layout pass with its re-settle animation visible and snapped the camera to auto-fit, losing any zoom, pan, or node the user had dragged into place. On a large vault that is a visible jolt plus a few hundred wasted physics ticks every time you glance at a note.

The graph's view state now outlives its mount, without changing how it is rendered.

Closes #732

## Changes

- **New `src/lib/graphViewStore.ts`**: a module-level `Map` keyed by workspace root holding `{ camera, autoFit, positions }`. It deliberately mirrors `src/lib/canvas/viewportStore.ts` and `useCanvasViewport`, which already solve the same remount-loses-the-viewport problem for canvas boards. `saveGraphView` patch-merges, so the simulation and the view write their own slices without clobbering each other.
- **`useGraphCamera(persistKey?)`** seeds its initial state from the store and writes through on change, the same shape as `useCanvasViewport`.
- **`useGraphSimulation(graph, { persistKey })`** seeds `previousPositions` from the store instead of an empty mount-local ref. It already snapshotted positions every animation frame, so the write costs nothing extra.
- **`GraphView`** reads the key from the existing `useWorkspaceRoot()` context hook, so no new prop is threaded through `TabContent`, and seeds and persists `autoFit` alongside. `createGraphLayout` now reports a `reseeded` flag, which gates whether the stored auto-fit is trusted.
- **Entries are pruned after the commit**, by one effect in `useTabs` keyed on `tabs` that reconciles the store against the graph tabs that still exist. This covers every removal path, including a workspace switch, from a single place.
- `samples/Graph View.md` describes the remembered view and its session lifetime.

### Two decisions worth review

**Written through on change, not on unmount.** The spec originally said `GraphView` writes on unmount. Writing as values change is both simpler and safer: the simulation's per-frame `capturePositions` result is pointed at the store, and camera and auto-fit follow the effect-on-change pattern. Nothing then depends on cleanup ordering, so a StrictMode double-mount and an unmount that races a workspace teardown are both harmless.

**Pruning has to happen after the commit.** The first version cleared the entry from inside the `closeTabs` / `closeWorkspaceTabs` `setState` updaters. That runs during render, while the graph is still mounted and its animation loop is still writing positions, so the next frame put the entry straight back and it was never cleared again for that session. Reconciling from an effect fixes the ordering by construction: effects run after the commit that unmounted the view and cancelled its loop.

**Positions and camera have to come back together.** Restoring the camera alone would look worse than today: unseeded d3 nodes fall back to phyllotaxis placement, so the fresh layout is a different arrangement and a restored camera would frame empty space. Seeded, `createGraphLayout` drops the simulation to `RESEED_ALPHA` and the shape barely moves, which is the same path the watcher-driven re-index already takes.

### Review fixes in the second commit

The `code-reviewer` pass found two real defects in the first commit, both fixed here with regression tests:

1. **The clear was undone by an in-flight animation frame** (the ordering described above). Reproduced before fixing: clear mid-pass, await one frame, and the entry is back.
2. **A restored camera could frame a layout that replayed from scratch.** Camera and auto-fit were restored unconditionally, but positions are only honoured when at least half the nodes arrive seeded. Below that, d3 replays the layout around the origin while the restored camera stays put. Concretely: pan to a cluster, switch to a note, let a sync bring the workspace from 20 to 220 notes, switch back, and the graph is framing empty space with auto-fit off. `createGraphLayout` now reports whether it resumed the stored shape, and the stored auto-fit is only honoured when it did. This is the spec's own reasoning for why positions and camera have to come back together, which the first pass failed to enforce.

Smaller review items also applied: `GraphView` is keyed by workspace root so the store key cannot change under hooks that seed from it once, the positions seed is read once rather than on every render, `RESEED_ALPHA` went back to private now that the layout reports the fact itself, and a test cleanup moved into `afterEach` so it runs on failure too.

### Spec correction made during planning

The issue originally asked for `fx`/`fy` to ride along so a dragged node restored pinned. That was a misreading of the code: `handlePointerUp` calls `releaseNode` on every drag release, so `fx`/`fy` are already `null` before anything could capture them, and persisting them would persist nothing. Restoring `x`/`y` is what actually brings a dragged node back where the user put it. The criterion and its task were rewritten in the issue body before implementation.

## Risk classification

- [x] Asynchronous ordering / races
- [x] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Persistence / data loss
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup

"Persistence" and "Migrations" are deliberately unchecked: this is in-memory view state for the session only. Nothing reaches the settings store or disk, so there is no persisted format to migrate and a restart auto-fits exactly as it does today. No user data is involved, only camera and layout coordinates.

### Invariants at stake and evidence

**INV-3: stale results never win.** The store is written from a running rAF loop and read by a fresh mount, so a write can land after the state it describes is gone.

- A re-index while mounted rebuilds the layout under a live camera: `GraphView.test.tsx` "keeps the camera through a re-index" rerenders with a changed file set and asserts the camera is unmoved.
- A remount must not restore a camera against a layout that no longer matches. Positions and camera are restored from the same entry, and `useGraphSimulation.test.ts` "seeds a fresh mount from the stored positions and reheats gently" asserts every node arrives pre-placed and the layout reports `reseeded`, so the restored camera frames the arrangement it was saved against.
- Independent writers cannot clobber each other: `graphViewStore.test.ts` "merges a patch instead of replacing the entry" asserts a camera write does not drop the positions the simulation stored.
- A prune must not be undone by a late frame: `useGraphSimulation.test.ts` "stops writing once unmounted, so a prune after a close stays clean" pins the premise the post-commit prune relies on.
- A replayed layout must not inherit the stored camera: `GraphView.test.tsx` "re-fits instead of restoring the camera when the layout replayed", and `useGraphSimulation.test.ts` "reports no reseed when too few nodes carry a stored position".
- One workspace's state cannot leak into another's: `graphViewStore.test.ts` "keeps workspaces apart" and `GraphView.test.tsx` "keeps one workspace's camera out of another's".

**INV-4: owners flush before they die.** The graph tab is an owner that dies on every tab switch. It owns no durable work, only view state, and it has nothing pending at death because every value is written through as it changes rather than queued for unmount. `useGraphCamera.test.ts` "survives an unmount and remount on the same key" and `GraphView.test.tsx` "comes back to the same camera, with no re-fit in between" prove the state is already in the store when the owner dies. The deliberate discards are covered too: `useTabs.graph.test.tsx` "closing the graph tab keeps the workspace open and forgets the view" and "closeWorkspace closes the graph tab and drops its view state".

**Store growth.** The prune effect reconciles the store against the live graph tabs on every tabs change, so the ceiling is one entry per open graph tab (`openGraph` de-dupes to one per window). `graphViewStore.test.ts` "prunes the entries whose graph tab is gone and keeps the rest" covers both sides of that.

## Testing

Automated gates only, on Windows. Not manually exercised on any platform, so all three boxes are left unchecked.

- `pnpm typecheck`, `pnpm check`, `pnpm test` (3828 tests), `cargo clippy --all-targets -- -D warnings`: all green.
- `pnpm test:coverage` read per file from the JSON report: no uncovered lines and no partial branches in any file this diff touches.
- The load-bearing paths were mutation-tested. Removing the camera seed, the position write-through, or the prune effect each fails a test that specifically covers it.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Screenshots

Not captured: the change is the absence of a jolt on returning to the graph tab, which a still frame cannot show.

---

Cut from `main` per the worktree convention, so it does not include #738 (issue #733, graph node focus). Both touch `GraphView.tsx` in different regions; whichever lands second needs a small rebase.
