### PR TITLE
docs(install): link README to the website, share one release notes block

### DIFF
--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -16,14 +16,15 @@ When a feature is worth documenting, still update in the same commit:
 
 Treat this as part of the feature's definition of done, not a follow-up.
 
-## Install instructions live in four places
+## Install instructions live in three places
 
-Install commands (Homebrew, winget, Chocolatey, Scoop, Snap, AUR, PPA, apt, dnf) are duplicated across the ecosystem. Changing any install command means updating **all four in the same delivery**, not just the one that prompted the change:
+Install commands (Homebrew, winget, Chocolatey, Scoop, Snap, AUR, PPA, apt, dnf) are duplicated across the ecosystem. Changing any install command means updating **all three in the same delivery**, not just the one that prompted the change:
 
-1. **`README.md`** in this repo (the Install section).
-2. **`.github/workflows/release.yml`** in this repo: the generated release notes carry the install commands in **two** heredoc blocks (the initial release body and the changelog INSTALL block); patch both.
-3. **The website**: `glyph-md/glyph-md.github.io`, `src/components/Download.astro`.
-4. **The org profile**: `glyph-md/.github`, `profile/README.md`.
+1. **`.github/release-install.md`** in this repo: `release.yml` puts it at the top of every release's notes, both when it creates the release and when it adds the changelog.
+2. **The website**: `glyph-md/glyph-md.github.io`, `src/components/Download.astro`.
+3. **The org profile**: `glyph-md/.github`, `profile/README.md`.
+
+`README.md` carries no install commands: its Install section links to the website's download section and the latest release. Don't copy the commands back into it.
 
 Homebrew commands always use fully qualified names (`brew install --cask --force glyph-md/tap/glyph` on macOS, `brew install glyph-md/tap/glyph` on Linux): homebrew-core ships an unrelated `glyph` formula (an ASCII-art converter) that a plain `brew install glyph` resolves to, shadowing the app's CLI with a tool that fails with "Error: input file must be specified."
 

--- a/.github/release-install.md
+++ b/.github/release-install.md
@@ -1,0 +1,50 @@
+## Install
+
+### macOS
+```bash
+brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask --force glyph-md/tap/glyph
+```
+Or download `Glyph_*_universal.dmg` below.
+
+### Windows
+```powershell
+# winget
+winget install hamidfzm.Glyph
+
+# Chocolatey
+choco install glyph
+
+# Scoop
+scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
+scoop install glyph
+```
+Or download `Glyph_*_x64_en-US.msi` below.
+
+### Linux
+```bash
+# Snap Store
+sudo snap install glyph
+
+# Arch (AUR)
+yay -S glyph-md-bin
+
+# Homebrew (Linuxbrew)
+brew tap glyph-md/tap && brew install glyph-md/tap/glyph
+
+# Debian/Ubuntu (PPA)
+sudo add-apt-repository ppa:hamidfzm/glyph
+sudo apt update
+sudo apt install glyph
+
+# Debian (apt repo)
+curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
+echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
+sudo apt update && sudo apt install glyph
+
+# Fedora/RHEL (dnf)
+sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
+sudo dnf install glyph
+```
+Or download the `.deb` / `.rpm` / `.AppImage` below.
+
+On Arch, when the AUR lags behind a release, download the `PKGBUILD` asset below and run `makepkg -si` next to it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,66 +19,15 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && exit 0
-          cat > /tmp/release-body.md <<'BODY'
-          ## Install
-
-          ### macOS
-          ```bash
-          brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask --force glyph-md/tap/glyph
-          ```
-          Or download `Glyph_*_universal.dmg` below.
-
-          ### Windows
-          ```powershell
-          # winget
-          winget install hamidfzm.Glyph
-
-          # Chocolatey
-          choco install glyph
-
-          # Scoop
-          scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
-          scoop install glyph
-          ```
-          Or download `Glyph_*_x64_en-US.msi` below.
-
-          ### Linux
-          ```bash
-          # Snap Store
-          sudo snap install glyph
-
-          # Arch (AUR)
-          yay -S glyph-md-bin
-
-          # Homebrew (Linuxbrew)
-          brew tap glyph-md/tap && brew install glyph-md/tap/glyph
-
-          # Debian/Ubuntu (PPA)
-          sudo add-apt-repository ppa:hamidfzm/glyph
-          sudo apt update
-          sudo apt install glyph
-
-          # Debian (apt repo)
-          curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
-          sudo apt update && sudo apt install glyph
-
-          # Fedora/RHEL (dnf)
-          sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
-          sudo dnf install glyph
-          ```
-          Or download the `.deb` / `.rpm` / `.AppImage` below.
-
-          On Arch, when the AUR lags behind a release, download the `PKGBUILD` asset below and run `makepkg -si` next to it.
-          BODY
           gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
             --title "Glyph $GITHUB_REF_NAME" \
