### PR TITLE
fix(ci): force the tauri-driver install over a rust-cache leftover

### DIFF
--- a/.github/actions/app-smoke/action.yml
+++ b/.github/actions/app-smoke/action.yml
@@ -18,7 +18,9 @@ runs:
         sudo apt-get update
         sudo apt-get install -y webkit2gtk-driver xvfb dbus
     # tauri-driver is a cargo binary; cache it so the ~30s build only runs when
-    # the version changes.
+    # the version changes. rust-cache also restores ~/.cargo/bin, so the binary
+    # can already be there on a cache miss: --force overwrites it instead of
+    # aborting with "binary `tauri-driver` already exists in destination".
     - name: Cache tauri-driver
       id: cache-tauri-driver
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
@@ -28,7 +30,7 @@ runs:
     - name: Install tauri-driver
       if: steps.cache-tauri-driver.outputs.cache-hit != 'true'
       shell: bash
-      run: cargo install tauri-driver --version 2.0.6 --locked
+      run: cargo install tauri-driver --version 2.0.6 --locked --force
     - name: Run built-app smoke
       shell: bash
       env:


### PR DESCRIPTION
## Summary

The `Build / ubuntu-22.04` job fails on `main` at the **Built-app smoke test** step with ``error: binary `tauri-driver` already exists in destination`` (exit 101), so the WebDriver smoke suite never runs.

Root cause: the composite action guards `cargo install tauri-driver` on its own `actions/cache` key (`tauri-driver-2.0.6-Linux-X64`), but `Swatinem/rust-cache` independently restores `~/.cargo/bin`. When that dedicated key misses while rust-cache hits, the binary is already on disk and `cargo install` aborts rather than reinstalling.

Failing run: https://github.com/hamidfzm/glyph/actions/runs/34411981277/job/102668403680

## Changes

- `.github/actions/app-smoke/action.yml`: install `tauri-driver` with `--force` so the pinned version overwrites a leftover binary instead of aborting, with a comment naming the rust-cache interaction.

## Risk classification

- [x] No risk areas touched

### Invariants at stake and evidence

None. CI-only change, no app code touched; the `--version 2.0.6 --locked` pin is unchanged, so the smoke suite still runs against the same driver version.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux

The `Build / ubuntu-22.04` job on this PR exercises the fixed step directly (the cache key is unchanged, so the install path re-runs).

## Screenshots

N/A
