### PR TITLE
fix(outline): find a first-line heading in notes that start with a UTF-8 BOM

### DIFF
--- a/src/lib/export/meta.ts
+++ b/src/lib/export/meta.ts
@@ -16,8 +16,7 @@ function basename(path: string): string {
 
 /** First `# heading` outside code fences, stripped of simple inline markup. */
 function firstHeadingTitle(content: string): string | null {
-  // FRONTMATTER_RE takes a BOM only along with a block; a bare one would hide a line-1 h1.
-  const body = content.replace(FRONTMATTER_RE, "").replace(/^\uFEFF/, "");
+  const body = content.replace(FRONTMATTER_RE, "");
   for (const heading of parseHeadings(body)) {
     if (heading.level !== 1) continue;
     const text = heading.text

--- a/src/lib/headingSection.test.ts
+++ b/src/lib/headingSection.test.ts
@@ -50,4 +50,8 @@ describe("extractHeadingSection", () => {
     expect(extractHeadingSection(crlf, "Recipes")).toBe("## Recipes\npasta\n\n### Sauce\ntomato");
     expect(extractHeadingSection(crlf, "Sauce")).toBe("### Sauce\ntomato");
   });
+
+  it("finds a first-line heading behind a BOM", () => {
+    expect(extractHeadingSection("\uFEFF# A\ntext\n# B\nmore", "A")).toBe("# A\ntext");
+  });
 });

--- a/src/lib/markdownHeadings.test.ts
+++ b/src/lib/markdownHeadings.test.ts
@@ -59,4 +59,12 @@ describe("parseHeadings", () => {
       { level: 2, text: "Two", line: 2 },
     ]);
   });
+
+  it("drops one leading BOM, as the renderer does", () => {
+    expect(parseHeadings("\uFEFF# A\r\ntext\r\n# B")).toEqual([
+      { level: 1, text: "A", line: 0 },
+      { level: 1, text: "B", line: 2 },
+    ]);
+    expect(parseHeadings("\uFEFF\uFEFF# A")).toEqual([]);
+  });
 });

--- a/src/lib/markdownHeadings.ts
+++ b/src/lib/markdownHeadings.ts
@@ -14,8 +14,9 @@ export interface MarkdownHeading {
 }
 
 // Every CommonMark line ending (CRLF, CR, LF); a leftover `\r` defeats ATX's `.*$`.
+// One leading BOM goes too, as micromark drops it; kept, it would sit before a line-1 `#`.
 export function splitLines(md: string): string[] {
-  return md.split(/\r\n|\r|\n/);
+  return md.replace(/^\uFEFF/, "").split(/\r\n|\r|\n/);
 }
 
 export function parseHeadings(md: string): MarkdownHeading[] {

--- a/src/lib/taskList.test.ts
+++ b/src/lib/taskList.test.ts
@@ -35,6 +35,12 @@ describe("toggleTaskAtLine", () => {
     expect(toggleTaskAtLine(src, 2)).toBe("- [ ] a\r\n- [ ] b");
   });
 
+  it("keeps a leading BOM", () => {
+    const src = "\uFEFF- [ ] a\n- [ ] b";
+    expect(toggleTaskAtLine(src, 1)).toBe("\uFEFF- [x] a\n- [ ] b");
+    expect(toggleTaskAtLine(src, 2)).toBe("\uFEFF- [ ] a\n- [x] b");
+  });
+
   it("returns input unchanged when the line has no checkbox", () => {
     const src = "regular paragraph";
     expect(toggleTaskAtLine(src, 1)).toBe(src);

--- a/src/lib/taskList.ts
+++ b/src/lib/taskList.ts
@@ -10,6 +10,8 @@ export function toggleTaskAtLine(source: string, line: number): string {
   // Track line endings so we don't normalise CRLF → LF on a save.
   const eolMatch = source.match(/\r\n|\r|\n/);
   const eol = eolMatch ? eolMatch[0] : "\n";
+  // splitLines drops a leading BOM; put it back so the save keeps it.
+  const bom = source.startsWith("\uFEFF") ? "\uFEFF" : "";
   const lines = splitLines(source);
   if (line > lines.length) return source;
 
@@ -24,5 +26,5 @@ export function toggleTaskAtLine(source: string, line: number): string {
   );
   if (replaced === original) return source;
   lines[idx] = replaced;
-  return lines.join(eol);
+  return bom + lines.join(eol);
 }


### PR DESCRIPTION
## Summary

Closes #754.

A note that starts with a UTF-8 BOM (Windows PowerShell 5 `Set-Content -Encoding utf8` and older Notepad write one) lost the heading on its first line: the Outline sidebar left it out, and `![[note#Heading]]` embeds and wikilink hover previews for it rendered "Heading not found". `parseHeadings` matches `^#` against the lines `splitLines` returns, and the BOM sat in front of the `#` on line 1. The rendered note showed the heading, because micromark drops a leading BOM.

This is the heading half of the BOM fix; #747 fixed the frontmatter half.

## Changes

- `src/lib/markdownHeadings.ts`: `splitLines` drops one leading BOM, as micromark does. `parseHeadings` and `extractHeadingSection` both split with it, so heading line indexes and the sliced lines stay aligned, and a BOM adds no line, so line numbers are unchanged. A second BOM stays text, as it does in the renderer.
- `src/lib/taskList.ts`: `toggleTaskAtLine` rejoins `splitLines` output for the save, so it now puts a leading BOM back. Without that, ticking a checkbox in a BOM note would save the file without its BOM.
- `src/lib/export/meta.ts`: drops the bare-BOM strip #747 added for a first-line export title; `parseHeadings` handles it now, and the `meta.test.ts` case from #747 still covers it.
- BOM cases in `markdownHeadings.test.ts`, `headingSection.test.ts` and `taskList.test.ts`.

Not changed: `read_file` still returns the file as stored. The Rust vault index has no heading parser, so there is nothing to keep in step there.

## Risk classification

- [x] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [ ] No risk areas touched

### Invariants at stake and evidence

Persistence: `toggleTaskAtLine` rewrites the note for a save, and the new BOM strip in `splitLines` would otherwise have dropped a leading BOM from that write. It re-prepends it, so the output differs from the source only in the toggled mark: covered by `taskList.test.ts` "keeps a leading BOM", next to the existing "preserves CRLF line endings". No numbered invariant in `docs/engineering-invariants.md` covers byte preservation; INV-1 (user edits are never silently discarded) is untouched, since the toggle still writes the user's change.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Automated only, not checked in the running app. `pnpm typecheck`, `pnpm check` and `pnpm test` (412 files, 3884 tests) pass locally on Windows. The pre-commit hook ran `cargo test --lib` (706 passed) and `cargo clippy --all-targets -- -D warnings`.

## Screenshots

N/A