-            --notes-file /tmp/release-body.md
+            --notes-file .github/release-install.md
 
   build:
     needs: create-release
@@ -182,62 +131,7 @@ jobs:
             echo "NOTES_EOF"
           } >> "$GITHUB_OUTPUT"
 
-          BODY=$(cat <<'INSTALL'
-          ## Install
-
-          ### macOS
-          ```bash
-          brew tap glyph-md/tap && brew trust glyph-md/tap && brew install --cask --force glyph-md/tap/glyph
-          ```
-          Or download `Glyph_*_universal.dmg` below.
-
-          ### Windows
-          ```powershell
-          # winget
-          winget install hamidfzm.Glyph
-
-          # Chocolatey
-          choco install glyph
-
-          # Scoop
-          scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
-          scoop install glyph
-          ```
-          Or download `Glyph_*_x64_en-US.msi` below.
-
-          ### Linux
-          ```bash
-          # Snap Store
-          sudo snap install glyph
-
-          # Arch (AUR)
-          yay -S glyph-md-bin
-
-          # Homebrew (Linuxbrew)
-          brew tap glyph-md/tap && brew install glyph-md/tap/glyph
-
-          # Debian/Ubuntu (PPA)
-          sudo add-apt-repository ppa:hamidfzm/glyph
-          sudo apt update
-          sudo apt install glyph
-
-          # Debian (apt repo)
-          curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-          echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
-          sudo apt update && sudo apt install glyph
-
-          # Fedora/RHEL (dnf)
-          sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
-          sudo dnf install glyph
-          ```
-          Or download the `.deb` / `.rpm` / `.AppImage` below.
-
-          ---
-
-          INSTALL
-          )
-
-          printf '%s\n\n%s' "$BODY" "$CHANGELOG" > /tmp/release-body.md
+          { cat .github/release-install.md; printf '\n---\n\n%s' "$CHANGELOG"; } > /tmp/release-body.md
           gh release edit "${{ github.ref_name }}" --repo "${{ github.repository }}" --notes-file /tmp/release-body.md
 
           # Create the linked Announcements discussion after the notes are

--- a/README.md
+++ b/README.md
@@ -72,95 +72,9 @@ The [`samples/`](samples) directory is a tiny demo workspace. Open it as a folde
 
 ## Install
 
