### PR TITLE
fix(headings): parse headings and export titles in linear time

### DIFF
--- a/src/hooks/useTableOfContents.test.ts
+++ b/src/hooks/useTableOfContents.test.ts
@@ -88,4 +88,9 @@ describe("useTableOfContents", () => {
     const { result } = renderHook(() => useTableOfContents(content));
     expect(result.current.map((e) => e.id)).toEqual(["setup", "setup-1", "setup-2"]);
   });
+
+  it("counts an empty heading's slug so later ids match the renderer", () => {
+    const { result } = renderHook(() => useTableOfContents("# #\n# ???"));
+    expect(result.current).toEqual([{ id: "-1", text: "???", level: 1 }]);
+  });
 });

--- a/src/hooks/useTableOfContents.ts
+++ b/src/hooks/useTableOfContents.ts
@@ -12,9 +12,10 @@ export function useTableOfContents(content: string | null): TocEntry[] {
   return useMemo(() => {
     if (!content) return [];
 
+    // Slug empty headings too before dropping them, so duplicate-id suffixes match the renderer's.
     const slugger = new GithubSlugger();
     return parseHeadings(content)
-      .filter((heading) => heading.text)
-      .map(({ text, level }) => ({ id: slugger.slug(text), text, level }));
+      .map(({ text, level }) => ({ id: slugger.slug(text), text, level }))
+      .filter((entry) => entry.text);
   }, [content]);
 }

--- a/src/lib/export/meta.test.ts
+++ b/src/lib/export/meta.test.ts
@@ -49,4 +49,18 @@ describe("deriveExportMeta", () => {
     const meta = deriveExportMeta(undefined, "---\ntitle: Only Title\n---\n");
     expect(meta.baseName).toBe("Only Title");
   });
+
+  it("keeps a `#` that belongs to the h1 text", () => {
+    expect(deriveExportMeta("/x/a.md", "# C#").title).toBe("C#");
+  });
+
+  it.each([
+    ["a long space run", `# a${" ".repeat(200_000)}b`, `a${" ".repeat(200_000)}b`],
+    ["unclosed link text brackets", `# ${"[".repeat(200_000)}`, "[".repeat(200_000)],
+    ["unclosed link target parens", `# ${"[](".repeat(70_000)}`, "[](".repeat(70_000)],
+  ])("titles an h1 with %s in linear time", (_, content, title) => {
+    const started = performance.now();
+    expect(deriveExportMeta("/x/a.md", content).title).toBe(title);
+    expect(performance.now() - started).toBeLessThan(1000);
+  });
 });

--- a/src/lib/export/meta.test.ts
+++ b/src/lib/export/meta.test.ts
@@ -50,14 +50,29 @@ describe("deriveExportMeta", () => {
     expect(meta.baseName).toBe("Only Title");
   });
 
