### PR TITLE
fix(outline): find headings in notes with CRLF line endings

### DIFF
--- a/src/lib/headingSection.test.ts
+++ b/src/lib/headingSection.test.ts
@@ -44,4 +44,10 @@ describe("extractHeadingSection", () => {
     expect(extractHeadingSection(doc, "Fake")).toBe("");
     expect(extractHeadingSection(doc, "Real")).toBe("## Real\ntext\n```\n## Fake\n```\nmore");
   });
+
+  it("slices CRLF documents without leaking carriage returns", () => {
+    const crlf = DOC.replaceAll("\n", "\r\n");
+    expect(extractHeadingSection(crlf, "Recipes")).toBe("## Recipes\npasta\n\n### Sauce\ntomato");
+    expect(extractHeadingSection(crlf, "Sauce")).toBe("### Sauce\ntomato");
+  });
 });

--- a/src/lib/headingSection.ts
+++ b/src/lib/headingSection.ts
@@ -5,7 +5,7 @@
 // and `note#my-heading` resolve to the same section (the slug is what
 // rehype-slug puts on the rendered anchor).
 import { slug } from "github-slugger";
-import { parseHeadings } from "@/lib/markdownHeadings";
+import { parseHeadings, splitLines } from "@/lib/markdownHeadings";
 
 function matches(heading: string, target: string): boolean {
   const a = heading.trim();
@@ -26,7 +26,7 @@ export function extractHeadingSection(md: string, heading: string): string {
   // Section runs to the next heading of the same or higher level.
   const end = headings.slice(startIdx + 1).find((h) => h.level <= start.level);
 
-  const lines = md.split("\n");
+  const lines = splitLines(md);
   const section = lines.slice(start.line, end?.line);
   return section.join("\n").trimEnd();
 }

--- a/src/lib/markdownHeadings.test.ts
+++ b/src/lib/markdownHeadings.test.ts
@@ -27,4 +27,11 @@ describe("parseHeadings", () => {
   it("strips trailing hashes from closed ATX headings", () => {
     expect(parseHeadings("# Title #").map((h) => h.text)).toEqual(["Title"]);
   });
+
+  it("parses CRLF line endings with the same line numbers as LF", () => {
+    expect(parseHeadings("# One\r\ntext\r\n## Two ##\r\n")).toEqual([
+      { level: 1, text: "One", line: 0 },
+      { level: 2, text: "Two", line: 2 },
+    ]);
+  });
 });

--- a/src/lib/markdownHeadings.test.ts
+++ b/src/lib/markdownHeadings.test.ts
@@ -28,8 +28,8 @@ describe("parseHeadings", () => {
     expect(parseHeadings("# Title #").map((h) => h.text)).toEqual(["Title"]);
   });
 
-  it("parses CRLF line endings with the same line numbers as LF", () => {
-    expect(parseHeadings("# One\r\ntext\r\n## Two ##\r\n")).toEqual([
+  it.each(["\r\n", "\r"])("numbers lines the same for %j endings as for LF", (eol) => {
+    expect(parseHeadings(["# One", "text", "## Two ##", ""].join(eol))).toEqual([
       { level: 1, text: "One", line: 0 },
       { level: 2, text: "Two", line: 2 },
     ]);

--- a/src/lib/markdownHeadings.ts
+++ b/src/lib/markdownHeadings.ts
@@ -12,9 +12,9 @@ export interface MarkdownHeading {
   line: number;
 }
 
-// Drops CRLF's `\r` too: ATX's `.*$` never matches across it.
+// Every CommonMark line ending (CRLF, CR, LF); a leftover `\r` defeats ATX's `.*$`.
 export function splitLines(md: string): string[] {
-  return md.split(/\r?\n/);
+  return md.split(/\r\n|\r|\n/);
 }
 
 export function parseHeadings(md: string): MarkdownHeading[] {

--- a/src/lib/markdownHeadings.ts
+++ b/src/lib/markdownHeadings.ts
@@ -8,13 +8,18 @@ const FENCE = /^\s{0,3}(```+|~~~+)/;
 export interface MarkdownHeading {
   level: number;
   text: string;
-  /** 0-based index into `md.split("\n")`. */
+  /** 0-based index into `splitLines(md)`. */
   line: number;
+}
+
+// Drops CRLF's `\r` too: ATX's `.*$` never matches across it.
+export function splitLines(md: string): string[] {
+  return md.split(/\r?\n/);
 }
 
 export function parseHeadings(md: string): MarkdownHeading[] {
   const headings: MarkdownHeading[] = [];
-  const lines = md.split("\n");
+  const lines = splitLines(md);
   let fence: string | null = null;
 
   for (let i = 0; i < lines.length; i++) {

--- a/src/lib/taskList.ts
+++ b/src/lib/taskList.ts
@@ -1,6 +1,8 @@
 // Toggle a single GFM task-list item in markdown source by line number.
 // We rewrite source rather than the rendered AST so the user's existing
 // formatting (indent, bullet style, line endings) is preserved exactly.
+import { splitLines } from "@/lib/markdownHeadings";
+
 const TASK_LINE = /^(\s*[-*+]\s+)\[([ xX])\](\s)/;
 
 export function toggleTaskAtLine(source: string, line: number): string {
@@ -8,7 +10,7 @@ export function toggleTaskAtLine(source: string, line: number): string {
   // Track line endings so we don't normalise CRLF → LF on a save.
   const eolMatch = source.match(/\r\n|\r|\n/);
   const eol = eolMatch ? eolMatch[0] : "\n";
-  const lines = source.split(/\r\n|\r|\n/);
+  const lines = splitLines(source);
   if (line > lines.length) return source;
 
   const idx = line - 1;


### PR DESCRIPTION
## Summary

Notes saved with CRLF line endings showed an empty Outline, and every `![[note#Heading]]` embed or wikilink hover preview into them rendered "Heading not found". `parseHeadings` split on `"\n"`, which leaves a trailing `\r` on each line, and the ATX pattern `/^(#{1,6})\s+(.*)$/` never matches across it (`.` excludes `\r`, and `$` without the `m` flag anchors only at end of input). `read_file` returns file content unmodified and no frontend layer normalizes line endings (the tab loader, display derivation, embed and preview reads, and edit-mode seeding all pass the raw string), so any CRLF note hit this. Files with lone CR endings had the same problem.

## Changes

- `src/lib/markdownHeadings.ts`: new `splitLines`, which splits on every CommonMark line ending (`/\r\n|\r|\n/`: CRLF, lone CR, LF) so heading line numbers match the renderer's. `parseHeadings` uses it.
- `src/lib/headingSection.ts`: `extractHeadingSection` slices with the same `splitLines`, so heading line indexes and the sliced lines always agree. A CRLF section comes back LF-joined, which the nested markdown renderer handles the same way.
- `src/lib/taskList.ts`: `toggleTaskAtLine` calls `splitLines` instead of keeping its own copy of the same regex. It still detects and rejoins with the file's own line ending.
- CRLF and lone-CR cases in `markdownHeadings.test.ts`, and a CRLF case in `headingSection.test.ts`.

Not changed: `read_file` still returns the file as stored, so nothing rewrites a note's line endings. The Rust vault index (`src-tauri/src/vault/`) has no heading parser and no shared `vault-headings.json` fixture yet; the heading port for #301 should split on the same three endings (Rust's `str::lines` handles CRLF and LF but not a lone CR).

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

None. Pure string parsing: no state, IPC, persistence, or sanitization involved. `toggleTaskAtLine` keeps writing the file's original line ending (covered by the existing "preserves CRLF line endings" case in `taskList.test.ts`).

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated only, not checked in the running app. Before the fix, a throwaway test (not committed) reproduced the bug on the real surfaces: `useTableOfContents` returned `[]` for a CRLF note, and `EmbedComponent` rendered "Heading not found: Heading" for `![[note#Heading]]`. After the fix, both assertions fail (the outline has entries and the section renders). `pnpm typecheck`, `pnpm check`, and `pnpm test:coverage` pass locally on Windows, with every changed file fully covered; the pre-commit hook also ran `cargo test --lib` and `cargo clippy --all-targets -- -D warnings`.

## Screenshots

N/A