-### macOS (Homebrew)
+Install commands for every package manager are on the [website](https://glyph-md.github.io/#download). Each [release](https://github.com/hamidfzm/glyph/releases/latest) lists them too, next to the `.dmg`, `.msi`, `.deb`, `.rpm`, and `.AppImage` downloads.
 
-```bash
-brew tap glyph-md/tap
-brew trust glyph-md/tap
-brew install --cask --force glyph-md/tap/glyph
-```
-
-`brew trust` is required once because Glyph ships from a third-party tap; recent Homebrew refuses to load casks from untrusted taps.
-
-Use the fully qualified name: homebrew-core ships an unrelated `glyph` formula (an ASCII-art converter), so a plain `brew install glyph` installs that instead. If the `glyph` command prints `Error: input file must be specified.`, that formula is shadowing the app; remove it with `brew uninstall --formula glyph` and reinstall the cask. `--force` also replaces an existing `/Applications/Glyph.app` left by a DMG install or an interrupted upgrade.
-
-### Windows (winget)
-
-```powershell
-winget install hamidfzm.Glyph
-```
-
-### Windows (Chocolatey)
-
-```powershell
-choco install glyph
-```
-
-### Windows (Scoop)
-
-```powershell
-scoop bucket add glyph-md https://github.com/glyph-md/scoop-bucket
-scoop install glyph
-```
-
-### Linux (Snap)
-
-```bash
-sudo snap install glyph
-```
-
-### Arch Linux (AUR)
-
-```bash
-yay -S glyph-md-bin
-```
-
-### Linux (Homebrew)
-
-```bash
-brew tap glyph-md/tap
-brew install glyph-md/tap/glyph
-```
-
-### Debian/Ubuntu (PPA)
-
-```bash
-sudo add-apt-repository ppa:hamidfzm/glyph
-sudo apt update
-sudo apt install glyph
-```
-
-### Debian
-
-```bash
-curl -fsSL https://glyph-md.github.io/apt-repo/gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/glyph.gpg
-echo "deb [signed-by=/usr/share/keyrings/glyph.gpg] https://glyph-md.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/glyph.list
-sudo apt update
-sudo apt install glyph
-```
-
-### Fedora / RHEL (DNF)
-
-```bash
-sudo tee /etc/yum.repos.d/glyph.repo < <(curl -fsSL https://glyph-md.github.io/rpm-repo/glyph.repo)
-sudo dnf install glyph
-```
-
-### Linux (manual)
-
-Download the `.deb`, `.rpm`, or `.AppImage` from [Releases](https://github.com/hamidfzm/glyph/releases).
-
-```bash
-# Debian/Ubuntu
-sudo dpkg -i glyph_*.deb
-
-# Fedora/RHEL
-sudo dnf install ./Glyph-*.rpm
-
-# AppImage
-chmod +x Glyph_*.AppImage
-./Glyph_*.AppImage
-```
+If `glyph` prints `Error: input file must be specified.` after a Homebrew install, homebrew-core's unrelated `glyph` formula (an ASCII-art converter) is shadowing the app: remove it with `brew uninstall --formula glyph` and reinstall the cask.
 
 ### Command-line usage
 


### PR DESCRIPTION
## Summary

Stops repeating every install command in the README and in two copies inside `release.yml`. The README now links to the website's download section and the latest release, and the release notes read their install block from one file.

## Changes

- `README.md`: the Install section links to https://glyph-md.github.io/#download and the latest release instead of listing every package manager command. The Homebrew shadowing tip stays. Command-line usage and Docker are unchanged.
- `.github/release-install.md`: the single install block for release notes.
- `.github/workflows/release.yml`: `create-release` checks out the repo and passes the file as `--notes-file`; `update-release-notes` prepends the same file to the changelog. The final notes previously dropped the Arch `PKGBUILD` note that only the first copy had; it now stays.
- Docs rules: install commands now live in three places (release notes file, website, org profile), and the README must not carry them again.

## Risk classification

- [ ] Persistence / data loss
- [ ] Asynchronous ordering / races
- [ ] Destructive lifecycle (close, unmount, workspace switch, app exit)
- [ ] Filesystem / IPC surface
- [ ] Untrusted rendering (Markdown, plugins, links)
- [ ] Secrets / credentials
- [ ] Network
- [ ] Migrations / persisted-format changes
- [ ] Accessibility
- [ ] Bundle size / startup
- [x] No risk areas touched

### Invariants at stake and evidence

None. Docs and release notes text only.

## Testing

Ran the composed release body locally with a sample changelog: output matches the old layout (install block, blank line, `---`, blank line, changelog). Confirmed `id="download"` exists on the live website. Pre-commit gates passed. The workflow change itself runs on the next tag.

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