+  it("titles a CRLF document from its first h1", () => {
+    const content = "intro\r\n\r\n# Getting Started\r\n\r\nbody";
+    expect(deriveExportMeta("/x/a.md", content).title).toBe("Getting Started");
+  });
+
   it("keeps a `#` that belongs to the h1 text", () => {
     expect(deriveExportMeta("/x/a.md", "# C#").title).toBe("C#");
+  });
+
+  it("strips a link whose URL holds parens", () => {
+    const content = "# [Foo](https://en.wikipedia.org/wiki/Foo_(bar))";
+    expect(deriveExportMeta("/x/a.md", content).title).toBe("Foo");
   });
 
   it.each([
     ["a long space run", `# a${" ".repeat(200_000)}b`, `a${" ".repeat(200_000)}b`],
     ["unclosed link text brackets", `# ${"[".repeat(200_000)}`, "[".repeat(200_000)],
     ["unclosed link target parens", `# ${"[](".repeat(70_000)}`, "[](".repeat(70_000)],
+    [
+      "an unclosed link target of paren pairs",
+      `# [a](${"(b)".repeat(70_000)}`,
+      `[a](${"(b)".repeat(70_000)}`,
+    ],
   ])("titles an h1 with %s in linear time", (_, content, title) => {
     const started = performance.now();
     expect(deriveExportMeta("/x/a.md", content).title).toBe(title);

--- a/src/lib/export/meta.ts
+++ b/src/lib/export/meta.ts
@@ -1,4 +1,5 @@
 import { parseFrontmatter } from "@/lib/frontmatter";
+import { parseHeadings } from "@/lib/markdownHeadings";
 
 export interface ExportMeta {
   // Default file name (no extension) for the save dialog.
@@ -16,17 +17,11 @@ function basename(path: string): string {
 /** First `# heading` outside code fences, stripped of simple inline markup. */
 function firstHeadingTitle(content: string): string | null {
   const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
-  let inFence = false;
-  for (const line of body.split("\n")) {
-    if (/^\s*(```|~~~)/.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    const match = line.match(/^#\s+(.*?)\s*#*\s*$/);
-    if (!match) continue;
-    const text = match[1]
-      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+  for (const heading of parseHeadings(body)) {
+    if (heading.level !== 1) continue;
+    const text = heading.text
+      // `[` and `(` stay out of the runs so unclosed brackets cannot backtrack quadratically.
+      .replace(/\[([^[\]]*)\]\([^()]*\)/g, "$1")
       .replace(/[*_`]/g, "")
       .trim();
     if (text) return text;

--- a/src/lib/export/meta.ts
+++ b/src/lib/export/meta.ts
@@ -20,8 +20,8 @@ function firstHeadingTitle(content: string): string | null {
   for (const heading of parseHeadings(body)) {
     if (heading.level !== 1) continue;
     const text = heading.text
-      // `[` and `(` stay out of the runs so unclosed brackets cannot backtrack quadratically.
-      .replace(/\[([^[\]]*)\]\([^()]*\)/g, "$1")
+      // One level of URL parens (`Foo_(bar)`); runs exclude `[` and `(` so unclosed ones stay linear.
+      .replace(/\[([^[\]]*)\]\([^()]*(?:\([^()]*\)[^()]*)*\)/g, "$1")
       .replace(/[*_`]/g, "")
       .trim();
     if (text) return text;

--- a/src/lib/export/site/nav.ts
+++ b/src/lib/export/site/nav.ts
@@ -5,7 +5,7 @@ import { encodeHref, relativeHref } from "./sitePaths";
 export interface SitePage {
   /** Site-relative path of the generated page ("guide/intro.html"). */
   rel: string;
-  /** Human title (frontmatter title or file basename). */
+  /** Human title (frontmatter title, first h1, or file basename). */
   title: string;
 }
 

--- a/src/lib/markdownHeadings.test.ts
+++ b/src/lib/markdownHeadings.test.ts
@@ -31,8 +31,13 @@ describe("parseHeadings", () => {
     ["# C#", "C#"],
     ["# #", ""],
     ["# Title #  ", "Title"],
+    ["# Title #\r", "Title"],
   ])("reads %j as %j", (md, text) => {
     expect(parseHeadings(md)[0].text).toBe(text);
+  });
+
+  it("skips a line whose text holds a line terminator", () => {
+    expect(parseHeadings("# a\u2028b\n# c\u2029d")).toEqual([]);
   });
 
   it.each([

--- a/src/lib/markdownHeadings.test.ts
+++ b/src/lib/markdownHeadings.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { parseHeadings } from "./markdownHeadings";
 
+const spaces = " ".repeat(200_000);
+
 describe("parseHeadings", () => {
   it("returns level, text, and line for each heading", () => {
     expect(parseHeadings("# One\ntext\n## Two")).toEqual([
@@ -22,6 +24,24 @@ describe("parseHeadings", () => {
   it("does not let a tilde line close a backtick fence", () => {
     const md = "```\n~~~\n# still code\n```\n# Real";
     expect(parseHeadings(md).map((h) => h.text)).toEqual(["Real"]);
+  });
+
+  it.each([
+    ["## Heading ##", "Heading"],
+    ["# C#", "C#"],
+    ["# #", ""],
+    ["# Title #  ", "Title"],
+  ])("reads %j as %j", (md, text) => {
+    expect(parseHeadings(md)[0].text).toBe(text);
+  });
+
+  it.each([
+    ["a long space run inside the text", `# a${spaces}b`, `a${spaces}b`],
+    ["a long space run before U+2028", `# ${spaces}a\u2028`, "a"],
+  ])("parses %s in linear time", (_, md, text) => {
+    const started = performance.now();
+    expect(parseHeadings(md)[0].text).toBe(text);
+    expect(performance.now() - started).toBeLessThan(1000);
   });
 
   it("strips trailing hashes from closed ATX headings", () => {

--- a/src/lib/markdownHeadings.ts
+++ b/src/lib/markdownHeadings.ts
@@ -32,13 +32,15 @@ export function parseHeadings(md: string): MarkdownHeading[] {
 
     const m = ATX.exec(lines[i]);
     if (!m) continue;
-    // Drop a CommonMark closing sequence: a trailing `#` run alone or after whitespace (`# C#` keeps
-    // it). Scanned by hand because a `$`-anchored regex backtracks quadratically on long whitespace.
-    const rest = lines[i].slice(m[0].length).trimEnd();
-    let runStart = rest.length;
-    while (runStart > 0 && rest[runStart - 1] === "#") runStart--;
-    const isClosing = runStart === 0 || /\s/.test(rest[runStart - 1]);
-    const text = (isClosing ? rest.slice(0, runStart) : rest).trim();
+    const content = lines[i].slice(m[0].length).trimEnd();
+    // A terminator inside the text (a lone-CR file) is not a heading; it would swallow later lines.
+    if (/[\r\u2028\u2029]/.test(content)) continue;
+    // CommonMark closing sequence: a trailing `#` run alone or after whitespace (`# C#` keeps it).
+    // Scanned by hand: a `$`-anchored regex backtracks quadratically on long whitespace.
+    let runStart = content.length;
+    while (runStart > 0 && content[runStart - 1] === "#") runStart--;
+    const isClosing = runStart === 0 || /\s/.test(content[runStart - 1]);
+    const text = (isClosing ? content.slice(0, runStart) : content).trim();
     headings.push({ level: m[1].length, text, line: i });
   }
 

--- a/src/lib/markdownHeadings.ts
+++ b/src/lib/markdownHeadings.ts
@@ -1,8 +1,9 @@
 // Parse ATX headings from markdown, skipping fenced code blocks so that `#`
 // comment lines inside ``` / ~~~ snippets are not mistaken for headings. Shared
-// by the Outline sidebar (`useTableOfContents`) and note-embed section slicing
-// (`extractHeadingSection`).
-const ATX = /^(#{1,6})\s+(.*)$/;
+// by the Outline sidebar (`useTableOfContents`), note-embed section slicing
+// (`extractHeadingSection`), and export titles (`deriveExportMeta`).
+// Opening sequence only: a `(.*)$` tail backtracks quadratically when `.` stops at `\r` or U+2028.
+const ATX = /^(#{1,6})\s+/;
 const FENCE = /^\s{0,3}(```+|~~~+)/;
 
 export interface MarkdownHeading {
@@ -31,8 +32,13 @@ export function parseHeadings(md: string): MarkdownHeading[] {
 
     const m = ATX.exec(lines[i]);
     if (!m) continue;
-    // Drop a trailing run of `#` (closed ATX headings) and surrounding space.
-    const text = m[2].replace(/\s+#+\s*$/, "").trim();
+    // Drop a CommonMark closing sequence: a trailing `#` run alone or after whitespace (`# C#` keeps
+    // it). Scanned by hand because a `$`-anchored regex backtracks quadratically on long whitespace.
+    const rest = lines[i].slice(m[0].length).trimEnd();
+    let runStart = rest.length;
+    while (runStart > 0 && rest[runStart - 1] === "#") runStart--;
+    const isClosing = runStart === 0 || /\s/.test(rest[runStart - 1]);
+    const text = (isClosing ? rest.slice(0, runStart) : rest).trim();
     headings.push({ level: m[1].length, text, line: i });
   }
 


### PR DESCRIPTION
## Summary

A crafted markdown file with one long heading line froze the UI. `parseHeadings` stripped a closed-ATX trailing `#` run with `/\s+#+\s*$/`, which backtracks quadratically when a long whitespace run inside the heading text is not followed by `#`: `"# a" + " ".repeat(40000) + "b"` takes about 380 ms, 200k spaces about 10 s. `parseHeadings` runs on the active document on every content change (Outline, via `useTableOfContents`) and on note embeds and wikilink hover previews (via `extractHeadingSection`). The bug predates #744 and is unrelated to it.

Two more super-linear patterns sat on the same paths:

- The ATX matcher `/^(#{1,6})\s+(.*)$/` backtracked the same way when the line held `\r` or U+2028 after the text, because `.` stops there and the failed `$` retries every split of the whitespace run: 466 ms at 40k spaces, about 12 s at 200k. On `main`, every heading line of a CRLF file ends in `\r`.
- `src/lib/export/meta.ts` had its own first-heading regex, `/^#\s+(.*?)\s*#*\s*$/`, which is cubic: 9.7 s at just 5k spaces. It runs on every export and once per page in a site export. Its link-stripping regex was quadratic on unclosed brackets (`"[".repeat(40000)` took 370 ms).

## Changes

- `src/lib/markdownHeadings.ts`:
  - The ATX pattern matches only the opening sequence (`/^(#{1,6})\s+/`), and the heading text is the rest of the line, end-trimmed.
  - Text that still holds `\r`, U+2028, or U+2029 is not a heading. That is what the old `.`-based pattern decided, and it keeps a lone-CR file from turning into one giant heading. It is now a single linear character-class test.
  - The closing sequence is stripped by a linear scan: walk back over the trailing `#` run, drop it only when it is the whole text or follows whitespace, then trim.
- `src/lib/export/meta.ts`:
  - `firstHeadingTitle` reuses `parseHeadings` (first non-empty level-1 heading) instead of its own fence loop and heading regex.
  - The link-stripping regex keeps `[` and `(` out of its character runs and allows one level of parens in the URL. `[Foo](https://en.wikipedia.org/wiki/Foo_(bar))` still strips to `Foo`, and unclosed brackets stay linear: the worst of 13 adversarial inputs, each 200k to 320k characters, took 1.6 ms.
- `src/hooks/useTableOfContents.ts`: every heading is slugged before the empty ones are dropped, so duplicate-id suffixes match what the renderer assigns. Before, the slugger skipped an empty heading (`#  `, and now `# #`), and a later heading with the same slug got a different id in the Outline than in the document (`# #` then `# ???`: the renderer uses `-1`, the Outline used an empty id).
- `src/lib/export/site/nav.ts`: the `SitePage.title` doc comment now mentions the first h1.
- Tests:
  - `markdownHeadings.test.ts`: closing-sequence and CRLF cases, the mid-text terminator skip, and 200k-character linear-time cases.
  - `meta.test.ts`: `# C#`, a CRLF document, a URL with parens, and four 200k-character linear-time cases.
  - `useTableOfContents.test.ts`: the empty-heading id case.

  The 1 s bound follows the existing `telemetry.test.ts` precedent. On the space and bracket rows the old code takes 3.5 to 12 s, and each of those rows was checked to fail with its guard reverted. The paren-pair row guards the new balanced-paren group.
- `src-tauri/src/vault/` has no heading parser (note titles come from frontmatter only), and the Rust `regex` crate matches in linear time, so nothing changed on the Rust side.

Behavior changes, all toward CommonMark and what the renderer shows:

- `# #` (and `# ###`) is now an empty heading, which the Outline hides. Before, the Outline listed it as `#`.
- `# C#` exports with the title `C#`. The old export regex dropped the `#` and produced `C`.
- A line terminator at the end of the heading text (the `\r` of a CRLF line, or a trailing U+2028) is trimmed like whitespace. So on `main`, CRLF notes get their Outline, embeds, and hover previews even before #744. The export title already handled CRLF and still does.
- Export titles follow `parseHeadings` fence detection: a `~~~` line no longer closes a backtick fence, and a fence indented four or more spaces is not a fence.

Relation to #744: the two PRs touch the same two files, but the hunks don't overlap and `git merge-tree` merges them cleanly, so either can land first. The merged tree with #744's current head also typechecks and passes the heading, section, Outline, export-meta, and task-list suites (62 tests). #744 is still needed for lone-CR files, and to keep `\r` out of sliced embed sections. Whichever PR lands second should reword #744's `splitLines` comment ("a leftover `\r` defeats ATX's `.*$`"). A trailing `\r` no longer defeats the heading match; a mid-line one still does.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [x] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

INV-5 (all external input is untrusted): Markdown content is untrusted, and one crafted heading line could block the UI thread for seconds to hours. `docs/engineering-invariants.md` has no invariant dedicated to UI responsiveness, so INV-5 is the one at stake here. The evidence is the adversarial matrix's "large" and "malformed" input rows:

- **Large:** 200k-character heading lines through `parseHeadings` and `deriveExportMeta`, each bounded to 1 s.
- **Malformed:** `# C#`, `# #`, trailing whitespace after a closing sequence, a line terminator inside the text, and unclosed link brackets and parens.

INV-2 (empty is not absent) holds: `# #` yields a present heading with empty text, and every consumer treats that the same way as the existing `#  ` case.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated only, not checked in the running app. `pnpm typecheck`, `pnpm check`, and `pnpm test` pass locally on Windows (412 files, 3872 tests). The pre-commit hook also ran `cargo test --lib` (700 passed) and `cargo clippy --all-targets -- -D warnings`. Timings are Node (V8) on Windows, the same engine as WebView2; WebKit (macOS, Linux) was not measured.

## Screenshots

N/A
