### PR TITLE
fix(frontmatter): read notes and canvases that start with a UTF-8 BOM

### DIFF
--- a/src-tauri/fixtures/vault/Aliased.md
+++ b/src-tauri/fixtures/vault/Aliased.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Aliased
 aliases: [Second Name, Third Name]
 ---

--- a/src-tauri/src/vault/frontmatter.rs
+++ b/src-tauri/src/vault/frontmatter.rs
@@ -59,6 +59,8 @@ impl Frontmatter {
 /// starts at. `None` unless the file opens with the fence and closes it within
 /// the byte cap.
 pub fn split_frontmatter(content: &str) -> (Option<String>, usize) {
+    // One leading BOM, as the renderer's pattern allows; it moves no line index.
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
     // `lines` has already taken the `\r` of a CRLF ending, and the renderer's
     // pattern allows nothing else around the delimiter, so `---   ` opens no
     // block there and must open none here.
@@ -385,6 +387,13 @@ mod tests {
         let fm = parse("---\r\ntitle: Note\r\ntags: [a]\r\n---\r\n").unwrap();
         assert_eq!(fm.title.as_deref(), Some("Note"));
         assert_eq!(fm.tags, vec!["a"]);
+    }
+
+    #[test]
+    fn a_leading_bom_does_not_hide_the_block() {
+        let (inner, body_start) = split_frontmatter("\u{feff}---\r\ntitle: Note\r\n---\r\n");
+        assert_eq!(inner.as_deref(), Some("title: Note\n"));
+        assert_eq!(body_start, 3);
     }
 
     #[test]

--- a/src-tauri/src/vault/frontmatter.rs
+++ b/src-tauri/src/vault/frontmatter.rs
@@ -57,20 +57,15 @@ impl Frontmatter {
 
 /// The leading `---` fenced block's inner text plus the line index the body
 /// starts at. `None` unless the file opens with the fence and closes it within
-/// the byte cap.
+/// the byte cap. A leading BOM is dropped by the caller (`index::strip_bom`).
 pub fn split_frontmatter(content: &str) -> (Option<String>, usize) {
-    // One leading BOM, as the renderer's pattern allows; it moves no line index.
-    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
-    // `lines` has already taken the `\r` of a CRLF ending, and the renderer's
-    // pattern allows nothing else around the delimiter, so `---   ` opens no
-    // block there and must open none here.
     let mut lines = content.lines();
-    if lines.next() != Some("---") {
+    if !lines.next().is_some_and(is_fence) {
         return (None, 0);
     }
     let mut inner = String::new();
     for (idx, line) in lines.enumerate() {
-        if line == "---" {
+        if is_fence(line) {
             return (Some(inner), idx + 2);
         }
         if inner.len() + line.len() > MAX_FRONTMATTER_BYTES {
@@ -80,6 +75,12 @@ pub fn split_frontmatter(content: &str) -> (Option<String>, usize) {
         inner.push('\n');
     }
     (None, 0)
+}
+
+/// `---` plus any trailing spaces or tabs, as remark-frontmatter reads a fence.
+/// `lines` has already taken the `\r` of a CRLF ending.
+fn is_fence(line: &str) -> bool {
+    line.trim_end_matches([' ', '\t']) == "---"
 }
 
 /// Parse the inner text of a frontmatter block. `None` when the YAML is
@@ -390,13 +391,6 @@ mod tests {
     }
 
     #[test]
-    fn a_leading_bom_does_not_hide_the_block() {
-        let (inner, body_start) = split_frontmatter("\u{feff}---\r\ntitle: Note\r\n---\r\n");
-        assert_eq!(inner.as_deref(), Some("title: Note\n"));
-        assert_eq!(body_start, 3);
-    }
-
-    #[test]
     fn an_oversized_block_is_skipped_entirely() {
         let block = format!(
             "---\nbig: {}\n---\nbody\n",
@@ -487,10 +481,11 @@ mod tests {
     }
 
     #[test]
-    fn a_delimiter_with_trailing_space_is_not_a_fence() {
-        // The renderer's pattern does not accept it, so neither does the index.
-        assert_eq!(parse("---   \ntitle: Note\n---\n"), None);
-        assert_eq!(parse("---\ntitle: Note\n---   \n"), None);
+    fn spaces_or_tabs_after_a_fence_still_close_it() {
+        // The renderer's parser accepts them, so the index does too.
+        let fm = parse("---   \ntitle: Note\n---\t\r\n").unwrap();
+        assert_eq!(fm.title.as_deref(), Some("Note"));
+        assert_eq!(parse("---\ntitle: Note\n--- x\n"), None);
     }
 
     #[test]

--- a/src-tauri/src/vault/index.rs
+++ b/src-tauri/src/vault/index.rs
@@ -212,7 +212,14 @@ impl Vault {
     }
 }
 
+/// micromark drops one leading BOM, so the index drops one here, for every file
+/// kind, before any parser runs; a second BOM is text to both.
+pub(crate) fn strip_bom(content: &str) -> &str {
+    content.strip_prefix('\u{feff}').unwrap_or(content)
+}
+
 fn index_file(path: &str, content: &str) -> (Note, Option<Canvas>) {
+    let content = strip_bom(content);
     if crate::is_canvas_file(Path::new(path)) {
         let (note, canvas) = canvas::extract_canvas(path, content);
         return (note, Some(canvas));
@@ -257,4 +264,33 @@ fn index_files(paths: &[PathBuf]) -> Vec<(Note, Option<Canvas>)> {
 fn read_and_index(path: &Path) -> Option<(Note, Option<Canvas>)> {
     let content = std::fs::read_to_string(path).ok()?;
     Some(index_file(&path.to_string_lossy(), &content))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_leading_bom_is_dropped_before_any_parser_sees_the_note() {
+        let (note, _) = index_file("/w/a.md", "\u{feff}#first and [[Other]]\n");
+        assert_eq!(note.tags, vec!["first"]);
+        assert_eq!(note.links[0].snippet, "#first and [[Other]]");
+
+        let (note, _) = index_file("/w/b.md", "\u{feff}---\ntitle: T\n---\n");
+        assert_eq!(note.title.as_deref(), Some("T"));
+    }
+
+    #[test]
+    fn only_one_bom_is_dropped() {
+        let (note, _) = index_file("/w/a.md", "\u{feff}\u{feff}---\ntitle: T\n---\n");
+        assert!(note.title.is_none());
+    }
+
+    #[test]
+    fn a_canvas_saved_with_a_bom_keeps_its_cards() {
+        let board = r#"{"nodes":[{"id":"a","type":"file","file":"Notes/A.md","x":0,"y":0,"width":1,"height":1}]}"#;
+        let (note, canvas) = index_file("/w/Board.canvas", &format!("\u{feff}{board}"));
+        assert_eq!(canvas.unwrap().nodes.len(), 1);
+        assert_eq!(note.links.len(), 1);
+    }
 }

--- a/src-tauri/src/vault/note.rs
+++ b/src-tauri/src/vault/note.rs
@@ -29,8 +29,6 @@ pub(crate) struct Note {
 }
 
 pub(crate) fn extract_note(path: &str, content: &str) -> Note {
-    // The renderer drops a leading BOM; kept, it would sit before a line-0 `#tag`.
-    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
     let (block, body_start) = split_frontmatter(content);
     let parsed = block.as_deref().and_then(parse_frontmatter);
 
@@ -262,13 +260,6 @@ mod tests {
         assert!(note.title.is_none());
         assert!(note.fields.is_empty());
         assert_eq!(note.links.len(), 1);
-    }
-
-    #[test]
-    fn a_leading_bom_is_not_part_of_the_first_line() {
-        let note = extract_note("/w/a.md", "\u{feff}#first and [[Other]]\n");
-        assert_eq!(note.tags, vec!["first"]);
-        assert_eq!(note.links[0].snippet, "#first and [[Other]]");
     }
 
     #[test]

--- a/src-tauri/src/vault/note.rs
+++ b/src-tauri/src/vault/note.rs
@@ -29,6 +29,8 @@ pub(crate) struct Note {
 }
 
 pub(crate) fn extract_note(path: &str, content: &str) -> Note {
+    // The renderer drops a leading BOM; kept, it would sit before a line-0 `#tag`.
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
     let (block, body_start) = split_frontmatter(content);
     let parsed = block.as_deref().and_then(parse_frontmatter);
 
@@ -260,6 +262,13 @@ mod tests {
         assert!(note.title.is_none());
         assert!(note.fields.is_empty());
         assert_eq!(note.links.len(), 1);
+    }
+
+    #[test]
+    fn a_leading_bom_is_not_part_of_the_first_line() {
+        let note = extract_note("/w/a.md", "\u{feff}#first and [[Other]]\n");
+        assert_eq!(note.tags, vec!["first"]);
+        assert_eq!(note.links[0].snippet, "#first and [[Other]]");
     }
 
     #[test]

--- a/src-tauri/src/vault/tests.rs
+++ b/src-tauri/src/vault/tests.rs
@@ -9,6 +9,7 @@ use tauri::Manager;
 
 use super::commands::*;
 use super::frontmatter::{parse_frontmatter, split_frontmatter};
+use super::index::strip_bom;
 use super::test_support::*;
 use super::Vault;
 use crate::grants::GrantRegistry;
@@ -137,7 +138,7 @@ fn frontmatter_matches_the_shared_expectation() {
 
     for (name, want) in expected.as_object().unwrap() {
         let content = fs::read_to_string(vault_dir.join(name)).unwrap();
-        let parsed = split_frontmatter(&content)
+        let parsed = split_frontmatter(strip_bom(&content))
             .0
             .as_deref()
             .and_then(parse_frontmatter);

--- a/src-tauri/src/vault/tests.rs
+++ b/src-tauri/src/vault/tests.rs
@@ -131,6 +131,9 @@ fn frontmatter_matches_the_shared_expectation() {
     )
     .unwrap();
     let vault_dir = fixtures_dir().join("vault");
+    // The BOM case: an editor that drops the invisible mark drops the coverage.
+    let aliased = fs::read_to_string(vault_dir.join("Aliased.md")).unwrap();
+    assert!(aliased.starts_with('\u{feff}'), "Aliased.md lost its BOM");
 
     for (name, want) in expected.as_object().unwrap() {
         let content = fs::read_to_string(vault_dir.join(name)).unwrap();

--- a/src/lib/export/meta.test.ts
+++ b/src/lib/export/meta.test.ts
@@ -23,6 +23,18 @@ describe("deriveExportMeta", () => {
     expect(deriveExportMeta("/x/bom.md", content).title).toBe("Real Title");
   });
 
+  it("finds a first-line h1 behind a BOM", () => {
+    const meta = deriveExportMeta("/x/getting-started.md", "\uFEFF# Getting Started\n\nbody");
+    expect(meta.title).toBe("Getting Started");
+  });
+
+  it("skips a block whose fences carry trailing spaces or tabs", () => {
+    const comment = "---\n# a yaml comment\nauthor: Ada\n---  \n# Real Title\n";
+    expect(deriveExportMeta("/x/a.md", comment).title).toBe("Real Title");
+    const laterBreak = "---\t\nauthor: Ada\n---  \n# Getting Started\n\n---\n\n# Appendix\n";
+    expect(deriveExportMeta("/x/b.md", laterBreak).title).toBe("Getting Started");
+  });
+
   it("strips simple inline markup from the h1 and skips deeper headings", () => {
     expect(deriveExportMeta("/x/a.md", "# The `ctx` *guide*").title).toBe("The ctx guide");
     expect(deriveExportMeta("/x/b.md", "# [API Reference](api.md)").title).toBe("API Reference");

--- a/src/lib/export/meta.test.ts
+++ b/src/lib/export/meta.test.ts
@@ -18,6 +18,11 @@ describe("deriveExportMeta", () => {
     expect(deriveExportMeta("/x/raw.md", content).title).toBe("Real Title");
   });
 
+  it("skips a frontmatter block that follows a BOM", () => {
+    const content = "\uFEFF---\n# a yaml comment\nauthor: Ada\n---\n# Real Title\n";
+    expect(deriveExportMeta("/x/bom.md", content).title).toBe("Real Title");
+  });
+
   it("strips simple inline markup from the h1 and skips deeper headings", () => {
     expect(deriveExportMeta("/x/a.md", "# The `ctx` *guide*").title).toBe("The ctx guide");
     expect(deriveExportMeta("/x/b.md", "# [API Reference](api.md)").title).toBe("API Reference");

--- a/src/lib/export/meta.ts
+++ b/src/lib/export/meta.ts
@@ -1,4 +1,4 @@
-import { parseFrontmatter } from "@/lib/frontmatter";
+import { FRONTMATTER_RE, parseFrontmatter } from "@/lib/frontmatter";
 import { parseHeadings } from "@/lib/markdownHeadings";
 
 export interface ExportMeta {
@@ -16,7 +16,7 @@ function basename(path: string): string {
 
 /** First `# heading` outside code fences, stripped of simple inline markup. */
 function firstHeadingTitle(content: string): string | null {
-  const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+  const body = content.replace(FRONTMATTER_RE, "");
   for (const heading of parseHeadings(body)) {
     if (heading.level !== 1) continue;
     const text = heading.text

--- a/src/lib/export/meta.ts
+++ b/src/lib/export/meta.ts
@@ -16,7 +16,8 @@ function basename(path: string): string {
 
 /** First `# heading` outside code fences, stripped of simple inline markup. */
 function firstHeadingTitle(content: string): string | null {
-  const body = content.replace(FRONTMATTER_RE, "");
+  // FRONTMATTER_RE takes a BOM only along with a block; a bare one would hide a line-1 h1.
+  const body = content.replace(FRONTMATTER_RE, "").replace(/^\uFEFF/, "");
   for (const heading of parseHeadings(body)) {
     if (heading.level !== 1) continue;
     const text = heading.text

--- a/src/lib/frontmatter.test.ts
+++ b/src/lib/frontmatter.test.ts
@@ -88,6 +88,11 @@ describe("parseFrontmatter", () => {
   it("parses a block after a leading BOM", () => {
     expect(parseFrontmatter("\uFEFF---\r\ntitle: Win\r\n---\r\n")?.title).toBe("Win");
   });
+
+  it("allows spaces or tabs after either fence, as the renderer does", () => {
+    expect(parseFrontmatter("---  \ntitle: T\n---\t\nbody")?.title).toBe("T");
+    expect(parseFrontmatter("---\ntitle: T\n--- x\n")).toBeNull();
+  });
 });
 
 // The Rust index parses the same blocks in `src-tauri/src/vault/frontmatter.rs`.

--- a/src/lib/frontmatter.test.ts
+++ b/src/lib/frontmatter.test.ts
@@ -84,6 +84,10 @@ describe("parseFrontmatter", () => {
     expect(result?.date).toBeUndefined();
     expect(result?.extra).toEqual([["slug", "x"]]);
   });
+
+  it("parses a block after a leading BOM", () => {
+    expect(parseFrontmatter("\uFEFF---\r\ntitle: Win\r\n---\r\n")?.title).toBe("Win");
+  });
 });
 
 // The Rust index parses the same blocks in `src-tauri/src/vault/frontmatter.rs`.

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -8,8 +8,9 @@ export interface ParsedFrontmatter {
   extra: Array<[key: string, value: string]>;
 }
 
-// One leading BOM may precede the fence: micromark, and so the renderer, drops it.
-export const FRONTMATTER_RE = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+// Fences as remark-frontmatter reads them: after one leading BOM (micromark drops
+// it), `---` with optional trailing spaces or tabs.
+export const FRONTMATTER_RE = /^\uFEFF?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
 const KNOWN_KEYS = new Set(["title", "author", "date", "tags"]);
 
 // FAILSAFE_SCHEMA keeps every scalar as a string so a date like `2026-04-15`

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -8,7 +8,8 @@ export interface ParsedFrontmatter {
   extra: Array<[key: string, value: string]>;
 }
 
-const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+// One leading BOM may precede the fence: micromark, and so the renderer, drops it.
+export const FRONTMATTER_RE = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 const KNOWN_KEYS = new Set(["title", "author", "date", "tags"]);
 
 // FAILSAFE_SCHEMA keeps every scalar as a string so a date like `2026-04-15`

--- a/src/lib/spellcheck/wordScanner.test.ts
+++ b/src/lib/spellcheck/wordScanner.test.ts
@@ -52,8 +52,12 @@ describe("scanWords", () => {
     expect(wordsOf("---\ntitel: xyz\n---\nreal wrods")).toEqual(["real", "wrods"]);
   });
 
-  it("excludes frontmatter closed with a ... fence", () => {
-    expect(wordsOf("---\ntitel: xyz\n...\nreal wrods")).toEqual(["real", "wrods"]);
+  it("excludes frontmatter behind a leading BOM", () => {
+    expect(wordsOf("\uFEFF---\ntitel: xyz\n---\nreal wrods")).toEqual(["real", "wrods"]);
+  });
+
+  it("checks a block closed with ..., which the renderer does not read as frontmatter", () => {
+    expect(wordsOf("---\ntitel: xyz\n...\nreal wrods")).toEqual(["titel", "xyz", "real", "wrods"]);
   });
 
   it("treats an unterminated frontmatter block as prose", () => {

--- a/src/lib/spellcheck/wordScanner.ts
+++ b/src/lib/spellcheck/wordScanner.ts
@@ -1,5 +1,6 @@
 import { syntaxTree } from "@codemirror/language";
 import type { EditorState } from "@codemirror/state";
+import { FRONTMATTER_RE } from "@/lib/frontmatter";
 
 export interface WordToken {
   from: number;
@@ -37,16 +38,14 @@ function overlapsAny(from: number, to: number, ranges: [number, number][]): bool
   return ranges.some(([start, end]) => from < end && to > start);
 }
 
-// YAML frontmatter (a leading `---` fence) is not modelled by the base markdown
-// parser, so detect it directly and exclude the whole block.
+// YAML frontmatter is not modelled by the base markdown parser, so exclude the block
+// the renderer's pattern finds. ponytail: head only, so a block past 64K chars is checked.
+const FRONTMATTER_SCAN_CHARS = 64 * 1024;
+
 function frontmatterRange(state: EditorState): [number, number] | null {
-  const doc = state.doc;
-  if (doc.lines < 2 || doc.line(1).text !== "---") return null;
-  for (let n = 2; n <= doc.lines; n++) {
-    const line = doc.line(n);
-    if (line.text === "---" || line.text === "...") return [0, line.to];
-  }
-  return null;
+  const head = state.doc.sliceString(0, Math.min(state.doc.length, FRONTMATTER_SCAN_CHARS));
+  const match = FRONTMATTER_RE.exec(head);
+  return match ? [0, match[0].length] : null;
 }
 
 // Collect prose word tokens in [from, to], skipping code/links/HTML/frontmatter,


### PR DESCRIPTION
## Summary

Closes #748.

A note that starts with a UTF-8 BOM (Windows PowerShell 5 `Set-Content -Encoding utf8` and older Notepad write one) lost its frontmatter: the metadata table did not render, and the vault index dropped the note's title, fields, tags and aliases. Both parsers anchored the `---` fence at the first character, and the BOM sits in front of it. micromark already drops a leading BOM when rendering, so remark-frontmatter hid the block while `parseFrontmatter` returned nothing, and the note showed neither. The same BOM also broke the export title, the editor's frontmatter spell-check exclusion, and canvas indexing.

Aligning the fence rule with remark-frontmatter also accepts spaces or tabs after a `---` fence, which the renderer already treated as frontmatter while the metadata table, the export title and the index did not.

The heading half of the BOM fix (Outline sidebar, `![[note#Heading]]` embeds and wikilink previews) strips the BOM inside `splitLines` from #744 and follows in a separate PR.

## Changes

- `src/lib/frontmatter.ts`: `FRONTMATTER_RE` reads fences the way remark-frontmatter does (after one leading BOM, `---` with optional trailing spaces or tabs) and is exported.
- `src/lib/export/meta.ts`: the export title lookup reuses `FRONTMATTER_RE` instead of its own copy of the pattern, and drops a bare BOM, so a first-line h1 in a BOM note still titles the export.
- `src/lib/spellcheck/wordScanner.ts`: the editor's spell check finds the frontmatter block with `FRONTMATTER_RE` instead of its own `---` line check, so a BOM note's YAML is no longer spellchecked. A block closed with `...` is now checked as prose, since the renderer does not read it as frontmatter either. Only the first 64K characters are searched, so a large note is not copied on every scan.
- `src-tauri/src/vault/index.rs`: `index_file`, which every indexed file passes through (notes and canvases, full build and watcher), drops one leading BOM (`strip_bom`). A second BOM stays text, as it does in the renderer. A canvas saved with a BOM no longer indexes as an empty board.
- `src-tauri/src/vault/frontmatter.rs`: `split_frontmatter` accepts spaces or tabs after a fence (`is_fence`), matching the TS pattern; the test that pinned the strict form is flipped.
- `src-tauri/fixtures/vault/Aliased.md` opens with a BOM, so `vault-frontmatter.json` pins the case for both parsers. The Rust parity test strips it through `strip_bom`, as the index does, and asserts the BOM is still there, so an editor that drops the invisible mark fails the test instead of silently dropping the coverage.
- Tests for each case in `frontmatter.test.ts`, `meta.test.ts`, `wordScanner.test.ts`, `index.rs` and `frontmatter.rs`.

Not changed: `read_file` still returns the file as stored, so saves keep the BOM. Lone CR line endings stay unsupported by both frontmatter parsers: the Rust index splits lines with `str::lines`, which has no lone CR (see #744).

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

None. Pure string parsing: no state, IPC, persistence, or sanitization involved. File content is never rewritten, so a note's bytes on disk are unchanged.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated only, not checked in the running app. `pnpm typecheck`, `pnpm check` and `pnpm test` (412 files, 3881 tests) pass locally on Windows, as do `cargo test --lib` and `cargo clippy --all-targets -- -D warnings`.

## Screenshots

N/A
