### PR TITLE
chore(hooks): reject AI attribution in commit messages

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,18 @@
+# Commit-msg gate: reject AI attribution in commit messages. Glyph credits
+# the humans who ship the change; agent tooling must not sign commits, and a
+# trailer that slips into a branch commit is harvested by GitHub's squash
+# merge straight onto main. See CLAUDE.md ("no co-authored-by lines").
+#
+# Strips the comment block and any `--verbose` diff first, so a commit that
+# legitimately edits documentation mentioning these strings still passes.
+
+msg=$(sed -e '/^# -\{1,\} >8 -\{1,\}$/,$d' -e '/^#/d' "$1")
+
+pattern='co-authored-by:.*(claude|anthropic|codex|copilot|chatgpt)|noreply@anthropic\.com|generated with .{0,4}claude'
+
+if printf '%s\n' "$msg" | grep -qiE "$pattern"; then
+  echo "commit-msg: AI attribution found in the commit message." >&2
+  printf '%s\n' "$msg" | grep -inE "$pattern" >&2
+  echo "Remove those lines and commit again. Glyph commits carry no AI attribution." >&2
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ The spec stays current throughout: acceptance-criteria and task checkboxes on th
   ```
   Fix Biome warnings by applying the suggested fix, never by suppressing.
 - **Branches** are cut from `main` as `feat/<slug>` or `fix/<slug>`, each in its own git worktree under `.claude/worktrees/`. See [.claude/rules/worktrees.md](.claude/rules/worktrees.md) for the GitHub Flow worktree workflow and how to clean up merged worktrees (see [CONTRIBUTING.md](CONTRIBUTING.md) for the wider conventions).
-- **No co-authored-by lines** in commits, and no em dashes anywhere in output.
+- **No co-authored-by lines** in commits, and no em dashes anywhere in output. No AI attribution of any kind (`Co-Authored-By:`, `Generated with ...`) in a commit message: the `.husky/commit-msg` hook rejects it, and GitHub's squash merge harvests such a trailer from a branch commit straight onto `main`.
 
 ### Agents
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ committed; regenerate them only when the Tauri CLI requires it.
 
 - **Commits**: [Conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`)
 - **Breaking changes**: mark the commit `feat(scope)!:` **and** label the PR `breaking`. The `!` on its own changes nothing in the release notes: GitHub groups them by label, and `.github/release.yml` keys the "💥 Breaking Changes" section off that label. A PR carrying both `breaking` and `enhancement` appears only under Breaking Changes, because the first matching category wins.
-- **No co-authored-by** lines in commits
+- **No co-authored-by** lines in commits, and no other AI attribution (`Generated with ...`). The `.husky/commit-msg` hook rejects both.
 - **Package manager**: pnpm only (not npm/yarn)
 - **Linting (TS)**: Biome (configured in `biome.json`); run `pnpm lint`
 - **Linting (Rust)**: Clippy; run `cargo clippy` in `src-tauri/`


### PR DESCRIPTION
## Summary

A `Co-Authored-By` trailer naming an AI agent reached `main`. It was added to the branch commit for #742, and GitHub's squash merge harvested it into the merge commit, so `main`'s tip carried AI attribution. `main` has been rewritten (`e60731a` -> `04f4b53`, message-only amend, tree identical) and the full history is now clean.

The rule already existed in `CLAUDE.md` and `CONTRIBUTING.md`, but it was prose with nothing enforcing it, so it lasted exactly as long as the agent that read it. This adds the gate.

## Changes

- `.husky/commit-msg` (new): rejects a commit message containing a co-authored trailer that names an AI agent, an agent bot address, or a generated-with footer. Strips the comment block and any `--verbose` diff before matching, so a commit that legitimately documents those strings (like this one) still passes. `dependabot[bot]` co-authored trailers are unaffected.
- `CLAUDE.md`, `CONTRIBUTING.md`: name the hook next to the rule it enforces, and note why a branch-commit trailer is not a local problem (squash merge carries it to `main`).

## Risk classification

- [x] No risk areas touched

### Invariants at stake and evidence

None. Tooling only; no app code, no build or CI configuration touched.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

Ran `sh .husky/commit-msg <file>` against four fixtures:

| Fixture | Expected | Result |
| --- | --- | --- |
| Co-authored trailer naming an agent | reject | exit 1 |
| Generated-with footer | reject | exit 1 |
| `dependabot[bot]` co-authored trailer (as on #724) | pass | exit 0 |
| Clean subject with a `--verbose` diff that adds the banned strings to a doc | pass | exit 0 |

This PR's own commit message is the fifth case: the first draft named the bot address in prose and the hook rejected it, so the message was reworded rather than the pattern loosened.

## Screenshots

N/A
